### PR TITLE
DEVPROD-3188: Attach additional data to ui.click breadcrumbs in Sentry

### DIFF
--- a/apps/parsley/src/components/BookmarksBar/__snapshots__/BookmarksBar.stories.storyshot
+++ b/apps/parsley/src/components/BookmarksBar/__snapshots__/BookmarksBar.stories.storyshot
@@ -31,7 +31,9 @@ exports[`Snapshot Tests BookmarksBar.stories Default 1`] = `
           class="css-1fmnfd"
           data-cy="bookmark-4"
         >
-          <span>
+          <span
+            data-bookmark="4"
+          >
             4
           </span>
         </div>
@@ -39,7 +41,9 @@ exports[`Snapshot Tests BookmarksBar.stories Default 1`] = `
           class="css-1fmnfd"
           data-cy="bookmark-5"
         >
-          <span>
+          <span
+            data-bookmark="5"
+          >
             5
           </span>
         </div>
@@ -47,7 +51,9 @@ exports[`Snapshot Tests BookmarksBar.stories Default 1`] = `
           class="css-1fmnfd"
           data-cy="bookmark-6"
         >
-          <span>
+          <span
+            data-bookmark="6"
+          >
             6
           </span>
         </div>
@@ -55,7 +61,9 @@ exports[`Snapshot Tests BookmarksBar.stories Default 1`] = `
           class="css-1fmnfd"
           data-cy="bookmark-7"
         >
-          <span>
+          <span
+            data-bookmark="7"
+          >
             7
           </span>
         </div>
@@ -63,7 +71,9 @@ exports[`Snapshot Tests BookmarksBar.stories Default 1`] = `
           class="css-zayph7"
           data-cy="bookmark-10"
         >
-          <span>
+          <span
+            data-bookmark="10"
+          >
             10
           </span>
         </div>
@@ -71,7 +81,9 @@ exports[`Snapshot Tests BookmarksBar.stories Default 1`] = `
           class="css-1fmnfd"
           data-cy="bookmark-21"
         >
-          <span>
+          <span
+            data-bookmark="21"
+          >
             21
           </span>
           <svg
@@ -98,7 +110,9 @@ exports[`Snapshot Tests BookmarksBar.stories Default 1`] = `
           class="css-1fmnfd"
           data-cy="bookmark-24"
         >
-          <span>
+          <span
+            data-bookmark="24"
+          >
             24
           </span>
         </div>
@@ -106,7 +120,9 @@ exports[`Snapshot Tests BookmarksBar.stories Default 1`] = `
           class="css-1fmnfd"
           data-cy="bookmark-30"
         >
-          <span>
+          <span
+            data-bookmark="30"
+          >
             30
           </span>
         </div>
