### PR TITLE
DEVPROD-2985: Quiet mongodump

### DIFF
--- a/scripts/evg-db-ops.sh
+++ b/scripts/evg-db-ops.sh
@@ -29,7 +29,7 @@ reseed_database() {
 dump_database() {
     clean_up
     # Use 'mongodump' to create a database dump.
-    if ! mongodump --uri="$URI" -o "$DUMP_ROOT"; then
+    if ! mongodump --quiet --uri="$URI" -o "$DUMP_ROOT"; then
         echo "Error creating dump from $DB_NAME db."
         exit 1
     fi


### PR DESCRIPTION
DEVPROD-2985

### Description
<!-- add description, context, thought process, etc -->
Add `--quiet` to `mongodump` invocation. The `mongorestore` call already includes it.

This doesn't really make a difference in the log length because the evergreen server is still pretty noisy around these operations, but oh well 🤷‍♀️ 