### PR TITLE
DEVPROD-4197: Add host uptime scheduler

### DIFF
--- a/apps/parsley/src/gql/generated/types.ts
+++ b/apps/parsley/src/gql/generated/types.ts
@@ -1270,7 +1270,7 @@ export type MutationSchedulePatchTasksArgs = {
 
 export type MutationScheduleTasksArgs = {
   taskIds: Array<Scalars["String"]["input"]>;
-  versionId?: InputMaybe<Scalars["String"]["input"]>;
+  versionId: Scalars["String"]["input"];
 };
 
 export type MutationScheduleUndispatchedBaseTasksArgs = {
@@ -1899,7 +1899,7 @@ export enum ProjectSettingsAccess {
 export type ProjectSettingsInput = {
   aliases?: InputMaybe<Array<ProjectAliasInput>>;
   githubWebhooksEnabled?: InputMaybe<Scalars["Boolean"]["input"]>;
-  projectId?: InputMaybe<Scalars["String"]["input"]>;
+  projectId: Scalars["String"]["input"];
   projectRef?: InputMaybe<ProjectInput>;
   subscriptions?: InputMaybe<Array<SubscriptionInput>>;
   vars?: InputMaybe<ProjectVarsInput>;
@@ -2037,8 +2037,7 @@ export type QueryGithubProjectConflictsArgs = {
 };
 
 export type QueryHasVersionArgs = {
-  id?: InputMaybe<Scalars["String"]["input"]>;
-  patchId?: InputMaybe<Scalars["String"]["input"]>;
+  patchId: Scalars["String"]["input"];
 };
 
 export type QueryHostArgs = {
@@ -2074,8 +2073,7 @@ export type QueryMainlineCommitsArgs = {
 };
 
 export type QueryPatchArgs = {
-  id?: InputMaybe<Scalars["String"]["input"]>;
-  patchId?: InputMaybe<Scalars["String"]["input"]>;
+  patchId: Scalars["String"]["input"];
 };
 
 export type QueryPodArgs = {
@@ -2098,14 +2096,12 @@ export type QueryProjectSettingsArgs = {
 
 export type QueryRepoEventsArgs = {
   before?: InputMaybe<Scalars["Time"]["input"]>;
-  id?: InputMaybe<Scalars["String"]["input"]>;
   limit?: InputMaybe<Scalars["Int"]["input"]>;
-  repoId?: InputMaybe<Scalars["String"]["input"]>;
+  repoId: Scalars["String"]["input"];
 };
 
 export type QueryRepoSettingsArgs = {
-  id?: InputMaybe<Scalars["String"]["input"]>;
-  repoId?: InputMaybe<Scalars["String"]["input"]>;
+  repoId: Scalars["String"]["input"];
 };
 
 export type QueryTaskArgs = {
@@ -2132,8 +2128,7 @@ export type QueryUserArgs = {
 };
 
 export type QueryVersionArgs = {
-  id?: InputMaybe<Scalars["String"]["input"]>;
-  versionId?: InputMaybe<Scalars["String"]["input"]>;
+  versionId: Scalars["String"]["input"];
 };
 
 export type RepoCommitQueueParams = {
@@ -2257,7 +2252,7 @@ export type RepoSettingsInput = {
   aliases?: InputMaybe<Array<ProjectAliasInput>>;
   githubWebhooksEnabled?: InputMaybe<Scalars["Boolean"]["input"]>;
   projectRef?: InputMaybe<RepoRefInput>;
-  repoId?: InputMaybe<Scalars["String"]["input"]>;
+  repoId: Scalars["String"]["input"];
   subscriptions?: InputMaybe<Array<SubscriptionInput>>;
   vars?: InputMaybe<ProjectVarsInput>;
 };

--- a/apps/parsley/src/gql/generated/types.ts
+++ b/apps/parsley/src/gql/generated/types.ts
@@ -453,7 +453,8 @@ export type DistroInput = {
   providerSettingsList: Array<Scalars["Map"]["input"]>;
   setup: Scalars["String"]["input"];
   setupAsSudo: Scalars["Boolean"]["input"];
-  sshKey: Scalars["String"]["input"];
+  /** @deprecated removing this field shortly */
+  sshKey?: InputMaybe<Scalars["String"]["input"]>;
   sshOptions: Array<Scalars["String"]["input"]>;
   user: Scalars["String"]["input"];
   userSpawnAllowed: Scalars["Boolean"]["input"];
@@ -2462,7 +2463,8 @@ export type SpruceConfig = {
   containerPools?: Maybe<ContainerPoolsConfig>;
   githubOrgs: Array<Scalars["String"]["output"]>;
   jira?: Maybe<JiraConfig>;
-  keys: Array<SshKey>;
+  /** @deprecated removing this field shortly */
+  keys?: Maybe<Array<SshKey>>;
   providers?: Maybe<CloudProviderConfig>;
   secretFields: Array<Scalars["String"]["output"]>;
   slack?: Maybe<SlackConfig>;

--- a/apps/spruce/cypress/integration/spawn/host.ts
+++ b/apps/spruce/cypress/integration/spawn/host.ts
@@ -88,23 +88,16 @@ describe("Navigating to Spawn Host page", () => {
   });
 
   describe("Spawn host modal", () => {
-    it("Should disable 'Never expire' checkbox when max number of unexpirable hosts is met (2)", () => {
+    it("Should disable 'Unexpirable Host' radio box when max number of unexpirable hosts is met (2)", () => {
       cy.visit("/spawn/host");
       cy.contains("Spawn a host").click();
       cy.dataCy("distro-input").click();
       cy.dataCy("distro-option-ubuntu1804-workstation")
         .should("be.visible")
         .click();
-      cy.dataCy("never-expire-checkbox").should(
-        "have.attr",
-        "aria-checked",
-        "false",
-      );
-      cy.dataCy("never-expire-checkbox").should(
-        "have.css",
-        "pointer-events",
-        "none",
-      );
+      cy.dataCy("expirable-radio-box").children().should("have.length", 2);
+      cy.getInputByLabel("Expirable Host").should("not.be.disabled");
+      cy.getInputByLabel("Unexpirable Host").should("be.disabled");
     });
 
     it("Clicking on the spawn host button should open a spawn host modal.", () => {

--- a/apps/spruce/src/components/ProjectSelect/__snapshots__/ProjectSelect.stories.storyshot
+++ b/apps/spruce/src/components/ProjectSelect/__snapshots__/ProjectSelect.stories.storyshot
@@ -12,7 +12,7 @@ exports[`Snapshot Tests ProjectSelect.stories Default 1`] = `
       Project
     </label>
     <div
-      class="css-gte0m8-Wrapper e17dnzmx4"
+      class="css-7yazxp-Wrapper e17dnzmx4"
     >
       <div
         class="css-1ry038z-Container e1yw4j304"
@@ -82,7 +82,7 @@ exports[`Snapshot Tests ProjectSelect.stories WithClickableHeader 1`] = `
       Project
     </label>
     <div
-      class="css-gte0m8-Wrapper e17dnzmx4"
+      class="css-7yazxp-Wrapper e17dnzmx4"
     >
       <div
         class="css-1ry038z-Container e1yw4j304"

--- a/apps/spruce/src/components/SearchableDropdown/__snapshots__/SearchableDropdown.stories.storyshot
+++ b/apps/spruce/src/components/SearchableDropdown/__snapshots__/SearchableDropdown.stories.storyshot
@@ -12,7 +12,7 @@ exports[`Snapshot Tests SearchableDropdown.stories CustomOption 1`] = `
       Custom option select
     </label>
     <div
-      class="css-gte0m8-Wrapper e17dnzmx4"
+      class="css-7yazxp-Wrapper e17dnzmx4"
     >
       <div
         class="css-1ry038z-Container e1yw4j304"
@@ -82,7 +82,7 @@ exports[`Snapshot Tests SearchableDropdown.stories Default 1`] = `
       Searchable Dropdown
     </label>
     <div
-      class="css-gte0m8-Wrapper e17dnzmx4"
+      class="css-7yazxp-Wrapper e17dnzmx4"
     >
       <div
         class="css-1ry038z-Container e1yw4j304"

--- a/apps/spruce/src/components/SearchableDropdown/index.tsx
+++ b/apps/spruce/src/components/SearchableDropdown/index.tsx
@@ -216,6 +216,7 @@ const ScrollableList = styled.div`
 `;
 
 const Wrapper = styled.div`
+  margin-top: ${size.xxs};
   width: ${(props: { width?: string }): string =>
     props.width ? props.width : ""};
 `;

--- a/apps/spruce/src/components/Spawn/getFormSchema.tsx
+++ b/apps/spruce/src/components/Spawn/getFormSchema.tsx
@@ -1,5 +1,6 @@
 import { css } from "@emotion/react";
 import Badge from "@leafygreen-ui/badge";
+import { Body } from "@leafygreen-ui/typography";
 import widgets from "components/SpruceForm/Widgets";
 import { prettifyTimeZone } from "constants/fieldMaps";
 import { size } from "constants/tokens";
@@ -121,19 +122,11 @@ export const getHostUptimeSchema = ({
       },
       timeSelection: {
         "ui:fieldSetCSS": css`
-          align-items: flex-end;
+          align-items: center;
           display: flex;
           gap: ${size.xs};
-
           > * {
             width: fit-content;
-          }
-
-          > h6 {
-            font-size: 0.8rem;
-            font-weight: normal;
-            margin-top: 0;
-            padding-bottom: ${size.s};
           }
         `,
         startTime: {
@@ -146,11 +139,15 @@ export const getHostUptimeSchema = ({
           "ui:useUtc": false,
           "ui:widget": widgets.TimeWidget,
         },
+        or: {
+          "ui:showLabel": false,
+          "ui:descriptionNode": <Body>or</Body>,
+        },
         runContinuously: {
           "ui:elementWrapperCSS": css`
-            padding-bottom: 10px;
-            width: fit-content;
+            margin-bottom: 0;
             white-space: nowrap;
+            width: fit-content;
           `,
         },
       },

--- a/apps/spruce/src/components/Spawn/getFormSchema.tsx
+++ b/apps/spruce/src/components/Spawn/getFormSchema.tsx
@@ -10,15 +10,18 @@ const defaultEndTime = new Date();
 defaultEndTime.setHours(20, 0, 0, 0);
 
 type HostUptimeProps = {
-  hostUptimeErrors: { [key: string]: string[] };
+  hostUptimeValidation?: {
+    enabledHoursCount: number;
+    errors: string[];
+    warnings: string[];
+  };
   timeZone?: string;
   totalUptimeHours?: number;
 };
 
 export const getHostUptimeSchema = ({
-  hostUptimeErrors,
+  hostUptimeValidation,
   timeZone,
-  totalUptimeHours,
 }: HostUptimeProps) => ({
   schema: {
     type: "object" as "object",
@@ -84,10 +87,7 @@ export const getHostUptimeSchema = ({
           },
         },
       },
-      timeZone: {
-        type: "null" as "null",
-      },
-      totalUptimeHours: {
+      details: {
         type: "null" as "null",
       },
     },
@@ -110,6 +110,9 @@ export const getHostUptimeSchema = ({
     },
   },
   uiSchema: {
+    useDefaultUptimeSchedule: {
+      "ui:bold": true,
+    },
     sleepSchedule: {
       enabledWeekdays: {
         "ui:addable": false,
@@ -152,27 +155,27 @@ export const getHostUptimeSchema = ({
         },
       },
     },
-    timeZone: {
-      "ui:descriptionNode": <TimeZone timeZone={timeZone} />,
-      "ui:showLabel": false,
-    },
-    totalUptimeHours: {
+    details: {
       "ui:descriptionNode": (
-        <TotalUptimeHours totalUptimeHours={totalUptimeHours} />
+        <Details
+          timeZone={timeZone}
+          totalUptimeHours={hostUptimeValidation?.enabledHoursCount}
+        />
       ),
       "ui:showLabel": false,
-      ...hostUptimeErrors,
+      "ui:warnings": hostUptimeValidation?.warnings,
+      "ui:errors": hostUptimeValidation?.errors,
     },
   },
 });
 
-const TotalUptimeHours: React.FC<{ totalUptimeHours: number }> = ({
+const Details: React.FC<{ timeZone: string; totalUptimeHours: number }> = ({
+  timeZone,
   totalUptimeHours,
-}) => <>Count: {totalUptimeHours}</>;
-
-const TimeZone: React.FC<{ timeZone: string }> = ({ timeZone }) => (
+}) => (
   <>
     All times are displayed in{" "}
-    <Badge>{prettifyTimeZone.get(timeZone) ?? timeZone}</Badge>
+    <Badge>{prettifyTimeZone.get(timeZone) ?? timeZone}</Badge> •{" "}
+    {totalUptimeHours} host uptime hours per week
   </>
 );

--- a/apps/spruce/src/components/Spawn/getFormSchema.tsx
+++ b/apps/spruce/src/components/Spawn/getFormSchema.tsx
@@ -1,0 +1,178 @@
+import { css } from "@emotion/react";
+import Badge from "@leafygreen-ui/badge";
+import widgets from "components/SpruceForm/Widgets";
+import { prettifyTimeZone } from "constants/fieldMaps";
+import { size } from "constants/tokens";
+
+const defaultStartTime = new Date();
+defaultStartTime.setHours(8, 0, 0, 0);
+const defaultEndTime = new Date();
+defaultEndTime.setHours(20, 0, 0, 0);
+
+type HostUptimeProps = {
+  hostUptimeErrors: { [key: string]: string[] };
+  timeZone?: string;
+  totalUptimeHours?: number;
+};
+
+export const getHostUptimeSchema = ({
+  hostUptimeErrors,
+  timeZone,
+  totalUptimeHours,
+}: HostUptimeProps) => ({
+  schema: {
+    type: "object" as "object",
+    title: "",
+    properties: {
+      useDefaultUptimeSchedule: {
+        type: "boolean" as "boolean",
+        title: "Use default host uptime schedule (Mon–Fri, 8am–8pm)",
+        default: true,
+      },
+      sleepSchedule: {
+        type: "object" as "object",
+        title: "",
+        properties: {
+          enabledWeekdays: {
+            type: "array" as "array",
+            title: "",
+            default: [false, true, true, true, true, true, false],
+            items: {
+              type: "boolean" as "boolean",
+            },
+          },
+          timeSelection: {
+            type: "object" as "object",
+            title: "",
+            properties: {
+              startTime: {
+                type: "string" as "string",
+                title: "Start Time",
+                default: defaultStartTime.toString(),
+              },
+              endTime: {
+                type: "string" as "string",
+                title: "End Time",
+                default: defaultEndTime.toString(),
+              },
+              or: {
+                type: "null" as "null",
+              },
+              runContinuously: {
+                type: "boolean" as "boolean",
+                title: "Run continuously for enabled days",
+              },
+            },
+            dependencies: {
+              runContinuously: {
+                oneOf: [
+                  {
+                    properties: {
+                      runContinuously: { enum: [false] },
+                    },
+                  },
+                  {
+                    properties: {
+                      runContinuously: { enum: [true] },
+                      startTime: { readOnly: true },
+                      endTime: { readOnly: true },
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        },
+      },
+      timeZone: {
+        type: "null" as "null",
+      },
+      totalUptimeHours: {
+        type: "null" as "null",
+      },
+    },
+    dependencies: {
+      useDefaultUptimeSchedule: {
+        oneOf: [
+          {
+            properties: {
+              useDefaultUptimeSchedule: { enum: [false] },
+            },
+          },
+          {
+            properties: {
+              useDefaultUptimeSchedule: { enum: [true] },
+              sleepSchedule: { readOnly: true },
+            },
+          },
+        ],
+      },
+    },
+  },
+  uiSchema: {
+    sleepSchedule: {
+      enabledWeekdays: {
+        "ui:addable": false,
+        "ui:showLabel": false,
+        "ui:widget": widgets.DayPickerWidget,
+      },
+      timeSelection: {
+        "ui:fieldSetCSS": css`
+          align-items: flex-end;
+          display: flex;
+          gap: ${size.xs};
+
+          > * {
+            width: fit-content;
+          }
+
+          > h6 {
+            font-size: 0.8rem;
+            font-weight: normal;
+            margin-top: 0;
+            padding-bottom: ${size.s};
+          }
+        `,
+        startTime: {
+          "ui:format": "HH:mm",
+          "ui:useUtc": false,
+          "ui:widget": widgets.TimeWidget,
+        },
+        endTime: {
+          "ui:format": "HH:mm",
+          "ui:useUtc": false,
+          "ui:widget": widgets.TimeWidget,
+        },
+        runContinuously: {
+          "ui:elementWrapperCSS": css`
+            padding-bottom: 10px;
+            width: fit-content;
+            white-space: nowrap;
+          `,
+        },
+      },
+    },
+    timeZone: {
+      "ui:descriptionNode": <TimeZone timeZone={timeZone} />,
+      "ui:showLabel": false,
+    },
+    totalUptimeHours: {
+      "ui:descriptionNode": (
+        <TotalUptimeHours totalUptimeHours={totalUptimeHours} />
+      ),
+      "ui:showLabel": false,
+      ...hostUptimeErrors,
+    },
+  },
+});
+
+const TotalUptimeHours: React.FC<{ totalUptimeHours: number }> = ({
+  totalUptimeHours,
+}) => <>Count: {totalUptimeHours}</>;
+
+const TimeZone: React.FC<{ timeZone: string }> = ({ timeZone }) => (
+  <>
+    All times are displayed in{" "}
+    <Badge>{prettifyTimeZone.get(timeZone) ?? timeZone}</Badge>
+  </>
+);

--- a/apps/spruce/src/components/Spawn/index.tsx
+++ b/apps/spruce/src/components/Spawn/index.tsx
@@ -1,8 +1,4 @@
 export * from "./Layout";
 export { DetailsCard } from "./DetailsCard";
 export { MountVolumeSelect } from "./MountVolumeSelect";
-export {
-  getEnabledHoursCount,
-  maxUptimeHours,
-  validateUptimeSchedule,
-} from "./utils";
+export { maxUptimeHours, validateUptimeSchedule } from "./utils";

--- a/apps/spruce/src/components/Spawn/index.tsx
+++ b/apps/spruce/src/components/Spawn/index.tsx
@@ -1,3 +1,8 @@
 export * from "./Layout";
 export { DetailsCard } from "./DetailsCard";
 export { MountVolumeSelect } from "./MountVolumeSelect";
+export {
+  getEnabledHoursCount,
+  maxUptimeHours,
+  validateUptimeSchedule,
+} from "./utils";

--- a/apps/spruce/src/components/Spawn/spawnHostModal/getFormSchema.tsx
+++ b/apps/spruce/src/components/Spawn/spawnHostModal/getFormSchema.tsx
@@ -8,6 +8,7 @@ import {
   SpawnTaskQuery,
   MyVolumesQuery,
 } from "gql/generated/types";
+import { isProduction } from "utils/environmentVariables";
 import { shortenGithash } from "utils/string";
 import { getHostUptimeSchema } from "../getFormSchema";
 import { getDefaultExpiration } from "../utils";
@@ -24,7 +25,11 @@ interface Props {
     isVirtualWorkStation: boolean;
     name?: string;
   }[];
-  hostUptimeErrors?: { [key: string]: string[] };
+  hostUptimeValidation?: {
+    enabledHoursCount: number;
+    errors: string[];
+    warnings: string[];
+  };
   isMigration: boolean;
   isVirtualWorkstation: boolean;
   myPublicKeys: MyPublicKeysQuery["myPublicKeys"];
@@ -42,7 +47,7 @@ export const getFormSchema = ({
   disableExpirationCheckbox,
   distroIdQueryParam,
   distros,
-  hostUptimeErrors,
+  hostUptimeValidation,
   isMigration,
   isVirtualWorkstation,
   myPublicKeys,
@@ -66,7 +71,7 @@ export const getFormSchema = ({
   const availableVolumes = volumes
     ? volumes.filter((v) => v.homeVolume && !v.hostID)
     : [];
-  const hostUptime = getHostUptimeSchema({ hostUptimeErrors, timeZone });
+  const hostUptime = getHostUptimeSchema({ hostUptimeValidation, timeZone });
 
   return {
     fields: {},
@@ -244,7 +249,7 @@ export const getFormSchema = ({
                     noExpiration: {
                       enum: [true],
                     },
-                    hostUptime: hostUptime.schema,
+                    ...(!isProduction() && { hostUptime: hostUptime.schema }),
                   },
                 },
               ],

--- a/apps/spruce/src/components/Spawn/spawnHostModal/getFormSchema.tsx
+++ b/apps/spruce/src/components/Spawn/spawnHostModal/getFormSchema.tsx
@@ -523,10 +523,10 @@ export const getFormSchema = ({
         },
       },
       expirationDetails: {
+        "ui:tooltipTitle": noExpirationCheckboxTooltip ?? "",
         noExpiration: {
-          "ui:disabled": disableExpirationCheckbox,
-          "ui:tooltipDescription": noExpirationCheckboxTooltip ?? "",
-          "ui:data-cy": "never-expire-checkbox",
+          "ui:enumDisabled": disableExpirationCheckbox ? [true] : null,
+          "ui:data-cy": "expirable-radio-box",
           "ui:widget": widgets.RadioBoxWidget,
         },
         hostUptime: hostUptime.uiSchema,

--- a/apps/spruce/src/components/Spawn/spawnHostModal/getFormSchema.tsx
+++ b/apps/spruce/src/components/Spawn/spawnHostModal/getFormSchema.tsx
@@ -9,29 +9,32 @@ import {
   MyVolumesQuery,
 } from "gql/generated/types";
 import { shortenGithash } from "utils/string";
+import { getHostUptimeSchema } from "../getFormSchema";
 import { getDefaultExpiration } from "../utils";
 import { DEFAULT_VOLUME_SIZE } from "./constants";
 import { validateTask } from "./utils";
 import { DistroDropdown } from "./Widgets/DistroDropdown";
 
 interface Props {
+  awsRegions: string[];
+  disableExpirationCheckbox: boolean;
+  distroIdQueryParam?: string;
   distros: {
     adminOnly: boolean;
     isVirtualWorkStation: boolean;
     name?: string;
   }[];
-  awsRegions: string[];
-  disableExpirationCheckbox: boolean;
-  distroIdQueryParam?: string;
-  isVirtualWorkstation: boolean;
-  noExpirationCheckboxTooltip: string;
-  myPublicKeys: MyPublicKeysQuery["myPublicKeys"];
-  spawnTaskData?: SpawnTaskQuery["task"];
-  userAwsRegion?: string;
-  volumes: MyVolumesQuery["myVolumes"];
+  hostUptimeErrors?: { [key: string]: string[] };
   isMigration: boolean;
+  isVirtualWorkstation: boolean;
+  myPublicKeys: MyPublicKeysQuery["myPublicKeys"];
+  noExpirationCheckboxTooltip: string;
+  spawnTaskData?: SpawnTaskQuery["task"];
+  timeZone?: string;
   useSetupScript?: boolean;
   useProjectSetupScript?: boolean;
+  userAwsRegion?: string;
+  volumes: MyVolumesQuery["myVolumes"];
 }
 
 export const getFormSchema = ({
@@ -39,11 +42,13 @@ export const getFormSchema = ({
   disableExpirationCheckbox,
   distroIdQueryParam,
   distros,
+  hostUptimeErrors,
   isMigration,
   isVirtualWorkstation,
   myPublicKeys,
   noExpirationCheckboxTooltip,
   spawnTaskData,
+  timeZone,
   useProjectSetupScript = false,
   useSetupScript = false,
   userAwsRegion,
@@ -61,44 +66,47 @@ export const getFormSchema = ({
   const availableVolumes = volumes
     ? volumes.filter((v) => v.homeVolume && !v.hostID)
     : [];
+  const hostUptime = getHostUptimeSchema({ hostUptimeErrors, timeZone });
 
   return {
     fields: {},
     schema: {
       type: "object" as "object",
       properties: {
-        requiredHostInformationTitle: {
-          title: "Required Host Information",
-          type: "null",
-        },
-        distro: {
-          type: "string" as "string",
-          title: "Distro",
-          default: distroIdQueryParam,
-          enum: distros?.map(({ name }) => name),
-          minLength: 1,
-        },
-        region: {
-          type: "string" as "string",
-          title: "Region",
-          default: userAwsRegion || (awsRegions?.length && awsRegions[0]),
-          oneOf: [
-            ...(awsRegions?.map((r) => ({
+        requiredSection: {
+          type: "object" as "object",
+          title: "",
+          properties: {
+            distro: {
               type: "string" as "string",
-              title: r,
-              enum: [r],
-            })) || []),
-          ],
-          minLength: 1,
+              title: "Distro",
+              default: distroIdQueryParam,
+              enum: distros?.map(({ name }) => name),
+              minLength: 1,
+            },
+            region: {
+              type: "string" as "string",
+              title: "Region",
+              default: userAwsRegion || (awsRegions?.length && awsRegions[0]),
+              oneOf: [
+                ...(awsRegions?.map((r) => ({
+                  type: "string" as "string",
+                  title: r,
+                  enum: [r],
+                })) || []),
+              ],
+              minLength: 1,
+            },
+          },
         },
         publicKeySection: {
-          title: "",
           type: "object",
+          title: "Key selection",
           properties: {
             useExisting: {
-              title: "Key selection",
               default: true,
               type: "boolean" as "boolean",
+              title: "",
               oneOf: [
                 {
                   type: "boolean" as "boolean",
@@ -187,6 +195,56 @@ export const getFormSchema = ({
                         },
                       ],
                     },
+                  },
+                },
+              ],
+            },
+          },
+        },
+        expirationDetails: {
+          title: "Expiration Details",
+          type: "object" as "object",
+          properties: {
+            noExpiration: {
+              default: false,
+              type: "boolean" as "boolean",
+              title: "",
+              oneOf: [
+                {
+                  type: "boolean" as "boolean",
+                  title: "Expirable Host",
+                  enum: [false],
+                },
+                {
+                  type: "boolean" as "boolean",
+                  title: "Unexpirable Host",
+                  enum: [true],
+                },
+              ],
+            },
+          },
+          dependencies: {
+            noExpiration: {
+              oneOf: [
+                {
+                  properties: {
+                    noExpiration: {
+                      enum: [false],
+                    },
+                    expiration: {
+                      type: "string" as "string",
+                      title: "Expiration",
+                      default: getDefaultExpiration(),
+                      minLength: 6,
+                    },
+                  },
+                },
+                {
+                  properties: {
+                    noExpiration: {
+                      enum: [true],
+                    },
+                    hostUptime: hostUptime.schema,
                   },
                 },
               ],
@@ -308,46 +366,6 @@ export const getFormSchema = ({
             },
           },
         }),
-        expirationDetails: {
-          title: "",
-          type: "object" as "object",
-          properties: {
-            noExpiration: {
-              default: false,
-              type: "boolean" as "boolean",
-              title: "Never expire",
-            },
-            expiration: {
-              type: "string" as "string",
-              title: "Expiration",
-              default: getDefaultExpiration(),
-              minLength: 6,
-            },
-          },
-          dependencies: {
-            noExpiration: {
-              oneOf: [
-                {
-                  properties: {
-                    noExpiration: {
-                      enum: [false],
-                    },
-                  },
-                },
-                {
-                  properties: {
-                    noExpiration: {
-                      enum: [true],
-                    },
-                    expiration: {
-                      readOnly: true,
-                    },
-                  },
-                },
-              ],
-            },
-          },
-        },
         ...(shouldRenderVolumeSelection && {
           homeVolumeDetails: {
             type: "object" as "object",
@@ -447,18 +465,23 @@ export const getFormSchema = ({
       },
     },
     uiSchema: {
-      distro: {
-        "ui:widget": DistroDropdown,
-        "ui:elementWrapperCSS": dropdownWrapperClassName,
-        "ui:data-cy": "distro-input",
-        "ui:distros": distros,
-      },
-      region: {
-        "ui:data-cy": "region-select",
-        "ui:disabled": isMigration,
-        "ui:elementWrapperCSS": dropdownWrapperClassName,
-        "ui:placeholder": "Select a region",
-        "ui:allowDeselect": false,
+      requiredSection: {
+        "ui:fieldSetCSS": css`
+          display: flex;
+        `,
+        distro: {
+          "ui:widget": DistroDropdown,
+          "ui:elementWrapperCSS": dropdownWrapperClassName,
+          "ui:data-cy": "distro-input",
+          "ui:distros": distros,
+        },
+        region: {
+          "ui:data-cy": "region-select",
+          "ui:disabled": isMigration,
+          "ui:elementWrapperCSS": dropdownWrapperClassName,
+          "ui:placeholder": "Select a region",
+          "ui:allowDeselect": false,
+        },
       },
       publicKeySection: {
         useExisting: {
@@ -499,7 +522,9 @@ export const getFormSchema = ({
           "ui:disabled": disableExpirationCheckbox,
           "ui:tooltipDescription": noExpirationCheckboxTooltip ?? "",
           "ui:data-cy": "never-expire-checkbox",
+          "ui:widget": widgets.RadioBoxWidget,
         },
+        hostUptime: hostUptime.uiSchema,
         expiration: {
           "ui:disableBefore": add(today, { days: 1 }),
           "ui:disableAfter": add(today, { days: 30 }),

--- a/apps/spruce/src/components/Spawn/spawnHostModal/transformer.test.ts
+++ b/apps/spruce/src/components/Spawn/spawnHostModal/transformer.test.ts
@@ -1,4 +1,6 @@
+import { SpawnHostInput } from "gql/generated/types";
 import { formToGql } from "./transformer";
+import { FormState } from "./types";
 
 describe("spawn host modal", () => {
   it("correctly converts from a form to GQL", () => {
@@ -9,6 +11,7 @@ describe("spawn host modal", () => {
           formData,
           myPublicKeys,
           spawnTaskData: null,
+          timeZone: "America/New_York",
         }),
       ).toStrictEqual(mutationInput);
     });
@@ -23,6 +26,7 @@ describe("spawn host modal", () => {
           myPublicKeys,
           spawnTaskData: null,
           migrateVolumeId,
+          timeZone: "America/New_York",
         }),
       ).toStrictEqual({
         ...mutationInput,
@@ -35,11 +39,13 @@ describe("spawn host modal", () => {
 
 const myPublicKeys = [{ name: "a_key", key: "key value" }];
 
-const data = [
+const data: Array<{ formData: FormState; mutationInput: SpawnHostInput }> = [
   {
     formData: {
-      distro: "ubuntu1804-workstation",
-      region: "us-east-1",
+      requiredSection: {
+        distro: "ubuntu1804-workstation",
+        region: "us-east-1",
+      },
       publicKeySection: {
         useExisting: false,
         newPublicKey: "blah blahsart",
@@ -85,12 +91,15 @@ const data = [
       setUpScript: "setup!!!",
       spawnHostsStartedByTask: false,
       taskSync: false,
+      sleepSchedule: null,
     },
   },
   {
     formData: {
-      distro: "rhel71-power8-large",
-      region: "rofl-east",
+      requiredSection: {
+        distro: "rhel71-power8-large",
+        region: "rofl-east",
+      },
       publicKeySection: {
         useExisting: true,
         publicKeyNameDropdown: "a_key",
@@ -100,7 +109,9 @@ const data = [
       setupScriptSection: { defineSetupScriptCheckbox: false },
       expirationDetails: {
         noExpiration: true,
-        expiration: "Wed Oct 19 2022 08:56:42 GMT-0400 (Eastern Daylight Time)",
+        hostUptime: {
+          useDefaultUptimeSchedule: true,
+        },
       },
       homeVolumeDetails: { selectExistingVolume: true, volumeSelect: "" },
     },
@@ -123,6 +134,14 @@ const data = [
       setUpScript: null,
       spawnHostsStartedByTask: false,
       taskSync: false,
+      sleepSchedule: {
+        dailyStartTime: "08:00",
+        dailyStopTime: "20:00",
+        permanentlyExempt: false,
+        timeZone: "America/New_York",
+        shouldKeepOff: false,
+        wholeWeekdaysOff: [0, 6],
+      },
     },
   },
 ];

--- a/apps/spruce/src/components/Spawn/spawnHostModal/transformer.ts
+++ b/apps/spruce/src/components/Spawn/spawnHostModal/transformer.ts
@@ -44,9 +44,10 @@ export const formToGql = ({
       ? null
       : new Date(expirationDetails?.expiration),
     noExpiration: expirationDetails?.noExpiration,
-    sleepSchedule: expirationDetails?.noExpiration
-      ? getSleepSchedule(hostUptime, timeZone)
-      : null,
+    sleepSchedule:
+      expirationDetails?.noExpiration && hostUptime
+        ? getSleepSchedule(hostUptime, timeZone)
+        : null,
     volumeId:
       migrateVolumeId ||
       (isVirtualWorkStation && homeVolumeDetails?.selectExistingVolume

--- a/apps/spruce/src/components/Spawn/spawnHostModal/types.ts
+++ b/apps/spruce/src/components/Spawn/spawnHostModal/types.ts
@@ -15,7 +15,7 @@ export type FormState = {
     expiration?: string;
     hostUptime?: {
       useDefaultUptimeSchedule: boolean;
-      sleepSchedule: {
+      sleepSchedule?: {
         enabledWeekdays: boolean[];
         timeSelection: {
           startTime: string;

--- a/apps/spruce/src/components/Spawn/spawnHostModal/types.ts
+++ b/apps/spruce/src/components/Spawn/spawnHostModal/types.ts
@@ -1,12 +1,29 @@
 export type FormState = {
-  distro?: string;
-  region?: string;
+  requiredSection?: {
+    distro?: string;
+    region?: string;
+  };
   publicKeySection?: {
     useExisting: boolean;
     newPublicKey?: string;
     publicKeyNameDropdown?: string;
     savePublicKey?: boolean;
     newPublicKeyName?: string;
+  };
+  expirationDetails?: {
+    noExpiration: boolean;
+    expiration?: string;
+    hostUptime?: {
+      useDefaultUptimeSchedule: boolean;
+      sleepSchedule: {
+        enabledWeekdays: boolean[];
+        timeSelection: {
+          startTime: string;
+          endTime: string;
+          runContinuously: boolean;
+        };
+      };
+    };
   };
   userdataScriptSection?: {
     runUserdataScript: boolean;
@@ -15,10 +32,6 @@ export type FormState = {
   setupScriptSection?: {
     defineSetupScriptCheckbox: boolean;
     setupScript?: string;
-  };
-  expirationDetails?: {
-    noExpiration: boolean;
-    expiration?: string;
   };
   homeVolumeDetails?: {
     selectExistingVolume: boolean;

--- a/apps/spruce/src/components/Spawn/utils.ts
+++ b/apps/spruce/src/components/Spawn/utils.ts
@@ -44,29 +44,42 @@ export const validateUptimeSchedule = ({
   runContinuously,
   startTime,
   useDefaultUptimeSchedule,
-}: ValidateInput): { [key: string]: string[] } => {
-  if (useDefaultUptimeSchedule) {
-    return {};
-  }
-
+}: ValidateInput): {
+  enabledHoursCount: number;
+  errors: string[];
+  warnings: string[];
+} => {
   const { enabledHoursCount, enabledWeekdaysCount } = getEnabledHoursCount({
     enabledWeekdays,
     endTime,
     runContinuously,
     startTime,
   });
+
+  if (useDefaultUptimeSchedule) {
+    return {
+      enabledHoursCount,
+      errors: [],
+      warnings: [],
+    };
+  }
+
   if (enabledHoursCount > maxUptimeHours) {
     // Return error based on whether runContinously enabled
     if (runContinuously) {
       return {
-        "ui:errors": ["Please pause your host for at least 1 day per week."],
+        enabledHoursCount,
+        errors: ["Please pause your host for at least 1 day per week."],
+        warnings: [],
       };
     }
     const hourlyRequirement = Math.floor(maxUptimeHours / enabledWeekdaysCount);
     return {
-      "ui:errors": [
+      enabledHoursCount,
+      errors: [
         `Please reduce your host uptime to a max of ${hourlyRequirement} hours per day.`,
       ],
+      warnings: [],
     };
   }
 
@@ -74,20 +87,28 @@ export const validateUptimeSchedule = ({
     // Return warning based on whether runContinuously enabled
     if (runContinuously) {
       return {
-        "ui:warnings": ["Consider pausing your host for 2 days per week."],
+        enabledHoursCount,
+        errors: [],
+        warnings: ["Consider pausing your host for 2 days per week."],
       };
     }
     const hourlySuggestion = Math.floor(
       suggestedUptimeHours / enabledWeekdaysCount,
     );
     return {
-      "ui:warnings": [
+      enabledHoursCount,
+      errors: [],
+      warnings: [
         `Consider running your host for ${hourlySuggestion} hours per day or fewer.`,
       ],
     };
   }
   // No error
-  return {};
+  return {
+    enabledHoursCount,
+    errors: [],
+    warnings: [],
+  };
 };
 
 export const getEnabledHoursCount = ({

--- a/apps/spruce/src/components/Spawn/utils.ts
+++ b/apps/spruce/src/components/Spawn/utils.ts
@@ -111,7 +111,7 @@ export const validateUptimeSchedule = ({
   };
 };
 
-export const getEnabledHoursCount = ({
+const getEnabledHoursCount = ({
   enabledWeekdays,
   endTime,
   runContinuously,

--- a/apps/spruce/src/components/Spawn/utils.ts
+++ b/apps/spruce/src/components/Spawn/utils.ts
@@ -1,8 +1,16 @@
+import { differenceInHours } from "date-fns";
+
+const daysInWeek = 7;
+const hoursInDay = 24;
+export const maxUptimeHours = (daysInWeek - 1) * hoursInDay;
+const suggestedUptimeHours = (daysInWeek - 2) * hoursInDay;
+
 interface GetNoExpirationCheckboxTooltipCopyProps {
   disableExpirationCheckbox: boolean;
   isVolume: boolean;
   limit: number;
 }
+
 export const getNoExpirationCheckboxTooltipCopy = ({
   disableExpirationCheckbox,
   isVolume,
@@ -21,3 +29,80 @@ export const getDefaultExpiration = () => {
   nextWeek.setDate(nextWeek.getDate() + 7);
   return nextWeek.toString();
 };
+
+type ValidateInput = {
+  enabledWeekdays: boolean[];
+  endTime: string;
+  runContinuously: boolean;
+  startTime: string;
+  useDefaultUptimeSchedule: boolean;
+};
+
+export const validateUptimeSchedule = ({
+  enabledWeekdays,
+  endTime,
+  runContinuously,
+  startTime,
+  useDefaultUptimeSchedule,
+}: ValidateInput): { [key: string]: string[] } => {
+  if (useDefaultUptimeSchedule) {
+    return {};
+  }
+
+  const { enabledHoursCount, enabledWeekdaysCount } = getEnabledHoursCount({
+    enabledWeekdays,
+    endTime,
+    runContinuously,
+    startTime,
+  });
+  if (enabledHoursCount > maxUptimeHours) {
+    // Return error based on whether runContinously enabled
+    if (runContinuously) {
+      return {
+        "ui:errors": ["Please pause your host for at least 1 day per week."],
+      };
+    }
+    const hourlyRequirement = Math.floor(maxUptimeHours / enabledWeekdaysCount);
+    return {
+      "ui:errors": [
+        `Please reduce your host uptime to a max of ${hourlyRequirement} hours per day.`,
+      ],
+    };
+  }
+
+  if (enabledHoursCount > suggestedUptimeHours) {
+    // Return warning based on whether runContinuously enabled
+    if (runContinuously) {
+      return {
+        "ui:warnings": ["Consider pausing your host for 2 days per week."],
+      };
+    }
+    const hourlySuggestion = Math.floor(
+      suggestedUptimeHours / enabledWeekdaysCount,
+    );
+    return {
+      "ui:warnings": [
+        `Consider running your host for ${hourlySuggestion} hours per day or fewer.`,
+      ],
+    };
+  }
+  // No error
+  return {};
+};
+
+export const getEnabledHoursCount = ({
+  enabledWeekdays,
+  endTime,
+  runContinuously,
+  startTime,
+}: Omit<ValidateInput, "useDefaultUptimeSchedule">) => {
+  const enabledWeekdaysCount =
+    enabledWeekdays?.filter((day) => day).length ?? 0;
+  const enabledHoursCount = runContinuously
+    ? enabledWeekdaysCount * hoursInDay
+    : enabledWeekdaysCount * getDailyUptime({ startTime, endTime });
+  return { enabledHoursCount, enabledWeekdaysCount };
+};
+
+const getDailyUptime = ({ endTime, startTime }) =>
+  differenceInHours(new Date(endTime), new Date(startTime));

--- a/apps/spruce/src/components/SpruceForm/FieldTemplates/ObjectFieldTemplates/index.tsx
+++ b/apps/spruce/src/components/SpruceForm/FieldTemplates/ObjectFieldTemplates/index.tsx
@@ -24,23 +24,16 @@ export const ObjectFieldTemplate = ({
   const tooltipTitle = uiSchema["ui:tooltipTitle"] ?? null;
   return (
     <fieldset css={uiSchema["ui:fieldSetCSS"]} id={idSchema.$id}>
-      {(uiSchema["ui:title"] || title) &&
-        (tooltipTitle ? (
-          <TitleContainer>
-            <TitleField
-              id={`${idSchema.$id}__title`}
-              title={title || uiSchema["ui:title"]}
-              required={required}
-            />
-            <InfoSprinkle>{tooltipTitle}</InfoSprinkle>
-          </TitleContainer>
-        ) : (
+      {(uiSchema["ui:title"] || title) && (
+        <TitleContainer>
           <TitleField
             id={`${idSchema.$id}__title`}
             title={title || uiSchema["ui:title"]}
             required={required}
           />
-        ))}
+          {tooltipTitle && <InfoSprinkle>{tooltipTitle}</InfoSprinkle>}
+        </TitleContainer>
+      )}
       {description && (
         <DescriptionField
           id={`${idSchema.$id}__description`}

--- a/apps/spruce/src/components/SpruceForm/FieldTemplates/ObjectFieldTemplates/index.tsx
+++ b/apps/spruce/src/components/SpruceForm/FieldTemplates/ObjectFieldTemplates/index.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable jsdoc/valid-types */
 import styled from "@emotion/styled";
 import Banner from "@leafygreen-ui/banner";
+import { InfoSprinkle } from "@leafygreen-ui/info-sprinkle";
 import { Subtitle } from "@leafygreen-ui/typography";
 import { ObjectFieldTemplateProps } from "@rjsf/core";
 import { Accordion } from "components/Accordion";
@@ -20,15 +21,26 @@ export const ObjectFieldTemplate = ({
 }: ObjectFieldTemplateProps) => {
   const errors = uiSchema["ui:errors"] ?? [];
   const warnings = uiSchema["ui:warnings"] ?? [];
+  const tooltipTitle = uiSchema["ui:tooltipTitle"] ?? null;
   return (
     <fieldset css={uiSchema["ui:fieldSetCSS"]} id={idSchema.$id}>
-      {(uiSchema["ui:title"] || title) && (
-        <TitleField
-          id={`${idSchema.$id}__title`}
-          title={title || uiSchema["ui:title"]}
-          required={required}
-        />
-      )}
+      {(uiSchema["ui:title"] || title) &&
+        (tooltipTitle ? (
+          <TitleContainer>
+            <TitleField
+              id={`${idSchema.$id}__title`}
+              title={title || uiSchema["ui:title"]}
+              required={required}
+            />
+            <InfoSprinkle>{tooltipTitle}</InfoSprinkle>
+          </TitleContainer>
+        ) : (
+          <TitleField
+            id={`${idSchema.$id}__title`}
+            title={title || uiSchema["ui:title"]}
+            required={required}
+          />
+        ))}
       {description && (
         <DescriptionField
           id={`${idSchema.$id}__description`}
@@ -49,6 +61,12 @@ export const ObjectFieldTemplate = ({
     </fieldset>
   );
 };
+
+const TitleContainer = styled.div`
+  align-items: baseline;
+  display: flex;
+  gap: ${size.xs};
+`;
 
 /**
  * `CardFieldTemplate` is a custom ObjectFieldTemplate that renders a card with a title and a list of properties.

--- a/apps/spruce/src/components/SpruceForm/FieldTemplates/index.tsx
+++ b/apps/spruce/src/components/SpruceForm/FieldTemplates/index.tsx
@@ -1,4 +1,5 @@
 import styled from "@emotion/styled";
+import Banner from "@leafygreen-ui/banner";
 import { palette } from "@leafygreen-ui/palette";
 import { FieldTemplateProps } from "@rjsf/core";
 import { size } from "constants/tokens";
@@ -25,6 +26,9 @@ export const DefaultFieldTemplate: React.FC<FieldTemplateProps> = ({
   const border = uiSchema["ui:border"];
   const showLabel = uiSchema["ui:showLabel"] ?? true;
   const fieldDataCy = uiSchema["ui:field-data-cy"];
+  const descriptionNode = uiSchema["ui:descriptionNode"];
+  const errors = uiSchema["ui:errors"] ?? [];
+  const warnings = uiSchema["ui:warnings"] ?? [];
   return (
     !hidden && (
       <>
@@ -32,7 +36,17 @@ export const DefaultFieldTemplate: React.FC<FieldTemplateProps> = ({
           <CustomTitleField id={id} title={label} uiSchema={uiSchema} />
         )}
         {/* eslint-disable-next-line react/jsx-no-useless-fragment */}
-        {isNullType && <>{description}</>}
+        {isNullType && <>{descriptionNode || description}</>}
+        {isNullType && !!errors.length && (
+          <StyledBanner variant="danger" data-cy="error-banner">
+            {errors.join(", ")}
+          </StyledBanner>
+        )}
+        {isNullType && !!warnings.length && (
+          <StyledBanner variant="warning" data-cy="warning-banner">
+            {warnings.join(", ")}
+          </StyledBanner>
+        )}
         <DefaultFieldContainer
           id={`${sectionId} ${id}`}
           className={classNames}
@@ -51,4 +65,8 @@ const DefaultFieldContainer = styled.div<{ border?: "top" | "bottom" }>`
     border &&
     `border-${border}: 1px solid ${gray.light1}; padding-${border}: ${size.s};`}
   width: 100%;
+`;
+
+const StyledBanner = styled(Banner)`
+  margin: ${size.xs} 0;
 `;

--- a/apps/spruce/src/components/SpruceForm/Widgets/DateTimePicker.tsx
+++ b/apps/spruce/src/components/SpruceForm/Widgets/DateTimePicker.tsx
@@ -108,11 +108,9 @@ export const TimePicker: React.FC<
   return (
     <ElementWrapper css={elementWrapperCSS}>
       {showLabel !== false && (
-        <div>
-          <Label disabled={isDisabled} htmlFor={id}>
-            {label}
-          </Label>
-        </div>
+        <Label disabled={isDisabled} htmlFor={id}>
+          {label}
+        </Label>
       )}
       {description && <Description>{description}</Description>}
       <AntdTimePicker

--- a/apps/spruce/src/components/SpruceForm/Widgets/DateTimePicker.tsx
+++ b/apps/spruce/src/components/SpruceForm/Widgets/DateTimePicker.tsx
@@ -2,7 +2,7 @@ import styled from "@emotion/styled";
 import { Description, Label } from "@leafygreen-ui/typography";
 import { utcToZonedTime, zonedTimeToUtc } from "date-fns-tz";
 import DatePicker from "components/DatePicker";
-import TimePicker from "components/TimePicker";
+import AntdTimePicker from "components/TimePicker";
 import { size } from "constants/tokens";
 import { useUserTimeZone } from "hooks/useUserTimeZone";
 import ElementWrapper from "../ElementWrapper";
@@ -56,7 +56,7 @@ export const DateTimePicker: React.FC<
           disabled={isDisabled}
           disabledDate={disabledDate}
         />
-        <TimePicker
+        <AntdTimePicker
           // @ts-expect-error
           getPopupContainer={getPopupContainer}
           data-cy="time-picker"
@@ -76,6 +76,58 @@ const DateTimeContainer = styled.div`
     margin-right: ${size.xs};
   }
 `;
+
+export const TimePicker: React.FC<
+  {
+    options: {
+      format?: string;
+      useUtc?: boolean;
+    };
+  } & SpruceWidgetProps
+> = ({ disabled, id, label, onChange, options, readonly, value = "" }) => {
+  const {
+    description,
+    elementWrapperCSS,
+    format,
+    showLabel,
+    useUtc = true,
+  } = options;
+  const timezone = useUserTimeZone();
+  const currentDateTime = useUtc
+    ? utcToZonedTime(new Date(value || null), timezone)
+    : new Date(value || null);
+  const isDisabled = disabled || readonly;
+  const handleChange = (d: Date) => {
+    if (useUtc) {
+      onChange(zonedTimeToUtc(d, timezone).toString());
+    } else {
+      onChange(d.toString());
+    }
+  };
+
+  return (
+    <ElementWrapper css={elementWrapperCSS}>
+      {showLabel !== false && (
+        <div>
+          <Label disabled={isDisabled} htmlFor={id}>
+            {label}
+          </Label>
+        </div>
+      )}
+      {description && <Description>{description}</Description>}
+      <AntdTimePicker
+        // @ts-expect-error
+        getPopupContainer={getPopupContainer}
+        data-cy="time-picker"
+        format={format}
+        onChange={handleChange}
+        value={currentDateTime}
+        allowClear={false}
+        disabled={isDisabled}
+      />
+    </ElementWrapper>
+  );
+};
 
 // Fixes bug where DatePicker won't handle onClick events
 const getPopupContainer = (triggerNode: HTMLElement) => triggerNode.parentNode;

--- a/apps/spruce/src/components/SpruceForm/Widgets/DateTimePicker.tsx
+++ b/apps/spruce/src/components/SpruceForm/Widgets/DateTimePicker.tsx
@@ -130,4 +130,5 @@ export const TimePicker: React.FC<
 };
 
 // Fixes bug where DatePicker won't handle onClick events
-const getPopupContainer = (triggerNode: HTMLElement) => triggerNode.parentNode;
+const getPopupContainer = (triggerNode: HTMLElement) =>
+  triggerNode.parentNode.parentNode;

--- a/apps/spruce/src/components/SpruceForm/Widgets/DayPicker.tsx
+++ b/apps/spruce/src/components/SpruceForm/Widgets/DayPicker.tsx
@@ -10,6 +10,7 @@ export const DayPickerWidget: React.FC<SpruceWidgetProps> = ({
   onChange,
   options,
   readonly,
+  value,
 }) => {
   const { description, elementWrapperCSS, showLabel } = options;
 
@@ -25,7 +26,11 @@ export const DayPickerWidget: React.FC<SpruceWidgetProps> = ({
         </div>
       )}
       {description && <Description>{description}</Description>}
-      <DayPicker onChange={onChange} disabled={isDisabled} />
+      <DayPicker
+        defaultState={value}
+        disabled={isDisabled}
+        onChange={onChange}
+      />
     </ElementWrapper>
   );
 };

--- a/apps/spruce/src/components/SpruceForm/Widgets/index.tsx
+++ b/apps/spruce/src/components/SpruceForm/Widgets/index.tsx
@@ -1,4 +1,4 @@
-import { DateTimePicker } from "./DateTimePicker";
+import { DateTimePicker, TimePicker } from "./DateTimePicker";
 import { DayPickerWidget } from "./DayPicker";
 import {
   LeafyGreenTextInput,
@@ -14,6 +14,7 @@ import { MultiSelect } from "./MultiSelect";
 const widgets = {
   DateTimeWidget: DateTimePicker,
   DayPickerWidget,
+  TimeWidget: TimePicker,
   TextWidget: LeafyGreenTextInput,
   TextareaWidget: LeafyGreenTextArea,
   CheckboxWidget: LeafyGreenCheckBox,

--- a/apps/spruce/src/components/SpruceForm/__snapshots__/SpruceForm.stories.storyshot
+++ b/apps/spruce/src/components/SpruceForm/__snapshots__/SpruceForm.stories.storyshot
@@ -16,7 +16,7 @@ exports[`Snapshot Tests SpruceForm.stories Example1 1`] = `
         novalidate=""
       >
         <div
-          class="form-group field field-object css-mg3yql-DefaultFieldContainer eny4k1v0"
+          class="form-group field field-object css-mg3yql-DefaultFieldContainer eny4k1v1"
           id=" root"
         >
           <fieldset
@@ -24,7 +24,7 @@ exports[`Snapshot Tests SpruceForm.stories Example1 1`] = `
             id="root"
           >
             <div
-              class="form-group field field-string css-mg3yql-DefaultFieldContainer eny4k1v0"
+              class="form-group field field-string css-mg3yql-DefaultFieldContainer eny4k1v1"
               id=" root_cloneMethod"
             >
               <div
@@ -92,7 +92,7 @@ exports[`Snapshot Tests SpruceForm.stories Example1 1`] = `
               </div>
             </div>
             <div
-              class="form-group field field-array css-mg3yql-DefaultFieldContainer eny4k1v0"
+              class="form-group field field-array css-mg3yql-DefaultFieldContainer eny4k1v1"
               id=" root_expansions"
             >
               <h6
@@ -145,7 +145,7 @@ exports[`Snapshot Tests SpruceForm.stories Example1 1`] = `
                   class="css-nbhfvd-ArrayItemRow e1jxkcec7"
                 >
                   <div
-                    class="form-group field field-object css-mg3yql-DefaultFieldContainer eny4k1v0"
+                    class="form-group field field-object css-mg3yql-DefaultFieldContainer eny4k1v1"
                     id=" root_expansions_0"
                   >
                     <fieldset
@@ -153,7 +153,7 @@ exports[`Snapshot Tests SpruceForm.stories Example1 1`] = `
                       id="root_expansions_0"
                     >
                       <div
-                        class="form-group field field-string css-mg3yql-DefaultFieldContainer eny4k1v0"
+                        class="form-group field field-string css-mg3yql-DefaultFieldContainer eny4k1v1"
                         id=" root_expansions_0_key"
                       >
                         <div
@@ -193,7 +193,7 @@ exports[`Snapshot Tests SpruceForm.stories Example1 1`] = `
                         </div>
                       </div>
                       <div
-                        class="form-group field field-string css-mg3yql-DefaultFieldContainer eny4k1v0"
+                        class="form-group field field-string css-mg3yql-DefaultFieldContainer eny4k1v1"
                         id=" root_expansions_0_value"
                       >
                         <div
@@ -273,7 +273,7 @@ exports[`Snapshot Tests SpruceForm.stories Example1 1`] = `
               </div>
             </div>
             <div
-              class="form-group field field-string css-mg3yql-DefaultFieldContainer eny4k1v0"
+              class="form-group field field-string css-mg3yql-DefaultFieldContainer eny4k1v1"
               id=" root_validProjects"
             >
               <div
@@ -321,7 +321,7 @@ exports[`Snapshot Tests SpruceForm.stories Example2 1`] = `
         novalidate=""
       >
         <div
-          class="form-group field field-object css-mg3yql-DefaultFieldContainer eny4k1v0"
+          class="form-group field field-object css-mg3yql-DefaultFieldContainer eny4k1v1"
           id=" root"
         >
           <fieldset
@@ -329,7 +329,7 @@ exports[`Snapshot Tests SpruceForm.stories Example2 1`] = `
             id="root"
           >
             <div
-              class="form-group field field-boolean css-mg3yql-DefaultFieldContainer eny4k1v0"
+              class="form-group field field-boolean css-mg3yql-DefaultFieldContainer eny4k1v1"
               id=" root_distroIsCluster"
             >
               <div
@@ -386,7 +386,7 @@ exports[`Snapshot Tests SpruceForm.stories Example2 1`] = `
               </div>
             </div>
             <div
-              class="form-group field field-boolean css-mg3yql-DefaultFieldContainer eny4k1v0"
+              class="form-group field field-boolean css-mg3yql-DefaultFieldContainer eny4k1v1"
               id=" root_disableShallowClone"
             >
               <div
@@ -443,7 +443,7 @@ exports[`Snapshot Tests SpruceForm.stories Example2 1`] = `
               </div>
             </div>
             <div
-              class="form-group field field-boolean css-mg3yql-DefaultFieldContainer eny4k1v0"
+              class="form-group field field-boolean css-mg3yql-DefaultFieldContainer eny4k1v1"
               id=" root_disableQueue"
             >
               <div
@@ -500,7 +500,7 @@ exports[`Snapshot Tests SpruceForm.stories Example2 1`] = `
               </div>
             </div>
             <div
-              class="form-group field field-boolean css-mg3yql-DefaultFieldContainer eny4k1v0"
+              class="form-group field field-boolean css-mg3yql-DefaultFieldContainer eny4k1v1"
               id=" root_decommissionHosts"
             >
               <div
@@ -558,7 +558,7 @@ exports[`Snapshot Tests SpruceForm.stories Example2 1`] = `
               </div>
             </div>
             <div
-              class="form-group field field-string css-mg3yql-DefaultFieldContainer eny4k1v0"
+              class="form-group field field-string css-mg3yql-DefaultFieldContainer eny4k1v1"
               id=" root_reprovisionMethod"
             >
               <div
@@ -651,7 +651,7 @@ exports[`Snapshot Tests SpruceForm.stories Example3 1`] = `
         novalidate=""
       >
         <div
-          class="form-group field field-object css-mg3yql-DefaultFieldContainer eny4k1v0"
+          class="form-group field field-object css-mg3yql-DefaultFieldContainer eny4k1v1"
           id=" root"
         >
           <fieldset
@@ -659,7 +659,7 @@ exports[`Snapshot Tests SpruceForm.stories Example3 1`] = `
             id="root"
           >
             <div
-              class="form-group field field-boolean css-mg3yql-DefaultFieldContainer eny4k1v0"
+              class="form-group field field-boolean css-mg3yql-DefaultFieldContainer eny4k1v1"
               id=" root_visible"
             >
               <div

--- a/apps/spruce/src/constants/fieldMaps.ts
+++ b/apps/spruce/src/constants/fieldMaps.ts
@@ -165,6 +165,11 @@ export const timeZones = [
   },
 ];
 
+// Access a time zone's readable name by its key value
+export const prettifyTimeZone = new Map(
+  timeZones.map(({ str, value }) => [value, str]),
+);
+
 export const listOfDateFormatStrings = [
   "MM-dd-yyyy",
   "dd-MM-yyyy",

--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -1270,7 +1270,7 @@ export type MutationSchedulePatchTasksArgs = {
 
 export type MutationScheduleTasksArgs = {
   taskIds: Array<Scalars["String"]["input"]>;
-  versionId?: InputMaybe<Scalars["String"]["input"]>;
+  versionId: Scalars["String"]["input"];
 };
 
 export type MutationScheduleUndispatchedBaseTasksArgs = {
@@ -1899,7 +1899,7 @@ export enum ProjectSettingsAccess {
 export type ProjectSettingsInput = {
   aliases?: InputMaybe<Array<ProjectAliasInput>>;
   githubWebhooksEnabled?: InputMaybe<Scalars["Boolean"]["input"]>;
-  projectId?: InputMaybe<Scalars["String"]["input"]>;
+  projectId: Scalars["String"]["input"];
   projectRef?: InputMaybe<ProjectInput>;
   subscriptions?: InputMaybe<Array<SubscriptionInput>>;
   vars?: InputMaybe<ProjectVarsInput>;
@@ -2037,8 +2037,7 @@ export type QueryGithubProjectConflictsArgs = {
 };
 
 export type QueryHasVersionArgs = {
-  id?: InputMaybe<Scalars["String"]["input"]>;
-  patchId?: InputMaybe<Scalars["String"]["input"]>;
+  patchId: Scalars["String"]["input"];
 };
 
 export type QueryHostArgs = {
@@ -2074,8 +2073,7 @@ export type QueryMainlineCommitsArgs = {
 };
 
 export type QueryPatchArgs = {
-  id?: InputMaybe<Scalars["String"]["input"]>;
-  patchId?: InputMaybe<Scalars["String"]["input"]>;
+  patchId: Scalars["String"]["input"];
 };
 
 export type QueryPodArgs = {
@@ -2098,14 +2096,12 @@ export type QueryProjectSettingsArgs = {
 
 export type QueryRepoEventsArgs = {
   before?: InputMaybe<Scalars["Time"]["input"]>;
-  id?: InputMaybe<Scalars["String"]["input"]>;
   limit?: InputMaybe<Scalars["Int"]["input"]>;
-  repoId?: InputMaybe<Scalars["String"]["input"]>;
+  repoId: Scalars["String"]["input"];
 };
 
 export type QueryRepoSettingsArgs = {
-  id?: InputMaybe<Scalars["String"]["input"]>;
-  repoId?: InputMaybe<Scalars["String"]["input"]>;
+  repoId: Scalars["String"]["input"];
 };
 
 export type QueryTaskArgs = {
@@ -2132,8 +2128,7 @@ export type QueryUserArgs = {
 };
 
 export type QueryVersionArgs = {
-  id?: InputMaybe<Scalars["String"]["input"]>;
-  versionId?: InputMaybe<Scalars["String"]["input"]>;
+  versionId: Scalars["String"]["input"];
 };
 
 export type RepoCommitQueueParams = {
@@ -2257,7 +2252,7 @@ export type RepoSettingsInput = {
   aliases?: InputMaybe<Array<ProjectAliasInput>>;
   githubWebhooksEnabled?: InputMaybe<Scalars["Boolean"]["input"]>;
   projectRef?: InputMaybe<RepoRefInput>;
-  repoId?: InputMaybe<Scalars["String"]["input"]>;
+  repoId: Scalars["String"]["input"];
   subscriptions?: InputMaybe<Array<SubscriptionInput>>;
   vars?: InputMaybe<ProjectVarsInput>;
 };

--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -453,7 +453,8 @@ export type DistroInput = {
   providerSettingsList: Array<Scalars["Map"]["input"]>;
   setup: Scalars["String"]["input"];
   setupAsSudo: Scalars["Boolean"]["input"];
-  sshKey: Scalars["String"]["input"];
+  /** @deprecated removing this field shortly */
+  sshKey?: InputMaybe<Scalars["String"]["input"]>;
   sshOptions: Array<Scalars["String"]["input"]>;
   user: Scalars["String"]["input"];
   userSpawnAllowed: Scalars["Boolean"]["input"];
@@ -2462,7 +2463,8 @@ export type SpruceConfig = {
   containerPools?: Maybe<ContainerPoolsConfig>;
   githubOrgs: Array<Scalars["String"]["output"]>;
   jira?: Maybe<JiraConfig>;
-  keys: Array<SshKey>;
+  /** @deprecated removing this field shortly */
+  keys?: Maybe<Array<SshKey>>;
   providers?: Maybe<CloudProviderConfig>;
   secretFields: Array<Scalars["String"]["output"]>;
   slack?: Maybe<SlackConfig>;
@@ -8261,7 +8263,11 @@ export type SpruceConfigQuery = {
       email?: string | null;
       host?: string | null;
     } | null;
-    keys: Array<{ __typename?: "SSHKey"; location: string; name: string }>;
+    keys?: Array<{
+      __typename?: "SSHKey";
+      location: string;
+      name: string;
+    }> | null;
     providers?: {
       __typename?: "CloudProviderConfig";
       aws?: {

--- a/apps/spruce/src/pages/spawn/spawnHost/spawnHostButton/SpawnHostModal.tsx
+++ b/apps/spruce/src/pages/spawn/spawnHost/spawnHostButton/SpawnHostModal.tsx
@@ -176,7 +176,6 @@ const validate = (enabledHoursCount: number) =>
 
     if (!useDefaultUptimeSchedule) {
       if (enabledHoursCount > maxUptimeHours) {
-        console.log(errors);
         errors.expirationDetails?.hostUptime?.sleepSchedule?.addError(
           "Insufficient hours",
         );

--- a/apps/spruce/src/pages/spawn/spawnHost/spawnHostButton/SpawnHostModal.tsx
+++ b/apps/spruce/src/pages/spawn/spawnHost/spawnHostButton/SpawnHostModal.tsx
@@ -92,7 +92,7 @@ export const SpawnHostModal: React.FC<SpawnHostModalProps> = ({
     disableExpirationCheckbox: formSchemaInput.disableExpirationCheckbox,
   });
 
-  const hostUptimeErrors = validateUptimeSchedule({
+  const hostUptimeValidation = validateUptimeSchedule({
     enabledWeekdays:
       formState?.expirationDetails?.hostUptime?.sleepSchedule?.enabledWeekdays,
     ...formState?.expirationDetails?.hostUptime?.sleepSchedule?.timeSelection,
@@ -103,7 +103,7 @@ export const SpawnHostModal: React.FC<SpawnHostModalProps> = ({
   const { schema, uiSchema } = getFormSchema({
     ...formSchemaInput,
     distroIdQueryParam,
-    hostUptimeErrors,
+    hostUptimeValidation,
     isMigration: false,
     isVirtualWorkstation: !!selectedDistro?.isVirtualWorkStation,
     spawnTaskData: spawnTaskData?.task,

--- a/apps/spruce/src/pages/spawn/spawnVolume/spawnVolumeTableActions/MigrateVolumeModal.tsx
+++ b/apps/spruce/src/pages/spawn/spawnVolume/spawnVolumeTableActions/MigrateVolumeModal.tsx
@@ -69,8 +69,8 @@ export const MigrateVolumeModal: React.FC<MigrateVolumeModalProps> = ({
   );
 
   const selectedDistro = useMemo(
-    () => distros?.find(({ name }) => name === form?.distro),
-    [distros, form.distro],
+    () => distros?.find(({ name }) => name === form?.requiredSection?.distro),
+    [distros, form?.requiredSection?.distro],
   );
 
   const { schema, uiSchema } = getFormSchema({


### PR DESCRIPTION
DEVPROD-4197

### Description
<!-- add description, context, thought process, etc -->
- For **non-production** environments, allow users to configure an uptime schedule when spawning a host
  - This PR is not feature complete for the product, but I wanted to put something up for @Kimchelly to use in staging/beta before I leave for vacation.
  - I'll implement this on the edit modal in a new PR.
- Reorganize spawn host modal slightly according to Will's designs
- Add validation preventing users from saving if they don't have at least 24 hours of sleep time/week. A warning is showed if they have less than 48 hours of sleep time (but they can still save). The messaging text is dependent on whether the user is running for continuous days or sleeping at night.

### Screenshots
<!-- add screenshots of visible changes -->
> <img width="573" alt="image" src="https://github.com/evergreen-ci/ui/assets/9298431/40870cab-53d6-495e-9991-6c7cb0752cf7">

> <img width="572" alt="image" src="https://github.com/evergreen-ci/ui/assets/9298431/822ca271-fb79-4da6-a430-70e93f329136">

> <img width="581" alt="image" src="https://github.com/evergreen-ci/ui/assets/9298431/0e1e5623-0467-4721-8cbc-f99ce90a959a">

On production, the interface for selecting an unexpirable host will change slightly from the current checkbox, but it still looks good without the host scheduling section:
<img width="454" alt="image" src="https://github.com/evergreen-ci/ui/assets/9298431/e50125e5-1c9b-4867-bc99-dea2d0e7683e">

### Testing
<!-- add a description of how you tested it -->
- Update transformer unit tests
- I didn't have time to add e2e tests 😢 I will add those in a followup PR, but I think this is low-risk for the time being since it won't be deployed to users.
- Will also add validation unit tests separately!
