### PR TITLE
DEVPROD-1128 Make spruce form titles linkable

### DIFF
--- a/apps/spruce/src/components/SpruceForm/Container.tsx
+++ b/apps/spruce/src/components/SpruceForm/Container.tsx
@@ -16,7 +16,11 @@ export const SpruceFormContainer: React.FC<ContainerProps> = ({
   title,
 }) => (
   <div>
-    {title && <SettingsCardTitle id={id}>{title}</SettingsCardTitle>}
+    {title && (
+      <a href={`#${id}`}>
+        <SettingsCardTitle id={id}>{title}</SettingsCardTitle>
+      </a>
+    )}
     {description}
     <SettingsCard data-cy={dataCy}>{children}</SettingsCard>
   </div>

--- a/apps/spruce/src/pages/projectSettings/index.tsx
+++ b/apps/spruce/src/pages/projectSettings/index.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { useQuery } from "@apollo/client";
 import styled from "@emotion/styled";
-import { Skeleton } from "antd";
+import { FormSkeleton } from "@leafygreen-ui/skeleton-loader";
 import { useParams, Link, Navigate } from "react-router-dom";
 import { useProjectSettingsAnalytics } from "analytics";
 import { ProjectBanner } from "components/Banners";
@@ -217,7 +217,7 @@ const ProjectSettings: React.FC = () => {
             repoData={repoData?.repoSettings}
           />
         ) : (
-          <Skeleton />
+          <FormSkeleton />
         )}
       </PageWrapper>
     </ProjectSettingsProvider>


### PR DESCRIPTION
DEVPROD-1128

### Description
Adds anchors to spruce form title fields which will make sections linkable. Added a hover affect that will show the anchor symbol to provide a visual indication that a section is linkable.
Took inspiration from [here](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#linking_to_an_element_on_the_same_page).
 
### Screenshots
<img width="1029" alt="image" src="https://github.com/evergreen-ci/ui/assets/4605522/08769cd9-961f-4d41-981b-50fbfe97cad2">

### Testing
Visit a project settings page and click on one of the titles.
ex.
http://localhost:3000/project/logkeeper/settings/general#root_historicalTaskDataCaching__title
### Evergreen PR
<!-- link to a corresponding Evergreen PR if applicable -->
