### PR TITLE
DEVPROD-7529 Include downstreamRevision in save project settings mutation

### DIFF
--- a/apps/parsley/src/gql/generated/types.ts
+++ b/apps/parsley/src/gql/generated/types.ts
@@ -1502,6 +1502,7 @@ export type PatchTriggerAlias = {
   alias: Scalars["String"]["output"];
   childProjectId: Scalars["String"]["output"];
   childProjectIdentifier: Scalars["String"]["output"];
+  downstreamRevision?: Maybe<Scalars["String"]["output"]>;
   parentAsModule?: Maybe<Scalars["String"]["output"]>;
   status?: Maybe<Scalars["String"]["output"]>;
   taskSpecifiers?: Maybe<Array<TaskSpecifier>>;
@@ -1511,6 +1512,7 @@ export type PatchTriggerAlias = {
 export type PatchTriggerAliasInput = {
   alias: Scalars["String"]["input"];
   childProjectIdentifier: Scalars["String"]["input"];
+  downstreamRevision?: InputMaybe<Scalars["String"]["input"]>;
   parentAsModule?: InputMaybe<Scalars["String"]["input"]>;
   status?: InputMaybe<Scalars["String"]["input"]>;
   taskSpecifiers: Array<TaskSpecifierInput>;

--- a/apps/spruce/src/gql/fragments/projectSettings/patchAliases.graphql
+++ b/apps/spruce/src/gql/fragments/projectSettings/patchAliases.graphql
@@ -3,6 +3,7 @@ fragment ProjectPatchAliasSettings on Project {
   patchTriggerAliases {
     alias
     childProjectIdentifier
+    downstreamRevision
     parentAsModule
     status
     taskSpecifiers {
@@ -18,6 +19,7 @@ fragment RepoPatchAliasSettings on RepoRef {
   patchTriggerAliases {
     alias
     childProjectIdentifier
+    downstreamRevision
     parentAsModule
     status
     taskSpecifiers {

--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -1502,6 +1502,7 @@ export type PatchTriggerAlias = {
   alias: Scalars["String"]["output"];
   childProjectId: Scalars["String"]["output"];
   childProjectIdentifier: Scalars["String"]["output"];
+  downstreamRevision?: Maybe<Scalars["String"]["output"]>;
   parentAsModule?: Maybe<Scalars["String"]["output"]>;
   status?: Maybe<Scalars["String"]["output"]>;
   taskSpecifiers?: Maybe<Array<TaskSpecifier>>;
@@ -1511,6 +1512,7 @@ export type PatchTriggerAlias = {
 export type PatchTriggerAliasInput = {
   alias: Scalars["String"]["input"];
   childProjectIdentifier: Scalars["String"]["input"];
+  downstreamRevision?: InputMaybe<Scalars["String"]["input"]>;
   parentAsModule?: InputMaybe<Scalars["String"]["input"]>;
   status?: InputMaybe<Scalars["String"]["input"]>;
   taskSpecifiers: Array<TaskSpecifierInput>;
@@ -3724,6 +3726,7 @@ export type ProjectSettingsFieldsFragment = {
       __typename?: "PatchTriggerAlias";
       alias: string;
       childProjectIdentifier: string;
+      downstreamRevision?: string | null;
       parentAsModule?: string | null;
       status?: string | null;
       taskSpecifiers?: Array<{
@@ -3915,6 +3918,7 @@ export type RepoSettingsFieldsFragment = {
       __typename?: "PatchTriggerAlias";
       alias: string;
       childProjectIdentifier: string;
+      downstreamRevision?: string | null;
       parentAsModule?: string | null;
       status?: string | null;
       taskSpecifiers?: Array<{
@@ -4124,6 +4128,7 @@ export type ProjectPatchAliasSettingsFragment = {
     __typename?: "PatchTriggerAlias";
     alias: string;
     childProjectIdentifier: string;
+    downstreamRevision?: string | null;
     parentAsModule?: string | null;
     status?: string | null;
     taskSpecifiers?: Array<{
@@ -4142,6 +4147,7 @@ export type RepoPatchAliasSettingsFragment = {
     __typename?: "PatchTriggerAlias";
     alias: string;
     childProjectIdentifier: string;
+    downstreamRevision?: string | null;
     parentAsModule?: string | null;
     status?: string | null;
     taskSpecifiers?: Array<{
@@ -4296,6 +4302,7 @@ export type ProjectEventSettingsFragment = {
       __typename?: "PatchTriggerAlias";
       alias: string;
       childProjectIdentifier: string;
+      downstreamRevision?: string | null;
       parentAsModule?: string | null;
       status?: string | null;
       taskSpecifiers?: Array<{
@@ -6748,6 +6755,7 @@ export type ProjectEventLogsQuery = {
             __typename?: "PatchTriggerAlias";
             alias: string;
             childProjectIdentifier: string;
+            downstreamRevision?: string | null;
             parentAsModule?: string | null;
             status?: string | null;
             taskSpecifiers?: Array<{
@@ -6954,6 +6962,7 @@ export type ProjectEventLogsQuery = {
             __typename?: "PatchTriggerAlias";
             alias: string;
             childProjectIdentifier: string;
+            downstreamRevision?: string | null;
             parentAsModule?: string | null;
             status?: string | null;
             taskSpecifiers?: Array<{
@@ -7239,6 +7248,7 @@ export type ProjectSettingsQuery = {
         __typename?: "PatchTriggerAlias";
         alias: string;
         childProjectIdentifier: string;
+        downstreamRevision?: string | null;
         parentAsModule?: string | null;
         status?: string | null;
         taskSpecifiers?: Array<{
@@ -7493,6 +7503,7 @@ export type RepoEventLogsQuery = {
             __typename?: "PatchTriggerAlias";
             alias: string;
             childProjectIdentifier: string;
+            downstreamRevision?: string | null;
             parentAsModule?: string | null;
             status?: string | null;
             taskSpecifiers?: Array<{
@@ -7699,6 +7710,7 @@ export type RepoEventLogsQuery = {
             __typename?: "PatchTriggerAlias";
             alias: string;
             childProjectIdentifier: string;
+            downstreamRevision?: string | null;
             parentAsModule?: string | null;
             status?: string | null;
             taskSpecifiers?: Array<{
@@ -7910,6 +7922,7 @@ export type RepoSettingsQuery = {
         __typename?: "PatchTriggerAlias";
         alias: string;
         childProjectIdentifier: string;
+        downstreamRevision?: string | null;
         parentAsModule?: string | null;
         status?: string | null;
         taskSpecifiers?: Array<{

--- a/apps/spruce/src/pages/projectSettings/tabs/PatchAliasesTab/transformers.test.ts
+++ b/apps/spruce/src/pages/projectSettings/tabs/PatchAliasesTab/transformers.test.ts
@@ -88,6 +88,7 @@ const repoForm: PatchAliasesFormState = {
       {
         alias: "alias1",
         childProjectIdentifier: "spruce",
+        downstreamRevision: "",
         status: "success",
         displayTitle: "alias1",
         parentAsModule: "",
@@ -120,6 +121,7 @@ const repoResult: Pick<RepoSettingsInput, "repoId" | "projectRef" | "aliases"> =
         {
           alias: "alias1",
           childProjectIdentifier: "spruce",
+          downstreamRevision: "",
           taskSpecifiers: [
             {
               patchAlias: "alias2",

--- a/apps/spruce/src/pages/projectSettings/tabs/PatchAliasesTab/transformers.ts
+++ b/apps/spruce/src/pages/projectSettings/tabs/PatchAliasesTab/transformers.ts
@@ -57,6 +57,7 @@ export const gqlToForm: GqlToFormFunction<Tab> = ((data, options) => {
             })) ?? [],
           status: migrateSuccessStatus(p.status),
           parentAsModule: p.parentAsModule ?? "",
+          downstreamRevision: p.downstreamRevision ?? "",
           isGithubTriggerAlias: githubTriggerAliases?.includes(p.alias),
           displayTitle: p.alias,
         })) ?? [],
@@ -102,6 +103,7 @@ export const formToGql = ((
             ) ?? [],
           status: a.status,
           parentAsModule: a.parentAsModule,
+          downstreamRevision: a.downstreamRevision,
         };
       })
     : null;

--- a/apps/spruce/src/pages/projectSettings/tabs/PatchAliasesTab/types.ts
+++ b/apps/spruce/src/pages/projectSettings/tabs/PatchAliasesTab/types.ts
@@ -17,6 +17,7 @@ type PatchTriggerAlias = {
   }>;
   status: string;
   parentAsModule: string;
+  downstreamRevision?: string;
   isGithubTriggerAlias: boolean;
 };
 

--- a/apps/spruce/src/pages/projectSettings/tabs/PatchAliasesTab/types.ts
+++ b/apps/spruce/src/pages/projectSettings/tabs/PatchAliasesTab/types.ts
@@ -17,7 +17,7 @@ type PatchTriggerAlias = {
   }>;
   status: string;
   parentAsModule: string;
-  downstreamRevision?: string;
+  downstreamRevision: string;
   isGithubTriggerAlias: boolean;
 };
 


### PR DESCRIPTION
DEVPROD-7529

### Description
Add new `downstreamRevision` field to the UI so that when saving patch trigger aliases in project settings, the field doesn't get cleared. Not implementing a UI component for this field because it's going to be API-only to start, per the linked Evergreen PR.

### Testing
Tested locally

### Evergreen PR
https://github.com/evergreen-ci/evergreen/pull/8012