### PR TITLE
DEVPROD-5137 fix: Trim execsync strings

### DIFF
--- a/apps/parsley/scripts/deploy/utils/deploy/index.ts
+++ b/apps/parsley/scripts/deploy/utils/deploy/index.ts
@@ -32,7 +32,9 @@ const runDeploy = () => {
   } else {
     const email = execSync("git config user.email", {
       encoding: "utf-8",
-    }).toString();
+    })
+      .toString()
+      .trim();
     console.log(yellow(`Dry run mode enabled. Sending email to ${email}`));
     execSync(`DEPLOYS_EMAIL=${email} ./scripts/deploy/email.sh`, {
       stdio: "inherit",

--- a/apps/parsley/scripts/deploy/utils/git/index.ts
+++ b/apps/parsley/scripts/deploy/utils/git/index.ts
@@ -17,7 +17,9 @@ const getCommitMessages = (currentlyDeployedCommit: string) => {
   const commitMessages = execSync(
     `git log ${currentlyDeployedCommit}..HEAD --oneline -- ${appDir} -- ${packagesDir}`,
     { encoding: "utf-8" },
-  ).toString();
+  )
+    .toString()
+    .trim();
   return commitMessages;
 };
 

--- a/apps/parsley/scripts/deploy/utils/git/index.ts
+++ b/apps/parsley/scripts/deploy/utils/git/index.ts
@@ -9,7 +9,9 @@ import { resolve } from "path";
 const getCommitMessages = (currentlyDeployedCommit: string) => {
   const gitRoot = execSync(`git rev-parse --show-toplevel`, {
     encoding: "utf-8",
-  }).toString();
+  })
+    .toString()
+    .trim();
   const appDir = resolve(gitRoot, "apps", "parsley");
   const packagesDir = resolve(gitRoot, "packages");
   const commitMessages = execSync(

--- a/apps/spruce/scripts/deploy/utils/deploy/index.ts
+++ b/apps/spruce/scripts/deploy/utils/deploy/index.ts
@@ -1,7 +1,7 @@
 import { execSync } from "child_process";
 import { yellow } from "../../../utils/colors";
-import { getCurrentCommit, getCurrentlyDeployedCommit } from "../git";
 import { isDryRun } from "../environment";
+import { getCurrentCommit, getCurrentlyDeployedCommit } from "../git";
 
 /**
  * `runDeploy` is a helper function that actually performs the deploy.
@@ -32,7 +32,9 @@ const runDeploy = () => {
   } else {
     const email = execSync("git config user.email", {
       encoding: "utf-8",
-    }).toString();
+    })
+      .toString()
+      .trim();
     console.log(yellow(`Dry run mode enabled. Sending email to ${email}`));
     execSync(`DEPLOYS_EMAIL=${email} ./scripts/deploy/email.sh`, {
       stdio: "inherit",

--- a/apps/spruce/scripts/deploy/utils/git/index.ts
+++ b/apps/spruce/scripts/deploy/utils/git/index.ts
@@ -17,7 +17,9 @@ const getCommitMessages = (currentlyDeployedCommit: string) => {
   const commitMessages = execSync(
     `git log ${currentlyDeployedCommit}..HEAD --oneline -- ${appDir} -- ${packagesDir}`,
     { encoding: "utf-8" },
-  ).toString();
+  )
+    .toString()
+    .trim();
   return commitMessages;
 };
 

--- a/apps/spruce/scripts/deploy/utils/git/index.ts
+++ b/apps/spruce/scripts/deploy/utils/git/index.ts
@@ -9,7 +9,9 @@ import { resolve } from "path";
 const getCommitMessages = (currentlyDeployedCommit: string) => {
   const gitRoot = execSync(`git rev-parse --show-toplevel`, {
     encoding: "utf-8",
-  }).toString();
+  })
+    .toString()
+    .trim();
   const appDir = resolve(gitRoot, "apps", "spruce");
   const packagesDir = resolve(gitRoot, "packages");
   const commitMessages = execSync(


### PR DESCRIPTION
DEVPROD-5137

### Description
<!-- add description, context, thought process, etc -->
Bynn saw this error when attempting to deploy:
```zsh
❯ yarn deploy:prod
yarn run v1.22.21
$ env-cmd -e production ts-node scripts/deploy/run-deploy
Checking if you are on the main branch
Currently Deployed Commit: 559f14a10b756c6e40f034e18b30756efd318eb7
/bin/sh: line 1: /apps/spruce: No such file or directory
/bin/sh: line 2: /packages: No such file or directory
Error: Command failed: git log 559f14a10b756c6e40f034e18b30756efd318eb7..HEAD --oneline -- /Users/bynn.lee/go/src/github.com/evergreen-ci/ui
/apps/spruce -- /Users/bynn.lee/go/src/github.com/evergreen-ci/ui
/packages
```
I forgot to trim the strings returned by `execSync`, which we do elsewhere, resulting in an extraneous newline. This meant that the paths created by `paths.resolve()` were invalid.

### Testing
<!-- add a description of how you tested it -->
- Tested locally