### PR TITLE
DEVPROD-795 Fix search input validation on PatchesPage

### DIFF
--- a/apps/spruce/cypress/integration/myPatches/my_patches.ts
+++ b/apps/spruce/cypress/integration/myPatches/my_patches.ts
@@ -34,9 +34,7 @@ describe("My Patches Page", () => {
   it("Typing in patch description input updates the url, requests patches and renders patches", () => {
     cy.visit(MY_PATCHES_ROUTE);
     const inputVal = "testtest";
-    cy.dataCy("patch-description-input").within(() => {
-      cy.get("input").type(inputVal);
-    });
+    cy.dataCy("patch-description-input").type(inputVal);
     urlSearchParamsAreUpdated({
       pathname: MY_PATCHES_ROUTE,
       paramName: "patchName",
@@ -47,27 +45,19 @@ describe("My Patches Page", () => {
       paramName: "page",
       search: 0,
     });
-    cy.dataCy("patch-description-input").within(() => {
-      cy.get("input").clear();
-    });
+    cy.dataCy("patch-description-input").clear();
   });
 
   it("Inputting a number successfully searches patches", () => {
     cy.visit(MY_PATCHES_ROUTE);
-    cy.dataCy("patch-description-input").within(() => {
-      cy.get("input").type("3186");
-    });
+    cy.dataCy("patch-description-input").type("3186");
     cy.dataCy("patch-card").should("have.length", "1");
-    cy.dataCy("patch-description-input").within(() => {
-      cy.get("input").clear();
-    });
+    cy.dataCy("patch-description-input").clear();
   });
 
   it("Searching for a nonexistent patch shows 'No patches found'", () => {
     cy.visit(MY_PATCHES_ROUTE);
-    cy.dataCy("patch-description-input").within(() => {
-      cy.get("input").type("satenarstharienht");
-    });
+    cy.dataCy("patch-description-input").type("satenarstharienht");
     cy.dataCy("no-patches-found").contains("No patches found");
   });
 

--- a/apps/spruce/src/components/PatchesPage/index.tsx
+++ b/apps/spruce/src/components/PatchesPage/index.tsx
@@ -108,6 +108,7 @@ export const PatchesPage: React.FC<Props> = ({
           onChange={(value) => setAndSubmitInputValue(value)}
           data-cy="patch-description-input"
           validator={validateRegexp}
+          validatorErrorMessage="Invalid regex"
         />
         <StatusSelector />
         {filterComp}

--- a/apps/spruce/src/components/PatchesPage/index.tsx
+++ b/apps/spruce/src/components/PatchesPage/index.tsx
@@ -1,6 +1,5 @@
 import styled from "@emotion/styled";
 import Checkbox from "@leafygreen-ui/checkbox";
-import { SearchInput } from "@leafygreen-ui/search-input";
 import Cookies from "js-cookie";
 import { Analytics } from "analytics/addPageAction";
 import PageSizeSelector, {
@@ -8,6 +7,7 @@ import PageSizeSelector, {
 } from "components/PageSizeSelector";
 import Pagination from "components/Pagination";
 import { PageWrapper, FiltersWrapper, PageTitle } from "components/styles";
+import TextInputWithValidation from "components/TextInputWithValidation";
 import {
   INCLUDE_COMMIT_QUEUE_PROJECT_PATCHES,
   INCLUDE_COMMIT_QUEUE_USER_PATCHES,
@@ -18,6 +18,7 @@ import { PatchesPagePatchesFragment } from "gql/generated/types";
 import { useFilterInputChangeHandler, usePageTitle } from "hooks";
 import { useQueryParam } from "hooks/useQueryParam";
 import { PatchPageQueryParams } from "types/patch";
+import { validateRegexp } from "utils/validators";
 import { ListArea } from "./ListArea";
 import { StatusSelector } from "./StatusSelector";
 import { usePatchesQueryParams } from "./usePatchesQueryParams";
@@ -65,7 +66,7 @@ export const PatchesPage: React.FC<Props> = ({
       Cookies.get(INCLUDE_HIDDEN_PATCHES) === "true",
     );
   const { limit, page } = usePatchesQueryParams();
-  const { inputValue, setAndSubmitInputValue } = useFilterInputChangeHandler({
+  const { setAndSubmitInputValue } = useFilterInputChangeHandler({
     urlParam: PatchPageQueryParams.PatchName,
     resetPage: true,
     sendAnalyticsEvent: (filterBy: string) =>
@@ -101,12 +102,12 @@ export const PatchesPage: React.FC<Props> = ({
     <PageWrapper>
       <PageTitle data-cy="patches-page-title">{pageTitle}</PageTitle>
       <FiltersWrapperSpaceBetween hasAdditionalFilterComp={!!filterComp}>
-        <SearchInput
+        <TextInputWithValidation
           aria-label="Search patch descriptions"
           placeholder="Patch description regex"
-          onChange={(e) => setAndSubmitInputValue(e.target.value)}
-          value={inputValue}
+          onChange={(value) => setAndSubmitInputValue(value)}
           data-cy="patch-description-input"
+          validator={validateRegexp}
         />
         <StatusSelector />
         {filterComp}


### PR DESCRIPTION
DEVPROD-795

### Description
Adds regex validation on the patches page search input

### Screenshots
<img width="364" alt="image" src="https://github.com/evergreen-ci/ui/assets/4605522/e3487ac6-9de3-4058-8a98-d132aa8575a7">

