### PR TITLE
DEVPROD-8143: Prevent searchbar error from pushing content 

### DIFF
--- a/apps/parsley/src/components/PaginatedVirtualList/index.tsx
+++ b/apps/parsley/src/components/PaginatedVirtualList/index.tsx
@@ -99,9 +99,6 @@ const PaginatedVirtualList = forwardRef<
         data-cy="paginated-virtual-list"
         itemContent={itemContent}
         overscan={300}
-        rangeChanged={(s) => {
-          console.log(s);
-        }}
         totalCount={pageSize}
       />
     );

--- a/apps/parsley/src/components/PaginatedVirtualList/index.tsx
+++ b/apps/parsley/src/components/PaginatedVirtualList/index.tsx
@@ -99,6 +99,9 @@ const PaginatedVirtualList = forwardRef<
         data-cy="paginated-virtual-list"
         itemContent={itemContent}
         overscan={300}
+        rangeChanged={(s) => {
+          console.log(s);
+        }}
         totalCount={pageSize}
       />
     );

--- a/apps/parsley/src/components/Search/SearchBar/__snapshots__/SearchBar_Default.storyshot
+++ b/apps/parsley/src/components/Search/SearchBar/__snapshots__/SearchBar_Default.storyshot
@@ -193,6 +193,7 @@
         >
           <div
             class="leafygreen-ui-cssveg"
+            data-cy="searchbar-error"
           >
             <svg
               aria-label="Warning Icon"

--- a/apps/parsley/src/components/Search/SearchBar/__snapshots__/SearchBar_Default.storyshot
+++ b/apps/parsley/src/components/Search/SearchBar/__snapshots__/SearchBar_Default.storyshot
@@ -1,9 +1,9 @@
 <div>
   <div
-    class="css-4c6myl-Container etjwcg15"
+    class="css-4c6myl-Container etjwcg14"
   >
     <div
-      class="leafygreen-ui-1iyoj2o css-1y59ez7-StyledSelect etjwcg14"
+      class="leafygreen-ui-1iyoj2o css-1y59ez7-StyledSelect etjwcg13"
       data-lgid="lg-select"
     >
       <button
@@ -62,7 +62,7 @@
       />
     </div>
     <div
-      class="css-b6dwfd-InputWrapper etjwcg13"
+      class="css-b6dwfd-InputWrapper etjwcg12"
     >
       <div
         class="css-jww8p9-IconButtonWrapper etjwcg10"
@@ -116,7 +116,7 @@
         </button>
       </div>
       <div
-        class="etjwcg12 css-qlxmo3-TextInputWrapper-StyledInput e17optw11"
+        class="etjwcg11 css-qlxmo3-TextInputWrapper-StyledInput e17optw11"
       >
         <div
           aria-labelledby="searchbar-input"
@@ -197,7 +197,7 @@
           >
             <svg
               aria-label="Warning Icon"
-              class="css-1mxmqo3-RedIcon etjwcg11"
+              class="leafygreen-ui-1xsx4zj"
               fill="none"
               height="16"
               role="img"

--- a/apps/parsley/src/components/Search/SearchBar/__snapshots__/SearchBar_Default.storyshot
+++ b/apps/parsley/src/components/Search/SearchBar/__snapshots__/SearchBar_Default.storyshot
@@ -65,7 +65,7 @@
       class="css-b6dwfd-InputWrapper etjwcg13"
     >
       <div
-        class="css-jww8p9-IconButtonWrapper etjwcg11"
+        class="css-jww8p9-IconButtonWrapper etjwcg10"
       >
         <button
           aria-disabled="false"
@@ -116,7 +116,7 @@
         </button>
       </div>
       <div
-        class="etjwcg12 css-1jzgame-TextInputWrapper-StyledInput e17optw11"
+        class="etjwcg12 css-qlxmo3-TextInputWrapper-StyledInput e17optw11"
       >
         <div
           aria-labelledby="searchbar-input"
@@ -192,9 +192,26 @@
           class="css-4bamt4-IconWrapper e17optw10"
         >
           <div
-            class="leafygreen-ui-cssveg css-122v0mq-IconPlaceholder etjwcg10"
-            data-cy="searchbar-error"
-          />
+            class="leafygreen-ui-cssveg"
+          >
+            <svg
+              aria-label="Warning Icon"
+              class="css-1mxmqo3-RedIcon etjwcg11"
+              fill="none"
+              height="16"
+              role="img"
+              viewBox="0 0 16 16"
+              width="16"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                clip-rule="evenodd"
+                d="M8.864 1.514a.983.983 0 0 0-1.728 0L1.122 12.539A.987.987 0 0 0 1.986 14h12.028a.987.987 0 0 0 .864-1.461L8.864 1.514ZM7 5a1 1 0 0 1 2 0v4a1 1 0 0 1-2 0V5Zm2 7a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z"
+                fill="currentColor"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </div>
         </div>
       </div>
     </div>

