### PR TITLE
DEVPROD-4798 remove ssh keys from distro host settings

### DIFF
--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -388,6 +388,7 @@ export type Distro = {
   providerSettingsList: Array<Scalars["Map"]["output"]>;
   setup: Scalars["String"]["output"];
   setupAsSudo: Scalars["Boolean"]["output"];
+  sshKey: Scalars["String"]["output"];
   sshOptions: Array<Scalars["String"]["output"]>;
   user: Scalars["String"]["output"];
   userSpawnAllowed: Scalars["Boolean"]["output"];
@@ -452,6 +453,8 @@ export type DistroInput = {
   providerSettingsList: Array<Scalars["Map"]["input"]>;
   setup: Scalars["String"]["input"];
   setupAsSudo: Scalars["Boolean"]["input"];
+  /** @deprecated removing this field shortly */
+  sshKey?: InputMaybe<Scalars["String"]["input"]>;
   sshOptions: Array<Scalars["String"]["input"]>;
   user: Scalars["String"]["input"];
   userSpawnAllowed: Scalars["Boolean"]["input"];
@@ -2303,6 +2306,12 @@ export enum RoundingRule {
   Up = "UP",
 }
 
+export type SshKey = {
+  __typename?: "SSHKey";
+  location: Scalars["String"]["output"];
+  name: Scalars["String"]["output"];
+};
+
 /** SaveDistroInput is the input to the saveDistro mutation. */
 export type SaveDistroInput = {
   distro: DistroInput;
@@ -2454,6 +2463,8 @@ export type SpruceConfig = {
   containerPools?: Maybe<ContainerPoolsConfig>;
   githubOrgs: Array<Scalars["String"]["output"]>;
   jira?: Maybe<JiraConfig>;
+  /** @deprecated removing this field shortly */
+  keys?: Maybe<Array<SshKey>>;
   providers?: Maybe<CloudProviderConfig>;
   secretFields: Array<Scalars["String"]["output"]>;
   slack?: Maybe<SlackConfig>;

--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -388,7 +388,6 @@ export type Distro = {
   providerSettingsList: Array<Scalars["Map"]["output"]>;
   setup: Scalars["String"]["output"];
   setupAsSudo: Scalars["Boolean"]["output"];
-  sshKey: Scalars["String"]["output"];
   sshOptions: Array<Scalars["String"]["output"]>;
   user: Scalars["String"]["output"];
   userSpawnAllowed: Scalars["Boolean"]["output"];
@@ -453,7 +452,6 @@ export type DistroInput = {
   providerSettingsList: Array<Scalars["Map"]["input"]>;
   setup: Scalars["String"]["input"];
   setupAsSudo: Scalars["Boolean"]["input"];
-  sshKey: Scalars["String"]["input"];
   sshOptions: Array<Scalars["String"]["input"]>;
   user: Scalars["String"]["input"];
   userSpawnAllowed: Scalars["Boolean"]["input"];
@@ -2310,12 +2308,6 @@ export enum RoundingRule {
   Up = "UP",
 }
 
-export type SshKey = {
-  __typename?: "SSHKey";
-  location: Scalars["String"]["output"];
-  name: Scalars["String"]["output"];
-};
-
 /** SaveDistroInput is the input to the saveDistro mutation. */
 export type SaveDistroInput = {
   distro: DistroInput;
@@ -2467,7 +2459,6 @@ export type SpruceConfig = {
   containerPools?: Maybe<ContainerPoolsConfig>;
   githubOrgs: Array<Scalars["String"]["output"]>;
   jira?: Maybe<JiraConfig>;
-  keys: Array<SshKey>;
   providers?: Maybe<CloudProviderConfig>;
   secretFields: Array<Scalars["String"]["output"]>;
   slack?: Maybe<SlackConfig>;
@@ -5832,7 +5823,6 @@ export type DistroQuery = {
     providerSettingsList: Array<any>;
     setup: string;
     setupAsSudo: boolean;
-    sshKey: string;
     sshOptions: Array<string>;
     user: string;
     userSpawnAllowed: boolean;
@@ -8266,7 +8256,6 @@ export type SpruceConfigQuery = {
       email?: string | null;
       host?: string | null;
     } | null;
-    keys: Array<{ __typename?: "SSHKey"; location: string; name: string }>;
     providers?: {
       __typename?: "CloudProviderConfig";
       aws?: {

--- a/apps/spruce/src/gql/mocks/getSpruceConfig.ts
+++ b/apps/spruce/src/gql/mocks/getSpruceConfig.ts
@@ -34,12 +34,6 @@ export const getSpruceConfigMock: ApolloMock<
             },
           ],
         },
-        keys: [
-          {
-            name: "fake_key",
-            location: "/path/to/key",
-          },
-        ],
         jira: {
           host: "jira.mongodb.org",
           __typename: "JiraConfig",

--- a/apps/spruce/src/gql/queries/distro.graphql
+++ b/apps/spruce/src/gql/queries/distro.graphql
@@ -79,7 +79,6 @@ query Distro($distroId: String!) {
     providerSettingsList
     setup
     setupAsSudo
-    sshKey
     sshOptions
     user
     userSpawnAllowed

--- a/apps/spruce/src/gql/queries/spruce-config.graphql
+++ b/apps/spruce/src/gql/queries/spruce-config.graphql
@@ -14,10 +14,6 @@ query SpruceConfig {
       email
       host
     }
-    keys {
-      location
-      name
-    }
     providers {
       aws {
         maxVolumeSizePerUser

--- a/apps/spruce/src/pages/distroSettings/tabs/HostTab/HostTab.tsx
+++ b/apps/spruce/src/pages/distroSettings/tabs/HostTab/HostTab.tsx
@@ -2,16 +2,12 @@ import { useMemo } from "react";
 import { ValidateProps } from "components/SpruceForm";
 import { DistroSettingsTabRoutes } from "constants/routes";
 import { BootstrapMethod, CommunicationMethod } from "gql/generated/types";
-import { useSpruceConfig } from "hooks";
 import { useDistroSettingsContext } from "pages/distroSettings/Context";
 import { BaseTab } from "../BaseTab";
 import { getFormSchema } from "./getFormSchema";
 import { HostFormState, TabProps } from "./types";
 
 export const HostTab: React.FC<TabProps> = ({ distroData, provider }) => {
-  const spruceConfig = useSpruceConfig();
-  const sshKeys = spruceConfig?.keys;
-
   const { getTab } = useDistroSettingsContext();
   // @ts-expect-error - see TabState for details.
   const { formData }: { formData: HostFormState } = getTab(
@@ -20,8 +16,8 @@ export const HostTab: React.FC<TabProps> = ({ distroData, provider }) => {
   const architecture = formData?.setup?.arch;
 
   const formSchema = useMemo(
-    () => getFormSchema({ architecture, provider, sshKeys }),
-    [architecture, provider, sshKeys],
+    () => getFormSchema({ architecture, provider }),
+    [architecture, provider],
   );
 
   return (

--- a/apps/spruce/src/pages/distroSettings/tabs/HostTab/getFormSchema.tsx
+++ b/apps/spruce/src/pages/distroSettings/tabs/HostTab/getFormSchema.tsx
@@ -1,5 +1,5 @@
 import { GetFormSchema } from "components/SpruceForm";
-import { Arch, BootstrapMethod, Provider, SshKey } from "gql/generated/types";
+import { Arch, BootstrapMethod, Provider } from "gql/generated/types";
 import { nonWindowsArchitectures, windowsArchitectures } from "./constants";
 import {
   allocation as allocationProperties,
@@ -15,13 +15,11 @@ import {
 type FormSchemaParams = {
   architecture: Arch;
   provider: Provider;
-  sshKeys: SshKey[];
 };
 
 export const getFormSchema = ({
   architecture,
   provider,
-  sshKeys,
 }: FormSchemaParams): ReturnType<GetFormSchema> => {
   const hasStaticProvider = provider === Provider.Static;
   const hasDockerProvider = provider === Provider.Docker;
@@ -102,7 +100,7 @@ export const getFormSchema = ({
                     bootstrapMethod: { enum: [BootstrapMethod.LegacySsh] },
                   },
                 },
-                sshConfig: sshConfig(sshKeys),
+                sshConfig,
                 allocation,
               },
             },
@@ -116,7 +114,7 @@ export const getFormSchema = ({
                   },
                 },
                 bootstrapSettings,
-                sshConfig: sshConfig(sshKeys),
+                sshConfig,
                 allocation,
               },
             },
@@ -142,11 +140,11 @@ const bootstrapSettings = {
   properties: bootstrapProperties.schema,
 };
 
-const sshConfig = (sshKeys: SshKey[]) => ({
+const sshConfig = {
   type: "object" as "object",
   title: "SSH Configuration",
-  properties: sshConfigProperties.schema(sshKeys),
-});
+  properties: sshConfigProperties.schema,
+};
 
 const allocation = {
   type: "object" as "object",

--- a/apps/spruce/src/pages/distroSettings/tabs/HostTab/schemaFields.tsx
+++ b/apps/spruce/src/pages/distroSettings/tabs/HostTab/schemaFields.tsx
@@ -7,7 +7,7 @@ import {
   FieldRow,
 } from "components/SpruceForm/FieldTemplates";
 import { size } from "constants/tokens";
-import { Arch, SshKey } from "gql/generated/types";
+import { Arch } from "gql/generated/types";
 import {
   architectureToCopy,
   bootstrapMethodToCopy,
@@ -408,21 +408,6 @@ const user = {
   },
 };
 
-const sshKey = {
-  schema: (sshKeys: SshKey[]) => ({
-    type: "string" as "string",
-    title: "SSH Key",
-    oneOf: sshKeys.map(({ location, name }) => ({
-      type: "string" as "string",
-      title: `${name} – ${location}`,
-      enum: [name],
-    })),
-  }),
-  uiSchema: {
-    "ui:allowDeselect": false,
-  },
-};
-
 const authorizedKeysFile = {
   schema: {
     type: "string" as "string",
@@ -665,16 +650,14 @@ export const allocation = {
 };
 
 export const sshConfig = {
-  schema: (sshKeys: SshKey[]) => ({
+  schema: {
     user: user.schema,
-    sshKey: sshKey.schema(sshKeys),
     authorizedKeysFile: authorizedKeysFile.schema,
     sshOptions: sshOptions.schema,
-  }),
+  },
   uiSchema: (hasStaticProvider: boolean) => ({
     "ui:ObjectFieldTemplate": CardFieldTemplate,
     user: user.uiSchema,
-    sshKey: sshKey.uiSchema,
     authorizedKeysFile: authorizedKeysFile.uiSchema(hasStaticProvider),
     sshOptions: sshOptions.uiSchema,
   }),

--- a/apps/spruce/src/pages/distroSettings/tabs/HostTab/transformers.test.ts
+++ b/apps/spruce/src/pages/distroSettings/tabs/HostTab/transformers.test.ts
@@ -68,7 +68,6 @@ const form: HostFormState = {
   },
   sshConfig: {
     user: "admin",
-    sshKey: "fakeSshKey",
     authorizedKeysFile: "",
     sshOptions: ["BatchMode=yes", "ConnectTimeout=10"],
   },

--- a/apps/spruce/src/pages/distroSettings/tabs/HostTab/transformers.ts
+++ b/apps/spruce/src/pages/distroSettings/tabs/HostTab/transformers.ts
@@ -29,7 +29,6 @@ export const gqlToForm = ((data) => {
     mountpoints,
     setup,
     setupAsSudo,
-    sshKey,
     sshOptions,
     user,
     userSpawnAllowed,
@@ -64,7 +63,6 @@ export const gqlToForm = ((data) => {
     },
     sshConfig: {
       user,
-      sshKey,
       authorizedKeysFile,
       sshOptions,
     },
@@ -104,7 +102,6 @@ export const formToGql = ((
   setupAsSudo: setup.setupAsSudo,
   setup: setup.setupScript,
   mountpoints: setup.mountpoints,
-  sshKey: sshConfig.sshKey,
   sshOptions: sshConfig.sshOptions,
   user: sshConfig.user,
   userSpawnAllowed: setup.userSpawnAllowed,

--- a/apps/spruce/src/pages/distroSettings/tabs/HostTab/types.ts
+++ b/apps/spruce/src/pages/distroSettings/tabs/HostTab/types.ts
@@ -49,7 +49,6 @@ export interface HostFormState {
   };
   sshConfig: {
     user: string;
-    sshKey: string;
     authorizedKeysFile: string;
     sshOptions: string[];
   };

--- a/apps/spruce/src/pages/distroSettings/tabs/testData.ts
+++ b/apps/spruce/src/pages/distroSettings/tabs/testData.ts
@@ -111,7 +111,6 @@ const distroData: DistroQuery["distro"] = {
   ],
   setup: "ls -alF",
   setupAsSudo: true,
-  sshKey: "fakeSshKey",
   sshOptions: ["BatchMode=yes", "ConnectTimeout=10"],
   user: "admin",
   userSpawnAllowed: false,


### PR DESCRIPTION
[DEVPROD-4798](https://jira.mongodb.org/browse/DEVPROD-4798)

### Description
https://github.com/evergreen-ci/evergreen/pull/7713 removes the ssh key field from distros and also from the admin config. This PR will remove it from Spruce as well.

I'm not 100% sure how to coordinate the merging/deploys of these. Does the Spruce change go first and then the Evergreen one? But wouldn't a distro update break without the mandatory ssh key field? But if Evergreen goes first it won't be providing the required field. 😕 

### Screenshots
![Screenshot 2024-04-08 at 3 38 58 PM](https://github.com/evergreen-ci/ui/assets/17027265/d4372978-b970-4417-998c-049d0367a1e6)

### Testing
Seems to still work locally.

### Evergreen PR
https://github.com/evergreen-ci/evergreen/pull/7713
