### PR TITLE
DEVPROD-4665 Disable performance plugin selection at repo level

### DIFF
--- a/apps/spruce/src/pages/projectSettings/tabs/PluginsTab/PluginsTab.tsx
+++ b/apps/spruce/src/pages/projectSettings/tabs/PluginsTab/PluginsTab.tsx
@@ -21,6 +21,7 @@ export const PluginsTab: React.FC<TabProps> = ({
   const formSchema = useMemo(
     () =>
       getFormSchema(
+        projectType === ProjectType.Repo,
         jiraEmail,
         projectType === ProjectType.AttachedProject ? repoData : null,
       ),

--- a/apps/spruce/src/pages/projectSettings/tabs/PluginsTab/getFormSchema.tsx
+++ b/apps/spruce/src/pages/projectSettings/tabs/PluginsTab/getFormSchema.tsx
@@ -32,6 +32,7 @@ const requesters = [
 ];
 
 export const getFormSchema = (
+  isRepo: boolean,
   jiraEmail?: string,
   repoData?: PluginsFormState,
 ): ReturnType<GetFormSchema> => ({
@@ -225,8 +226,8 @@ export const getFormSchema = (
       "ui:ObjectFieldTemplate": CardFieldTemplate,
       perfEnabled: {
         "ui:widget": widgets.RadioBoxWidget,
-        "ui:description":
-          "Enable the performance plugin (this requires the project to have matching ID and identifier).",
+        "ui:disabled": isRepo,
+        "ui:description": `Enable the performance plugin (this requires the project to have matching ID and identifier). ${isRepo && "This setting is disabled at the repo level."}`,
       },
     },
     buildBaronSettings: {


### PR DESCRIPTION
DEVPROD-4665 

### Description
Disables the ability to toggle performance plugin settings when looking at a repo
### Screenshots
<img width="698" alt="image" src="https://github.com/evergreen-ci/ui/assets/4605522/9587f73d-d11b-42e5-ba6c-744a4e43c415">

