### PR TITLE
DEVPROD-5058: Apply pretty print setting after log pane has loaded

### DIFF
--- a/apps/parsley/src/components/DetailsMenu/DetailsMenuCard/Toggles/PrettyPrintToggle/PrettyPrintToggle.test.tsx
+++ b/apps/parsley/src/components/DetailsMenu/DetailsMenuCard/Toggles/PrettyPrintToggle/PrettyPrintToggle.test.tsx
@@ -14,27 +14,19 @@ import { renderComponentWithHook } from "test_utils/TestHooks";
 import PrettyPrintToggle from ".";
 
 vi.mock("js-cookie");
-const mockedGet = vi.spyOn(Cookie, "get") as MockInstance;
+const mockedSet = vi.spyOn(Cookie, "set") as MockInstance;
 
 const wrapper = logContextWrapper();
 
 describe("pretty print toggle", () => {
   beforeEach(() => {
-    mockedGet.mockImplementation(() => "true");
     InitializeFakeToastContext();
   });
 
-  it("defaults to 'false' if cookie is unset", () => {
-    mockedGet.mockImplementation(() => "");
+  it("defaults to 'false'", () => {
     render(<PrettyPrintToggle />, { wrapper });
     const prettyPrintToggle = screen.getByDataCy("pretty-print-toggle");
     expect(prettyPrintToggle).toHaveAttribute("aria-checked", "false");
-  });
-
-  it("should read from the cookie properly", () => {
-    render(<PrettyPrintToggle />, { wrapper });
-    const prettyPrintToggle = screen.getByDataCy("pretty-print-toggle");
-    expect(prettyPrintToggle).toHaveAttribute("aria-checked", "true");
   });
 
   it("should disable the toggle if the logType is not resmoke", () => {
@@ -46,7 +38,6 @@ describe("pretty print toggle", () => {
     act(() => {
       hook.current.setLogMetadata({ renderingType: LogRenderingTypes.Default });
     });
-
     const prettyPrintToggle = screen.getByDataCy("pretty-print-toggle");
     expect(prettyPrintToggle).toHaveAttribute("aria-disabled", "true");
   });
@@ -60,7 +51,6 @@ describe("pretty print toggle", () => {
     act(() => {
       hook.current.setLogMetadata({ renderingType: LogRenderingTypes.Resmoke });
     });
-
     const prettyPrintToggle = screen.getByDataCy("pretty-print-toggle");
     expect(prettyPrintToggle).toHaveAttribute("aria-disabled", "false");
   });
@@ -78,7 +68,8 @@ describe("pretty print toggle", () => {
     const prettyPrintToggle = screen.getByDataCy("pretty-print-toggle");
 
     await user.click(prettyPrintToggle);
-    expect(prettyPrintToggle).toHaveAttribute("aria-checked", "false");
+    expect(prettyPrintToggle).toHaveAttribute("aria-checked", "true");
+    expect(mockedSet).toHaveBeenCalledTimes(1);
     expect(router.state.location.search).toBe("");
   });
 });

--- a/apps/parsley/src/components/LogPane/LogPane.test.tsx
+++ b/apps/parsley/src/components/LogPane/LogPane.test.tsx
@@ -27,11 +27,6 @@ const wrapper = ({ children }: { children: React.ReactNode }) => (
 vi.mock("js-cookie");
 
 describe("logPane", () => {
-  beforeEach(() => {
-    // @ts-expect-error
-    vi.spyOn(Cookie, "get").mockReturnValue("true");
-  });
-
   afterEach(() => {
     vi.restoreAllMocks();
     vi.useRealTimers();
@@ -46,7 +41,42 @@ describe("logPane", () => {
     expect(screen.queryByText("Some Line: 99")).not.toBeInTheDocument();
   });
 
-  it("should execute wrap and pretty print functionality after log pane loads", async () => {
+  it("should not execute wrap and pretty print functionality if cookie is false", async () => {
+    // @ts-expect-error
+    vi.spyOn(Cookie, "get").mockReturnValue("false");
+
+    vi.useFakeTimers();
+    const mockedLogContext = vi.spyOn(logContext, "useLogContext");
+    const mockedSetWrap = vi.fn();
+    const mockedSetPrettyPrint = vi.fn();
+
+    mockedLogContext.mockImplementation(() => ({
+      listRef: createRef(),
+      // @ts-expect-error - Only mocking a subset of useLogContext needed for this test.
+      preferences: {
+        setPrettyPrint: mockedSetPrettyPrint,
+        setWrap: mockedSetWrap,
+      },
+      processedLogLines: Array.from(list.keys()),
+    }));
+
+    RenderFakeToastContext();
+    render(<LogPane rowCount={list.length} rowRenderer={RowRenderer} />, {
+      wrapper,
+    });
+    vi.advanceTimersByTime(100);
+    await waitFor(() => {
+      expect(mockedSetWrap).not.toHaveBeenCalled();
+    });
+    await waitFor(() => {
+      expect(mockedSetPrettyPrint).not.toHaveBeenCalled();
+    });
+  });
+
+  it("should execute wrap and pretty print functionality if cookie is true", async () => {
+    // @ts-expect-error
+    vi.spyOn(Cookie, "get").mockReturnValue("true");
+
     vi.useFakeTimers();
     const mockedLogContext = vi.spyOn(logContext, "useLogContext");
     const mockedSetWrap = vi.fn();

--- a/apps/parsley/src/components/LogPane/LogPane.test.tsx
+++ b/apps/parsley/src/components/LogPane/LogPane.test.tsx
@@ -46,15 +46,17 @@ describe("logPane", () => {
     expect(screen.queryByText("Some Line: 99")).not.toBeInTheDocument();
   });
 
-  it("should execute wrap functionality after log pane loads", async () => {
+  it("should execute wrap and pretty print functionality after log pane loads", async () => {
     vi.useFakeTimers();
     const mockedLogContext = vi.spyOn(logContext, "useLogContext");
     const mockedSetWrap = vi.fn();
+    const mockedSetPrettyPrint = vi.fn();
 
     mockedLogContext.mockImplementation(() => ({
       listRef: createRef(),
       // @ts-expect-error - Only mocking a subset of useLogContext needed for this test.
       preferences: {
+        setPrettyPrint: mockedSetPrettyPrint,
         setWrap: mockedSetWrap,
       },
       processedLogLines: Array.from(list.keys()),
@@ -67,6 +69,9 @@ describe("logPane", () => {
     vi.advanceTimersByTime(100);
     await waitFor(() => {
       expect(mockedSetWrap).toHaveBeenCalledTimes(1);
+    });
+    await waitFor(() => {
+      expect(mockedSetPrettyPrint).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -81,6 +86,7 @@ describe("logPane", () => {
         listRef: createRef(),
         // @ts-expect-error - Only mocking a subset of useLogContext needed for this test.
         preferences: {
+          setPrettyPrint: vi.fn(),
           setWrap: vi.fn(),
         },
         processedLogLines: Array.from(list.keys()),
@@ -108,6 +114,7 @@ describe("logPane", () => {
         listRef: createRef(),
         // @ts-expect-error - Only mocking a subset of useLogContext needed for this test.
         preferences: {
+          setPrettyPrint: vi.fn(),
           setWrap: vi.fn(),
         },
         processedLogLines: Array.from(list.keys()),

--- a/apps/parsley/src/components/LogPane/index.tsx
+++ b/apps/parsley/src/components/LogPane/index.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef } from "react";
 import { css } from "@leafygreen-ui/emotion";
 import Cookies from "js-cookie";
 import PaginatedVirtualList from "components/PaginatedVirtualList";
-import { WRAP } from "constants/cookies";
+import { PRETTY_PRINT_BOOKMARKS, WRAP } from "constants/cookies";
 import { QueryParams } from "constants/queryParams";
 import { useLogContext } from "context/LogContext";
 import { useParsleySettings } from "hooks/useParsleySettings";
@@ -17,7 +17,7 @@ interface LogPaneProps {
 const LogPane: React.FC<LogPaneProps> = ({ rowCount, rowRenderer }) => {
   const { failingLine, listRef, preferences, processedLogLines, scrollToLine } =
     useLogContext();
-  const { setWrap, zebraStriping } = preferences;
+  const { setPrettyPrint, setWrap, zebraStriping } = preferences;
   const { settings } = useParsleySettings();
 
   const [shareLine] = useQueryParam<number | undefined>(
@@ -49,9 +49,12 @@ const LogPane: React.FC<LogPaneProps> = ({ rowCount, rowRenderer }) => {
             SentryBreadcrumb.UI,
           );
         }
-        // Wrap can be enabled after the log pane has initially loaded.
+        // Wrap and pretty print can be enabled after the log pane has initially loaded.
         if (Cookies.get(WRAP) === "true") {
           setWrap(true);
+        }
+        if (Cookies.get(PRETTY_PRINT_BOOKMARKS) === "true") {
+          setPrettyPrint(true);
         }
         performedScroll.current = true;
       }, 100);

--- a/apps/parsley/src/context/LogContext/index.tsx
+++ b/apps/parsley/src/context/LogContext/index.tsx
@@ -107,8 +107,9 @@ const LogContextProvider: React.FC<LogContextProviderProps> = ({
     undefined,
   );
 
-  // Wrap settings are evaluated after the logs have initially rendered - see LogPane component.
+  // Wrap and pretty print settings are evaluated after the logs have initially rendered - see LogPane component.
   const [wrap, setWrap] = useState(false);
+  const [prettyPrint, setPrettyPrint] = useState(false);
   const [filterLogic, setFilterLogic] = useQueryParam(
     QueryParams.FilterLogic,
     (Cookie.get(FILTER_LOGIC) as FilterLogic) ?? FilterLogic.And,
@@ -117,9 +118,7 @@ const LogContextProvider: React.FC<LogContextProviderProps> = ({
     QueryParams.Expandable,
     Cookie.get(EXPANDABLE_ROWS) ? Cookie.get(EXPANDABLE_ROWS) === "true" : true,
   );
-  const [prettyPrint, setPrettyPrint] = useState(
-    Cookie.get(PRETTY_PRINT_BOOKMARKS) === "true",
-  );
+
   const [zebraStriping, setZebraStriping] = useState(
     Cookie.get(ZEBRA_STRIPING) === "true",
   );

--- a/apps/parsley/src/context/LogContext/index.tsx
+++ b/apps/parsley/src/context/LogContext/index.tsx
@@ -118,7 +118,6 @@ const LogContextProvider: React.FC<LogContextProviderProps> = ({
     QueryParams.Expandable,
     Cookie.get(EXPANDABLE_ROWS) ? Cookie.get(EXPANDABLE_ROWS) === "true" : true,
   );
-
   const [zebraStriping, setZebraStriping] = useState(
     Cookie.get(ZEBRA_STRIPING) === "true",
   );


### PR DESCRIPTION
DEVPROD-5058

### Description
There is a problem where the virtualization library can't compute correct heights without loading initially. This PR makes it so that pretty print is evaluated once the log pane loads. Note that we already do this for the wrap setting. 

### Testing
* Tested the log in the ticket on Parsley beta