@@ -114,7 +130,9 @@ exports[`Snapshot Tests BookmarksBar.stories Default 1`] = `
           class="css-1fmnfd"
           data-cy="bookmark-85"
         >
-          <span>
+          <span
+            data-bookmark="85"
+          >
             85
           </span>
         </div>

--- a/apps/parsley/src/components/BookmarksBar/index.tsx
+++ b/apps/parsley/src/components/BookmarksBar/index.tsx
@@ -103,7 +103,7 @@ const BookmarksBar: React.FC<BookmarksBarProps> = ({
               scrollToIndex(l);
             }}
           >
-            <span>{l}</span>
+            <span data-bookmark={l}>{l}</span>
             {l === shareLine && <StyledIcon glyph="Link" size="small" />}
           </LogLineNumber>
         ))}

--- a/apps/parsley/src/components/ErrorHandling/Sentry.tsx
+++ b/apps/parsley/src/components/ErrorHandling/Sentry.tsx
@@ -14,6 +14,7 @@ import {
   isProduction,
 } from "utils/environmentVariables";
 import ErrorFallback from "./ErrorFallback";
+import { processHtmlAttributes } from "./utils";
 
 const initializeSentry = () => {
   try {
@@ -21,9 +22,9 @@ const initializeSentry = () => {
       beforeBreadcrumb: (breadcrumb, hint) => {
         if (breadcrumb?.category?.startsWith("ui")) {
           const { target } = hint?.event ?? {};
-          if (target.dataset.cy) {
+          if (target?.dataset?.cy) {
             // eslint-disable-next-line no-param-reassign
-            breadcrumb.message = `${target.tagName.toLowerCase()}[data-cy=${target.dataset.cy}]`;
+            breadcrumb.message = `${target.tagName.toLowerCase()}[data-cy="${target.dataset.cy}"]`;
           }
           // eslint-disable-next-line no-param-reassign
           breadcrumb.data = processHtmlAttributes(target);
@@ -42,17 +43,6 @@ const initializeSentry = () => {
 
 const isInitialized = () => !!getClient();
 
-const processHtmlAttributes = (htmlElement: HTMLElement) => {
-  const { ariaLabel, dataset, title } = htmlElement ?? {};
-  return {
-    ...(ariaLabel && { ariaLabel }),
-    ...(dataset &&
-      Object.keys(dataset).length > 0 && {
-        dataset: htmlElement.dataset,
-      }),
-    ...(title && { title }),
-  };
-};
 export type ErrorInput = {
   err: Error;
   fingerprint?: string[];

--- a/apps/parsley/src/components/ErrorHandling/initialize.test.ts
+++ b/apps/parsley/src/components/ErrorHandling/initialize.test.ts
@@ -29,6 +29,7 @@ describe("should initialize error handlers according to release stage", () => {
     initializeErrorHandling();
 
     expect(Sentry.init).toHaveBeenCalledWith({
+      beforeBreadcrumb: expect.any(Function),
       debug: false,
       dsn: "fake-sentry-key",
       environment: "production",
@@ -43,6 +44,7 @@ describe("should initialize error handlers according to release stage", () => {
     initializeErrorHandling();
 
     expect(Sentry.init).toHaveBeenCalledWith({
+      beforeBreadcrumb: expect.any(Function),
       debug: true,
       dsn: "fake-sentry-key",
       environment: "beta",
@@ -57,6 +59,7 @@ describe("should initialize error handlers according to release stage", () => {
     initializeErrorHandling();
 
     expect(Sentry.init).toHaveBeenCalledWith({
+      beforeBreadcrumb: expect.any(Function),
       debug: true,
       dsn: "fake-sentry-key",
       environment: "staging",

--- a/apps/parsley/src/components/ErrorHandling/utils.test.ts
+++ b/apps/parsley/src/components/ErrorHandling/utils.test.ts
@@ -3,24 +3,24 @@ import { processHtmlAttributes } from "./utils";
 describe("processHtmlAttributes", () => {
   it("properly extracts attributes", () => {
     const htmlElement = document.createElement("input");
-    htmlElement.setAttribute("aria-label", "my-aria-label");
-    htmlElement.setAttribute("title", "my-title");
-    htmlElement.setAttribute("data-cy", "my-data-cy");
+    htmlElement.setAttribute("aria-label", "custom-aria-label");
+    htmlElement.setAttribute("title", "custom-title");
+    htmlElement.setAttribute("data-cy", "custom-data-cy");
     htmlElement.setAttribute("data-loading", "false");
 
     const htmlAttributes = processHtmlAttributes(htmlElement);
-    expect(htmlAttributes.ariaLabel).toBe("my-aria-label");
-    expect(htmlAttributes?.dataset?.cy).toBe("my-data-cy");
+    expect(htmlAttributes.ariaLabel).toBe("custom-aria-label");
+    expect(htmlAttributes?.dataset?.cy).toBe("custom-data-cy");
     expect(htmlAttributes?.dataset?.loading).toBe("false");
-    expect(htmlAttributes.title).toBe("my-title");
+    expect(htmlAttributes.title).toBe("custom-title");
   });
 
   it("omits attributes that are unset", () => {
     const htmlElement = document.createElement("div");
-    htmlElement.setAttribute("data-cy", "my-data-cy");
+    htmlElement.setAttribute("data-cy", "custom-data-cy");
 
     const htmlAttributes = processHtmlAttributes(htmlElement);
-    expect(htmlAttributes?.dataset?.cy).toBe("my-data-cy");
+    expect(htmlAttributes?.dataset?.cy).toBe("custom-data-cy");
     expect(htmlAttributes.ariaLabel).toBeUndefined();
     expect(htmlAttributes.title).toBeUndefined();
   });

--- a/apps/parsley/src/components/ErrorHandling/utils.test.ts
+++ b/apps/parsley/src/components/ErrorHandling/utils.test.ts
@@ -1,0 +1,27 @@
+import { processHtmlAttributes } from "./utils";
+
+describe("processHtmlAttributes", () => {
+  it("properly extracts attributes", () => {
+    const htmlElement = document.createElement("input");
+    htmlElement.setAttribute("aria-label", "my-aria-label");
+    htmlElement.setAttribute("title", "my-title");
+    htmlElement.setAttribute("data-cy", "my-data-cy");
+    htmlElement.setAttribute("data-loading", "false");
+
+    const htmlAttributes = processHtmlAttributes(htmlElement);
+    expect(htmlAttributes.ariaLabel).toBe("my-aria-label");
+    expect(htmlAttributes?.dataset?.cy).toBe("my-data-cy");
+    expect(htmlAttributes?.dataset?.loading).toBe("false");
+    expect(htmlAttributes.title).toBe("my-title");
+  });
+
+  it("omits attributes that are unset", () => {
+    const htmlElement = document.createElement("div");
+    htmlElement.setAttribute("data-cy", "my-data-cy");
+
+    const htmlAttributes = processHtmlAttributes(htmlElement);
+    expect(htmlAttributes?.dataset?.cy).toBe("my-data-cy");
+    expect(htmlAttributes.ariaLabel).toBeUndefined();
+    expect(htmlAttributes.title).toBeUndefined();
+  });
+});

--- a/apps/parsley/src/components/ErrorHandling/utils.ts
+++ b/apps/parsley/src/components/ErrorHandling/utils.ts
@@ -1,3 +1,9 @@
+/**
+ * `processHtmlAttributes` extracts useful attributes to attach as
+ * Sentry breadcrumb data.
+ * @param htmlElement - HTML element detected by Sentry
+ * @returns an object containing attributes of the HTML element
+ */
 const processHtmlAttributes = (htmlElement: HTMLElement) => {
   const ariaLabel = htmlElement.getAttribute("aria-label");
   const title = htmlElement.getAttribute("title");

--- a/apps/parsley/src/components/ErrorHandling/utils.ts
+++ b/apps/parsley/src/components/ErrorHandling/utils.ts
@@ -1,0 +1,13 @@
+const processHtmlAttributes = (htmlElement: HTMLElement) => {
+  const ariaLabel = htmlElement.getAttribute("aria-label");
+  const title = htmlElement.getAttribute("title");
+  // Get dataset directly to handle all data-* attributes.
+  const { dataset } = htmlElement ?? {};
+  return {
+    ...(ariaLabel && { ariaLabel }),
+    ...(dataset && Object.keys(dataset).length > 0 && { dataset }),
+    ...(title && { title }),
+  };
+};
+
+export { processHtmlAttributes };

--- a/apps/parsley/src/gql/generated/types.ts
+++ b/apps/parsley/src/gql/generated/types.ts
@@ -1330,8 +1330,9 @@ export type MutationUpdatePublicKeyArgs = {
 };
 
 export type MutationUpdateSpawnHostStatusArgs = {
-  action: SpawnHostStatusActions;
-  hostId: Scalars["String"]["input"];
+  action?: InputMaybe<SpawnHostStatusActions>;
+  hostId?: InputMaybe<Scalars["String"]["input"]>;
+  updateSpawnHostStatusInput?: InputMaybe<UpdateSpawnHostStatusInput>;
 };
 
 export type MutationUpdateUserSettingsArgs = {
@@ -2919,6 +2920,12 @@ export type UpdateParsleySettingsInput = {
 export type UpdateParsleySettingsPayload = {
   __typename?: "UpdateParsleySettingsPayload";
   parsleySettings?: Maybe<ParsleySettings>;
+};
+
+export type UpdateSpawnHostStatusInput = {
+  action: SpawnHostStatusActions;
+  hostId: Scalars["String"]["input"];
+  shouldKeepOff?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
 /**

--- a/apps/parsley/src/gql/generated/types.ts
+++ b/apps/parsley/src/gql/generated/types.ts
@@ -853,17 +853,6 @@ export type JiraConfig = {
   host?: Maybe<Scalars["String"]["output"]>;
 };
 
-export type JiraField = {
-  __typename?: "JiraField";
-  displayText: Scalars["String"]["output"];
-  field: Scalars["String"]["output"];
-};
-
-export type JiraFieldInput = {
-  displayText: Scalars["String"]["input"];
-  field: Scalars["String"]["input"];
-};
-
 export type JiraIssueSubscriber = {
   __typename?: "JiraIssueSubscriber";
   issueType: Scalars["String"]["output"];
@@ -2600,12 +2589,10 @@ export type TaskTestsArgs = {
 export type TaskAnnotationSettings = {
   __typename?: "TaskAnnotationSettings";
   fileTicketWebhook: Webhook;
-  jiraCustomFields?: Maybe<Array<JiraField>>;
 };
 
 export type TaskAnnotationSettingsInput = {
   fileTicketWebhook?: InputMaybe<WebhookInput>;
-  jiraCustomFields?: InputMaybe<Array<JiraFieldInput>>;
 };
 
 export type TaskContainerCreationOpts = {

--- a/apps/spruce/src/components/ErrorHandling/Sentry.tsx
+++ b/apps/spruce/src/components/ErrorHandling/Sentry.tsx
@@ -10,6 +10,7 @@ import type { Scope, SeverityLevel } from "@sentry/react";
 import type { Context, Primitive } from "@sentry/types";
 import { environmentVariables } from "utils";
 import ErrorFallback from "./ErrorFallback";
+import { processHtmlAttributes } from "./utils";
 
 const { getReleaseStage, getSentryDSN, isProduction } = environmentVariables;
 
@@ -19,9 +20,9 @@ const initializeSentry = () => {
       beforeBreadcrumb: (breadcrumb, hint) => {
         if (breadcrumb?.category?.startsWith("ui")) {
           const { target } = hint?.event ?? {};
-          if (target.dataset.cy) {
+          if (target?.dataset?.cy) {
             // eslint-disable-next-line no-param-reassign
-            breadcrumb.message = `${target.tagName.toLowerCase()}[data-cy=${target.dataset.cy}]`;
+            breadcrumb.message = `${target.tagName.toLowerCase()}[data-cy="${target.dataset.cy}"]`;
           }
           // eslint-disable-next-line no-param-reassign
           breadcrumb.data = processHtmlAttributes(target);
@@ -39,18 +40,6 @@ const initializeSentry = () => {
 };
 
 const isInitialized = () => !!getCurrentHub().getClient();
-
-const processHtmlAttributes = (htmlElement: HTMLElement) => {
-  const { ariaLabel, dataset, title } = htmlElement ?? {};
-  return {
-    ...(ariaLabel && { ariaLabel }),
-    ...(dataset &&
-      Object.keys(dataset).length > 0 && {
-        dataset: htmlElement.dataset,
-      }),
-    ...(title && { title }),
-  };
-};
 
 export type ErrorInput = {
   err: Error;

--- a/apps/spruce/src/components/ErrorHandling/initialize.test.ts
+++ b/apps/spruce/src/components/ErrorHandling/initialize.test.ts
@@ -31,6 +31,7 @@ describe("should initialize error handlers according to release stage", () => {
     initializeErrorHandling();
 
     expect(Sentry.init).toHaveBeenCalledWith({
+      beforeBreadcrumb: expect.any(Function),
       dsn: "fake-sentry-key",
       debug: false,
       normalizeDepth: 5,
@@ -46,6 +47,7 @@ describe("should initialize error handlers according to release stage", () => {
     initializeErrorHandling();
 
     expect(Sentry.init).toHaveBeenCalledWith({
+      beforeBreadcrumb: expect.any(Function),
       dsn: "fake-sentry-key",
       debug: true,
       normalizeDepth: 5,
@@ -61,6 +63,7 @@ describe("should initialize error handlers according to release stage", () => {
     initializeErrorHandling();
 
     expect(Sentry.init).toHaveBeenCalledWith({
+      beforeBreadcrumb: expect.any(Function),
       dsn: "fake-sentry-key",
       debug: true,
       normalizeDepth: 5,

--- a/apps/spruce/src/components/ErrorHandling/utils.test.ts
+++ b/apps/spruce/src/components/ErrorHandling/utils.test.ts
@@ -3,24 +3,24 @@ import { processHtmlAttributes } from "./utils";
 describe("processHtmlAttributes", () => {
   it("properly extracts attributes", () => {
     const htmlElement = document.createElement("input");
-    htmlElement.setAttribute("aria-label", "my-aria-label");
-    htmlElement.setAttribute("title", "my-title");
-    htmlElement.setAttribute("data-cy", "my-data-cy");
+    htmlElement.setAttribute("aria-label", "custom-aria-label");
+    htmlElement.setAttribute("title", "custom-title");
+    htmlElement.setAttribute("data-cy", "custom-data-cy");
     htmlElement.setAttribute("data-loading", "false");
 
     const htmlAttributes = processHtmlAttributes(htmlElement);
-    expect(htmlAttributes.ariaLabel).toBe("my-aria-label");
-    expect(htmlAttributes?.dataset?.cy).toBe("my-data-cy");
+    expect(htmlAttributes.ariaLabel).toBe("custom-aria-label");
+    expect(htmlAttributes?.dataset?.cy).toBe("custom-data-cy");
     expect(htmlAttributes?.dataset?.loading).toBe("false");
-    expect(htmlAttributes.title).toBe("my-title");
+    expect(htmlAttributes.title).toBe("custom-title");
   });
 
   it("omits attributes that are unset", () => {
     const htmlElement = document.createElement("div");
-    htmlElement.setAttribute("data-cy", "my-data-cy");
+    htmlElement.setAttribute("data-cy", "custom-data-cy");
 
     const htmlAttributes = processHtmlAttributes(htmlElement);
-    expect(htmlAttributes?.dataset?.cy).toBe("my-data-cy");
+    expect(htmlAttributes?.dataset?.cy).toBe("custom-data-cy");
     expect(htmlAttributes.ariaLabel).toBeUndefined();
     expect(htmlAttributes.title).toBeUndefined();
   });

--- a/apps/spruce/src/components/ErrorHandling/utils.test.ts
+++ b/apps/spruce/src/components/ErrorHandling/utils.test.ts
@@ -1,0 +1,27 @@
+import { processHtmlAttributes } from "./utils";
+
+describe("processHtmlAttributes", () => {
+  it("properly extracts attributes", () => {
+    const htmlElement = document.createElement("input");
+    htmlElement.setAttribute("aria-label", "my-aria-label");
+    htmlElement.setAttribute("title", "my-title");
+    htmlElement.setAttribute("data-cy", "my-data-cy");
+    htmlElement.setAttribute("data-loading", "false");
+
+    const htmlAttributes = processHtmlAttributes(htmlElement);
+    expect(htmlAttributes.ariaLabel).toBe("my-aria-label");
+    expect(htmlAttributes?.dataset?.cy).toBe("my-data-cy");
+    expect(htmlAttributes?.dataset?.loading).toBe("false");
+    expect(htmlAttributes.title).toBe("my-title");
+  });
+
+  it("omits attributes that are unset", () => {
+    const htmlElement = document.createElement("div");
+    htmlElement.setAttribute("data-cy", "my-data-cy");
+
+    const htmlAttributes = processHtmlAttributes(htmlElement);
+    expect(htmlAttributes?.dataset?.cy).toBe("my-data-cy");
+    expect(htmlAttributes.ariaLabel).toBeUndefined();
+    expect(htmlAttributes.title).toBeUndefined();
+  });
+});

--- a/apps/spruce/src/components/ErrorHandling/utils.ts
+++ b/apps/spruce/src/components/ErrorHandling/utils.ts
@@ -1,3 +1,9 @@
+/**
+ * `processHtmlAttributes` extracts useful attributes to attach as
+ * Sentry breadcrumb data.
+ * @param htmlElement - HTML element detected by Sentry
+ * @returns an object containing attributes of the HTML element
+ */
 const processHtmlAttributes = (htmlElement: HTMLElement) => {
   const ariaLabel = htmlElement.getAttribute("aria-label");
   const title = htmlElement.getAttribute("title");

--- a/apps/spruce/src/components/ErrorHandling/utils.ts
+++ b/apps/spruce/src/components/ErrorHandling/utils.ts
@@ -1,0 +1,13 @@
+const processHtmlAttributes = (htmlElement: HTMLElement) => {
+  const ariaLabel = htmlElement.getAttribute("aria-label");
+  const title = htmlElement.getAttribute("title");
+  // Get dataset directly to handle all data-* attributes.
+  const { dataset } = htmlElement ?? {};
+  return {
+    ...(ariaLabel && { ariaLabel }),
+    ...(dataset && Object.keys(dataset).length > 0 && { dataset }),
+    ...(title && { title }),
+  };
+};
+
+export { processHtmlAttributes };

--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -1330,8 +1330,9 @@ export type MutationUpdatePublicKeyArgs = {
 };
 
 export type MutationUpdateSpawnHostStatusArgs = {
-  action: SpawnHostStatusActions;
-  hostId: Scalars["String"]["input"];
+  action?: InputMaybe<SpawnHostStatusActions>;
+  hostId?: InputMaybe<Scalars["String"]["input"]>;
+  updateSpawnHostStatusInput?: InputMaybe<UpdateSpawnHostStatusInput>;
 };
 
 export type MutationUpdateUserSettingsArgs = {
@@ -2919,6 +2920,12 @@ export type UpdateParsleySettingsInput = {
 export type UpdateParsleySettingsPayload = {
   __typename?: "UpdateParsleySettingsPayload";
   parsleySettings?: Maybe<ParsleySettings>;
+};
+
+export type UpdateSpawnHostStatusInput = {
+  action: SpawnHostStatusActions;
+  hostId: Scalars["String"]["input"];
+  shouldKeepOff?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
 /**

--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -853,17 +853,6 @@ export type JiraConfig = {
   host?: Maybe<Scalars["String"]["output"]>;
 };
 
-export type JiraField = {
-  __typename?: "JiraField";
-  displayText: Scalars["String"]["output"];
-  field: Scalars["String"]["output"];
-};
-
-export type JiraFieldInput = {
-  displayText: Scalars["String"]["input"];
-  field: Scalars["String"]["input"];
-};
-
 export type JiraIssueSubscriber = {
   __typename?: "JiraIssueSubscriber";
   issueType: Scalars["String"]["output"];
@@ -2600,12 +2589,10 @@ export type TaskTestsArgs = {
 export type TaskAnnotationSettings = {
   __typename?: "TaskAnnotationSettings";
   fileTicketWebhook: Webhook;
-  jiraCustomFields?: Maybe<Array<JiraField>>;
 };
 
 export type TaskAnnotationSettingsInput = {
   fileTicketWebhook?: InputMaybe<WebhookInput>;
-  jiraCustomFields?: InputMaybe<Array<JiraFieldInput>>;
 };
 
 export type TaskContainerCreationOpts = {


### PR DESCRIPTION
DEVPROD-3188

### Description
This PR overwrites the breadcrumb message for `ui.click` events if a data-cy attribute is available. Otherwise, the breadcrumb message remains the same.

It also adds additional data to the breadcrumb.


### Caveats
Sometimes this doesn't work that well, and that could be because:
* We don't have a data-cy or any other helpful attributes on the element. We would have to go through and manually add them where missing.
* It is somewhat out of our control. For example, Sentry will pick up on this [hidden div](https://github.com/mongodb/leafygreen-ui/blob/a149857b2bd05dbae003f89ba2a8ba449ff7b213/packages/button/src/ButtonContent/ButtonContent.tsx#L93) that LeafyGreen has on its buttons and not the button itself. I feel like the solution for this would be for LeafyGreen to remove hidden divs.

### Screenshots
Here is what it looks like when the breadcrumb message gets replaced with the tag name and data-cy value. Additional data is also present:

<img width="978" alt="Screenshot 2024-05-07 at 11 36 51 AM" src="https://github.com/evergreen-ci/ui/assets/47064971/078b3fd3-fac3-43f5-9a02-7dd3b1bfbdfd">


Here is what it looks like when the breadcrumb message could not be replaced. We just add whatever additional data we have:
<img width="974" alt="Screenshot 2024-05-07 at 11 38 28 AM" src="https://github.com/evergreen-ci/ui/assets/47064971/c312cbbd-be11-4d84-b442-35cc80f93482">



### Testing
* Manually throw errors in Parsley & Spruce beta
