### PR TITLE
DEVPROD-1131 Add confirmation dialog when clearing all bookmarks in Parsley

### DIFF
--- a/apps/parsley/src/components/BookmarksBar/BookmarksBar.test.tsx
+++ b/apps/parsley/src/components/BookmarksBar/BookmarksBar.test.tsx
@@ -76,6 +76,10 @@ describe("bookmarks bar", () => {
       },
     );
     await user.click(screen.getByDataCy("clear-bookmarks"));
+    expect(
+      screen.queryByText("Are you sure you want to clear all bookmarks?"),
+    ).toBeVisible();
+    await user.click(screen.getByRole("button", { name: "Yes" }));
     expect(router.state.location.search).toBe("?shareLine=5");
   });
 

--- a/apps/parsley/src/components/BookmarksBar/index.tsx
+++ b/apps/parsley/src/components/BookmarksBar/index.tsx
@@ -1,10 +1,11 @@
-import { useEffect } from "react";
+import { useEffect, useRef, useState } from "react";
 import styled from "@emotion/styled";
 import Button from "@leafygreen-ui/button";
 import { palette } from "@leafygreen-ui/palette";
 import Tooltip from "@leafygreen-ui/tooltip";
 import { useLogWindowAnalytics } from "analytics";
 import Icon from "components/Icon";
+import Popconfirm from "components/Popconfirm";
 import { QueryParams } from "constants/queryParams";
 import { size, zIndex } from "constants/tokens";
 import { useQueryParam } from "hooks/useQueryParam";
