### PR TITLE
DEVPROD-3606 Add a scrollable container to version restart modal

### DIFF
--- a/apps/spruce/src/components/VersionRestartModal/VersionRestartModal.tsx
+++ b/apps/spruce/src/components/VersionRestartModal/VersionRestartModal.tsx
@@ -202,7 +202,7 @@ const ConfirmationMessage = styled(Body)<BodyProps>`
   padding: ${size.s} 0;
 `;
 
-export const TitleContainer = styled.div`
+const TitleContainer = styled.div`
   margin-top: ${size.s};
 `;
 

--- a/apps/spruce/src/components/VersionRestartModal/VersionTasks.tsx
+++ b/apps/spruce/src/components/VersionRestartModal/VersionTasks.tsx
@@ -57,9 +57,9 @@ const VersionTasks: React.FC<VersionTasksProps> = ({
   ) : null;
 };
 
-// 350px represents the height to subtract to prevent an overflow on the modal
+// 425px represents the height to subtract to prevent an overflow on the modal
 const ContentWrapper = styled.div`
-  max-height: calc(100vh - 350px);
+  max-height: calc(100vh - 425px);
   overflow-y: auto;
 `;
 

--- a/apps/spruce/src/components/VersionRestartModal/VersionTasks.tsx
+++ b/apps/spruce/src/components/VersionRestartModal/VersionTasks.tsx
@@ -1,3 +1,4 @@
+import styled from "@emotion/styled";
 import { Divider } from "components/styles/divider";
 import { TaskStatusFilters } from "components/TaskStatusFilters";
 import { BuildVariantsWithChildrenQuery } from "gql/generated/types";
@@ -37,21 +38,29 @@ const VersionTasks: React.FC<VersionTasksProps> = ({
         selectedBaseStatuses={baseStatusFilterTerm || []}
         selectedStatuses={versionStatusFilterTerm || []}
       />
-      {[...buildVariants]
-        .sort((a, b) => a.displayName.localeCompare(b.displayName))
-        .map((patchBuildVariant) => (
-          <BuildVariantAccordion
-            versionId={versionId}
-            key={`accordion_${patchBuildVariant.variant}`}
-            tasks={patchBuildVariant.tasks}
-            displayName={patchBuildVariant.displayName}
-            selectedTasks={tasks}
-            toggleSelectedTask={toggleSelectedTask}
-          />
-        ))}
-      <Divider />
+      <ContentWrapper>
+        {[...buildVariants]
+          .sort((a, b) => a.displayName.localeCompare(b.displayName))
+          .map((patchBuildVariant) => (
+            <BuildVariantAccordion
+              versionId={versionId}
+              key={`accordion_${patchBuildVariant.variant}`}
+              tasks={patchBuildVariant.tasks}
+              displayName={patchBuildVariant.displayName}
+              selectedTasks={tasks}
+              toggleSelectedTask={toggleSelectedTask}
+            />
+          ))}
+        <Divider />
+      </ContentWrapper>
     </>
   ) : null;
 };
+
+// 350px represents the height to subtract to prevent an overflow on the modal
+const ContentWrapper = styled.div`
+  max-height: calc(100vh - 350px);
+  overflow-y: auto;
+`;
 
 export default VersionTasks;


### PR DESCRIPTION
DEVPROD-3606

### Description
Adds a scrollable container to the restart modal
### Screenshots
<img width="850" alt="image" src="https://github.com/evergreen-ci/ui/assets/4605522/c29eaba1-920d-4ea6-86fb-416c05658fd4">

