### PR TITLE
DEVPROD-5879 Update no code change text

### DIFF
--- a/apps/parsley/src/gql/generated/types.ts
+++ b/apps/parsley/src/gql/generated/types.ts
@@ -1270,7 +1270,7 @@ export type MutationSchedulePatchTasksArgs = {
 
 export type MutationScheduleTasksArgs = {
   taskIds: Array<Scalars["String"]["input"]>;
-  versionId?: InputMaybe<Scalars["String"]["input"]>;
+  versionId: Scalars["String"]["input"];
 };
 
 export type MutationScheduleUndispatchedBaseTasksArgs = {
@@ -1899,7 +1899,7 @@ export enum ProjectSettingsAccess {
 export type ProjectSettingsInput = {
   aliases?: InputMaybe<Array<ProjectAliasInput>>;
   githubWebhooksEnabled?: InputMaybe<Scalars["Boolean"]["input"]>;
-  projectId?: InputMaybe<Scalars["String"]["input"]>;
+  projectId: Scalars["String"]["input"];
   projectRef?: InputMaybe<ProjectInput>;
   subscriptions?: InputMaybe<Array<SubscriptionInput>>;
   vars?: InputMaybe<ProjectVarsInput>;
@@ -2037,8 +2037,7 @@ export type QueryGithubProjectConflictsArgs = {
 };
 
 export type QueryHasVersionArgs = {
-  id?: InputMaybe<Scalars["String"]["input"]>;
-  patchId?: InputMaybe<Scalars["String"]["input"]>;
+  patchId: Scalars["String"]["input"];
 };
 
 export type QueryHostArgs = {
@@ -2074,8 +2073,7 @@ export type QueryMainlineCommitsArgs = {
 };
 
 export type QueryPatchArgs = {
-  id?: InputMaybe<Scalars["String"]["input"]>;
-  patchId?: InputMaybe<Scalars["String"]["input"]>;
+  patchId: Scalars["String"]["input"];
 };
 
 export type QueryPodArgs = {
@@ -2098,14 +2096,12 @@ export type QueryProjectSettingsArgs = {
 
 export type QueryRepoEventsArgs = {
   before?: InputMaybe<Scalars["Time"]["input"]>;
-  id?: InputMaybe<Scalars["String"]["input"]>;
   limit?: InputMaybe<Scalars["Int"]["input"]>;
-  repoId?: InputMaybe<Scalars["String"]["input"]>;
+  repoId: Scalars["String"]["input"];
 };
 
 export type QueryRepoSettingsArgs = {
-  id?: InputMaybe<Scalars["String"]["input"]>;
-  repoId?: InputMaybe<Scalars["String"]["input"]>;
+  repoId: Scalars["String"]["input"];
 };
 
 export type QueryTaskArgs = {
@@ -2132,8 +2128,7 @@ export type QueryUserArgs = {
 };
 
 export type QueryVersionArgs = {
-  id?: InputMaybe<Scalars["String"]["input"]>;
-  versionId?: InputMaybe<Scalars["String"]["input"]>;
+  versionId: Scalars["String"]["input"];
 };
 
 export type RepoCommitQueueParams = {
@@ -2257,7 +2252,7 @@ export type RepoSettingsInput = {
   aliases?: InputMaybe<Array<ProjectAliasInput>>;
   githubWebhooksEnabled?: InputMaybe<Scalars["Boolean"]["input"]>;
   projectRef?: InputMaybe<RepoRefInput>;
-  repoId?: InputMaybe<Scalars["String"]["input"]>;
+  repoId: Scalars["String"]["input"];
   subscriptions?: InputMaybe<Array<SubscriptionInput>>;
   vars?: InputMaybe<ProjectVarsInput>;
 };

--- a/apps/spruce/src/components/CodeChanges/index.tsx
+++ b/apps/spruce/src/components/CodeChanges/index.tsx
@@ -42,7 +42,11 @@ export const CodeChanges: React.FC<CodeChangesProps> = ({ patchId }) => {
     return <div id="patch-error">{error.message}</div>;
   }
   if (!moduleCodeChanges.length) {
-    return <Title className="cy-no-code-changes">No code changes</Title>;
+    return (
+      <Title className="cy-no-code-changes">
+        Code changes do not exist, or are too large to display.
+      </Title>
+    );
   }
   return (
     <div data-cy="code-changes">

--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -1270,7 +1270,7 @@ export type MutationSchedulePatchTasksArgs = {
 
 export type MutationScheduleTasksArgs = {
   taskIds: Array<Scalars["String"]["input"]>;
-  versionId?: InputMaybe<Scalars["String"]["input"]>;
+  versionId: Scalars["String"]["input"];
 };
 
 export type MutationScheduleUndispatchedBaseTasksArgs = {
@@ -1899,7 +1899,7 @@ export enum ProjectSettingsAccess {
 export type ProjectSettingsInput = {
   aliases?: InputMaybe<Array<ProjectAliasInput>>;
   githubWebhooksEnabled?: InputMaybe<Scalars["Boolean"]["input"]>;
-  projectId?: InputMaybe<Scalars["String"]["input"]>;
+  projectId: Scalars["String"]["input"];
   projectRef?: InputMaybe<ProjectInput>;
   subscriptions?: InputMaybe<Array<SubscriptionInput>>;
   vars?: InputMaybe<ProjectVarsInput>;
@@ -2037,8 +2037,7 @@ export type QueryGithubProjectConflictsArgs = {
 };
 
 export type QueryHasVersionArgs = {
-  id?: InputMaybe<Scalars["String"]["input"]>;
-  patchId?: InputMaybe<Scalars["String"]["input"]>;
+  patchId: Scalars["String"]["input"];
 };
 
 export type QueryHostArgs = {
@@ -2074,8 +2073,7 @@ export type QueryMainlineCommitsArgs = {
 };
 
 export type QueryPatchArgs = {
-  id?: InputMaybe<Scalars["String"]["input"]>;
-  patchId?: InputMaybe<Scalars["String"]["input"]>;
+  patchId: Scalars["String"]["input"];
 };
 
 export type QueryPodArgs = {
@@ -2098,14 +2096,12 @@ export type QueryProjectSettingsArgs = {
 
 export type QueryRepoEventsArgs = {
   before?: InputMaybe<Scalars["Time"]["input"]>;
-  id?: InputMaybe<Scalars["String"]["input"]>;
   limit?: InputMaybe<Scalars["Int"]["input"]>;
-  repoId?: InputMaybe<Scalars["String"]["input"]>;
+  repoId: Scalars["String"]["input"];
 };
 
 export type QueryRepoSettingsArgs = {
-  id?: InputMaybe<Scalars["String"]["input"]>;
-  repoId?: InputMaybe<Scalars["String"]["input"]>;
+  repoId: Scalars["String"]["input"];
 };
 
 export type QueryTaskArgs = {
@@ -2132,8 +2128,7 @@ export type QueryUserArgs = {
 };
 
 export type QueryVersionArgs = {
-  id?: InputMaybe<Scalars["String"]["input"]>;
-  versionId?: InputMaybe<Scalars["String"]["input"]>;
+  versionId: Scalars["String"]["input"];
 };
 
 export type RepoCommitQueueParams = {
@@ -2257,7 +2252,7 @@ export type RepoSettingsInput = {
   aliases?: InputMaybe<Array<ProjectAliasInput>>;
   githubWebhooksEnabled?: InputMaybe<Scalars["Boolean"]["input"]>;
   projectRef?: InputMaybe<RepoRefInput>;
-  repoId?: InputMaybe<Scalars["String"]["input"]>;
+  repoId: Scalars["String"]["input"];
   subscriptions?: InputMaybe<Array<SubscriptionInput>>;
   vars?: InputMaybe<ProjectVarsInput>;
 };


### PR DESCRIPTION
DEVPROD-5879

### Description
Updates the "No code changes" text to handle a case with diff too large to display 

https://jira.mongodb.org/browse/DEVPROD-5926
This is a quick fix until we differentiate no code change and too many code change


### Screenshots
<img width="534" alt="image" src="https://github.com/evergreen-ci/ui/assets/26491602/c9e5728b-346e-406f-831b-93fcb3b058a9">

