### PR TITLE
DEVPROD-7766: Fix timepicker bug, use nextStartTime from app

### DIFF
--- a/apps/parsley/src/gql/generated/types.ts
+++ b/apps/parsley/src/gql/generated/types.ts
@@ -2363,6 +2363,9 @@ export type SleepSchedule = {
   __typename?: "SleepSchedule";
   dailyStartTime: Scalars["String"]["output"];
   dailyStopTime: Scalars["String"]["output"];
+  isBetaTester: Scalars["Boolean"]["output"];
+  nextStartTime?: Maybe<Scalars["Time"]["output"]>;
+  nextStopTime?: Maybe<Scalars["Time"]["output"]>;
   permanentlyExempt: Scalars["Boolean"]["output"];
   shouldKeepOff: Scalars["Boolean"]["output"];
   temporarilyExemptUntil?: Maybe<Scalars["Time"]["output"]>;
@@ -2373,6 +2376,7 @@ export type SleepSchedule = {
 export type SleepScheduleInput = {
   dailyStartTime: Scalars["String"]["input"];
   dailyStopTime: Scalars["String"]["input"];
+  isBetaTester?: InputMaybe<Scalars["Boolean"]["input"]>;
   permanentlyExempt: Scalars["Boolean"]["input"];
   shouldKeepOff: Scalars["Boolean"]["input"];
   temporarilyExemptUntil?: InputMaybe<Scalars["Time"]["input"]>;

--- a/apps/spruce/src/components/Spawn/getFormSchema.tsx
+++ b/apps/spruce/src/components/Spawn/getFormSchema.tsx
@@ -134,12 +134,10 @@ const getHostUptimeSchema = ({
         `,
         startTime: {
           "ui:format": "HH:mm",
-          "ui:useUtc": false,
           "ui:widget": widgets.TimeWidget,
         },
         stopTime: {
           "ui:format": "HH:mm",
-          "ui:useUtc": false,
           "ui:widget": widgets.TimeWidget,
         },
         or: {

--- a/apps/spruce/src/components/Spawn/spawnHostModal/transformer.test.ts
+++ b/apps/spruce/src/components/Spawn/spawnHostModal/transformer.test.ts
@@ -111,6 +111,14 @@ const data: Array<{ formData: FormState; mutationInput: SpawnHostInput }> = [
         noExpiration: true,
         hostUptime: {
           useDefaultUptimeSchedule: true,
+          sleepSchedule: {
+            enabledWeekdays: [false, false, true, true, true, true],
+            timeSelection: {
+              startTime: "08:00",
+              stopTime: "20:00",
+              runContinuously: false,
+            },
+          },
         },
       },
       homeVolumeDetails: { selectExistingVolume: true, volumeSelect: "" },

--- a/apps/spruce/src/components/Spawn/utils/hostUptime.test.ts
+++ b/apps/spruce/src/components/Spawn/utils/hostUptime.test.ts
@@ -215,7 +215,22 @@ describe("getHostUptimeFromGql", () => {
 describe("getSleepSchedule", () => {
   it("sets the default schedule", () => {
     expect(
-      getSleepSchedule({ useDefaultUptimeSchedule: true }, "America/New_York"),
+      getSleepSchedule(
+        {
+          useDefaultUptimeSchedule: true,
+          sleepSchedule: {
+            enabledWeekdays: [false, false, true, true, true, true, false],
+            timeSelection: {
+              runContinuously: true,
+              startTime:
+                "Sun Dec 31 1899 08:00:00 GMT+0000 (Coordinated Universal Time)",
+              stopTime:
+                "Sun Dec 31 1899 20:00:00 GMT+0000 (Coordinated Universal Time)",
+            },
+          },
+        },
+        "America/New_York",
+      ),
     ).toStrictEqual({
       dailyStartTime: "08:00",
       dailyStopTime: "20:00",
@@ -316,69 +331,33 @@ describe("getHostUptimeWarnings", () => {
 });
 
 describe("getNextHostStart", () => {
+  beforeEach(() => {
+    vi.useFakeTimers().setSystemTime("2024-06-02");
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("calculates the next start with time", () => {
-    const sched = {
-      dailyStartTime: "08:00",
-      dailyStopTime: "20:00",
-      permanentlyExempt: true,
-      shouldKeepOff: true,
-      timeZone: "America/New_York",
-      wholeWeekdaysOff: [0, 6],
-    };
-    // @ts-expect-error: FIXME. This comment was added by an automated script.
-    const monday = new Date(null, null);
-    expect(getNextHostStart(sched, monday)).toStrictEqual({
+    const tuesday = new Date("2024-06-04T08:00").toString();
+    expect(getNextHostStart("08:00", tuesday)).toStrictEqual({
       nextStartDay: "Tuesday",
       nextStartTime: "8:00",
     });
   });
 
-  it("calculates the next start with time when current day is off", () => {
-    const sched = {
-      dailyStartTime: "08:00",
-      dailyStopTime: "20:00",
-      permanentlyExempt: true,
-      shouldKeepOff: true,
-      timeZone: "America/New_York",
-      wholeWeekdaysOff: [0, 1, 6],
-    };
-    // @ts-expect-error: FIXME. This comment was added by an automated script.
-    const monday = new Date(null, null);
-    expect(getNextHostStart(sched, monday)).toStrictEqual({
-      nextStartDay: "Tuesday",
+  it("calculates starting tomorrow with time", () => {
+    const monday = new Date("2024-06-03T08:00").toString();
+    expect(getNextHostStart("08:00", monday)).toStrictEqual({
+      nextStartDay: "tomorrow",
       nextStartTime: "8:00",
     });
   });
 
   it("calculates the next start when running continuously", () => {
-    const sched = {
-      dailyStartTime: "",
-      dailyStopTime: "",
-      permanentlyExempt: true,
-      shouldKeepOff: true,
-      timeZone: "America/New_York",
-      wholeWeekdaysOff: [0, 6],
-    };
-    // @ts-expect-error: FIXME. This comment was added by an automated script.
-    const monday = new Date(null, null);
-    expect(getNextHostStart(sched, monday)).toStrictEqual({
-      nextStartDay: "Monday",
-      nextStartTime: null,
-    });
-  });
-
-  it("calculates the next start when running continuously and current day is off", () => {
-    const sched = {
-      dailyStartTime: "",
-      dailyStopTime: "",
-      permanentlyExempt: true,
-      shouldKeepOff: true,
-      timeZone: "America/New_York",
-      wholeWeekdaysOff: [0, 1, 6],
-    };
-    // @ts-expect-error: FIXME. This comment was added by an automated script.
-    const monday = new Date(null, null);
-    expect(getNextHostStart(sched, monday)).toStrictEqual({
+    const tuesday = new Date("2024-06-04T08:00").toString();
+    expect(getNextHostStart("", tuesday)).toStrictEqual({
       nextStartDay: "Tuesday",
       nextStartTime: null,
     });

--- a/apps/spruce/src/components/Spawn/utils/hostUptime.ts
+++ b/apps/spruce/src/components/Spawn/utils/hostUptime.ts
@@ -311,6 +311,12 @@ export const isNullSleepSchedule = (sleepSchedule: RequiredSleepSchedule) => {
   return true;
 };
 
+/**
+ * getNextHostStart returns strings representing the next time a host will start as computed using the server-returned timestamp.
+ * @param dailyStartTime - hourly time that the host will wake from sleep. Empty string indicates the host runs continuously on enabled days.
+ * @param nextStart - Date string from the server indiciating the next start.
+ * @returns object with nextStartDay and nextStartTime strings. Either/both values are null if the server does not specify a time.
+ */
 export const getNextHostStart = (
   dailyStartTime: string,
   nextStart: string,

--- a/apps/spruce/src/components/SpruceForm/Widgets/DateTimePicker.tsx
+++ b/apps/spruce/src/components/SpruceForm/Widgets/DateTimePicker.tsx
@@ -25,16 +25,21 @@ export const DateTimePicker: React.FC<
   } = options;
 
   const timezone = useUserTimeZone();
-  // @ts-expect-error: FIXME. This comment was added by an automated script.
-  const currentDateTime = toZonedTime(new Date(value || null), timezone);
+  const currentDateTime = timezone
+    ? toZonedTime(new Date(value || null), timezone)
+    : new Date(value || null);
   const isDisabled = disabled || readonly;
-  const handleChange = (d: Date) => {
-    // @ts-expect-error: FIXME. This comment was added by an automated script.
-    onChange(fromZonedTime(d, timezone).toString());
+  const handleChange = (d: Date | null) => {
+    if (!d) return;
+
+    if (timezone) {
+      onChange(fromZonedTime(d, timezone).toString());
+    } else {
+      onChange(d.toString());
+    }
   };
 
-  // @ts-expect-error: FIXME. This comment was added by an automated script.
-  const disabledDate = (current) => {
+  const disabledDate = (current: Date) => {
     const disablePast = disableBefore ? current < disableBefore : false;
     const disableFuture = disableAfter ? current > disableAfter : false;
     return disableFuture || disablePast;
@@ -53,7 +58,6 @@ export const DateTimePicker: React.FC<
           // @ts-expect-error
           getPopupContainer={getPopupContainer}
           data-cy="date-picker"
-          // @ts-expect-error: FIXME. This comment was added by an automated script.
           onChange={handleChange}
           value={currentDateTime}
           allowClear={false}
@@ -64,7 +68,6 @@ export const DateTimePicker: React.FC<
           // @ts-expect-error
           getPopupContainer={getPopupContainer}
           data-cy="time-picker"
-          // @ts-expect-error: FIXME. This comment was added by an automated script.
           onChange={handleChange}
           value={currentDateTime}
           allowClear={false}
@@ -86,28 +89,14 @@ export const TimePicker: React.FC<
   {
     options: {
       format?: string;
-      useUtc?: boolean;
     };
   } & SpruceWidgetProps
 > = ({ disabled, id, label, onChange, options, readonly, value = "" }) => {
-  const {
-    description,
-    elementWrapperCSS,
-    format,
-    showLabel,
-    useUtc = true,
-  } = options;
-  const timezone = useUserTimeZone();
-  const currentDateTime = useUtc
-    ? // @ts-expect-error: FIXME. This comment was added by an automated script.
-      toZonedTime(new Date(value || null), timezone)
-    : new Date(value || null);
+  const { description, elementWrapperCSS, format, showLabel } = options;
+  const currentDateTime = new Date(value || null);
   const isDisabled = disabled || readonly;
-  const handleChange = (d: Date) => {
-    if (useUtc) {
-      // @ts-expect-error: FIXME. This comment was added by an automated script.
-      onChange(fromZonedTime(d, timezone).toString());
-    } else {
+  const handleChange = (d: Date | null) => {
+    if (d) {
       onChange(d.toString());
     }
   };
@@ -126,11 +115,15 @@ export const TimePicker: React.FC<
         id={id}
         data-cy="time-picker"
         format={format}
-        // @ts-expect-error: FIXME. This comment was added by an automated script.
+        needConfirm
         onChange={handleChange}
         value={currentDateTime}
         allowClear={false}
         disabled={isDisabled}
+        showNow={false}
+        // Disable typing into timepicker due to Antd bug:
+        // https://github.com/ant-design/ant-design/issues/45564
+        inputReadOnly
       />
     </ElementWrapper>
   );
@@ -138,5 +131,4 @@ export const TimePicker: React.FC<
 
 // Fixes bug where DatePicker won't handle onClick events
 const getPopupContainer = (triggerNode: HTMLElement) =>
-  // @ts-expect-error: FIXME. This comment was added by an automated script.
-  triggerNode.parentNode.parentNode;
+  triggerNode?.parentNode?.parentNode;

--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -2363,6 +2363,9 @@ export type SleepSchedule = {
   __typename?: "SleepSchedule";
   dailyStartTime: Scalars["String"]["output"];
   dailyStopTime: Scalars["String"]["output"];
+  isBetaTester: Scalars["Boolean"]["output"];
+  nextStartTime?: Maybe<Scalars["Time"]["output"]>;
+  nextStopTime?: Maybe<Scalars["Time"]["output"]>;
   permanentlyExempt: Scalars["Boolean"]["output"];
   shouldKeepOff: Scalars["Boolean"]["output"];
   temporarilyExemptUntil?: Maybe<Scalars["Time"]["output"]>;
@@ -2373,6 +2376,7 @@ export type SleepSchedule = {
 export type SleepScheduleInput = {
   dailyStartTime: Scalars["String"]["input"];
   dailyStopTime: Scalars["String"]["input"];
+  isBetaTester?: InputMaybe<Scalars["Boolean"]["input"]>;
   permanentlyExempt: Scalars["Boolean"]["input"];
   shouldKeepOff: Scalars["Boolean"]["input"];
   temporarilyExemptUntil?: InputMaybe<Scalars["Time"]["input"]>;
@@ -6441,6 +6445,7 @@ export type MyHostsQuery = {
       __typename?: "SleepSchedule";
       dailyStartTime: string;
       dailyStopTime: string;
+      nextStartTime?: Date | null;
       permanentlyExempt: boolean;
       shouldKeepOff: boolean;
       temporarilyExemptUntil?: Date | null;

--- a/apps/spruce/src/gql/queries/my-hosts.graphql
+++ b/apps/spruce/src/gql/queries/my-hosts.graphql
@@ -6,6 +6,7 @@ query MyHosts {
     sleepSchedule {
       dailyStartTime
       dailyStopTime
+      nextStartTime
       permanentlyExempt
       shouldKeepOff
       temporarilyExemptUntil

--- a/apps/spruce/src/pages/spawn/spawnHost/PauseSleepScheduleModal.tsx
+++ b/apps/spruce/src/pages/spawn/spawnHost/PauseSleepScheduleModal.tsx
@@ -6,8 +6,6 @@ import { getNextHostStart } from "components/Spawn/utils";
 import { size } from "constants/tokens";
 import { SleepSchedule } from "gql/generated/types";
 
-const todayDate = new Date();
-
 export const PauseSleepScheduleModal: React.FC<{
   handleConfirm: (shouldKeepOff?: boolean) => void;
   open: boolean;
@@ -17,12 +15,21 @@ export const PauseSleepScheduleModal: React.FC<{
   const [shouldKeepOff, setShouldKeepOff] = useState(false);
 
   const { nextStartDay, nextStartTime } = getNextHostStart(
-    sleepSchedule,
-    todayDate,
+    sleepSchedule.dailyStartTime,
+    // This "date" is really a string (DEVPROD-1028)
+    sleepSchedule.nextStartTime as unknown as string,
   );
+
+  let pauseButtonText = "Pause host";
+  if (shouldKeepOff) {
+    pauseButtonText += " indefinitely";
+  } else if (nextStartDay) {
+    pauseButtonText += ` until ${nextStartDay}`;
+  }
+
   return (
     <ConfirmationModal
-      buttonText={`Pause host ${shouldKeepOff ? "indefinitely" : `until ${nextStartDay}`}`}
+      buttonText={pauseButtonText}
       data-cy="pause-sleep-schedule-modal"
       open={open}
       onCancel={() => setOpen(false)}

--- a/apps/spruce/src/pages/spawn/spawnHost/SpawnHostTableActions.test.tsx
+++ b/apps/spruce/src/pages/spawn/spawnHost/SpawnHostTableActions.test.tsx
@@ -139,7 +139,9 @@ describe("copySSHCommandButton", () => {
 
 describe("spawn host table", () => {
   it("prompts user to permanently pause host when a sleep schedule is configured", async () => {
-    const user = userEvent.setup();
+    vi.useFakeTimers().setSystemTime("2024-06-05");
+
+    const user = userEvent.setup({ delay: null });
     const { Component } = RenderFakeToastContext(
       <SpawnHostTable hosts={[baseSpawnHost]} />,
     );
@@ -173,6 +175,8 @@ describe("spawn host table", () => {
         screen.getByRole("button", { name: "Pause host indefinitely" }),
       ).toBeVisible();
     });
+
+    vi.useRealTimers();
   });
 
   it("does not prompt user when pausing expirable host", async () => {
@@ -240,6 +244,8 @@ const baseSpawnHost: MyHost = {
   availabilityZone: "us-east-1c",
   sleepSchedule: {
     ...defaultSleepSchedule,
+    nextStartTime: new Date("2024-06-06T08:00:00Z"),
+    temporarilyExemptUntil: null,
     timeZone: "America/New_York",
   },
   __typename: "Host",


### PR DESCRIPTION
DEVPROD-7766

### Description
<!-- add description, context, thought process, etc -->
- The antd timepicker has a [bug](https://github.com/ant-design/ant-design/issues/45564) that resets the date when the input is typed rather than selected. Disabling typing is the easiest way to get around this (and imo that UX is subpar anyway)
- Use the value for `nextStartDate` from the backend rather than calculating it on the client
- Fix some type errors introduced by `use strict` and app PR

### Testing
<!-- add a description of how you tested it -->
- Validated that datepicker can't have input typed anymore

### Evergreen PR
https://github.com/evergreen-ci/evergreen/pull/7950