### PR TITLE
DEVPROD-4265: Remove error toasts for relevant commits

### DIFF
--- a/apps/spruce/src/hooks/useBreakingTask/index.ts
+++ b/apps/spruce/src/hooks/useBreakingTask/index.ts
@@ -1,5 +1,4 @@
 import { useQuery } from "@apollo/client";
-import { useToastContext } from "context/toast";
 import {
   BaseVersionAndTaskQuery,
   BaseVersionAndTaskQueryVariables,
@@ -15,8 +14,6 @@ import { getTaskFromMainlineCommitsQuery } from "utils/getTaskFromMainlineCommit
 import { isFailedTaskStatus } from "utils/statuses";
 
 export const useBreakingTask = (taskId: string) => {
-  const dispatchToast = useToastContext();
-
   const { data: taskData } = useQuery<
     BaseVersionAndTaskQuery,
     BaseVersionAndTaskQueryVariables
@@ -53,9 +50,6 @@ export const useBreakingTask = (taskId: string) => {
         ...bvOptionsBase,
         statuses: [TaskStatus.Failed],
       },
-    },
-    onError: (err) => {
-      dispatchToast.error(`Breaking commit unavailable: '${err.message}'`);
     },
   });
   const task = getTaskFromMainlineCommitsQuery(breakingTaskData);

--- a/apps/spruce/src/hooks/useBreakingTask/useBreakingTask.test.tsx
+++ b/apps/spruce/src/hooks/useBreakingTask/useBreakingTask.test.tsx
@@ -58,7 +58,9 @@ describe("useBreakingTask", () => {
         }),
     });
 
-    expect(result.current.task).toBeUndefined();
+    await waitFor(() => {
+      expect(result.current.task).toBeUndefined();
+    });
   });
 });
 

--- a/apps/spruce/src/hooks/useBreakingTask/useBreakingTask.test.tsx
+++ b/apps/spruce/src/hooks/useBreakingTask/useBreakingTask.test.tsx
@@ -1,5 +1,4 @@
 import { MockedProvider, MockedProviderProps } from "@apollo/client/testing";
