### PR TITLE
DEVPROD-5460: Remove id argument from repo queries

### DIFF
--- a/apps/spruce/src/gql/queries/repo-event-logs.graphql
+++ b/apps/spruce/src/gql/queries/repo-event-logs.graphql
@@ -1,7 +1,7 @@
 #import "../fragments/projectSettings/projectEventSettings.graphql"
 
 query RepoEventLogs($id: String!, $limit: Int, $before: Time) {
-  repoEvents(id: $id, repoId: $id, limit: $limit, before: $before) {
+  repoEvents(repoId: $id, limit: $limit, before: $before) {
     count
     eventLogEntries {
       after {

--- a/apps/spruce/src/gql/queries/repo-settings.graphql
+++ b/apps/spruce/src/gql/queries/repo-settings.graphql
@@ -1,7 +1,7 @@
 #import "../fragments/projectSettings/index.graphql"
 
 query RepoSettings($repoId: String!) {
-  repoSettings(id: $repoId, repoId: $repoId) {
+  repoSettings(repoId: $repoId) {
     ...RepoSettingsFields
   }
 }


### PR DESCRIPTION
DEVPROD-5460

### Description
Small PR to remove `id` argument from repo queries, since the directive should now be applied to the new `repoId` argument.

### Evergreen PR
* evergreen-ci/evergreen/pull/7702
