### PR TITLE
DEVPROD-4724 Add link to task queue page from distro settings

### DIFF
--- a/apps/spruce/cypress/integration/distroSettings/navigation.ts
+++ b/apps/spruce/cypress/integration/distroSettings/navigation.ts
@@ -13,6 +13,13 @@ describe("using the distro dropdown", () => {
     cy.location("pathname").should("not.contain", "localhost");
     cy.location("pathname").should("contain", "rhel71-power8-large");
   });
+  it("navigates to the task queue for the selected distro", () => {
+    cy.dataCy("navitem-task-queue-link").should(
+      "have.attr",
+      "href",
+      "/task-queue/localhost",
+    );
+  });
 
   describe("warning modal", () => {
     it("warns when navigating away from distro settings with unsaved changes and allows returning to distro settings", () => {

--- a/apps/spruce/src/components/styles/SideNav.tsx
+++ b/apps/spruce/src/components/styles/SideNav.tsx
@@ -1,10 +1,16 @@
 import styled from "@emotion/styled";
+import { palette } from "@leafygreen-ui/palette";
 import {
   SideNav as LGSideNav,
   SideNavItem as LGSideNavItem,
   SideNavGroup as LGSideNavGroup,
 } from "@leafygreen-ui/side-nav";
-import { zIndex } from "constants/tokens";
+import { Body, BodyProps } from "@leafygreen-ui/typography";
+import { Link } from "react-router-dom";
+import Icon from "components/Icon";
+import { zIndex, size } from "constants/tokens";
+
+const { blue } = palette;
 
 export const SideNav = styled(LGSideNav)`
   grid-area: sidenav;
@@ -14,3 +20,29 @@ export const SideNav = styled(LGSideNav)`
 export const SideNavGroup = LGSideNavGroup;
 
 export const SideNavItem = LGSideNavItem;
+
+interface SideNavItemProps
+  extends Omit<React.ComponentProps<typeof LGSideNavItem>, "as"> {
+  to?: string;
+  href?: string;
+  glyph?: React.ReactNode;
+}
+export const SideNavItemLink: React.FC<SideNavItemProps> = ({
+  children,
+  glyph,
+  ...props
+}) => (
+  <StyledSideNavItemLink as={Link} {...props}>
+    <StyledBody weight="medium">{children}</StyledBody>
+    <Icon glyph="ArrowRight" />
+  </StyledSideNavItemLink>
+);
+
+// @ts-expect-error
+const StyledSideNavItemLink = styled(LGSideNavItem)<SideNavItemProps>`
+  color: ${blue.base};
+`;
+const StyledBody = styled(Body)<BodyProps>`
+  color: ${blue.base};
+  margin-right: ${size.xxs};
+`;

--- a/apps/spruce/src/pages/distroSettings/index.tsx
+++ b/apps/spruce/src/pages/distroSettings/index.tsx
@@ -2,15 +2,18 @@ import { useQuery } from "@apollo/client";
 import styled from "@emotion/styled";
 import { sideNavItemSidePadding } from "@leafygreen-ui/side-nav";
 import { useParams, Link, Navigate } from "react-router-dom";
+import Icon from "components/Icon";
 import {
   SideNav,
   SideNavGroup,
   SideNavItem,
   PageWrapper,
 } from "components/styles";
+import { SideNavItemLink } from "components/styles/SideNav";
 import {
   DistroSettingsTabRoutes,
   getDistroSettingsRoute,
+  getTaskQueueRoute,
   slugs,
 } from "constants/routes";
 import { size } from "constants/tokens";
@@ -72,6 +75,14 @@ const DistroSettings: React.FC = () => {
               {getTabTitle(tab).title}
             </SideNavItem>
           ))}
+        </SideNavGroup>
+        <SideNavGroup glyph={<Icon glyph="Link" />} header="Links">
+          <SideNavItemLink
+            to={getTaskQueueRoute(distroId)}
+            data-cy="navitem-task-queue-link"
+          >
+            Task Queue
+          </SideNavItemLink>
         </SideNavGroup>
       </SideNav>
       <PageWrapper data-cy="distro-settings-page">


### PR DESCRIPTION
DEVPROD-4724

### Description
Adds a link to the task queue page from distro settings. cc @minnakt if this location makes sense I based it off of your designs [here](https://www.figma.com/file/f3EEf8eDYgh6tsC9Owkg2M/Image-Visibility-Page?type=design&node-id=465-8844&mode=design&t=zxsD00aysRgAJeOv-0). 

### Screenshots
<img width="290" alt="image" src="https://github.com/evergreen-ci/ui/assets/4605522/5ee88316-067a-437a-8db2-388efb520038">


