### PR TITLE
DEVPROD-4730 Add projectIdentifier field to TaskQuery for Execution tasks table

### DIFF
--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -8968,7 +8968,6 @@ export type VersionTaskDurationsQuery = {
           displayName: string;
           execution: number;
           id: string;
-          projectIdentifier?: string | null;
           startTime?: Date | null;
           status: string;
           timeTaken?: number | null;

--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -8688,6 +8688,7 @@ export type TaskQuery = {
       displayName: string;
       execution: number;
       id: string;
+      projectIdentifier?: string | null;
       status: string;
     }> | null;
     files: { __typename?: "TaskFiles"; fileCount: number };
@@ -8967,6 +8968,7 @@ export type VersionTaskDurationsQuery = {
           displayName: string;
           execution: number;
           id: string;
+          projectIdentifier?: string | null;
           startTime?: Date | null;
           status: string;
           timeTaken?: number | null;

--- a/apps/spruce/src/gql/queries/task.graphql
+++ b/apps/spruce/src/gql/queries/task.graphql
@@ -71,6 +71,7 @@ query Task($taskId: String!, $execution: Int) {
       displayName
       execution
       id
+      projectIdentifier
       status
     }
     expectedDuration

--- a/apps/spruce/src/gql/queries/version-task-durations.graphql
+++ b/apps/spruce/src/gql/queries/version-task-durations.graphql
@@ -18,6 +18,7 @@ query VersionTaskDurations(
           displayName
           execution
           id
+          projectIdentifier
           startTime
           status
           timeTaken

--- a/apps/spruce/src/gql/queries/version-task-durations.graphql
+++ b/apps/spruce/src/gql/queries/version-task-durations.graphql
@@ -18,7 +18,6 @@ query VersionTaskDurations(
           displayName
           execution
           id
-          projectIdentifier
           startTime
           status
           timeTaken


### PR DESCRIPTION
DEVPROD-4730

### Description
Rendering the variant history link requires knowing the projectIdentifier for tasks 

### Screenshots
<img width="1484" alt="image" src="https://github.com/evergreen-ci/ui/assets/4605522/c59fae2d-436a-4ee5-99ff-b3d64f1d5ec0">

### Testing
The link now works