--- a/apps/parsley/src/components/Search/SearchBar/__snapshots__/SearchBar_Default.storyshot
+++ b/apps/parsley/src/components/Search/SearchBar/__snapshots__/SearchBar_Default.storyshot
@@ -116,7 +116,7 @@
         </button>
       </div>
       <div
-        class="etjwcg12 css-1f7nsoh-TextInputWrapper-StyledInput e17optw11"
+        class="etjwcg12 css-1jzgame-TextInputWrapper-StyledInput e17optw11"
       >
         <div
           aria-labelledby="searchbar-input"

--- a/apps/parsley/src/components/Search/SearchBar/__snapshots__/SearchBar_WithSearchSuggestions.storyshot
+++ b/apps/parsley/src/components/Search/SearchBar/__snapshots__/SearchBar_WithSearchSuggestions.storyshot
@@ -65,7 +65,7 @@
       class="css-b6dwfd-InputWrapper etjwcg13"
     >
       <div
-        class="css-jww8p9-IconButtonWrapper etjwcg11"
+        class="css-jww8p9-IconButtonWrapper etjwcg10"
       >
         <button
           aria-disabled="false"
@@ -116,7 +116,7 @@
         </button>
       </div>
       <div
-        class="etjwcg12 css-1jzgame-TextInputWrapper-StyledInput e17optw11"
+        class="etjwcg12 css-qlxmo3-TextInputWrapper-StyledInput e17optw11"
       >
         <div
           aria-labelledby="searchbar-input"

--- a/apps/parsley/src/components/Search/SearchBar/__snapshots__/SearchBar_WithSearchSuggestions.storyshot
+++ b/apps/parsley/src/components/Search/SearchBar/__snapshots__/SearchBar_WithSearchSuggestions.storyshot
@@ -1,9 +1,9 @@
 <div>
   <div
-    class="css-4c6myl-Container etjwcg15"
+    class="css-4c6myl-Container etjwcg14"
   >
     <div
-      class="leafygreen-ui-1iyoj2o css-1y59ez7-StyledSelect etjwcg14"
+      class="leafygreen-ui-1iyoj2o css-1y59ez7-StyledSelect etjwcg13"
       data-lgid="lg-select"
     >
       <button
@@ -62,7 +62,7 @@
       />
     </div>
     <div
-      class="css-b6dwfd-InputWrapper etjwcg13"
+      class="css-b6dwfd-InputWrapper etjwcg12"
     >
       <div
         class="css-jww8p9-IconButtonWrapper etjwcg10"
@@ -116,7 +116,7 @@
         </button>
       </div>
       <div
-        class="etjwcg12 css-qlxmo3-TextInputWrapper-StyledInput e17optw11"
+        class="etjwcg11 css-qlxmo3-TextInputWrapper-StyledInput e17optw11"
       >
         <div
           aria-labelledby="searchbar-input"

--- a/apps/parsley/src/components/Search/SearchBar/__snapshots__/SearchBar_WithSearchSuggestions.storyshot
+++ b/apps/parsley/src/components/Search/SearchBar/__snapshots__/SearchBar_WithSearchSuggestions.storyshot
@@ -116,7 +116,7 @@
         </button>
       </div>
       <div
-        class="etjwcg12 css-1f7nsoh-TextInputWrapper-StyledInput e17optw11"
+        class="etjwcg12 css-1jzgame-TextInputWrapper-StyledInput e17optw11"
       >
         <div
           aria-labelledby="searchbar-input"

