### PR TITLE
DEVPROD-5460: Update GraphQL queries to use specific arguments

### DIFF
--- a/apps/parsley/src/gql/generated/types.ts
+++ b/apps/parsley/src/gql/generated/types.ts
@@ -1268,6 +1268,7 @@ export type MutationSchedulePatchTasksArgs = {
 
 export type MutationScheduleTasksArgs = {
   taskIds: Array<Scalars["String"]["input"]>;
+  versionId?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type MutationScheduleUndispatchedBaseTasksArgs = {
@@ -1420,10 +1421,12 @@ export type ParsleyFilterInput = {
 /** ParsleySettings contains information about a user's settings for Parsley. */
 export type ParsleySettings = {
   __typename?: "ParsleySettings";
+  jumpToFailingLineEnabled: Scalars["Boolean"]["output"];
   sectionsEnabled: Scalars["Boolean"]["output"];
 };
 
 export type ParsleySettingsInput = {
+  jumpToFailingLineEnabled?: InputMaybe<Scalars["Boolean"]["input"]>;
   sectionsEnabled?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
@@ -1892,6 +1895,7 @@ export enum ProjectSettingsAccess {
 export type ProjectSettingsInput = {
   aliases?: InputMaybe<Array<ProjectAliasInput>>;
   githubWebhooksEnabled?: InputMaybe<Scalars["Boolean"]["input"]>;
+  projectId?: InputMaybe<Scalars["String"]["input"]>;
   projectRef?: InputMaybe<ProjectInput>;
   subscriptions?: InputMaybe<Array<SubscriptionInput>>;
   vars?: InputMaybe<ProjectVarsInput>;
@@ -2029,7 +2033,8 @@ export type QueryGithubProjectConflictsArgs = {
 };
 
 export type QueryHasVersionArgs = {
-  id: Scalars["String"]["input"];
+  id?: InputMaybe<Scalars["String"]["input"]>;
+  patchId?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type QueryHostArgs = {
@@ -2065,7 +2070,8 @@ export type QueryMainlineCommitsArgs = {
 };
 
 export type QueryPatchArgs = {
-  id: Scalars["String"]["input"];
+  id?: InputMaybe<Scalars["String"]["input"]>;
+  patchId?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type QueryPodArgs = {
@@ -2088,12 +2094,14 @@ export type QueryProjectSettingsArgs = {
 
 export type QueryRepoEventsArgs = {
   before?: InputMaybe<Scalars["Time"]["input"]>;
-  id: Scalars["String"]["input"];
+  id?: InputMaybe<Scalars["String"]["input"]>;
   limit?: InputMaybe<Scalars["Int"]["input"]>;
+  repoId?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type QueryRepoSettingsArgs = {
-  id: Scalars["String"]["input"];
+  id?: InputMaybe<Scalars["String"]["input"]>;
+  repoId?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type QueryTaskArgs = {
@@ -2120,7 +2128,8 @@ export type QueryUserArgs = {
 };
 
 export type QueryVersionArgs = {
-  id: Scalars["String"]["input"];
+  id?: InputMaybe<Scalars["String"]["input"]>;
+  versionId?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type RepoCommitQueueParams = {
@@ -2242,6 +2251,7 @@ export type RepoSettingsInput = {
   aliases?: InputMaybe<Array<ProjectAliasInput>>;
   githubWebhooksEnabled?: InputMaybe<Scalars["Boolean"]["input"]>;
   projectRef?: InputMaybe<RepoRefInput>;
+  repoId?: InputMaybe<Scalars["String"]["input"]>;
   subscriptions?: InputMaybe<Array<SubscriptionInput>>;
   vars?: InputMaybe<ProjectVarsInput>;
 };

--- a/apps/spruce/src/components/ScheduleTasksModal/index.tsx
+++ b/apps/spruce/src/components/ScheduleTasksModal/index.tsx
@@ -81,7 +81,9 @@ export const ScheduleTasksModal: React.FC<ScheduleTasksModalProps> = ({
         loadingTaskData || loadingScheduleTasksMutation || !selectedTasks.size
       }
       onConfirm={() => {
-        scheduleTasks({ variables: { taskIds: Array.from(selectedTasks) } });
+        scheduleTasks({
+          variables: { taskIds: Array.from(selectedTasks), versionId },
+        });
       }}
     >
       <ContentWrapper>

--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -1268,6 +1268,7 @@ export type MutationSchedulePatchTasksArgs = {
 
 export type MutationScheduleTasksArgs = {
   taskIds: Array<Scalars["String"]["input"]>;
+  versionId?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type MutationScheduleUndispatchedBaseTasksArgs = {
@@ -1420,10 +1421,12 @@ export type ParsleyFilterInput = {
 /** ParsleySettings contains information about a user's settings for Parsley. */
 export type ParsleySettings = {
   __typename?: "ParsleySettings";
+  jumpToFailingLineEnabled: Scalars["Boolean"]["output"];
   sectionsEnabled: Scalars["Boolean"]["output"];
 };
 
 export type ParsleySettingsInput = {
+  jumpToFailingLineEnabled?: InputMaybe<Scalars["Boolean"]["input"]>;
   sectionsEnabled?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
@@ -1892,6 +1895,7 @@ export enum ProjectSettingsAccess {
 export type ProjectSettingsInput = {
   aliases?: InputMaybe<Array<ProjectAliasInput>>;
   githubWebhooksEnabled?: InputMaybe<Scalars["Boolean"]["input"]>;
+  projectId?: InputMaybe<Scalars["String"]["input"]>;
   projectRef?: InputMaybe<ProjectInput>;
   subscriptions?: InputMaybe<Array<SubscriptionInput>>;
   vars?: InputMaybe<ProjectVarsInput>;
@@ -2029,7 +2033,8 @@ export type QueryGithubProjectConflictsArgs = {
 };
 
 export type QueryHasVersionArgs = {
-  id: Scalars["String"]["input"];
+  id?: InputMaybe<Scalars["String"]["input"]>;
+  patchId?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type QueryHostArgs = {
@@ -2065,7 +2070,8 @@ export type QueryMainlineCommitsArgs = {
 };
 
 export type QueryPatchArgs = {
-  id: Scalars["String"]["input"];
+  id?: InputMaybe<Scalars["String"]["input"]>;
+  patchId?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type QueryPodArgs = {
@@ -2088,12 +2094,14 @@ export type QueryProjectSettingsArgs = {
 
 export type QueryRepoEventsArgs = {
   before?: InputMaybe<Scalars["Time"]["input"]>;
-  id: Scalars["String"]["input"];
+  id?: InputMaybe<Scalars["String"]["input"]>;
   limit?: InputMaybe<Scalars["Int"]["input"]>;
+  repoId?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type QueryRepoSettingsArgs = {
-  id: Scalars["String"]["input"];
+  id?: InputMaybe<Scalars["String"]["input"]>;
+  repoId?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type QueryTaskArgs = {
@@ -2120,7 +2128,8 @@ export type QueryUserArgs = {
 };
 
 export type QueryVersionArgs = {
-  id: Scalars["String"]["input"];
+  id?: InputMaybe<Scalars["String"]["input"]>;
+  versionId?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type RepoCommitQueueParams = {
@@ -2242,6 +2251,7 @@ export type RepoSettingsInput = {
   aliases?: InputMaybe<Array<ProjectAliasInput>>;
   githubWebhooksEnabled?: InputMaybe<Scalars["Boolean"]["input"]>;
   projectRef?: InputMaybe<RepoRefInput>;
+  repoId?: InputMaybe<Scalars["String"]["input"]>;
   subscriptions?: InputMaybe<Array<SubscriptionInput>>;
   vars?: InputMaybe<ProjectVarsInput>;
 };
@@ -5121,6 +5131,7 @@ export type SchedulePatchMutation = {
 
 export type ScheduleTasksMutationVariables = Exact<{
   taskIds: Array<Scalars["String"]["input"]>;
+  versionId: Scalars["String"]["input"];
 }>;
 
 export type ScheduleTasksMutation = {

--- a/apps/spruce/src/gql/mutations/schedule-tasks.graphql
+++ b/apps/spruce/src/gql/mutations/schedule-tasks.graphql
@@ -1,7 +1,7 @@
 #import "../fragments/baseTask.graphql"
 
-mutation ScheduleTasks($taskIds: [String!]!) {
-  scheduleTasks(taskIds: $taskIds) {
+mutation ScheduleTasks($taskIds: [String!]!, $versionId: String!) {
+  scheduleTasks(taskIds: $taskIds, versionId: $versionId) {
     ...BaseTask
   }
 }

--- a/apps/spruce/src/gql/queries/build-variant-stats.graphql
+++ b/apps/spruce/src/gql/queries/build-variant-stats.graphql
@@ -1,5 +1,5 @@
 query BuildVariantStats($id: String!) {
-  version(id: $id) {
+  version(versionId: $id) {
     buildVariantStats(options: {}) {
       displayName
       statusCounts {

--- a/apps/spruce/src/gql/queries/build-variants-with-children.graphql
+++ b/apps/spruce/src/gql/queries/build-variants-with-children.graphql
@@ -1,5 +1,5 @@
 query BuildVariantsWithChildren($id: String!) {
-  version(id: $id) {
+  version(versionId: $id) {
     buildVariants(options: {}) {
       displayName
       tasks {

--- a/apps/spruce/src/gql/queries/code-changes.graphql
+++ b/apps/spruce/src/gql/queries/code-changes.graphql
@@ -1,7 +1,7 @@
 #import "../fragments/moduleCodeChanges.graphql"
 
 query CodeChanges($id: String!) {
-  patch(id: $id) {
+  patch(patchId: $id) {
     id
     moduleCodeChanges {
       ...ModuleCodeChange

--- a/apps/spruce/src/gql/queries/has-version.graphql
+++ b/apps/spruce/src/gql/queries/has-version.graphql
@@ -1,3 +1,3 @@
 query HasVersion($id: String!) {
-  hasVersion(id: $id)
+  hasVersion(patchId: $id)
 }

--- a/apps/spruce/src/gql/queries/is-patch-configured.graphql
+++ b/apps/spruce/src/gql/queries/is-patch-configured.graphql
@@ -1,5 +1,5 @@
 query IsPatchConfigured($id: String!) {
-  patch(id: $id) {
+  patch(patchId: $id) {
     activated
     alias
     id

--- a/apps/spruce/src/gql/queries/patch-configure.graphql
+++ b/apps/spruce/src/gql/queries/patch-configure.graphql
@@ -1,7 +1,7 @@
 #import "../fragments/basePatch.graphql"
 
 query ConfigurePatch($id: String!) {
-  patch(id: $id) {
+  patch(patchId: $id) {
     ...BasePatch
     childPatchAliases {
       alias

--- a/apps/spruce/src/gql/queries/patch-task-statuses.graphql
+++ b/apps/spruce/src/gql/queries/patch-task-statuses.graphql
@@ -1,5 +1,5 @@
 query PatchTaskStatuses($id: String!) {
-  patch(id: $id) {
+  patch(patchId: $id) {
     baseTaskStatuses
     id
     taskStatuses

--- a/apps/spruce/src/gql/queries/patch.graphql
+++ b/apps/spruce/src/gql/queries/patch.graphql
@@ -1,7 +1,7 @@
 #import "../fragments/basePatch.graphql"
 
 query Patch($id: String!) {
-  patch(id: $id) {
+  patch(patchId: $id) {
     ...BasePatch
     githash
     patchNumber

--- a/apps/spruce/src/gql/queries/repo-event-logs.graphql
+++ b/apps/spruce/src/gql/queries/repo-event-logs.graphql
@@ -1,7 +1,7 @@
 #import "../fragments/projectSettings/projectEventSettings.graphql"
 
 query RepoEventLogs($id: String!, $limit: Int, $before: Time) {
-  repoEvents(id: $id, limit: $limit, before: $before) {
+  repoEvents(id: $id, repoId: $id, limit: $limit, before: $before) {
     count
     eventLogEntries {
       after {

--- a/apps/spruce/src/gql/queries/repo-settings.graphql
+++ b/apps/spruce/src/gql/queries/repo-settings.graphql
@@ -1,7 +1,7 @@
 #import "../fragments/projectSettings/index.graphql"
 
 query RepoSettings($repoId: String!) {
-  repoSettings(id: $repoId) {
+  repoSettings(id: $repoId, repoId: $repoId) {
     ...RepoSettingsFields
   }
 }

--- a/apps/spruce/src/gql/queries/task-statuses.graphql
+++ b/apps/spruce/src/gql/queries/task-statuses.graphql
@@ -1,5 +1,5 @@
 query TaskStatuses($id: String!) {
-  version(id: $id) {
+  version(versionId: $id) {
     baseTaskStatuses
     id
     taskStatuses

--- a/apps/spruce/src/gql/queries/undispatched-tasks.graphql
+++ b/apps/spruce/src/gql/queries/undispatched-tasks.graphql
@@ -1,5 +1,5 @@
 query UndispatchedTasks($versionId: String!) {
-  version(id: $versionId) {
+  version(versionId: $versionId) {
     id
     tasks(
       options: { statuses: ["unscheduled"], includeEmptyActivation: true }

--- a/apps/spruce/src/gql/queries/version-task-durations.graphql
+++ b/apps/spruce/src/gql/queries/version-task-durations.graphql
@@ -2,7 +2,7 @@ query VersionTaskDurations(
   $versionId: String!
   $taskFilterOptions: TaskFilterOptions!
 ) {
-  version(id: $versionId) {
+  version(versionId: $versionId) {
     id
     tasks(options: $taskFilterOptions) {
       count

--- a/apps/spruce/src/gql/queries/version-tasks.graphql
+++ b/apps/spruce/src/gql/queries/version-tasks.graphql
@@ -2,7 +2,7 @@ query VersionTasks(
   $versionId: String!
   $taskFilterOptions: TaskFilterOptions!
 ) {
-  version(id: $versionId) {
+  version(versionId: $versionId) {
     id
     isPatch
     tasks(options: $taskFilterOptions) {

--- a/apps/spruce/src/gql/queries/version.graphql
+++ b/apps/spruce/src/gql/queries/version.graphql
@@ -1,7 +1,7 @@
 #import "../fragments/upstreamProject.graphql"
 
 query Version($id: String!) {
-  version(id: $id) {
+  version(versionId: $id) {
     activated
     author
     authorEmail

--- a/apps/spruce/src/pages/projectSettings/HeaderButtons.tsx
+++ b/apps/spruce/src/pages/projectSettings/HeaderButtons.tsx
@@ -105,7 +105,7 @@ export const HeaderButtons: React.FC<Props> = ({ id, projectType, tab }) => {
 
   const onClick = () => {
     const formToGql: FormToGqlFunction<typeof tab> = formToGqlMap[tab];
-    const newData = formToGql(formData, id);
+    const newData = formToGql(formData, isRepo, id);
     const save = (update, section) =>
       isRepo
         ? saveRepoSection({

--- a/apps/spruce/src/pages/projectSettings/tabs/AccessTab/transformers.test.ts
+++ b/apps/spruce/src/pages/projectSettings/tabs/AccessTab/transformers.test.ts
@@ -11,7 +11,7 @@ describe("repo data", () => {
   });
 
   it("correctly converts from a form to GQL", () => {
-    expect(formToGql(repoForm, "repo")).toStrictEqual(repoResult);
+    expect(formToGql(repoForm, true, "repo")).toStrictEqual(repoResult);
   });
 });
 
@@ -21,7 +21,9 @@ describe("project data", () => {
   });
 
   it("correctly converts from a form to GQL", () => {
-    expect(formToGql(projectForm, "project")).toStrictEqual(projectResult);
+    expect(formToGql(projectForm, false, "project")).toStrictEqual(
+      projectResult,
+    );
   });
 });
 
@@ -34,7 +36,8 @@ const projectForm: AccessFormState = {
   },
 };
 
-const projectResult: Pick<ProjectSettingsInput, "projectRef"> = {
+const projectResult: Pick<ProjectSettingsInput, "projectId" | "projectRef"> = {
+  projectId: "project",
   projectRef: {
     id: "project",
     restricted: true,
@@ -51,7 +54,8 @@ const repoForm: AccessFormState = {
   },
 };
 
-const repoResult: Pick<RepoSettingsInput, "projectRef"> = {
+const repoResult: Pick<RepoSettingsInput, "repoId" | "projectRef"> = {
+  repoId: "repo",
   projectRef: {
     id: "repo",
     restricted: true,

--- a/apps/spruce/src/pages/projectSettings/tabs/AccessTab/transformers.ts
+++ b/apps/spruce/src/pages/projectSettings/tabs/AccessTab/transformers.ts
@@ -18,12 +18,12 @@ export const gqlToForm = ((data) => {
   };
 }) satisfies GqlToFormFunction<Tab>;
 
-export const formToGql = (({ accessSettings, admin }, id) => {
+export const formToGql = (({ accessSettings, admin }, isRepo, id) => {
   const projectRef: ProjectInput = {
     id,
     restricted: accessSettings.restricted,
     admins: admin.admins,
   };
 
-  return { projectRef };
+  return { ...(isRepo ? { repoId: id } : { projectId: id }), projectRef };
 }) satisfies FormToGqlFunction<Tab>;

--- a/apps/spruce/src/pages/projectSettings/tabs/ContainersTab/transformers.test.ts
+++ b/apps/spruce/src/pages/projectSettings/tabs/ContainersTab/transformers.test.ts
@@ -10,7 +10,7 @@ describe("containers", () => {
     expect(gqlToForm(projectBase)).toStrictEqual(projectFormBase);
   });
   it("correctly converts from a form to GQL", () => {
-    expect(formToGql(projectFormBase, "spruce")).toStrictEqual(
+    expect(formToGql(projectFormBase, false, "spruce")).toStrictEqual(
       projectResultBase,
     );
   });
@@ -29,6 +29,7 @@ const projectFormBase: ContainersFormState = {
 };
 
 const projectResultBase: ProjectSettingsInput = {
+  projectId: "spruce",
   projectRef: {
     id: "spruce",
     containerSizeDefinitions: [

--- a/apps/spruce/src/pages/projectSettings/tabs/ContainersTab/transformers.ts
+++ b/apps/spruce/src/pages/projectSettings/tabs/ContainersTab/transformers.ts
@@ -15,9 +15,10 @@ export const gqlToForm = ((data) => {
   };
 }) satisfies GqlToFormFunction<Tab>;
 
-export const formToGql = ((formState, id) => {
+export const formToGql = ((formState, isRepo, id) => {
   const { containerSizeDefinitions } = formState;
   return {
+    ...(isRepo ? { repoId: id } : { projectId: id }),
     projectRef: {
       id,
       containerSizeDefinitions: containerSizeDefinitions.variables,

--- a/apps/spruce/src/pages/projectSettings/tabs/GeneralTab/transformers.test.ts
+++ b/apps/spruce/src/pages/projectSettings/tabs/GeneralTab/transformers.test.ts
@@ -14,7 +14,7 @@ describe("repo data", () => {
   });
 
   it("correctly converts from a form to GQL", () => {
-    expect(formToGql(repoForm, "repo")).toStrictEqual(repoResult);
+    expect(formToGql(repoForm, true, "repo")).toStrictEqual(repoResult);
   });
 });
 
@@ -24,7 +24,9 @@ describe("project data", () => {
   });
 
   it("correctly converts from a form to GQL", () => {
-    expect(formToGql(projectForm, "project")).toStrictEqual(projectResult);
+    expect(formToGql(projectForm, false, "project")).toStrictEqual(
+      projectResult,
+    );
   });
 });
 
@@ -67,7 +69,8 @@ const repoForm: GeneralFormState = {
   },
 };
 
-const repoResult: Pick<RepoSettingsInput, "projectRef"> = {
+const repoResult: Pick<RepoSettingsInput, "repoId" | "projectRef"> = {
+  repoId: "repo",
   projectRef: {
     id: "repo",
     owner: "evergreen-ci",
@@ -133,7 +136,8 @@ const projectForm: GeneralFormState = {
   },
 };
 
-const projectResult: Pick<ProjectSettingsInput, "projectRef"> = {
+const projectResult: Pick<ProjectSettingsInput, "projectId" | "projectRef"> = {
+  projectId: "project",
   projectRef: {
     id: "project",
     enabled: false,

--- a/apps/spruce/src/pages/projectSettings/tabs/GeneralTab/transformers.ts
+++ b/apps/spruce/src/pages/projectSettings/tabs/GeneralTab/transformers.ts
@@ -68,6 +68,7 @@ export const formToGql = ((
     historicalTaskDataCaching: { disabledStatsCache },
     projectFlags,
   },
+  isRepo,
   id,
 ) => {
   const projectRef: ProjectInput = {
@@ -101,5 +102,5 @@ export const formToGql = ((
     disabledStatsCache,
   };
 
-  return { projectRef };
+  return { ...(isRepo ? { repoId: id } : { projectId: id }), projectRef };
 }) satisfies FormToGqlFunction<Tab>;

--- a/apps/spruce/src/pages/projectSettings/tabs/GithubCommitQueueTab/transformers.test.ts
+++ b/apps/spruce/src/pages/projectSettings/tabs/GithubCommitQueueTab/transformers.test.ts
@@ -19,7 +19,7 @@ describe("repo data", () => {
   });
 
   it("correctly converts from a form to GQL", () => {
-    expect(formToGql(repoForm, "repo")).toStrictEqual(repoResult);
+    expect(formToGql(repoForm, true, "repo")).toStrictEqual(repoResult);
   });
 });
 
@@ -31,7 +31,9 @@ describe("project data", () => {
   });
 
   it("correctly converts from a form to GQL and omits empty strings", () => {
-    expect(formToGql(projectForm, "project")).toStrictEqual(projectResult);
+    expect(formToGql(projectForm, false, "project")).toStrictEqual(
+      projectResult,
+    );
   });
 
   it("correctly merges project and repo form states", () => {
@@ -139,7 +141,11 @@ const projectForm: GCQFormState = {
   },
 };
 
-const projectResult: Pick<ProjectSettingsInput, "projectRef" | "aliases"> = {
+const projectResult: Pick<
+  ProjectSettingsInput,
+  "projectId" | "projectRef" | "aliases"
+> = {
+  projectId: "project",
   projectRef: {
     id: "project",
     prTestingEnabled: null,
@@ -275,37 +281,39 @@ const repoForm: GCQFormState = {
   },
 };
 
-const repoResult: Pick<RepoSettingsInput, "projectRef" | "aliases"> = {
-  projectRef: {
-    id: "repo",
-    prTestingEnabled: false,
-    manualPrTestingEnabled: false,
-    githubChecksEnabled: true,
-    gitTagVersionsEnabled: false,
-    gitTagAuthorizedUsers: ["admin"],
-    gitTagAuthorizedTeams: [],
-    commitQueue: {
-      enabled: true,
-      message: "Commit Queue Message",
-      mergeMethod: "squash",
-      mergeQueue: MergeQueue.Github,
+const repoResult: Pick<RepoSettingsInput, "repoId" | "projectRef" | "aliases"> =
+  {
+    repoId: "repo",
+    projectRef: {
+      id: "repo",
+      prTestingEnabled: false,
+      manualPrTestingEnabled: false,
+      githubChecksEnabled: true,
+      gitTagVersionsEnabled: false,
+      gitTagAuthorizedUsers: ["admin"],
+      gitTagAuthorizedTeams: [],
+      commitQueue: {
+        enabled: true,
+        message: "Commit Queue Message",
+        mergeMethod: "squash",
+        mergeQueue: MergeQueue.Github,
+      },
     },
-  },
-  aliases: [
-    {
-      id: "2",
-      alias: "__github_checks",
-      description: "",
-      gitTag: "",
-      remotePath: "",
-      task: "",
-      taskTags: ["tTag"],
-      variant: "",
-      variantTags: ["vTag"],
-      parameters: [],
-    },
-  ],
-};
+    aliases: [
+      {
+        id: "2",
+        alias: "__github_checks",
+        description: "",
+        gitTag: "",
+        remotePath: "",
+        task: "",
+        taskTags: ["tTag"],
+        variant: "",
+        variantTags: ["vTag"],
+        parameters: [],
+      },
+    ],
+  };
 
 const mergedForm: GCQFormState = {
   github: {

--- a/apps/spruce/src/pages/projectSettings/tabs/GithubCommitQueueTab/transformers.ts
+++ b/apps/spruce/src/pages/projectSettings/tabs/GithubCommitQueueTab/transformers.ts
@@ -127,6 +127,7 @@ export const formToGql = ((
       users: { gitTagAuthorizedUsers, gitTagAuthorizedUsersOverride },
     },
   },
+  isRepo,
   id,
 ) => {
   const projectRef: ProjectInput = {
@@ -181,6 +182,7 @@ export const formToGql = ((
   ];
 
   return {
+    ...(isRepo ? { repoId: id } : { projectId: id }),
     projectRef,
     aliases,
   };

--- a/apps/spruce/src/pages/projectSettings/tabs/NotificationsTab/transformers.test.ts
+++ b/apps/spruce/src/pages/projectSettings/tabs/NotificationsTab/transformers.test.ts
@@ -20,7 +20,9 @@ describe("project data", () => {
   });
 
   it("correctly converts from a form to GQL when a banner value exists in the form", () => {
-    expect(formToGql({ ...projectFormBase, banner }, "spruce")).toStrictEqual({
+    expect(
+      formToGql({ ...projectFormBase, banner }, false, "spruce"),
+    ).toStrictEqual({
       ...projectResultBase,
       projectRef: {
         ...projectResultBase.projectRef,
@@ -30,7 +32,7 @@ describe("project data", () => {
   });
 
   it("correctly converts from a form to GQL when the subscriptions field is empty", () => {
-    expect(formToGql(projectFormBase, "spruce")).toStrictEqual(
+    expect(formToGql(projectFormBase, false, "spruce")).toStrictEqual(
       projectResultBase,
     );
   });
@@ -88,7 +90,9 @@ describe("project data", () => {
       ],
     };
 
-    expect(formToGql(projectForm, "spruce")).toStrictEqual(projectResult);
+    expect(formToGql(projectForm, false, "spruce")).toStrictEqual(
+      projectResult,
+    );
   });
 
   it("handles jira issue subscriptions", () => {
@@ -150,7 +154,9 @@ describe("project data", () => {
         },
       ],
     };
-    expect(formToGql(projectForm, "spruce")).toStrictEqual(projectResult);
+    expect(formToGql(projectForm, false, "spruce")).toStrictEqual(
+      projectResult,
+    );
   });
   it("handles webhook subscriptions", () => {
     const projectForm = {
@@ -230,7 +236,9 @@ describe("project data", () => {
       ],
     };
 
-    expect(formToGql(projectForm, "spruce")).toStrictEqual(projectResult);
+    expect(formToGql(projectForm, false, "spruce")).toStrictEqual(
+      projectResult,
+    );
   });
 });
 
@@ -242,6 +250,7 @@ const projectFormBase: NotificationsFormState = {
 };
 
 const projectResultBase: ProjectSettingsInput = {
+  projectId: "spruce",
   projectRef: {
     id: "spruce",
     notifyOnBuildFailure: null,

--- a/apps/spruce/src/pages/projectSettings/tabs/NotificationsTab/transformers.ts
+++ b/apps/spruce/src/pages/projectSettings/tabs/NotificationsTab/transformers.ts
@@ -138,17 +138,18 @@ export const gqlToForm = ((data, { projectType }) => {
   };
 }) satisfies GqlToFormFunction<Tab>;
 
-export const formToGql = ((formState, projectId) => {
+export const formToGql = ((formState, isRepo, id) => {
   const { banner, buildBreakSettings, subscriptions } = formState;
   const projectRef: ProjectInput = {
-    id: projectId,
+    id,
     notifyOnBuildFailure: buildBreakSettings.notifyOnBuildFailure,
     ...(banner && { banner: banner.bannerData }),
   };
   const transformedSubscriptions: SubscriptionInput[] = subscriptions.map(
-    getGqlPayload(projectId),
+    getGqlPayload(id),
   );
   return {
+    ...(isRepo ? { repoId: id } : { projectId: id }),
     projectRef,
     subscriptions: transformedSubscriptions,
   };

--- a/apps/spruce/src/pages/projectSettings/tabs/PatchAliasesTab/transformers.test.ts
+++ b/apps/spruce/src/pages/projectSettings/tabs/PatchAliasesTab/transformers.test.ts
@@ -15,7 +15,7 @@ describe("repo data", () => {
   });
 
   it("correctly converts from a form to GQL", () => {
-    expect(formToGql(repoForm, "repo")).toStrictEqual(repoResult);
+    expect(formToGql(repoForm, true, "repo")).toStrictEqual(repoResult);
   });
 });
 
@@ -27,7 +27,9 @@ describe("project data", () => {
   });
 
   it("correctly converts from a form to GQL and omits empty strings", () => {
-    expect(formToGql(projectForm, "project")).toStrictEqual(projectResult);
+    expect(formToGql(projectForm, false, "project")).toStrictEqual(
+      projectResult,
+    );
   });
 });
 
@@ -42,7 +44,11 @@ const projectForm: PatchAliasesFormState = {
   },
 };
 
-const projectResult: Pick<ProjectSettingsInput, "projectRef" | "aliases"> = {
+const projectResult: Pick<
+  ProjectSettingsInput,
+  "projectId" | "projectRef" | "aliases"
+> = {
+  projectId: "project",
   projectRef: {
     id: "project",
     patchTriggerAliases: null,
@@ -105,43 +111,45 @@ const repoForm: PatchAliasesFormState = {
   },
 };
 
-const repoResult: Pick<RepoSettingsInput, "projectRef" | "aliases"> = {
-  projectRef: {
-    id: "repo",
-    patchTriggerAliases: [
+const repoResult: Pick<RepoSettingsInput, "repoId" | "projectRef" | "aliases"> =
+  {
+    repoId: "repo",
+    projectRef: {
+      id: "repo",
+      patchTriggerAliases: [
+        {
+          alias: "alias1",
+          childProjectIdentifier: "spruce",
+          taskSpecifiers: [
+            {
+              patchAlias: "alias2",
+              taskRegex: "",
+              variantRegex: "",
+            },
+            {
+              patchAlias: "",
+              taskRegex: ".*",
+              variantRegex: ".*",
+            },
+          ],
+          status: "success",
+          parentAsModule: "",
+        },
+      ],
+      githubTriggerAliases: ["alias1"],
+    },
+    aliases: [
       {
-        alias: "alias1",
-        childProjectIdentifier: "spruce",
-        taskSpecifiers: [
-          {
-            patchAlias: "alias2",
-            taskRegex: "",
-            variantRegex: "",
-          },
-          {
-            patchAlias: "",
-            taskRegex: ".*",
-            variantRegex: ".*",
-          },
-        ],
-        status: "success",
-        parentAsModule: "",
+        id: "4",
+        alias: "my alias name",
+        description: "my description",
+        gitTag: "",
+        variant: "",
+        task: "",
+        remotePath: "",
+        parameters: [],
+        variantTags: ["okay"],
+        taskTags: ["hi"],
       },
     ],
-    githubTriggerAliases: ["alias1"],
-  },
-  aliases: [
-    {
-      id: "4",
-      alias: "my alias name",
-      description: "my description",
-      gitTag: "",
-      variant: "",
-      task: "",
-      remotePath: "",
-      parameters: [],
-      variantTags: ["okay"],
-      taskTags: ["hi"],
-    },
-  ],
-};
+  };

--- a/apps/spruce/src/pages/projectSettings/tabs/PatchAliasesTab/transformers.ts
+++ b/apps/spruce/src/pages/projectSettings/tabs/PatchAliasesTab/transformers.ts
@@ -60,6 +60,7 @@ export const gqlToForm: GqlToFormFunction<Tab> = ((data, options) => {
 
 export const formToGql = ((
   { patchAliases, patchTriggerAliases: ptaData },
+  isRepo,
   id,
 ) => {
   const aliases = transformAliases(
@@ -98,6 +99,7 @@ export const formToGql = ((
     : null;
 
   return {
+    ...(isRepo ? { repoId: id } : { projectId: id }),
     projectRef: { id, patchTriggerAliases, githubTriggerAliases },
     aliases,
   };

--- a/apps/spruce/src/pages/projectSettings/tabs/PeriodicBuildsTab/transformers.test.ts
+++ b/apps/spruce/src/pages/projectSettings/tabs/PeriodicBuildsTab/transformers.test.ts
@@ -14,7 +14,9 @@ describe("project data", () => {
   });
 
   it("correctly converts from a form to GQL and omits empty strings", () => {
-    expect(formToGql(projectForm, "project")).toStrictEqual(projectResult);
+    expect(formToGql(projectForm, false, "project")).toStrictEqual(
+      projectResult,
+    );
   });
 });
 
@@ -26,7 +28,7 @@ describe("repo data", () => {
   });
 
   it("correctly converts from a form to GQL", () => {
-    expect(formToGql(repoForm, "repo")).toStrictEqual(repoResult);
+    expect(formToGql(repoForm, true, "repo")).toStrictEqual(repoResult);
   });
 });
 
@@ -35,7 +37,8 @@ const projectForm: PeriodicBuildsFormState = {
   periodicBuilds: [],
 };
 
-const projectResult: Pick<ProjectSettingsInput, "projectRef"> = {
+const projectResult: Pick<ProjectSettingsInput, "projectId" | "projectRef"> = {
+  projectId: "project",
   projectRef: {
     id: "project",
     periodicBuilds: [],
@@ -76,7 +79,8 @@ const repoForm: PeriodicBuildsFormState = {
   ],
 };
 
-const repoResult: Pick<RepoSettingsInput, "projectRef"> = {
+const repoResult: Pick<RepoSettingsInput, "repoId" | "projectRef"> = {
+  repoId: "repo",
   projectRef: {
     id: "repo",
     periodicBuilds: [

--- a/apps/spruce/src/pages/projectSettings/tabs/PeriodicBuildsTab/transformers.ts
+++ b/apps/spruce/src/pages/projectSettings/tabs/PeriodicBuildsTab/transformers.ts
@@ -65,16 +65,25 @@ export const gqlToForm = ((data, { projectType }) => {
 
 export const formToGql = ((
   { periodicBuilds, periodicBuildsOverride },
-  projectId,
+  isRepo,
+  id,
 ) => ({
+  ...(isRepo ? { repoId: id } : { projectId: id }),
   projectRef: {
-    id: projectId,
+    id,
     periodicBuilds: periodicBuildsOverride
       ? periodicBuilds.map(
-          ({ alias, configFile, id, interval, message, nextRunTime }) => ({
+          ({
             alias,
             configFile,
-            id: id || "",
+            id: periodicBuildId,
+            interval,
+            message,
+            nextRunTime,
+          }) => ({
+            alias,
+            configFile,
+            id: periodicBuildId || "",
             message,
             nextRunTime: new Date(nextRunTime),
             ...(interval.specifier === IntervalSpecifier.Cron

--- a/apps/spruce/src/pages/projectSettings/tabs/PluginsTab/transformers.test.ts
+++ b/apps/spruce/src/pages/projectSettings/tabs/PluginsTab/transformers.test.ts
@@ -12,7 +12,7 @@ describe("repo data", () => {
   });
 
   it("correctly converts from a form to GQL", () => {
-    expect(formToGql(repoForm, "repo")).toStrictEqual(repoResult);
+    expect(formToGql(repoForm, true, "repo")).toStrictEqual(repoResult);
   });
 });
 
@@ -22,7 +22,9 @@ describe("project data", () => {
   });
 
   it("correctly converts from a form to GQL", () => {
-    expect(formToGql(projectForm, "project")).toStrictEqual(projectResult);
+    expect(formToGql(projectForm, false, "project")).toStrictEqual(
+      projectResult,
+    );
   });
 });
 
@@ -63,7 +65,8 @@ const projectForm: PluginsFormState = {
   ],
 };
 
-const projectResult: Pick<ProjectSettingsInput, "projectRef"> = {
+const projectResult: Pick<ProjectSettingsInput, "projectId" | "projectRef"> = {
+  projectId: "project",
   projectRef: {
     id: "project",
     perfEnabled: true,
@@ -135,7 +138,8 @@ const repoForm: PluginsFormState = {
   ],
 };
 
-const repoResult: Pick<RepoSettingsInput, "projectRef"> = {
+const repoResult: Pick<RepoSettingsInput, "repoId" | "projectRef"> = {
+  repoId: "repo",
   projectRef: {
     id: "repo",
     perfEnabled: true,

--- a/apps/spruce/src/pages/projectSettings/tabs/PluginsTab/transformers.ts
+++ b/apps/spruce/src/pages/projectSettings/tabs/PluginsTab/transformers.ts
@@ -54,6 +54,7 @@ export const gqlToForm = ((data) => {
 
 export const formToGql = ((
   { buildBaronSettings, externalLinks, performanceSettings },
+  isRepo,
   id,
 ) => {
   const projectRef: ProjectInput = {
@@ -79,7 +80,7 @@ export const formToGql = ((
           }))
         : null,
   };
-  return { projectRef };
+  return { ...(isRepo ? { repoId: id } : { projectId: id }), projectRef };
 }) satisfies FormToGqlFunction<Tab>;
 
 // conditionally include the buildBaronSettings field based on the useBuildBaron boolean

--- a/apps/spruce/src/pages/projectSettings/tabs/ProjectTriggersTab/transformers.test.ts
+++ b/apps/spruce/src/pages/projectSettings/tabs/ProjectTriggersTab/transformers.test.ts
@@ -14,7 +14,9 @@ describe("project data", () => {
   });
 
   it("correctly converts from a form to GQL", () => {
-    expect(formToGql(projectForm, "project")).toStrictEqual(projectResult);
+    expect(formToGql(projectForm, false, "project")).toStrictEqual(
+      projectResult,
+    );
   });
 });
 
@@ -26,7 +28,7 @@ describe("repo data", () => {
   });
 
   it("correctly converts from a form to GQL", () => {
-    expect(formToGql(repoForm, "repo")).toStrictEqual(repoResult);
+    expect(formToGql(repoForm, true, "repo")).toStrictEqual(repoResult);
   });
 });
 
@@ -35,7 +37,8 @@ const projectForm: ProjectTriggersFormState = {
   triggers: [],
 };
 
-const projectResult: Pick<ProjectSettingsInput, "projectRef"> = {
+const projectResult: Pick<ProjectSettingsInput, "projectId" | "projectRef"> = {
+  projectId: "project",
   projectRef: {
     id: "project",
     triggers: [],
@@ -60,7 +63,8 @@ const repoForm: ProjectTriggersFormState = {
   ],
 };
 
-const repoResult: Pick<RepoSettingsInput, "projectRef"> = {
+const repoResult: Pick<RepoSettingsInput, "repoId" | "projectRef"> = {
+  repoId: "repo",
   projectRef: {
     id: "repo",
     triggers: [

--- a/apps/spruce/src/pages/projectSettings/tabs/ProjectTriggersTab/transformers.ts
+++ b/apps/spruce/src/pages/projectSettings/tabs/ProjectTriggersTab/transformers.ts
@@ -37,9 +37,10 @@ export const gqlToForm = ((data, { projectType }) => {
   };
 }) satisfies GqlToFormFunction<Tab>;
 
-export const formToGql = (({ triggers, triggersOverride }, projectId) => ({
+export const formToGql = (({ triggers, triggersOverride }, isRepo, id) => ({
+  ...(isRepo ? { repoId: id } : { projectId: id }),
   projectRef: {
-    id: projectId,
+    id,
     triggers: triggersOverride
       ? triggers.map((trigger) => ({
           project: trigger.project,

--- a/apps/spruce/src/pages/projectSettings/tabs/VariablesTab/transformers.test.ts
+++ b/apps/spruce/src/pages/projectSettings/tabs/VariablesTab/transformers.test.ts
@@ -17,6 +17,7 @@ describe("project data", () => {
         {
           vars: [...form.vars, {} as Unpacked<VariablesFormState["vars"]>],
         },
+        false,
         "project",
       ),
     ).toStrictEqual(result);
@@ -42,13 +43,15 @@ const form: VariablesFormState = {
   ],
 };
 
-const result: Pick<ProjectSettingsInput, "projectRef" | "vars"> = {
-  projectRef: {
-    id: "project",
-  },
-  vars: {
-    vars: { test_name: "", test_two: "val" },
-    privateVarsList: ["test_name"],
-    adminOnlyVarsList: ["test_name"],
-  },
-};
+const result: Pick<ProjectSettingsInput, "projectId" | "projectRef" | "vars"> =
+  {
+    projectId: "project",
+    projectRef: {
+      id: "project",
+    },
+    vars: {
+      vars: { test_name: "", test_two: "val" },
+      privateVarsList: ["test_name"],
+      adminOnlyVarsList: ["test_name"],
+    },
+  };

--- a/apps/spruce/src/pages/projectSettings/tabs/VariablesTab/transformers.ts
+++ b/apps/spruce/src/pages/projectSettings/tabs/VariablesTab/transformers.ts
@@ -21,7 +21,7 @@ export const gqlToForm = ((data) => {
   };
 }) satisfies GqlToFormFunction<Tab>;
 
-export const formToGql = (({ vars: varsData }, id) => {
+export const formToGql = (({ vars: varsData }, isRepo, id) => {
   const vars = varsData.reduce(
     (acc, { isAdminOnly, isDisabled, isPrivate, varName, varValue }) => {
       if (!varName || !varValue) return acc;
@@ -45,6 +45,7 @@ export const formToGql = (({ vars: varsData }, id) => {
     },
   );
   return {
+    ...(isRepo ? { repoId: id } : { projectId: id }),
     projectRef: { id },
     vars,
   };

--- a/apps/spruce/src/pages/projectSettings/tabs/ViewsAndFiltersTab/transformers.test.ts
+++ b/apps/spruce/src/pages/projectSettings/tabs/ViewsAndFiltersTab/transformers.test.ts
@@ -18,7 +18,7 @@ describe("repo data", () => {
   });
 
   it("correctly converts from a form to GQL", () => {
-    expect(formToGql(repoForm, "repo")).toStrictEqual(repoResult);
+    expect(formToGql(repoForm, true, "repo")).toStrictEqual(repoResult);
   });
 });
 
@@ -30,7 +30,9 @@ describe("project data", () => {
   });
 
   it("correctly converts from a form to GQL", () => {
-    expect(formToGql(projectForm, "project")).toStrictEqual(projectResult);
+    expect(formToGql(projectForm, false, "project")).toStrictEqual(
+      projectResult,
+    );
   });
 });
 
@@ -45,7 +47,8 @@ const repoForm: ViewsFormState = {
   ],
 };
 
-const repoResult: Pick<RepoSettingsInput, "projectRef"> = {
+const repoResult: Pick<RepoSettingsInput, "repoId" | "projectRef"> = {
+  repoId: "repo",
   projectRef: {
     id: "repo",
     parsleyFilters: [
@@ -78,7 +81,8 @@ const projectForm: ViewsFormState = {
   },
 };
 
-const projectResult: Pick<ProjectSettingsInput, "projectRef"> = {
+const projectResult: Pick<ProjectSettingsInput, "projectId" | "projectRef"> = {
+  projectId: "project",
   projectRef: {
     id: "project",
     parsleyFilters: [

--- a/apps/spruce/src/pages/projectSettings/tabs/ViewsAndFiltersTab/transformers.ts
+++ b/apps/spruce/src/pages/projectSettings/tabs/ViewsAndFiltersTab/transformers.ts
@@ -28,7 +28,8 @@ export const gqlToForm = ((data, { projectType }) => {
   };
 }) satisfies GqlToFormFunction<Tab>;
 
-export const formToGql = (({ parsleyFilters, view }, id) => ({
+export const formToGql = (({ parsleyFilters, view }, isRepo, id) => ({
+  ...(isRepo ? { repoId: id } : { projectId: id }),
   projectRef: {
     id,
     parsleyFilters: parsleyFilters.map(

--- a/apps/spruce/src/pages/projectSettings/tabs/VirtualWorkstationTab/transformers.test.ts
+++ b/apps/spruce/src/pages/projectSettings/tabs/VirtualWorkstationTab/transformers.test.ts
@@ -14,7 +14,9 @@ describe("project data", () => {
   });
 
   it("correctly converts from a form to GQL and omits empty strings", () => {
-    expect(formToGql(projectForm, "project")).toStrictEqual(projectResult);
+    expect(formToGql(projectForm, false, "project")).toStrictEqual(
+      projectResult,
+    );
   });
 });
 
@@ -26,7 +28,7 @@ describe("repo data", () => {
   });
 
   it("correctly converts from a form to GQL", () => {
-    expect(formToGql(repoForm, "repo")).toStrictEqual(repoResult);
+    expect(formToGql(repoForm, true, "repo")).toStrictEqual(repoResult);
   });
 });
 
@@ -43,7 +45,8 @@ const projectForm: VWFormState = {
   },
 };
 
-const projectResult: Pick<ProjectSettingsInput, "projectRef"> = {
+const projectResult: Pick<ProjectSettingsInput, "projectId" | "projectRef"> = {
+  projectId: "project",
   projectRef: {
     id: "project",
     workstationConfig: {
@@ -66,7 +69,8 @@ const repoForm: VWFormState = {
   },
 };
 
-const repoResult: Pick<RepoSettingsInput, "projectRef"> = {
+const repoResult: Pick<RepoSettingsInput, "repoId" | "projectRef"> = {
+  repoId: "repo",
   projectRef: {
     id: "repo",
     workstationConfig: {

--- a/apps/spruce/src/pages/projectSettings/tabs/VirtualWorkstationTab/transformers.ts
+++ b/apps/spruce/src/pages/projectSettings/tabs/VirtualWorkstationTab/transformers.ts
@@ -29,8 +29,10 @@ export const gqlToForm = ((data, options) => {
 
 export const formToGql = ((
   { commands: { setupCommands, setupCommandsOverride }, gitClone },
+  isRepo,
   id,
 ) => ({
+  ...(isRepo ? { repoId: id } : { projectId: id }),
   projectRef: {
     id,
     workstationConfig: {

--- a/apps/spruce/src/pages/projectSettings/tabs/types.ts
+++ b/apps/spruce/src/pages/projectSettings/tabs/types.ts
@@ -2,6 +2,7 @@ import { ProjectSettingsTabRoutes } from "constants/routes";
 import {
   ProjectSettingsInput,
   ProjectSettingsQuery,
+  RepoSettingsInput,
   RepoSettingsQuery,
 } from "gql/generated/types";
 import { AccessFormState } from "./AccessTab/types";
@@ -51,8 +52,9 @@ export type GqlToFormFunction<T extends WritableProjectSettingsType> = (
 
 export type FormToGqlFunction<T extends WritableProjectSettingsType> = (
   form: FormStateMap[T],
+  isRepo: boolean,
   id?: string,
-) => ProjectSettingsInput;
+) => ProjectSettingsInput | RepoSettingsInput;
 
 const { EventLog, ...WritableProjectSettingsTabs } = ProjectSettingsTabRoutes;
 export { WritableProjectSettingsTabs };

--- a/apps/spruce/src/pages/task/ActionButtons.tsx
+++ b/apps/spruce/src/pages/task/ActionButtons.tsx
@@ -70,7 +70,7 @@ export const ActionButtons: React.FC<Props> = ({
     versionMetadata,
   } = task || {};
 
-  const { isPatch, order } = versionMetadata || {};
+  const { id: versionId, isPatch, order } = versionMetadata || {};
   const { identifier: projectIdentifier } = project || {};
   const isPatchOnCommitQueue = requester === commitQueueRequester;
   const allExecutionTasksSucceeded =
@@ -88,7 +88,7 @@ export const ActionButtons: React.FC<Props> = ({
     ScheduleTasksMutation,
     ScheduleTasksMutationVariables
   >(SCHEDULE_TASKS, {
-    variables: { taskIds: [taskId] },
+    variables: { taskIds: [taskId], versionId },
     onCompleted: () => {
       dispatchToast.success("Task marked as scheduled");
     },


### PR DESCRIPTION
DEVPROD-5460

### Description
Uses the new GraphQL arguments.

I'm going to temporarily support both ID and repoID for the `RepoSettings` and `RepoEvents` queries, because I noticed a weird bug where the directive didn't behave as expected (even after making updates in the backend) and I was able to bypass restrictions as a regular user. I'll have to update the directive in the backend anyways, so I'll do that after this PR is merged.

### Testing
- Since I changed the definition of `FormToGql` for project settings, I updated transformers tests

