### PR TITLE
DEVPROD-5136: Only log commits in current directory for deploy

### DIFF
--- a/apps/parsley/scripts/deploy/email.sh
+++ b/apps/parsley/scripts/deploy/email.sh
@@ -85,7 +85,7 @@ else
   fi
   echo "Getting commits between $BASE_COMMIT and $CURRENT_COMMIT_HASH"
   # get all commits since the base commit
-  git log --no-merges "$BASE_COMMIT".."$CURRENT_COMMIT_HASH" --pretty="%h %s" > body.txt
+  git log --no-merges "$BASE_COMMIT".."$CURRENT_COMMIT_HASH" --pretty="%h %s" -- . > body.txt
 fi
 
 

--- a/apps/parsley/scripts/deploy/utils/git/index.ts
+++ b/apps/parsley/scripts/deploy/utils/git/index.ts
@@ -7,7 +7,7 @@ import { execSync } from "child_process";
  */
 const getCommitMessages = (currentlyDeployedCommit: string) => {
   const commitMessages = execSync(
-    `git log ${currentlyDeployedCommit}..HEAD --oneline`,
+    `git log ${currentlyDeployedCommit}..HEAD --oneline -- .`,
     { encoding: "utf-8" }
   ).toString();
   return commitMessages;

--- a/apps/spruce/scripts/deploy/email.sh
+++ b/apps/spruce/scripts/deploy/email.sh
@@ -85,7 +85,7 @@ else
   fi
   echo "Getting commits between $BASE_COMMIT and $CURRENT_COMMIT_HASH"
   # get all commits since the base commit
-  git log --no-merges "$BASE_COMMIT".."$CURRENT_COMMIT_HASH" --pretty="%h %s" > body.txt
+  git log --no-merges "$BASE_COMMIT".."$CURRENT_COMMIT_HASH" --pretty="%h %s" -- . > body.txt
 fi
 
 

--- a/apps/spruce/scripts/deploy/utils/git/index.ts
+++ b/apps/spruce/scripts/deploy/utils/git/index.ts
@@ -7,7 +7,7 @@ import { execSync } from "child_process";
  */
 const getCommitMessages = (currentlyDeployedCommit: string) => {
   const commitMessages = execSync(
-    `git log ${currentlyDeployedCommit}..HEAD --oneline`,
+    `git log ${currentlyDeployedCommit}..HEAD --oneline -- .`,
     { encoding: "utf-8" }
   ).toString();
   return commitMessages;


### PR DESCRIPTION
DEVPROD-5136

### Description
<!-- add description, context, thought process, etc -->
Append `-- .` to `git log` commands used to populate deploy script and email. This should result in only the commits with changes in the current directory (i.e. Spruce or Parsley respectively) being logged.

### Testing
<!-- add a description of how you tested it -->
Tested locally