### PR TITLE
DEVPROD-4268: Add link to GitHub merge queue in patch metadata

### DIFF
--- a/apps/parsley/cypress/integration/ansiLogs/ansi_logView.ts
+++ b/apps/parsley/cypress/integration/ansiLogs/ansi_logView.ts
@@ -262,15 +262,6 @@ describe("jump to failing log line", () => {
     cy.visit(logLink);
   });
 
-  it("shows guide cue based on cookie", () => {
-    cy.setCookie("has-seen-jump-to-failing-line-guide-cue", "false");
-    cy.dataCy("jump-to-failing-line-guide-cue").should("be.visible");
-
-    cy.setCookie("has-seen-jump-to-failing-line-guide-cue", "true");
-    cy.reload();
-    cy.dataCy("jump-to-failing-line-guide-cue").should("not.exist");
-  });
-
   it("should jump to failing log line based on user setting", () => {
     cy.clickToggle("jump-to-failing-line-toggle", false, "log-viewing");
     cy.reload();

--- a/apps/spruce/src/constants/externalResources.ts
+++ b/apps/spruce/src/constants/externalResources.ts
@@ -60,6 +60,12 @@ export const getGithubCommitUrl = (
   githash: string,
 ) => `https://github.com/${owner}/${repo}/commit/${githash}`;
 
+export const getGithubMergeQueueUrl = (
+  owner: string,
+  repo: string,
+  branch: string,
+) => `https://github.com/${owner}/${repo}/queue/${branch}`;
+
 export const getParsleyTaskLogLink = (
   logType: LogTypes,
   taskId: string,

--- a/apps/spruce/src/constants/patch.ts
+++ b/apps/spruce/src/constants/patch.ts
@@ -1,3 +1,4 @@
 export const commitQueueAlias = "__commit_queue";
 export const commitQueueRequester = "merge_test";
+export const githubMergeRequester = "github_merge_request";
 export const unlinkedPRUsers = new Set(["github_pull_request", "parent_patch"]);

--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -9048,6 +9048,7 @@ export type VersionQuery = {
     project: string;
     projectIdentifier: string;
     repo: string;
+    requester: string;
     revision: string;
     startTime?: Date | null;
     status: string;
@@ -9109,6 +9110,7 @@ export type VersionQuery = {
     } | null;
     projectMetadata?: {
       __typename?: "Project";
+      branch: string;
       id: string;
       owner: string;
       repo: string;

--- a/apps/spruce/src/gql/queries/version.graphql
+++ b/apps/spruce/src/gql/queries/version.graphql
@@ -69,11 +69,13 @@ query Version($id: String!) {
     project
     projectIdentifier
     projectMetadata {
+      branch
       id
       owner
       repo
     }
     repo
+    requester
     revision
     startTime
     status

--- a/apps/spruce/src/pages/version/Metadata.tsx
+++ b/apps/spruce/src/pages/version/Metadata.tsx
@@ -158,8 +158,9 @@ export const Metadata: React.FC<Props> = ({ loading, version }) => {
       {isGithubMergePatch && (
         <MetadataItem>
           <StyledLink
-            href={getGithubMergeQueueUrl(owner, repo, branch)}
             data-cy="github-merge-queue-link"
+            hideExternalIcon={false}
+            href={getGithubMergeQueueUrl(owner, repo, branch)}
           >
             GitHub Merge Queue
           </StyledLink>
@@ -240,12 +241,12 @@ const BaseCommitMetadata: React.FC<BaseCommitMetadataProps> = ({
   onClick,
   revision,
 }) => {
-  const isPending = isGithubMergePatch && !baseVersionId;
+  const isBaseVersionPending = isGithubMergePatch && !baseVersionId;
 
   return (
     <MetadataItem>
       Base commit:{" "}
-      {isPending ? (
+      {isBaseVersionPending ? (
         <InlineCode data-cy="patch-base-commit">
           {shortenGithash(revision)}
         </InlineCode>
@@ -259,7 +260,7 @@ const BaseCommitMetadata: React.FC<BaseCommitMetadataProps> = ({
           {shortenGithash(revision)}
         </InlineCode>
       )}
-      {isPending && " (pending)"}
+      {isBaseVersionPending && " (pending)"}
     </MetadataItem>
   );
 };


### PR DESCRIPTION
DEVPROD-4268

### Description
After speaking to Brian, we can't always link to the base commit for certain patches in the GitHub merge queue. In these cases, we should remove the hyperlink.

Geoff also requested a link to the project's merge queue on GitHub. I showed Geoff the changes and he said they would work for him.

### Screenshots
<!-- add screenshots of visible changes -->
(Should I add an external link icon through `hideExternalIcon`?)

<img width="294" alt="Screenshot 2024-05-02 at 3 09 44 PM" src="https://github.com/evergreen-ci/ui/assets/47064971/23943f1c-1033-4ad4-9e08-a703cd001c7a">

<img width="294" alt="Screenshot 2024-05-02 at 3 11 19 PM" src="https://github.com/evergreen-ci/ui/assets/47064971/c63bb9ad-3214-4f56-bf5a-aebc3f9c4f61">


### Testing
* Test using `yarn prod`
