### PR TITLE
DEVPROD-7541: Don't validate host sleep schedule in prod

### DIFF
--- a/apps/spruce/src/components/Spawn/utils/hostUptime.ts
+++ b/apps/spruce/src/components/Spawn/utils/hostUptime.ts
@@ -3,6 +3,7 @@ import { ValidateProps } from "components/SpruceForm";
 import { SleepScheduleInput } from "gql/generated/types";
 import { MyHost } from "types/spawn";
 import { arraySymmetricDifference } from "utils/array";
+import { isProduction } from "utils/environmentVariables";
 
 const daysInWeek = 7;
 const hoursInDay = 24;
@@ -227,6 +228,9 @@ export const matchesDefaultUptimeSchedule = (
 };
 
 export const validator = (({ expirationDetails }, errors) => {
+  // TODO DEVPROD-6908 remove check when beta period ends
+  if (isProduction()) return errors;
+
   const { hostUptime, noExpiration } = expirationDetails ?? {};
   if (!hostUptime || noExpiration === false) return errors;
 


### PR DESCRIPTION
DEVPROD-7541

### Description
<!-- add description, context, thought process, etc -->
The validator was being too aggressive in applying host uptime rules to production hosts. Remove this check so that the edit spawn host modal is saveable.

### Testing
<!-- add a description of how you tested it -->
- Tested locally