### PR TITLE
DEVPROD-6782: Update container events table

### DIFF
--- a/apps/spruce/cypress/integration/container/container_events.ts
+++ b/apps/spruce/cypress/integration/container/container_events.ts
@@ -73,4 +73,4 @@ describe("Container events", () => {
   });
 });
 
-const allRows = "[data-cy=container-events] > tbody > tr";
+const allRows = "[data-cy=container-events-table] > tbody > tr";

--- a/apps/spruce/src/pages/container/EventsTable/EventCopy.tsx
+++ b/apps/spruce/src/pages/container/EventsTable/EventCopy.tsx
@@ -6,9 +6,13 @@ import { Unpacked } from "types/utils";
 import { reportError } from "utils/errorReporting";
 
 interface EventCopyProps {
+  "data-cy": string;
   event: Unpacked<PodEventsQuery["pod"]["events"]["eventLogEntries"]>;
 }
-export const EventCopy: React.FC<EventCopyProps> = ({ event }) => {
+export const EventCopy: React.FC<EventCopyProps> = ({
+  "data-cy": dataCy,
+  event,
+}) => {
   const { data, eventType } = event;
   const taskLink = (
     <ShortenedRouterLink
@@ -21,21 +25,21 @@ export const EventCopy: React.FC<EventCopyProps> = ({ event }) => {
   switch (eventType) {
     case PodEvent.StatusChange:
       return (
-        <span>
+        <span data-cy={dataCy}>
           Container status changed from <b>{data?.oldStatus}</b> to{" "}
           <b>{data?.newStatus}</b>.
         </span>
       );
     case PodEvent.ContainerTaskFinished:
       return (
-        <span>
+        <span data-cy={dataCy}>
           Task {taskLink} finished with status <b>{data?.taskStatus}</b>.
         </span>
       );
     case PodEvent.ClearedTask:
-      return <span>Task {taskLink} cleared.</span>;
+      return <span data-cy={dataCy}>Task {taskLink} cleared.</span>;
     case PodEvent.AssignedTask:
-      return <span>Task {taskLink} assigned.</span>;
+      return <span data-cy={dataCy}>Task {taskLink} assigned.</span>;
     default:
       reportError(
         new Error(`Unrecognized pod event type: ${eventType}`),

--- a/apps/spruce/src/pages/container/EventsTable/index.tsx
+++ b/apps/spruce/src/pages/container/EventsTable/index.tsx
@@ -65,10 +65,9 @@ const EventsTable: React.FC<{}> = () => {
       },
       {
         header: "Event",
-        accessorKey: "eventType",
-        cell: ({ getValue, row }) => (
+        cell: ({ row }) => (
           <EventCopy
-            data-cy={`event-type-${getValue()}`}
+            data-cy={`event-type-${row.original.eventType}`}
             event={row.original}
           />
         ),

--- a/apps/spruce/src/pages/container/EventsTable/index.tsx
+++ b/apps/spruce/src/pages/container/EventsTable/index.tsx
@@ -57,12 +57,21 @@ const EventsTable: React.FC<{}> = () => {
       {
         header: "Date",
         accessorKey: "timestamp",
-        cell: ({ getValue }) => getDateCopy(getValue() as Date),
+        cell: ({ getValue, row }) => (
+          <span data-cy={`${row.original.eventType}-time`}>
+            {getDateCopy(getValue() as Date)}
+          </span>
+        ),
       },
       {
         header: "Event",
         accessorKey: "eventType",
-        cell: ({ row }) => <EventCopy event={row.original} />,
+        cell: ({ getValue, row }) => (
+          <EventCopy
+            data-cy={`event-type-${getValue()}`}
+            event={row.original}
+          />
+        ),
       },
     ],
     [getDateCopy],


### PR DESCRIPTION
DEVPROD-6782

### Description
Stop using V11 adapter for this table. Note that V11 adapter cannot be removed from the codebase because it is still being used for the EventDiff table.

### Screenshots
<img width="984" alt="Screenshot 2024-05-02 at 11 17 15 AM" src="https://github.com/evergreen-ci/ui/assets/47064971/e64c3b2b-83e4-4093-ada1-ca3665a2572c">


### Testing
* Update Cypress test