-import { RenderFakeToastContext } from "context/toast/__mocks__";
 import {
   BaseVersionAndTaskQuery,
   BaseVersionAndTaskQueryVariables,
@@ -21,20 +20,13 @@ const ProviderWrapper: React.FC<ProviderProps> = ({ children, mocks = [] }) => (
 
 describe("useBreakingTask", () => {
   it("no breaking task is found when task is not found", () => {
-    const { dispatchToast } = RenderFakeToastContext();
-
     const { result } = renderHook(() => useBreakingTask("t1"), {
       wrapper: ({ children }) => ProviderWrapper({ children }),
     });
 
     expect(result.current.task).toBeUndefined();
-
-    // No error is dispatched when the task is not found.
-    expect(dispatchToast.error).toHaveBeenCalledTimes(0);
   });
   it("a breaking task is found when there is a previous failing task", async () => {
-    const { dispatchToast } = RenderFakeToastContext();
-
     const { result } = renderHook(() => useBreakingTask("t1"), {
       wrapper: ({ children }) =>
         ProviderWrapper({
@@ -52,13 +44,8 @@ describe("useBreakingTask", () => {
     });
 
     expect(result.current.task.id).toBe("breaking_commit");
-
-    // No error is dispatched for success scenarios.
-    expect(dispatchToast.error).toHaveBeenCalledTimes(0);
   });
-  it("a breaking task is not found due to an error in the query and a toast is dispatched", async () => {
-    const { dispatchToast } = RenderFakeToastContext();
-
+  it("a breaking task is not found due to an error in the query", async () => {
     const { result } = renderHook(() => useBreakingTask("t1"), {
       wrapper: ({ children }) =>
         ProviderWrapper({
@@ -69,11 +56,6 @@ describe("useBreakingTask", () => {
             getBreakingCommitWithError,
           ],
         }),
-    });
-
-    await waitFor(() => {
-      // An error is dispatched when the query fails.
-      expect(dispatchToast.error).toHaveBeenCalledTimes(1);
     });
 
     expect(result.current.task).toBeUndefined();

--- a/apps/spruce/src/hooks/useLastExecutedTask/index.ts
+++ b/apps/spruce/src/hooks/useLastExecutedTask/index.ts
@@ -1,6 +1,5 @@
 import { useQuery } from "@apollo/client";
 import { finishedTaskStatuses } from "constants/task";
-import { useToastContext } from "context/toast";
 import {
   BaseVersionAndTaskQuery,
   BaseVersionAndTaskQueryVariables,
@@ -14,7 +13,6 @@ import { getTaskFromMainlineCommitsQuery } from "utils/getTaskFromMainlineCommit
 import { isFinishedTaskStatus } from "utils/statuses";
 
 export const useLastExecutedTask = (taskId: string) => {
-  const dispatchToast = useToastContext();
   const { data: taskData } = useQuery<
     BaseVersionAndTaskQuery,
     BaseVersionAndTaskQueryVariables
@@ -45,11 +43,6 @@ export const useLastExecutedTask = (taskId: string) => {
         ...bvOptionsBase,
         statuses: finishedTaskStatuses,
       },
-    },
-    onError: (err) => {
-      dispatchToast.error(
-        `Could not fetch last task execution: '${err.message}'`,
-      );
     },
   });
   const task = getTaskFromMainlineCommitsQuery(lastExecutedTaskData);

--- a/apps/spruce/src/hooks/useLastExecutedTask/useLastExecutedTask.test.tsx
+++ b/apps/spruce/src/hooks/useLastExecutedTask/useLastExecutedTask.test.tsx
@@ -53,7 +53,9 @@ describe("useLastExecutedTask", () => {
         }),
     });
 
-    expect(result.current.task).toBeUndefined();
+    await waitFor(() => {
+      expect(result.current.task).toBeUndefined();
+    });
   });
 });
 

--- a/apps/spruce/src/hooks/useLastExecutedTask/useLastExecutedTask.test.tsx
+++ b/apps/spruce/src/hooks/useLastExecutedTask/useLastExecutedTask.test.tsx
@@ -1,5 +1,4 @@
 import { MockedProvider, MockedProviderProps } from "@apollo/client/testing";
-import { RenderFakeToastContext } from "context/toast/__mocks__";
 import {
   BaseVersionAndTaskQuery,
   BaseVersionAndTaskQueryVariables,
@@ -21,20 +20,13 @@ const ProviderWrapper: React.FC<ProviderProps> = ({ children, mocks = [] }) => (
 
 describe("useLastExecutedTask", () => {
   it("no last executed task is found when task is not found", () => {
-    const { dispatchToast } = RenderFakeToastContext();
-
     const { result } = renderHook(() => useLastExecutedTask("t1"), {
       wrapper: ({ children }) => ProviderWrapper({ children }),
     });
 
     expect(result.current.task).toBeUndefined();
-
-    // No error is dispatched when the task is not found.
-    expect(dispatchToast.error).toHaveBeenCalledTimes(0);
   });
   it("a last executed task is found", async () => {
-    const { dispatchToast } = RenderFakeToastContext();
-
     const { result } = renderHook(() => useLastExecutedTask("t1"), {
       wrapper: ({ children }) =>
         ProviderWrapper({
@@ -48,13 +40,8 @@ describe("useLastExecutedTask", () => {
     });
 
     expect(result.current.task.id).toBe("last_executed_task");
-
-    // No error is dispatched for success scenarios.
-    expect(dispatchToast.error).toHaveBeenCalledTimes(0);
   });
-  it("a last executed task is not found due to an error in the query and a toast is dispatched", async () => {
-    const { dispatchToast } = RenderFakeToastContext();
-
+  it("a last executed task is not found due to an error in the query", async () => {
     const { result } = renderHook(() => useLastExecutedTask("t1"), {
       wrapper: ({ children }) =>
         ProviderWrapper({
@@ -64,11 +51,6 @@ describe("useLastExecutedTask", () => {
             getLastExecutedVersionWithError,
           ],
         }),
-    });
-
-    await waitFor(() => {
-      // An error is dispatched when the query fails.
-      expect(dispatchToast.error).toHaveBeenCalledTimes(1);
     });
 
     expect(result.current.task).toBeUndefined();

--- a/apps/spruce/src/hooks/useLastPassingTask/index.ts
+++ b/apps/spruce/src/hooks/useLastPassingTask/index.ts
@@ -1,5 +1,4 @@
 import { useQuery } from "@apollo/client";
-import { useToastContext } from "context/toast";
 import {
   BaseVersionAndTaskQuery,
   BaseVersionAndTaskQueryVariables,
@@ -13,8 +12,6 @@ import { string } from "utils";
 import { getTaskFromMainlineCommitsQuery } from "utils/getTaskFromMainlineCommitsQuery";
 
 export const useLastPassingTask = (taskId: string) => {
-  const dispatchToast = useToastContext();
-
   const { data: taskData } = useQuery<
     BaseVersionAndTaskQuery,
     BaseVersionAndTaskQueryVariables
@@ -45,9 +42,6 @@ export const useLastPassingTask = (taskId: string) => {
         ...bvOptionsBase,
         statuses: [TaskStatus.Succeeded],
       },
-    },
-    onError: (err) => {
-      dispatchToast.error(`Last passing version unavailable: '${err.message}'`);
     },
   });
   const task = getTaskFromMainlineCommitsQuery(lastPassingTaskData);

--- a/apps/spruce/src/hooks/useLastPassingTask/useLastPassingTask.test.tsx
+++ b/apps/spruce/src/hooks/useLastPassingTask/useLastPassingTask.test.tsx
@@ -54,7 +54,9 @@ describe("useLastPassingTask", () => {
         }),
     });
 
-    expect(result.current.task).toBeUndefined();
+    await waitFor(() => {
+      expect(result.current.task).toBeUndefined();
+    });
   });
 });
 

--- a/apps/spruce/src/hooks/useLastPassingTask/useLastPassingTask.test.tsx
+++ b/apps/spruce/src/hooks/useLastPassingTask/useLastPassingTask.test.tsx
@@ -1,5 +1,5 @@
 import { MockedProvider, MockedProviderProps } from "@apollo/client/testing";
-import { RenderFakeToastContext } from "context/toast/__mocks__";
+
 import {
   BaseVersionAndTaskQuery,
   BaseVersionAndTaskQueryVariables,
@@ -21,20 +21,13 @@ const ProviderWrapper: React.FC<ProviderProps> = ({ children, mocks = [] }) => (
 
 describe("useLastPassingTask", () => {
   it("no last passing task is found when task is not found", () => {
-    const { dispatchToast } = RenderFakeToastContext();
-
     const { result } = renderHook(() => useLastPassingTask("t1"), {
       wrapper: ({ children }) => ProviderWrapper({ children }),
     });
 
     expect(result.current.task).toBeUndefined();
-
-    // No error is dispatched when the task is not found.
-    expect(dispatchToast.error).toHaveBeenCalledTimes(0);
   });
   it("a last passing task is found", async () => {
-    const { dispatchToast } = RenderFakeToastContext();
-
     const { result } = renderHook(() => useLastPassingTask("t1"), {
       wrapper: ({ children }) =>
         ProviderWrapper({
@@ -48,13 +41,8 @@ describe("useLastPassingTask", () => {
     });
 
     expect(result.current.task.id).toBe("last_passing_task");
-
-    // No error is dispatched for success scenarios.
-    expect(dispatchToast.error).toHaveBeenCalledTimes(0);
   });
-  it("a last passing task is not found due to an error in the query and a toast is dispatched", async () => {
-    const { dispatchToast } = RenderFakeToastContext();
-
+  it("a last passing task is not found due to an error in the query", async () => {
     const { result } = renderHook(() => useLastPassingTask("t1"), {
       wrapper: ({ children }) =>
         ProviderWrapper({
@@ -64,11 +52,6 @@ describe("useLastPassingTask", () => {
             getLastPassingVersionWithError,
           ],
         }),
-    });
-
-    await waitFor(() => {
-      // An error is dispatched when the query fails.
-      expect(dispatchToast.error).toHaveBeenCalledTimes(1);
     });
 
     expect(result.current.task).toBeUndefined();

--- a/apps/spruce/src/hooks/useLastPassingTask/useLastPassingTask.test.tsx
+++ b/apps/spruce/src/hooks/useLastPassingTask/useLastPassingTask.test.tsx
@@ -1,5 +1,4 @@
 import { MockedProvider, MockedProviderProps } from "@apollo/client/testing";
-
 import {
   BaseVersionAndTaskQuery,
   BaseVersionAndTaskQueryVariables,


### PR DESCRIPTION
DEVPROD-4265

### Description
I think we should just remove these toasts. It's confusing to discern their origin because they're hidden within the previous commits selector. 

The options in the previous commits selector will be disabled is there's no commit to navigate to, and I think that is enough of a signal for now.

It's also the cause of many other problem tickets:
* [DEVPROD-3492](https://jira.mongodb.org/browse/DEVPROD-3492)
* [DEVPROD-5909](https://jira.mongodb.org/browse/DEVPROD-5909)

### Testing
* Updated tests