### PR TITLE
DEVPROD-8219 add --alias flag to manual patch testing description

### DIFF
--- a/apps/spruce/src/pages/projectSettings/tabs/GithubCommitQueueTab/getFormSchema.tsx
+++ b/apps/spruce/src/pages/projectSettings/tabs/GithubCommitQueueTab/getFormSchema.tsx
@@ -346,8 +346,10 @@ export const getFormSchema = (
         manualPrTestingEnabled: {
           "ui:data-cy": "manual-pr-testing-enabled-radio-box",
           "ui:widget": widgets.RadioBoxWidget,
-          "ui:description":
-            "Patches can be run manually by commenting ‘evergreen patch’ on the PR even if automated testing isn't enabled.",
+          "ui:description": `
+              Patches can be run manually by commenting ‘evergreen patch’ on the PR even if automated testing isn't enabled;
+              The ‘--alias’ flag is also available to allow users to overwrite the default PR configuration.
+          `,
           ...githubConflictErrorStyling(
             // @ts-expect-error: FIXME. This comment was added by an automated script.
             githubProjectConflicts?.prTestingIdentifiers,


### PR DESCRIPTION
DEVPROD-8219 

### Description
Tweak description text to include --alias flag.
### Screenshots
<img width="662" alt="image" src="https://github.com/evergreen-ci/ui/assets/26798134/79c77ba8-2600-4881-8565-dc227566e0b6">

