### PR TITLE
DEVPROD-4779 Show GitHub username banner on all pages

### DIFF
--- a/apps/spruce/src/components/Banners/GithubUsernameBanner.tsx
+++ b/apps/spruce/src/components/Banners/GithubUsernameBanner.tsx
@@ -1,31 +1,19 @@
 import { useQuery } from "@apollo/client";
 import Banner from "@leafygreen-ui/banner";
-import { matchPath, useLocation } from "react-router-dom";
 import { StyledRouterLink } from "components/styles";
-import {
-  getPreferencesRoute,
-  PreferencesTabRoutes,
-  routes,
-} from "constants/routes";
+import { getPreferencesRoute, PreferencesTabRoutes } from "constants/routes";
 import { UserSettingsQuery } from "gql/generated/types";
 import { USER_SETTINGS } from "gql/queries";
 
 export const GithubUsernameBanner = () => {
-  const { pathname } = useLocation();
-  const matchedPath = matchPath(routes.user, pathname);
-  const isPatchesPage = !!matchedPath;
-
   // USER SETTINGS QUERY
-  const { data: userSettingsData } = useQuery<UserSettingsQuery>(
-    USER_SETTINGS,
-    { skip: !isPatchesPage },
-  );
+  const { data: userSettingsData } = useQuery<UserSettingsQuery>(USER_SETTINGS);
   const { userSettings } = userSettingsData || {};
   const { githubUser } = userSettings || {};
   const { lastKnownAs } = githubUser || {};
   const hasNoGithubUser = lastKnownAs === "";
 
-  return isPatchesPage && hasNoGithubUser ? (
+  return hasNoGithubUser ? (
     <Banner data-cy="github-username-banner" variant="warning">
       Please set your GitHub username on the{" "}
       <StyledRouterLink to={getPreferencesRoute(PreferencesTabRoutes.Profile)}>


### PR DESCRIPTION
DEVPROD-4779

### Screenshots
<img width="1208" alt="image" src="https://github.com/evergreen-ci/ui/assets/4605522/49f10b57-6b78-4394-9cf9-dd1dfee74361">

