### PR TITLE
DEVPROD-597: Delete unused tests in task_table.ts

### DIFF
--- a/apps/spruce/cypress/integration/version/task_table.ts
+++ b/apps/spruce/cypress/integration/version/task_table.ts
@@ -85,14 +85,6 @@ describe("Task table", () => {
     });
   });
 
-  ["NAME", "STATUS", "BASE_STATUS", "VARIANT"].forEach((sortBy) => {
-    // TODO: This test doesn't work bc of issues with assertCorrectRequestVariables.
-    // Remove skip in DEVPROD-597.
-    it.skip(`Fetches tasks sorted by ${sortBy} when ${sortBy} header is clicked`, () => {
-      // clickSorterAndAssertTasksAreFetched(sortBy);
-    });
-  });
-
   describe("Changing page number", () => {
     // Instead of checking the entire table rows lets just check if the elements on the table have changed
     it("Displays the next page of results and updates URL when right arrow is clicked and next page exists", () => {


### PR DESCRIPTION
DEVPROD-597

### Description
I think these tests should be deleted (and I was going to delete them anyways in [DEVPROD-5935](https://jira.mongodb.org/browse/DEVPROD-5935)). They have been skipped for more than 3 years now; it's unlikely that they have a large impact else we would have fixed them by now. Additionally, the functions `assertCorrectRequestVariables` and `clickSorterAndAssertTasksAreFetched` appear to have been erased from the codebase.