--- a/apps/parsley/src/components/Search/SearchBar/index.tsx
+++ b/apps/parsley/src/components/Search/SearchBar/index.tsx
@@ -179,7 +179,7 @@ const SearchBar: React.FC<SearchBarProps> = ({
               <Tooltip
                 justify="middle"
                 trigger={
-                  <div>
+                  <div data-cy="searchbar-error">
                     <RedIcon glyph="Warning" />
                   </div>
                 }

--- a/apps/parsley/src/components/Search/SearchBar/index.tsx
+++ b/apps/parsley/src/components/Search/SearchBar/index.tsx
@@ -16,6 +16,7 @@ import { useKeyboardShortcut } from "hooks";
 import { SentryBreadcrumb, leaveBreadcrumb } from "utils/errorReporting";
 import SearchPopover from "./SearchPopover";
 
+const { red } = palette;
 interface SearchBarProps {
   className?: string;
   disabled?: boolean;
@@ -180,7 +181,7 @@ const SearchBar: React.FC<SearchBarProps> = ({
                 justify="middle"
                 trigger={
                   <div data-cy="searchbar-error">
-                    <Icon fill={palette.red.base} glyph="Warning" />
+                    <Icon fill={red.base} glyph="Warning" />
                   </div>
                 }
                 triggerEvent="hover"

--- a/apps/parsley/src/components/Search/SearchBar/index.tsx
+++ b/apps/parsley/src/components/Search/SearchBar/index.tsx
@@ -226,6 +226,10 @@ const StyledInput = styled(TextInputWithGlyph)`
     border-left: 0;
     padding-left: 42px;
   }
+  div[data-lgid="lg-form_field-feedback"] {
+    position: absolute;
+    top: 29px;
+  }
 `;
 
 const IconButtonWrapper = styled.div`

--- a/apps/parsley/src/components/Search/SearchBar/index.tsx
+++ b/apps/parsley/src/components/Search/SearchBar/index.tsx
@@ -180,7 +180,7 @@ const SearchBar: React.FC<SearchBarProps> = ({
                 justify="middle"
                 trigger={
                   <div data-cy="searchbar-error">
-                    <RedIcon glyph="Warning" />
+                    <Icon fill={red.base} glyph="Warning" />
                   </div>
                 }
                 triggerEvent="hover"

--- a/apps/parsley/src/components/Search/SearchBar/index.tsx
+++ b/apps/parsley/src/components/Search/SearchBar/index.tsx
@@ -2,6 +2,7 @@ import { KeyboardEvent, useRef, useState } from "react";
 import styled from "@emotion/styled";
 import { TextInputWithGlyph } from "@evg-ui/lib/components/TextInputWithGlyph";
 import IconButton from "@leafygreen-ui/icon-button";
+import { palette } from "@leafygreen-ui/palette";
 import { Option, Select } from "@leafygreen-ui/select";
 import Tooltip from "@leafygreen-ui/tooltip";
 import debounce from "lodash.debounce";
@@ -177,7 +178,11 @@ const SearchBar: React.FC<SearchBarProps> = ({
             ) : (
               <Tooltip
                 justify="middle"
-                trigger={<IconPlaceholder data-cy="searchbar-error" />}
+                trigger={
+                  <div>
+                    <RedIcon glyph="Warning" />
+                  </div>
+                }
                 triggerEvent="hover"
               >
                 {validatorMessage}
@@ -220,16 +225,20 @@ const InputWrapper = styled.div`
 
 const StyledInput = styled(TextInputWithGlyph)`
   /* overwrite lg borders https://jira.mongodb.org/browse/PD-1995 */
-  div input {
+  div > div {
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
-    border-left: 0;
+    border-left: none;
+  }
+  input[data-cy="searchbar-input"] {
     padding-left: 42px;
   }
   div[data-lgid="lg-form_field-feedback"] {
-    position: absolute;
-    top: 29px;
+    display: none;
   }
+`;
+const RedIcon = styled(Icon)`
+  color: ${palette.red.base};
 `;
 
 const IconButtonWrapper = styled.div`
@@ -244,11 +253,6 @@ const IconButtonWrapper = styled.div`
   z-index: 1;
   width: ${size.l};
   height: ${textInputHeight};
-`;
-
-const IconPlaceholder = styled.div`
-  height: 100%;
-  width: ${size.l};
 `;
 
 export default SearchBar;

--- a/apps/parsley/src/components/Search/SearchBar/index.tsx
+++ b/apps/parsley/src/components/Search/SearchBar/index.tsx
@@ -237,9 +237,6 @@ const StyledInput = styled(TextInputWithGlyph)`
     display: none;
   }
 `;
-const RedIcon = styled(Icon)`
-  color: ${palette.red.base};
-`;
 
 const IconButtonWrapper = styled.div`
   display: flex;

--- a/apps/parsley/src/components/Search/SearchBar/index.tsx
+++ b/apps/parsley/src/components/Search/SearchBar/index.tsx
@@ -180,7 +180,7 @@ const SearchBar: React.FC<SearchBarProps> = ({
                 justify="middle"
                 trigger={
                   <div data-cy="searchbar-error">
-                    <Icon fill={red.base} glyph="Warning" />
+                    <Icon fill={palette.red.base} glyph="Warning" />
                   </div>
                 }
                 triggerEvent="hover"

--- a/apps/parsley/src/gql/generated/types.ts
+++ b/apps/parsley/src/gql/generated/types.ts
@@ -1502,6 +1502,7 @@ export type PatchTriggerAlias = {
   alias: Scalars["String"]["output"];
   childProjectId: Scalars["String"]["output"];
   childProjectIdentifier: Scalars["String"]["output"];
+  downstreamRevision?: Maybe<Scalars["String"]["output"]>;
   parentAsModule?: Maybe<Scalars["String"]["output"]>;
   status?: Maybe<Scalars["String"]["output"]>;
   taskSpecifiers?: Maybe<Array<TaskSpecifier>>;
@@ -1511,6 +1512,7 @@ export type PatchTriggerAlias = {
 export type PatchTriggerAliasInput = {
   alias: Scalars["String"]["input"];
   childProjectIdentifier: Scalars["String"]["input"];
+  downstreamRevision?: InputMaybe<Scalars["String"]["input"]>;
   parentAsModule?: InputMaybe<Scalars["String"]["input"]>;
   status?: InputMaybe<Scalars["String"]["input"]>;
   taskSpecifiers: Array<TaskSpecifierInput>;

--- a/apps/spruce/src/components/TupleSelect/__snapshots__/TupleSelect_Default.storyshot
+++ b/apps/spruce/src/components/TupleSelect/__snapshots__/TupleSelect_Default.storyshot
@@ -74,7 +74,7 @@
         />
       </div>
       <div
-        class="e5gn9hl0 css-47706i-TextInputWrapper-GroupedTextInput e17optw11"
+        class="e5gn9hl0 css-1opv5d5-TextInputWrapper-GroupedTextInput e17optw11"
       >
         <div
           aria-label="Build Variant"

--- a/apps/spruce/src/components/TupleSelect/index.tsx
+++ b/apps/spruce/src/components/TupleSelect/index.tsx
@@ -104,7 +104,7 @@ const GroupedSelect = styled(Select)`
 
 const GroupedTextInput = styled(TextInput)`
   /* overwrite lg borders https://jira.mongodb.org/browse/PD-1995 */
-  div input {
+  div > div {
     border-bottom-left-radius: 0;
     border-top-left-radius: 0;
   }

--- a/apps/spruce/src/components/TupleSelectWithRegexConditional/__snapshots__/TupleSelectWithRegexConditional_WithConditional.storyshot
+++ b/apps/spruce/src/components/TupleSelectWithRegexConditional/__snapshots__/TupleSelectWithRegexConditional_WithConditional.storyshot
@@ -153,7 +153,7 @@
         />
       </div>
       <div
-        class="e5gn9hl0 css-47706i-TextInputWrapper-GroupedTextInput e17optw11"
+        class="e5gn9hl0 css-1opv5d5-TextInputWrapper-GroupedTextInput e17optw11"
       >
         <div
           aria-label="Build Variant"

--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -1502,6 +1502,7 @@ export type PatchTriggerAlias = {
   alias: Scalars["String"]["output"];
   childProjectId: Scalars["String"]["output"];
   childProjectIdentifier: Scalars["String"]["output"];
+  downstreamRevision?: Maybe<Scalars["String"]["output"]>;
   parentAsModule?: Maybe<Scalars["String"]["output"]>;
   status?: Maybe<Scalars["String"]["output"]>;
   taskSpecifiers?: Maybe<Array<TaskSpecifier>>;
@@ -1511,6 +1512,7 @@ export type PatchTriggerAlias = {
 export type PatchTriggerAliasInput = {
   alias: Scalars["String"]["input"];
   childProjectIdentifier: Scalars["String"]["input"];
+  downstreamRevision?: InputMaybe<Scalars["String"]["input"]>;
   parentAsModule?: InputMaybe<Scalars["String"]["input"]>;
   status?: InputMaybe<Scalars["String"]["input"]>;
   taskSpecifiers: Array<TaskSpecifierInput>;


### PR DESCRIPTION
DEVPROD-8143

### Description
The most recent upgrade to TextInput resulted in an error message underneath the text-input which pushed content, removed the error icon and adjusted which elements in the dom controlled styles. These code changes remove the error message copy, add in the error icon and adjust the text-input border when it's next a select component. 

