### PR TITLE
DEVPROD-6691: Replace deprecated patch mutations with equivalent version mutations

### DIFF
--- a/apps/parsley/src/gql/generated/types.ts
+++ b/apps/parsley/src/gql/generated/types.ts
@@ -1051,19 +1051,24 @@ export type Mutation = {
   saveRepoSettingsForSection: RepoSettings;
   saveSubscription: Scalars["Boolean"]["output"];
   schedulePatch: Patch;
-  schedulePatchTasks?: Maybe<Scalars["String"]["output"]>;
   scheduleTasks: Array<Task>;
+  /** @deprecated Use scheduleUndispatchedBaseVersionTasks instead */
   scheduleUndispatchedBaseTasks?: Maybe<Array<Task>>;
+  scheduleUndispatchedBaseVersionTasks?: Maybe<Array<Task>>;
   setAnnotationMetadataLinks: Scalars["Boolean"]["output"];
   setLastRevision: SetLastRevisionPayload;
+  /** @deprecated Use setVersionPriority instead */
   setPatchPriority?: Maybe<Scalars["String"]["output"]>;
   /** setPatchVisibility takes a list of patch ids and a boolean to set the visibility on the my patches queries */
   setPatchVisibility: Array<Patch>;
   setTaskPriority: Task;
+  setVersionPriority?: Maybe<Scalars["String"]["output"]>;
   spawnHost: Host;
   spawnVolume: Scalars["Boolean"]["output"];
+  /** @deprecated Use unscheduleVersionTasks instead */
   unschedulePatchTasks?: Maybe<Scalars["String"]["output"]>;
   unscheduleTask: Task;
+  unscheduleVersionTasks?: Maybe<Scalars["String"]["output"]>;
   updateHostStatus: Scalars["Int"]["output"];
   updateParsleySettings?: Maybe<UpdateParsleySettingsPayload>;
   updatePublicKey: Array<PublicKey>;
@@ -1264,10 +1269,6 @@ export type MutationSchedulePatchArgs = {
   patchId: Scalars["String"]["input"];
 };
 
-export type MutationSchedulePatchTasksArgs = {
-  patchId: Scalars["String"]["input"];
-};
-
 export type MutationScheduleTasksArgs = {
   taskIds: Array<Scalars["String"]["input"]>;
   versionId: Scalars["String"]["input"];
@@ -1275,6 +1276,10 @@ export type MutationScheduleTasksArgs = {
 
 export type MutationScheduleUndispatchedBaseTasksArgs = {
   patchId: Scalars["String"]["input"];
+};
+
+export type MutationScheduleUndispatchedBaseVersionTasksArgs = {
+  versionId: Scalars["String"]["input"];
 };
 
 export type MutationSetAnnotationMetadataLinksArgs = {
@@ -1302,6 +1307,11 @@ export type MutationSetTaskPriorityArgs = {
   taskId: Scalars["String"]["input"];
 };
 
+export type MutationSetVersionPriorityArgs = {
+  priority: Scalars["Int"]["input"];
+  versionId: Scalars["String"]["input"];
+};
+
 export type MutationSpawnHostArgs = {
   spawnHostInput?: InputMaybe<SpawnHostInput>;
 };
@@ -1317,6 +1327,11 @@ export type MutationUnschedulePatchTasksArgs = {
 
 export type MutationUnscheduleTaskArgs = {
   taskId: Scalars["String"]["input"];
+};
+
+export type MutationUnscheduleVersionTasksArgs = {
+  abort: Scalars["Boolean"]["input"];
+  versionId: Scalars["String"]["input"];
 };
 
 export type MutationUpdateHostStatusArgs = {

--- a/apps/parsley/src/gql/generated/types.ts
+++ b/apps/parsley/src/gql/generated/types.ts
@@ -1052,9 +1052,7 @@ export type Mutation = {
   saveSubscription: Scalars["Boolean"]["output"];
   schedulePatch: Patch;
   scheduleTasks: Array<Task>;
-  /** @deprecated Use scheduleUndispatchedBaseVersionTasks instead */
   scheduleUndispatchedBaseTasks?: Maybe<Array<Task>>;
-  scheduleUndispatchedBaseVersionTasks?: Maybe<Array<Task>>;
   setAnnotationMetadataLinks: Scalars["Boolean"]["output"];
   setLastRevision: SetLastRevisionPayload;
   /** @deprecated Use setVersionPriority instead */
@@ -1275,11 +1273,8 @@ export type MutationScheduleTasksArgs = {
 };
 
 export type MutationScheduleUndispatchedBaseTasksArgs = {
-  patchId: Scalars["String"]["input"];
-};
-
-export type MutationScheduleUndispatchedBaseVersionTasksArgs = {
-  versionId: Scalars["String"]["input"];
+  patchId?: InputMaybe<Scalars["String"]["input"]>;
+  versionId?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type MutationSetAnnotationMetadataLinksArgs = {

--- a/apps/spruce/src/components/PatchActionButtons/DisableTasks.tsx
+++ b/apps/spruce/src/components/PatchActionButtons/DisableTasks.tsx
@@ -5,32 +5,32 @@ import { Body } from "@leafygreen-ui/typography";
 import Popconfirm from "components/Popconfirm";
 import { useToastContext } from "context/toast";
 import {
-  SetPatchPriorityMutation,
-  SetPatchPriorityMutationVariables,
+  SetVersionPriorityMutation,
+  SetVersionPriorityMutationVariables,
 } from "gql/generated/types";
-import { SET_PATCH_PRIORITY } from "gql/mutations";
+import { SET_VERSION_PRIORITY } from "gql/mutations";
 
 interface Props {
-  patchId: string;
+  versionId: string;
   refetchQueries?: string[];
 }
 export const DisableTasks: React.FC<Props> = ({
-  patchId,
   refetchQueries = [],
+  versionId,
 }) => {
   const dispatchToast = useToastContext();
   const [open, setOpen] = useState(false);
   const menuItemRef = useRef<HTMLDivElement>(null);
 
-  const [disablePatch] = useMutation<
-    SetPatchPriorityMutation,
-    SetPatchPriorityMutationVariables
-  >(SET_PATCH_PRIORITY, {
+  const [disableVersion] = useMutation<
+    SetVersionPriorityMutation,
+    SetVersionPriorityMutationVariables
+  >(SET_VERSION_PRIORITY, {
     onCompleted: () => {
-      dispatchToast.success(`Tasks in this patch were disabled`);
+      dispatchToast.success("Tasks in this version were disabled");
     },
     onError: (err) => {
-      dispatchToast.error(`Unable to disable patch tasks: ${err.message}`);
+      dispatchToast.error(`Unable to disable version's tasks: ${err.message}`);
     },
     refetchQueries,
   });
@@ -49,8 +49,8 @@ export const DisableTasks: React.FC<Props> = ({
       <Popconfirm
         align="left"
         onConfirm={() => {
-          disablePatch({
-            variables: { patchId, priority: -1 },
+          disableVersion({
+            variables: { versionId, priority: -1 },
           });
         }}
         open={open}

--- a/apps/spruce/src/components/PatchActionButtons/ScheduleUndispatchedBaseTasks.tsx
+++ b/apps/spruce/src/components/PatchActionButtons/ScheduleUndispatchedBaseTasks.tsx
@@ -10,24 +10,24 @@ import {
 import { SCHEDULE_UNDISPATCHED_BASE_TASKS } from "gql/mutations";
 
 interface Props {
-  patchId: string;
+  versionId: string;
   disabled: boolean;
 }
 
 export const ScheduleUndispatchedBaseTasks: React.FC<Props> = ({
   disabled,
-  patchId,
+  versionId,
 }) => {
   const dispatchToast = useToastContext();
   const [open, setOpen] = useState(false);
   const menuItemRef = useRef<HTMLDivElement>(null);
 
-  const [scheduleBasePatchTasks] = useMutation<
+  const [scheduleBaseVersionTasks] = useMutation<
     ScheduleUndispatchedBaseTasksMutation,
     ScheduleUndispatchedBaseTasksMutationVariables
   >(SCHEDULE_UNDISPATCHED_BASE_TASKS, {
-    onCompleted({ scheduleUndispatchedBaseTasks }) {
-      const successMessage = `Successfully scheduled ${scheduleUndispatchedBaseTasks.length} tasks`;
+    onCompleted({ scheduleUndispatchedBaseVersionTasks }) {
+      const successMessage = `Successfully scheduled ${scheduleUndispatchedBaseVersionTasks.length} tasks`;
       dispatchToast.success(successMessage);
     },
     onError({ message }) {
@@ -36,7 +36,7 @@ export const ScheduleUndispatchedBaseTasks: React.FC<Props> = ({
   });
 
   const onConfirm = () => {
-    scheduleBasePatchTasks({ variables: { patchId } });
+    scheduleBaseVersionTasks({ variables: { versionId } });
   };
 
   return (

--- a/apps/spruce/src/components/PatchActionButtons/ScheduleUndispatchedBaseTasks.tsx
+++ b/apps/spruce/src/components/PatchActionButtons/ScheduleUndispatchedBaseTasks.tsx
@@ -26,8 +26,8 @@ export const ScheduleUndispatchedBaseTasks: React.FC<Props> = ({
     ScheduleUndispatchedBaseTasksMutation,
     ScheduleUndispatchedBaseTasksMutationVariables
   >(SCHEDULE_UNDISPATCHED_BASE_TASKS, {
-    onCompleted({ scheduleUndispatchedBaseVersionTasks }) {
-      const successMessage = `Successfully scheduled ${scheduleUndispatchedBaseVersionTasks.length} tasks`;
+    onCompleted({ scheduleUndispatchedBaseTasks }) {
+      const successMessage = `Successfully scheduled ${scheduleUndispatchedBaseTasks.length} tasks`;
       dispatchToast.success(successMessage);
     },
     onError({ message }) {

--- a/apps/spruce/src/components/PatchActionButtons/UnscheduleTasks.tsx
+++ b/apps/spruce/src/components/PatchActionButtons/UnscheduleTasks.tsx
@@ -7,33 +7,33 @@ import { useVersionAnalytics } from "analytics";
 import Popconfirm from "components/Popconfirm";
 import { useToastContext } from "context/toast";
 import {
-  UnschedulePatchTasksMutation,
-  UnschedulePatchTasksMutationVariables,
+  UnscheduleVersionTasksMutation,
+  UnscheduleVersionTasksMutationVariables,
 } from "gql/generated/types";
-import { UNSCHEDULE_PATCH_TASKS } from "gql/mutations";
+import { UNSCHEDULE_VERSION_TASKS } from "gql/mutations";
 
 interface props {
-  patchId: string;
-  refetchQueries?: string[];
   disabled?: boolean;
+  refetchQueries?: string[];
+  versionId: string;
 }
 export const UnscheduleTasks: React.FC<props> = ({
   disabled,
-  patchId,
   refetchQueries = [],
+  versionId,
 }) => {
   const dispatchToast = useToastContext();
-  const { sendEvent } = useVersionAnalytics(patchId);
+  const { sendEvent } = useVersionAnalytics(versionId);
 
   const [abort, setAbort] = useState(true);
   const [open, setOpen] = useState(false);
   const menuItemRef = useRef<HTMLDivElement>(null);
 
-  const [unschedulePatchTasks, { loading: loadingUnschedulePatchTasks }] =
+  const [unscheduleVersionTasks, { loading: loadingUnscheduleVersionTasks }] =
     useMutation<
-      UnschedulePatchTasksMutation,
-      UnschedulePatchTasksMutationVariables
-    >(UNSCHEDULE_PATCH_TASKS, {
+      UnscheduleVersionTasksMutation,
+      UnscheduleVersionTasksMutationVariables
+    >(UNSCHEDULE_VERSION_TASKS, {
       onCompleted: () => {
         dispatchToast.success(
           `All tasks were unscheduled ${
@@ -49,7 +49,7 @@ export const UnscheduleTasks: React.FC<props> = ({
     });
 
   const onConfirm = () => {
-    unschedulePatchTasks({ variables: { patchId, abort } });
+    unscheduleVersionTasks({ variables: { versionId, abort } });
     sendEvent({ name: "Unschedule", abort });
   };
 
@@ -59,7 +59,7 @@ export const UnscheduleTasks: React.FC<props> = ({
         <MenuItem
           active={open}
           data-cy="unschedule-patch"
-          disabled={disabled || loadingUnschedulePatchTasks}
+          disabled={disabled || loadingUnscheduleVersionTasks}
           onClick={() => setOpen(!open)}
         >
           Unschedule all tasks

--- a/apps/spruce/src/components/PatchesPage/PatchCard/DropdownMenu.tsx
+++ b/apps/spruce/src/components/PatchesPage/PatchCard/DropdownMenu.tsx
@@ -37,7 +37,7 @@ export const DropdownMenu: React.FC<Props> = ({
     <ScheduleTasks key="schedule" versionId={patchId} disabled={!hasVersion} />,
     <UnscheduleTasks
       key="unschedule"
-      patchId={patchId}
+      versionId={patchId}
       refetchQueries={refetchQueries}
       disabled={!hasVersion}
     />,

--- a/apps/spruce/src/components/SetPriority/SetPriority.test.tsx
+++ b/apps/spruce/src/components/SetPriority/SetPriority.test.tsx
@@ -1,12 +1,12 @@
 import { MockedProvider } from "@apollo/client/testing";
 import { RenderFakeToastContext } from "context/toast/__mocks__";
 import {
-  SetPatchPriorityMutation,
-  SetPatchPriorityMutationVariables,
+  SetVersionPriorityMutation,
+  SetVersionPriorityMutationVariables,
   SetTaskPriorityMutation,
   SetTaskPriorityMutationVariables,
 } from "gql/generated/types";
-import { SET_PATCH_PRIORITY, SET_TASK_PRIORITY } from "gql/mutations";
+import { SET_VERSION_PRIORITY, SET_TASK_PRIORITY } from "gql/mutations";
 import { renderWithRouterMatch, screen, userEvent, waitFor } from "test_utils";
 import { ApolloMock } from "types/gql";
 import SetPriority from ".";
@@ -16,8 +16,8 @@ describe("setPriority", () => {
     it("shows default message", async () => {
       const user = userEvent.setup();
       const { Component } = RenderFakeToastContext(
-        <MockedProvider mocks={[setPatchPriority]}>
-          <SetPriority patchId="patch_id" />
+        <MockedProvider mocks={[setVersionPriority]}>
+          <SetPriority versionId="version_id" />
         </MockedProvider>,
       );
       renderWithRouterMatch(<Component />);
@@ -34,8 +34,8 @@ describe("setPriority", () => {
     it("shows warning message", async () => {
       const user = userEvent.setup();
       const { Component } = RenderFakeToastContext(
-        <MockedProvider mocks={[setPatchPriority]}>
-          <SetPriority patchId="patch_id" />
+        <MockedProvider mocks={[setVersionPriority]}>
+          <SetPriority versionId="version_id" />
         </MockedProvider>,
       );
       renderWithRouterMatch(<Component />);
@@ -52,8 +52,8 @@ describe("setPriority", () => {
     it("shows admin message", async () => {
       const user = userEvent.setup();
       const { Component } = RenderFakeToastContext(
-        <MockedProvider mocks={[setPatchPriority]}>
-          <SetPriority patchId="patch_id" />
+        <MockedProvider mocks={[setVersionPriority]}>
+          <SetPriority versionId="version_id" />
         </MockedProvider>,
       );
       renderWithRouterMatch(<Component />);
@@ -70,8 +70,8 @@ describe("setPriority", () => {
     it("successfully sets priority", async () => {
       const user = userEvent.setup();
       const { Component, dispatchToast } = RenderFakeToastContext(
-        <MockedProvider mocks={[setPatchPriority]}>
-          <SetPriority patchId="patch_id" />
+        <MockedProvider mocks={[setVersionPriority]}>
+          <SetPriority versionId="version_id" />
         </MockedProvider>,
       );
       renderWithRouterMatch(<Component />);
@@ -187,17 +187,17 @@ describe("setPriority", () => {
   });
 });
 
-const setPatchPriority: ApolloMock<
-  SetPatchPriorityMutation,
-  SetPatchPriorityMutationVariables
+const setVersionPriority: ApolloMock<
+  SetVersionPriorityMutation,
+  SetVersionPriorityMutationVariables
 > = {
   request: {
-    query: SET_PATCH_PRIORITY,
-    variables: { patchId: "patch_id", priority: 99 },
+    query: SET_VERSION_PRIORITY,
+    variables: { versionId: "version_id", priority: 99 },
   },
   result: {
     data: {
-      setPatchPriority: "patch_id",
+      setVersionPriority: "version_id",
     },
   },
 };

--- a/apps/spruce/src/components/SetPriority/index.tsx
+++ b/apps/spruce/src/components/SetPriority/index.tsx
@@ -10,23 +10,23 @@ import Popconfirm from "components/Popconfirm";
 import { size } from "constants/tokens";
 import { useToastContext } from "context/toast";
 import {
-  SetPatchPriorityMutation,
-  SetPatchPriorityMutationVariables,
+  SetVersionPriorityMutation,
+  SetVersionPriorityMutationVariables,
   SetTaskPriorityMutation,
   SetTaskPriorityMutationVariables,
 } from "gql/generated/types";
-import { SET_PATCH_PRIORITY, SET_TASK_PRIORITY } from "gql/mutations";
+import { SET_VERSION_PRIORITY, SET_TASK_PRIORITY } from "gql/mutations";
 
 const { gray, red, yellow } = palette;
 
 type SetPriorityProps = (
   | {
-      patchId: string;
+      versionId: string;
       taskId?: never;
     }
   | {
       taskId: string;
-      patchId?: never;
+      versionId?: never;
     }
 ) & {
   initialPriority?: number;
@@ -36,10 +36,10 @@ type SetPriorityProps = (
 const SetPriority: React.FC<SetPriorityProps> = ({
   disabled,
   initialPriority = 0,
-  patchId,
   taskId,
+  versionId,
 }) => {
-  const { sendEvent: sendPatchEvent } = useVersionAnalytics(patchId);
+  const { sendEvent: sendVersionEvent } = useVersionAnalytics(versionId);
   const { sendEvent: sendTaskEvent } = useTaskAnalytics();
   const dispatchToast = useToastContext();
 
@@ -48,17 +48,18 @@ const SetPriority: React.FC<SetPriorityProps> = ({
   const [inputRef, setInputRef] = useState<HTMLInputElement | null>(null);
   const menuItemRef = useRef<HTMLDivElement>(null);
 
-  const [setPatchPriority, { loading: loadingSetPatchPriority }] = useMutation<
-    SetPatchPriorityMutation,
-    SetPatchPriorityMutationVariables
-  >(SET_PATCH_PRIORITY, {
-    onCompleted: () => {
-      dispatchToast.success(`Priority was set to ${priority}`);
-    },
-    onError: (err) => {
-      dispatchToast.error(`Error setting priority: ${err.message}`);
-    },
-  });
+  const [setVersionPriority, { loading: loadingSetVersionPriority }] =
+    useMutation<
+      SetVersionPriorityMutation,
+      SetVersionPriorityMutationVariables
+    >(SET_VERSION_PRIORITY, {
+      onCompleted: () => {
+        dispatchToast.success(`Priority was set to ${priority}`);
+      },
+      onError: (err) => {
+        dispatchToast.error(`Error setting priority: ${err.message}`);
+      },
+    });
 
   const [setTaskPriority, { loading: loadingSetTaskPriority }] = useMutation<
     SetTaskPriorityMutation,
@@ -81,8 +82,8 @@ const SetPriority: React.FC<SetPriorityProps> = ({
       setTaskPriority({ variables: { taskId, priority } });
       sendTaskEvent({ name: "Set Priority", priority });
     } else {
-      setPatchPriority({ variables: { patchId, priority } });
-      sendPatchEvent({ name: "Set Priority", priority });
+      setVersionPriority({ variables: { versionId, priority } });
+      sendVersionEvent({ name: "Set Priority", priority });
     }
   };
 
@@ -100,7 +101,7 @@ const SetPriority: React.FC<SetPriorityProps> = ({
           active={open}
           data-cy={`prioritize-${dataCy}`}
           disabled={
-            disabled || loadingSetPatchPriority || loadingSetTaskPriority
+            disabled || loadingSetVersionPriority || loadingSetTaskPriority
           }
           onClick={() => setOpen(!open)}
         >

--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -1051,19 +1051,24 @@ export type Mutation = {
   saveRepoSettingsForSection: RepoSettings;
   saveSubscription: Scalars["Boolean"]["output"];
   schedulePatch: Patch;
-  schedulePatchTasks?: Maybe<Scalars["String"]["output"]>;
   scheduleTasks: Array<Task>;
+  /** @deprecated Use scheduleUndispatchedBaseVersionTasks instead */
   scheduleUndispatchedBaseTasks?: Maybe<Array<Task>>;
+  scheduleUndispatchedBaseVersionTasks?: Maybe<Array<Task>>;
   setAnnotationMetadataLinks: Scalars["Boolean"]["output"];
   setLastRevision: SetLastRevisionPayload;
+  /** @deprecated Use setVersionPriority instead */
   setPatchPriority?: Maybe<Scalars["String"]["output"]>;
   /** setPatchVisibility takes a list of patch ids and a boolean to set the visibility on the my patches queries */
   setPatchVisibility: Array<Patch>;
   setTaskPriority: Task;
+  setVersionPriority?: Maybe<Scalars["String"]["output"]>;
   spawnHost: Host;
   spawnVolume: Scalars["Boolean"]["output"];
+  /** @deprecated Use unscheduleVersionTasks instead */
   unschedulePatchTasks?: Maybe<Scalars["String"]["output"]>;
   unscheduleTask: Task;
+  unscheduleVersionTasks?: Maybe<Scalars["String"]["output"]>;
   updateHostStatus: Scalars["Int"]["output"];
   updateParsleySettings?: Maybe<UpdateParsleySettingsPayload>;
   updatePublicKey: Array<PublicKey>;
@@ -1264,10 +1269,6 @@ export type MutationSchedulePatchArgs = {
   patchId: Scalars["String"]["input"];
 };
 
-export type MutationSchedulePatchTasksArgs = {
-  patchId: Scalars["String"]["input"];
-};
-
 export type MutationScheduleTasksArgs = {
   taskIds: Array<Scalars["String"]["input"]>;
   versionId: Scalars["String"]["input"];
@@ -1275,6 +1276,10 @@ export type MutationScheduleTasksArgs = {
 
 export type MutationScheduleUndispatchedBaseTasksArgs = {
   patchId: Scalars["String"]["input"];
+};
+
+export type MutationScheduleUndispatchedBaseVersionTasksArgs = {
+  versionId: Scalars["String"]["input"];
 };
 
 export type MutationSetAnnotationMetadataLinksArgs = {
@@ -1302,6 +1307,11 @@ export type MutationSetTaskPriorityArgs = {
   taskId: Scalars["String"]["input"];
 };
 
+export type MutationSetVersionPriorityArgs = {
+  priority: Scalars["Int"]["input"];
+  versionId: Scalars["String"]["input"];
+};
+
 export type MutationSpawnHostArgs = {
   spawnHostInput?: InputMaybe<SpawnHostInput>;
 };
@@ -1317,6 +1327,11 @@ export type MutationUnschedulePatchTasksArgs = {
 
 export type MutationUnscheduleTaskArgs = {
   taskId: Scalars["String"]["input"];
+};
+
+export type MutationUnscheduleVersionTasksArgs = {
+  abort: Scalars["Boolean"]["input"];
+  versionId: Scalars["String"]["input"];
 };
 
 export type MutationUpdateHostStatusArgs = {
@@ -5169,12 +5184,12 @@ export type ScheduleTasksMutation = {
 };
 
 export type ScheduleUndispatchedBaseTasksMutationVariables = Exact<{
-  patchId: Scalars["String"]["input"];
+  versionId: Scalars["String"]["input"];
 }>;
 
 export type ScheduleUndispatchedBaseTasksMutation = {
   __typename?: "Mutation";
-  scheduleUndispatchedBaseTasks?: Array<{
+  scheduleUndispatchedBaseVersionTasks?: Array<{
     __typename?: "Task";
     execution: number;
     id: string;
@@ -5193,16 +5208,6 @@ export type SetLastRevisionMutation = {
     __typename?: "SetLastRevisionPayload";
     mergeBaseRevision: string;
   };
-};
-
-export type SetPatchPriorityMutationVariables = Exact<{
-  patchId: Scalars["String"]["input"];
-  priority: Scalars["Int"]["input"];
-}>;
-
-export type SetPatchPriorityMutation = {
-  __typename?: "Mutation";
-  setPatchPriority?: string | null;
 };
 
 export type SetPatchVisibilityMutationVariables = Exact<{
@@ -5234,6 +5239,16 @@ export type SetTaskPriorityMutation = {
   };
 };
 
+export type SetVersionPriorityMutationVariables = Exact<{
+  versionId: Scalars["String"]["input"];
+  priority: Scalars["Int"]["input"];
+}>;
+
+export type SetVersionPriorityMutation = {
+  __typename?: "Mutation";
+  setVersionPriority?: string | null;
+};
+
 export type SpawnHostMutationVariables = Exact<{
   spawnHostInput?: InputMaybe<SpawnHostInput>;
 }>;
@@ -5252,16 +5267,6 @@ export type SpawnVolumeMutation = {
   spawnVolume: boolean;
 };
 
-export type UnschedulePatchTasksMutationVariables = Exact<{
-  patchId: Scalars["String"]["input"];
-  abort: Scalars["Boolean"]["input"];
-}>;
-
-export type UnschedulePatchTasksMutation = {
-  __typename?: "Mutation";
-  unschedulePatchTasks?: string | null;
-};
-
 export type UnscheduleTaskMutationVariables = Exact<{
   taskId: Scalars["String"]["input"];
 }>;
@@ -5269,6 +5274,16 @@ export type UnscheduleTaskMutationVariables = Exact<{
 export type UnscheduleTaskMutation = {
   __typename?: "Mutation";
   unscheduleTask: { __typename?: "Task"; execution: number; id: string };
+};
+
+export type UnscheduleVersionTasksMutationVariables = Exact<{
+  versionId: Scalars["String"]["input"];
+  abort: Scalars["Boolean"]["input"];
+}>;
+
+export type UnscheduleVersionTasksMutation = {
+  __typename?: "Mutation";
+  unscheduleVersionTasks?: string | null;
 };
 
 export type UpdateHostStatusMutationVariables = Exact<{

--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -1052,9 +1052,7 @@ export type Mutation = {
   saveSubscription: Scalars["Boolean"]["output"];
   schedulePatch: Patch;
   scheduleTasks: Array<Task>;
-  /** @deprecated Use scheduleUndispatchedBaseVersionTasks instead */
   scheduleUndispatchedBaseTasks?: Maybe<Array<Task>>;
-  scheduleUndispatchedBaseVersionTasks?: Maybe<Array<Task>>;
   setAnnotationMetadataLinks: Scalars["Boolean"]["output"];
   setLastRevision: SetLastRevisionPayload;
   /** @deprecated Use setVersionPriority instead */
@@ -1275,11 +1273,8 @@ export type MutationScheduleTasksArgs = {
 };
 
 export type MutationScheduleUndispatchedBaseTasksArgs = {
-  patchId: Scalars["String"]["input"];
-};
-
-export type MutationScheduleUndispatchedBaseVersionTasksArgs = {
-  versionId: Scalars["String"]["input"];
+  patchId?: InputMaybe<Scalars["String"]["input"]>;
+  versionId?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type MutationSetAnnotationMetadataLinksArgs = {
@@ -5189,7 +5184,7 @@ export type ScheduleUndispatchedBaseTasksMutationVariables = Exact<{
 
 export type ScheduleUndispatchedBaseTasksMutation = {
   __typename?: "Mutation";
-  scheduleUndispatchedBaseVersionTasks?: Array<{
+  scheduleUndispatchedBaseTasks?: Array<{
     __typename?: "Task";
     execution: number;
     id: string;

--- a/apps/spruce/src/gql/mutations/index.ts
+++ b/apps/spruce/src/gql/mutations/index.ts
@@ -43,13 +43,13 @@ import SCHEDULE_PATCH from "./schedule-patch.graphql";
 import SCHEDULE_TASKS from "./schedule-tasks.graphql";
 import SCHEDULE_UNDISPATCHED_BASE_TASKS from "./schedule-undispatched-base-tasks.graphql";
 import SET_LAST_REVISION from "./set-last-revision.graphql";
-import SET_PATCH_PRIORITY from "./set-patch-priority.graphql";
 import SET_PATCH_VISIBILITY from "./set-patch-visibility.graphql";
 import SET_TASK_PRIORITY from "./set-task-priority.graphql";
+import SET_VERSION_PRIORITY from "./set-version-priority.graphql";
 import SPAWN_HOST from "./spawn-host.graphql";
 import SPAWN_VOLUME from "./spawn-volume.graphql";
-import UNSCHEDULE_PATCH_TASKS from "./unschedule-patch-tasks.graphql";
 import UNSCHEDULE_TASK from "./unschedule-task.graphql";
+import UNSCHEDULE_VERSION_TASKS from "./unschedule-version-tasks.graphql";
 import UPDATE_HOST_STATUS from "./update-host-status.graphql";
 import UPDATE_PATCH_DESCRIPTION from "./update-patch-description.graphql";
 import UPDATE_PUBLIC_KEY from "./update-public-key.graphql";
@@ -103,12 +103,12 @@ export {
   SCHEDULE_TASKS,
   SCHEDULE_UNDISPATCHED_BASE_TASKS,
   SET_LAST_REVISION,
-  SET_PATCH_PRIORITY,
+  SET_VERSION_PRIORITY,
   SET_PATCH_VISIBILITY,
   SET_TASK_PRIORITY,
   SPAWN_HOST,
   SPAWN_VOLUME,
-  UNSCHEDULE_PATCH_TASKS,
+  UNSCHEDULE_VERSION_TASKS,
   UNSCHEDULE_TASK,
   UPDATE_HOST_STATUS,
   UPDATE_PATCH_DESCRIPTION,

--- a/apps/spruce/src/gql/mutations/schedule-undispatched-base-tasks.graphql
+++ b/apps/spruce/src/gql/mutations/schedule-undispatched-base-tasks.graphql
@@ -1,5 +1,5 @@
-mutation ScheduleUndispatchedBaseTasks($patchId: String!) {
-  scheduleUndispatchedBaseTasks(patchId: $patchId) {
+mutation ScheduleUndispatchedBaseTasks($versionId: String!) {
+  scheduleUndispatchedBaseVersionTasks(versionId: $versionId) {
     execution
     id
     status

--- a/apps/spruce/src/gql/mutations/schedule-undispatched-base-tasks.graphql
+++ b/apps/spruce/src/gql/mutations/schedule-undispatched-base-tasks.graphql
@@ -1,5 +1,5 @@
 mutation ScheduleUndispatchedBaseTasks($versionId: String!) {
-  scheduleUndispatchedBaseVersionTasks(versionId: $versionId) {
+  scheduleUndispatchedBaseTasks(versionId: $versionId) {
     execution
     id
     status

--- a/apps/spruce/src/gql/mutations/set-patch-priority.graphql
+++ b/apps/spruce/src/gql/mutations/set-patch-priority.graphql
@@ -1,3 +1,0 @@
-mutation SetPatchPriority($patchId: String!, $priority: Int!) {
-  setPatchPriority(patchId: $patchId, priority: $priority)
-}

--- a/apps/spruce/src/gql/mutations/set-version-priority.graphql
+++ b/apps/spruce/src/gql/mutations/set-version-priority.graphql
@@ -1,0 +1,3 @@
+mutation SetVersionPriority($versionId: String!, $priority: Int!) {
+  setVersionPriority(versionId: $versionId, priority: $priority)
+}

--- a/apps/spruce/src/gql/mutations/unschedule-patch-tasks.graphql
+++ b/apps/spruce/src/gql/mutations/unschedule-patch-tasks.graphql
@@ -1,3 +1,0 @@
-mutation UnschedulePatchTasks($patchId: String!, $abort: Boolean!) {
-  unschedulePatchTasks(patchId: $patchId, abort: $abort)
-}

--- a/apps/spruce/src/gql/mutations/unschedule-version-tasks.graphql
+++ b/apps/spruce/src/gql/mutations/unschedule-version-tasks.graphql
@@ -1,0 +1,3 @@
+mutation UnscheduleVersionTasks($versionId: String!, $abort: Boolean!) {
+  unscheduleVersionTasks(versionId: $versionId, abort: $abort)
+}

--- a/apps/spruce/src/pages/version/ActionButtons.tsx
+++ b/apps/spruce/src/pages/version/ActionButtons.tsx
@@ -35,14 +35,14 @@ export const ActionButtons: React.FC<ActionButtonProps> = ({
       patchId={versionId}
       disabled={!canReconfigure}
     />,
-    <UnscheduleTasks patchId={versionId} key="unschedule-tasks" />,
-    <DisableTasks key="disable-tasks" patchId={versionId} />,
+    <UnscheduleTasks versionId={versionId} key="unschedule-tasks" />,
+    <DisableTasks key="disable-tasks" versionId={versionId} />,
     <ScheduleUndispatchedBaseTasks
       key="schedule-undispatched-base-tasks"
-      patchId={versionId}
+      versionId={versionId}
       disabled={!isPatch}
     />,
-    <SetPriority patchId={versionId} key="priority" />,
+    <SetPriority versionId={versionId} key="priority" />,
     <EnqueuePatch
       patchId={versionId}
       commitMessage={patchDescription}


### PR DESCRIPTION
DEVPROD-6691

### Description
Just replaces old patch mutations with new version mutations. Cleaned up some usage of `versionId` vs `patchId`.

### Testing
* Against staging & production
  * These mutations already have directives applied, so confirmed that I can set priority / unschedule mainline commits and patches.
* [Patch with module](https://spruce.mongodb.com/version/6626bef09ed761000764a714/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)

### Evergreen PR
* evergreen-ci/evergreen/pull/7778
