### PR TITLE
DEVPROD-7025: Update event diff table

### DIFF
--- a/apps/spruce/src/components/Settings/EventLog/EventDiffTable.tsx
+++ b/apps/spruce/src/components/Settings/EventLog/EventDiffTable.tsx
@@ -73,6 +73,7 @@ const columns: LGColumnDef<EventDiffLine>[] = [
     header: "Property",
     accessorKey: "key",
     cell: ({ getValue }) => <CellText>{getValue() as string}</CellText>,
+    enableSorting: true,
   },
   {
     header: "Before",

--- a/apps/spruce/src/components/Table/BaseTable.tsx
+++ b/apps/spruce/src/components/Table/BaseTable.tsx
@@ -165,7 +165,9 @@ export const BaseTable = forwardRef(
         </StyledTable>
         {!loading &&
           rows.length === 0 &&
-          (emptyComponent || "No data to display")}
+          (emptyComponent || (
+            <DefaultEmptyMessage>No data to display</DefaultEmptyMessage>
+          ))}
       </>
     );
   },
@@ -228,6 +230,10 @@ const RenderableRow = <T extends LGRowData>({
 
 const StyledTable = styled(Table)`
   transition: none !important;
+`;
+
+const DefaultEmptyMessage = styled.span`
+  margin-left: ${size.l};
 `;
 
 const StyledExpandedContent = styled(ExpandedContent)`

--- a/apps/spruce/src/components/Table/__snapshots__/BaseTable.stories.storyshot
+++ b/apps/spruce/src/components/Table/__snapshots__/BaseTable.stories.storyshot
@@ -3,7 +3,7 @@
 exports[`Snapshot Tests BaseTable.stories Default 1`] = `
 <div>
   <div
-    class="leafygreen-ui-1xn4uvd css-1wf6e6y-StyledTable e1bwwd861"
+    class="leafygreen-ui-1xn4uvd css-1wf6e6y-StyledTable e1bwwd862"
     tabindex="0"
   >
     <table
@@ -6738,7 +6738,7 @@ exports[`Snapshot Tests BaseTable.stories Default 1`] = `
 exports[`Snapshot Tests BaseTable.stories EmptyState 1`] = `
 <div>
   <div
-    class="leafygreen-ui-1xn4uvd css-1wf6e6y-StyledTable e1bwwd861"
+    class="leafygreen-ui-1xn4uvd css-1wf6e6y-StyledTable e1bwwd862"
     tabindex="0"
   >
     <table
@@ -6966,14 +6966,18 @@ exports[`Snapshot Tests BaseTable.stories EmptyState 1`] = `
       <tbody />
     </table>
   </div>
-  No data to display
+  <span
+    class="css-2tacef-DefaultEmptyMessage e1bwwd861"
+  >
+    No data to display
+  </span>
 </div>
 `;
 
 exports[`Snapshot Tests BaseTable.stories Loading 1`] = `
 <div>
   <div
-    class="leafygreen-ui-1xn4uvd css-1wf6e6y-StyledTable e1bwwd861"
+    class="leafygreen-ui-1xn4uvd css-1wf6e6y-StyledTable e1bwwd862"
     tabindex="0"
   >
     <table
@@ -7408,7 +7412,7 @@ exports[`Snapshot Tests BaseTable.stories Loading 1`] = `
 exports[`Snapshot Tests BaseTable.stories LongContent 1`] = `
 <div>
   <div
-    class="leafygreen-ui-1xn4uvd css-1wf6e6y-StyledTable e1bwwd861"
+    class="leafygreen-ui-1xn4uvd css-1wf6e6y-StyledTable e1bwwd862"
     tabindex="0"
   >
     <table
@@ -8124,7 +8128,7 @@ exports[`Snapshot Tests BaseTable.stories LongContent 1`] = `
 exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
 <div>
   <div
-    class="leafygreen-ui-1xn4uvd css-1wf6e6y-StyledTable e1bwwd861"
+    class="leafygreen-ui-1xn4uvd css-1wf6e6y-StyledTable e1bwwd862"
     tabindex="0"
   >
     <table
@@ -16407,7 +16411,7 @@ exports[`Snapshot Tests BaseTable.stories NestedRows 1`] = `
 exports[`Snapshot Tests BaseTable.stories VirtualTable 1`] = `
 <div>
   <div
-    class="leafygreen-ui-1xn4uvd leafygreen-ui-13vi68r css-1wf6e6y-StyledTable e1bwwd861"
+    class="leafygreen-ui-1xn4uvd leafygreen-ui-13vi68r css-1wf6e6y-StyledTable e1bwwd862"
     tabindex="0"
   >
     <table

--- a/apps/spruce/src/pages/task/taskTabs/FileTable/GroupedFileTable/__snapshots__/GroupedFileTable.stories.storyshot
+++ b/apps/spruce/src/pages/task/taskTabs/FileTable/GroupedFileTable/__snapshots__/GroupedFileTable.stories.storyshot
@@ -11,7 +11,7 @@ exports[`Snapshot Tests GroupedFileTable.stories DefaultTable 1`] = `
       Task 1
     </h6>
     <div
-      class="leafygreen-ui-1xn4uvd css-1wf6e6y-StyledTable e1bwwd861"
+      class="leafygreen-ui-1xn4uvd css-1wf6e6y-StyledTable e1bwwd862"
       tabindex="0"
     >
       <table

--- a/apps/spruce/src/pages/task/taskTabs/__snapshots__/ExecutionTasksTable.stories.storyshot
+++ b/apps/spruce/src/pages/task/taskTabs/__snapshots__/ExecutionTasksTable.stories.storyshot
@@ -3,7 +3,7 @@
 exports[`Snapshot Tests ExecutionTasksTable.stories MultipleExecutions 1`] = `
 <div>
   <div
-    class="leafygreen-ui-1xn4uvd css-1wf6e6y-StyledTable e1bwwd861"
+    class="leafygreen-ui-1xn4uvd css-1wf6e6y-StyledTable e1bwwd862"
     tabindex="0"
   >
     <table
@@ -340,7 +340,7 @@ exports[`Snapshot Tests ExecutionTasksTable.stories MultipleExecutions 1`] = `
 exports[`Snapshot Tests ExecutionTasksTable.stories SingleExecution 1`] = `
 <div>
   <div
-    class="leafygreen-ui-1xn4uvd css-1wf6e6y-StyledTable e1bwwd861"
+    class="leafygreen-ui-1xn4uvd css-1wf6e6y-StyledTable e1bwwd862"
     tabindex="0"
   >
     <table

--- a/apps/spruce/src/pages/taskQueue/TaskQueueTable/__snapshots__/TaskQueueTable.stories.storyshot
+++ b/apps/spruce/src/pages/taskQueue/TaskQueueTable/__snapshots__/TaskQueueTable.stories.storyshot
@@ -6,7 +6,7 @@ exports[`Snapshot Tests TaskQueueTable.stories Default 1`] = `
     class="leafygreen-ui-1a574ai"
   >
     <div
-      class="leafygreen-ui-1xn4uvd e1hj893t1 css-kcblj1-StyledTable-StyledBaseTable e1bwwd861"
+      class="leafygreen-ui-1xn4uvd e1hj893t1 css-kcblj1-StyledTable-StyledBaseTable e1bwwd862"
       tabindex="0"
     >
       <table

--- a/apps/spruce/src/pages/version/taskDuration/__snapshots__/TaskDurationTable.stories.storyshot
+++ b/apps/spruce/src/pages/version/taskDuration/__snapshots__/TaskDurationTable.stories.storyshot
@@ -3,7 +3,7 @@
 exports[`Snapshot Tests TaskDurationTable.stories Default 1`] = `
 <div>
   <div
-    class="leafygreen-ui-1xn4uvd css-1wf6e6y-StyledTable e1bwwd861"
+    class="leafygreen-ui-1xn4uvd css-1wf6e6y-StyledTable e1bwwd862"
     tabindex="0"
   >
     <table
@@ -1277,7 +1277,7 @@ exports[`Snapshot Tests TaskDurationTable.stories Default 1`] = `
 exports[`Snapshot Tests TaskDurationTable.stories LongContent 1`] = `
 <div>
   <div
-    class="leafygreen-ui-1xn4uvd css-1wf6e6y-StyledTable e1bwwd861"
+    class="leafygreen-ui-1xn4uvd css-1wf6e6y-StyledTable e1bwwd862"
     tabindex="0"
   >
     <table


### PR DESCRIPTION
DEVPROD-7025

### Description
Just one last quick win to remove V11 adapter from the event diff table. I believe this means we no longer have any usage of V11 adapter.

### Screenshots
A nice side effect of this is that things will no longer be cut-off in project & distro events logs:

Before:
<img width="859" alt="Screenshot 2024-05-03 at 2 33 09 PM" src="https://github.com/evergreen-ci/ui/assets/47064971/23afa368-71dc-42bc-9adc-8ff5d014a502">

After:
<img width="827" alt="Screenshot 2024-05-03 at 2 43 36 PM" src="https://github.com/evergreen-ci/ui/assets/47064971/57fd7fca-2b87-4ba2-99cc-ec9a48c4f836">
