### PR TITLE
DEVPROD-5859 Remove commit queue language

### DIFF
--- a/apps/spruce/src/pages/projectSettings/getTabTitle.ts
+++ b/apps/spruce/src/pages/projectSettings/getTabTitle.ts
@@ -16,7 +16,7 @@ export const getTabTitle = (
         title: "Variables",
       },
       [ProjectSettingsTabRoutes.GithubCommitQueue]: {
-        title: "GitHub & Commit Queue",
+        title: "GitHub",
       },
       [ProjectSettingsTabRoutes.Notifications]: {
         title: "Notifications",

--- a/apps/spruce/src/pages/projectSettings/tabs/GithubCommitQueueTab/getFormSchema.tsx
+++ b/apps/spruce/src/pages/projectSettings/tabs/GithubCommitQueueTab/getFormSchema.tsx
@@ -195,7 +195,7 @@ export const getFormSchema = (
         },
         commitQueue: {
           type: "object" as "object",
-          title: "Commit Queue",
+          title: "Merge Queue",
           properties: {
             enabled: {
               type: ["boolean", "null"],


### PR DESCRIPTION
DEVPROD-5859 Remove commit queue language

### Description

This is a fixup for
https://github.com/evergreen-ci/ui/commit/2e3181a084845839809a38ec44f1e0856cd1159f,
which removes commit queue fields from the project admin UI.