### PR TITLE
DEVPROD-4560: Show blocking task in event logs

### DIFF
--- a/apps/parsley/src/gql/generated/types.ts
+++ b/apps/parsley/src/gql/generated/types.ts
@@ -2113,9 +2113,8 @@ export type QueryTaskNamesForBuildVariantArgs = {
 
 export type QueryTaskTestSampleArgs = {
   filters: Array<TestFilter>;
-  taskIds?: InputMaybe<Array<Scalars["String"]["input"]>>;
-  tasks?: InputMaybe<Array<Scalars["String"]["input"]>>;
-  versionId?: InputMaybe<Scalars["String"]["input"]>;
+  taskIds: Array<Scalars["String"]["input"]>;
+  versionId: Scalars["String"]["input"];
 };
 
 export type QueryUserArgs = {

--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -2113,9 +2113,8 @@ export type QueryTaskNamesForBuildVariantArgs = {
 
 export type QueryTaskTestSampleArgs = {
   filters: Array<TestFilter>;
-  taskIds?: InputMaybe<Array<Scalars["String"]["input"]>>;
-  tasks?: InputMaybe<Array<Scalars["String"]["input"]>>;
-  versionId?: InputMaybe<Scalars["String"]["input"]>;
+  taskIds: Array<Scalars["String"]["input"]>;
+  versionId: Scalars["String"]["input"];
 };
 
 export type QueryUserArgs = {
@@ -8342,6 +8341,7 @@ export type TaskEventLogsQuery = {
         timestamp?: Date | null;
         data: {
           __typename?: "TaskEventLogData";
+          blockedOn?: string | null;
           hostId?: string | null;
           jiraIssue?: string | null;
           jiraLink?: string | null;

--- a/apps/spruce/src/gql/queries/task-event-logs.graphql
+++ b/apps/spruce/src/gql/queries/task-event-logs.graphql
@@ -5,6 +5,7 @@ query TaskEventLogs($id: String!, $execution: Int) {
     taskLogs {
       eventLogs {
         data {
+          blockedOn
           hostId
           jiraIssue
           jiraLink

--- a/apps/spruce/src/pages/task/taskTabs/logs/logTypes/TaskEventLogLine.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/logs/logTypes/TaskEventLogLine.tsx
@@ -1,6 +1,10 @@
 import styled from "@emotion/styled";
-import { StyledLink, StyledRouterLink } from "components/styles";
-import { getHostRoute, getPodRoute } from "constants/routes";
+import {
+  StyledLink,
+  StyledRouterLink,
+  ShortenedRouterLink,
+} from "components/styles";
+import { getHostRoute, getPodRoute, getTaskRoute } from "constants/routes";
 import { size } from "constants/tokens";
 import { TaskEventLogEntry } from "gql/generated/types";
 import { useDateFormat } from "hooks";
@@ -12,13 +16,34 @@ export const TaskEventLogLine: React.FC<TaskEventLogEntry> = ({
   timestamp,
 }) => {
   const getDateCopy = useDateFormat();
-  const { hostId, jiraIssue, jiraLink, podId, priority, status, userId } = data;
+  const {
+    blockedOn,
+    hostId,
+    jiraIssue,
+    jiraLink,
+    podId,
+    priority,
+    status,
+    userId,
+  } = data;
   const route = podId ? getPodRoute(podId) : getHostRoute(hostId);
   const containerOrHostCopy = podId ? "container" : "host";
   let message: JSX.Element;
   switch (eventType) {
     case TaskEventType.TaskBlocked:
-      message = <>Task is blocked.</>;
+      message = (
+        <>
+          Task is blocked on{" "}
+          <ShortenedRouterLink
+            title={blockedOn}
+            to={getTaskRoute(blockedOn)}
+            width={500}
+          >
+            {blockedOn}
+          </ShortenedRouterLink>
+          .
+        </>
+      );
       break;
     case TaskEventType.TaskFinished:
       message = (


### PR DESCRIPTION
[DEVPROD-4560](https://jira.mongodb.org/browse/DEVPROD-4560)

### Description
Adds the blocking task to the task event logs. I shortened the link since the task ID can be really long.

### Screenshots
<!-- add screenshots of visible changes -->
<img width="1268" alt="Screenshot 2024-04-18 at 7 38 18 PM" src="https://github.com/evergreen-ci/ui/assets/47064971/140c9ca8-980b-4df8-be1e-53a7ea55ea0d">

### Testing
- Manually. [Example on staging](https://spruce-staging.corp.mongodb.com/task/sandbox_release_validate_commit_message2_6621acfcb647630007809071_24_04_18_23_30_04/logs?execution=0&logtype=event)