@@ -27,6 +28,9 @@ const BookmarksBar: React.FC<BookmarksBarProps> = ({
 }) => {
   const { sendEvent } = useLogWindowAnalytics();
 
+  const clearButtonRef = useRef(null);
+  const [clearButtonConfirmationOpen, setClearButtonConfirmationOpen] =
+    useState(false);
   const [shareLine] = useQueryParam<number | undefined>(
     QueryParams.ShareLine,
     undefined,
@@ -61,15 +65,24 @@ const BookmarksBar: React.FC<BookmarksBarProps> = ({
 
   return (
     <Container>
+      <Popconfirm
+        onConfirm={() => {
+          setBookmarks([]);
+          sendEvent({ name: "Cleared All Bookmarks" });
+        }}
+        open={clearButtonConfirmationOpen}
+        refEl={clearButtonRef}
+        setOpen={setClearButtonConfirmationOpen}
+      >
+        <div>Are you sure you want to clear all bookmarks?</div>
+      </Popconfirm>
       <Tooltip
         popoverZIndex={zIndex.tooltip}
         trigger={
           <StyledButton
+            ref={clearButtonRef}
             data-cy="clear-bookmarks"
-            onClick={() => {
-              setBookmarks([]);
-              sendEvent({ name: "Cleared All Bookmarks" });
-            }}
+            onClick={() => setClearButtonConfirmationOpen(true)}
             size="xsmall"
           >
             Clear

--- a/apps/parsley/src/components/Popconfirm/Popconfirm.test.tsx
+++ b/apps/parsley/src/components/Popconfirm/Popconfirm.test.tsx
@@ -1,0 +1,77 @@
+import { renderWithRouterMatch as render, screen, userEvent } from "test_utils";
+import Popconfirm from ".";
+
+describe("controlled popconfirm", () => {
+  it("properly shows content inside the popconfirm", () => {
+    render(
+      <Popconfirm confirmText="OK" open setOpen={jest.fn()}>
+        <div>hello</div>
+      </Popconfirm>,
+    );
+    expect(screen.getByText("hello")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "OK" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
+  });
+
+  it("pressing the Confirm button calls the onConfirm callback and closes the popconfirm", async () => {
+    const user = userEvent.setup();
+    const onConfirm = jest.fn();
+    const setOpen = jest.fn();
+    render(
+      <Popconfirm onConfirm={onConfirm} open setOpen={setOpen}>
+        <div>hello</div>
+      </Popconfirm>,
+    );
+    await user.click(screen.getByRole("button", { name: "Yes" }));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    expect(setOpen).toHaveBeenCalledTimes(1);
+    expect(setOpen).toHaveBeenCalledWith(false);
+  });
+
+  it("pressing the Cancel button calls the onClose callback and closes the popconfirm", async () => {
+    const user = userEvent.setup();
+    const onClose = jest.fn();
+    const setOpen = jest.fn();
+    render(
+      <Popconfirm onClose={onClose} open setOpen={setOpen}>
+        <div>hello</div>
+      </Popconfirm>,
+    );
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(setOpen).toHaveBeenCalledTimes(1);
+    expect(setOpen).toHaveBeenCalledWith(false);
+  });
+
+  it("disables the confirm button when confirmDisabled is true", () => {
+    render(
+      <Popconfirm confirmDisabled onClose={jest.fn()} open setOpen={jest.fn()}>
+        <div>hello</div>
+      </Popconfirm>,
+    );
+    expect(screen.getByRole("button", { name: "Yes" })).toHaveAttribute(
+      "aria-disabled",
+      "true",
+    );
+  });
+});
+
+describe("uncontrolled popconfirm", () => {
+  it("uses a trigger to open and close the component", async () => {
+    const user = userEvent.setup();
+    const onClose = jest.fn();
+    render(
+      <Popconfirm
+        onClose={onClose}
+        trigger={<button type="button">Open</button>}
+      >
+        <div>hello</div>
+      </Popconfirm>,
+    );
+    await user.click(screen.getByRole("button", { name: "Open" }));
+    expect(screen.getByText("hello")).toBeVisible();
+    await user.click(screen.getByRole("button", { name: "Open" }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(screen.getByText("hello")).not.toBeVisible();
+  });
+});

--- a/apps/parsley/src/components/Popconfirm/index.tsx
+++ b/apps/parsley/src/components/Popconfirm/index.tsx
@@ -1,0 +1,93 @@
+import { useRef, useState } from "react";
+import styled from "@emotion/styled";
+import Button from "@leafygreen-ui/button";
+import Tooltip, { TooltipProps } from "@leafygreen-ui/tooltip";
+import { wordBreakCss } from "components/styles";
+import { size, zIndex } from "constants/tokens";
+import { useOnClickOutside } from "hooks";
+
+type PopconfirmProps = TooltipProps & {
+  confirmDisabled?: boolean;
+  confirmText?: string;
+  "data-cy"?: string;
+  onConfirm?: (e?: React.MouseEvent) => void;
+  children: React.ReactNode;
+};
+
+const Popconfirm: React.FC<PopconfirmProps> = ({
+  children,
+  confirmDisabled = false,
+  confirmText = "Yes",
+  onClose = () => {},
+  onConfirm = () => {},
+  open: controlledOpen,
+  refEl,
+  setOpen: controlledSetOpen,
+  ...props
+}) => {
+  const isControlled = !!(controlledOpen !== undefined && controlledSetOpen);
+  const [uncontrolledOpen, uncontrolledSetOpen] = useState(false);
+  const open = isControlled ? controlledOpen : uncontrolledOpen;
+  const setOpen = isControlled ? controlledSetOpen : uncontrolledSetOpen;
+
+  const popoverRef = useRef<HTMLDivElement>(null);
+  useOnClickOutside([popoverRef, ...(refEl ? [refEl] : [])], () => {
+    onClose();
+    setOpen(false);
+  });
+
+  return (
+    <Tooltip
+      onClose={onClose}
+      open={open}
+      popoverZIndex={zIndex.popover}
+      refEl={refEl}
+      setOpen={setOpen}
+      triggerEvent="click"
+      {...props}
+    >
+      <ContentWrapper ref={popoverRef}>
+        {children}
+        <ButtonWrapper>
+          <Button
+            onClick={() => {
+              onClose();
+              setOpen(false);
+            }}
+            size="small"
+          >
+            Cancel
+          </Button>
+          <Button
+            disabled={confirmDisabled}
+            onClick={(e) => {
+              onConfirm(e);
+              setOpen(false);
+            }}
+            size="small"
+            variant="primary"
+          >
+            {confirmText}
+          </Button>
+        </ButtonWrapper>
+      </ContentWrapper>
+    </Tooltip>
+  );
+};
+
+const ContentWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${size.xs};
+
+  ${wordBreakCss}
+`;
+
+const ButtonWrapper = styled.div`
+  display: flex;
+  align-self: flex-end;
+  margin-top: ${size.xs};
+  gap: ${size.xxs};
+`;
+
+export default Popconfirm;


### PR DESCRIPTION
DEVPROD-1131

### Description
Adds a confirmation dialog for clearing bookmarks. 
Featuring a guest appearance from the PopConfirm component in Spruce!
### Screenshots
<img width="420" alt="image" src="https://github.com/evergreen-ci/ui/assets/4605522/62033016-918f-4098-9a07-f2ce00dd49c1">

### Testing
Updated unit tests 
