### PR TITLE
DEVPROD-6860: Return data alongside errors for some Task GQL queries

### DIFF
--- a/apps/parsley/src/gql/generated/types.ts
+++ b/apps/parsley/src/gql/generated/types.ts
@@ -1502,6 +1502,7 @@ export type PatchTriggerAlias = {
   alias: Scalars["String"]["output"];
   childProjectId: Scalars["String"]["output"];
   childProjectIdentifier: Scalars["String"]["output"];
+  downstreamRevision?: Maybe<Scalars["String"]["output"]>;
   parentAsModule?: Maybe<Scalars["String"]["output"]>;
   status?: Maybe<Scalars["String"]["output"]>;
   taskSpecifiers?: Maybe<Array<TaskSpecifier>>;
@@ -1511,6 +1512,7 @@ export type PatchTriggerAlias = {
 export type PatchTriggerAliasInput = {
   alias: Scalars["String"]["input"];
   childProjectIdentifier: Scalars["String"]["input"];
+  downstreamRevision?: InputMaybe<Scalars["String"]["input"]>;
   parentAsModule?: InputMaybe<Scalars["String"]["input"]>;
   status?: InputMaybe<Scalars["String"]["input"]>;
   taskSpecifiers: Array<TaskSpecifierInput>;

--- a/apps/parsley/src/hooks/useTaskQuery/index.ts
+++ b/apps/parsley/src/hooks/useTaskQuery/index.ts
@@ -48,6 +48,7 @@ export const useTaskQuery = ({
     TaskQuery,
     TaskQueryVariables
   >(GET_TASK, {
+    errorPolicy: "all",
     skip: isLogkeeper || !taskID,
     variables: { execution: Number(execution), taskId: String(taskID) },
   });

--- a/apps/spruce/src/analytics/task/useTaskAnalytics.ts
+++ b/apps/spruce/src/analytics/task/useTaskAnalytics.ts
@@ -77,6 +77,7 @@ export const useTaskAnalytics = () => {
     skip: !taskId,
     // @ts-expect-error: FIXME. This comment was added by an automated script.
     variables: { taskId, execution },
+    errorPolicy: "all",
     fetchPolicy: "cache-first",
   });
 

--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -1502,6 +1502,7 @@ export type PatchTriggerAlias = {
   alias: Scalars["String"]["output"];
   childProjectId: Scalars["String"]["output"];
   childProjectIdentifier: Scalars["String"]["output"];
+  downstreamRevision?: Maybe<Scalars["String"]["output"]>;
   parentAsModule?: Maybe<Scalars["String"]["output"]>;
   status?: Maybe<Scalars["String"]["output"]>;
   taskSpecifiers?: Maybe<Array<TaskSpecifier>>;
@@ -1511,6 +1512,7 @@ export type PatchTriggerAlias = {
 export type PatchTriggerAliasInput = {
   alias: Scalars["String"]["input"];
   childProjectIdentifier: Scalars["String"]["input"];
+  downstreamRevision?: InputMaybe<Scalars["String"]["input"]>;
   parentAsModule?: InputMaybe<Scalars["String"]["input"]>;
   status?: InputMaybe<Scalars["String"]["input"]>;
   taskSpecifiers: Array<TaskSpecifierInput>;

--- a/apps/spruce/src/pages/Task.tsx
+++ b/apps/spruce/src/pages/Task.tsx
@@ -47,6 +47,7 @@ export const Task = () => {
     variables: { taskId, execution: selectedExecution },
     pollInterval: DEFAULT_POLL_INTERVAL,
     fetchPolicy: "network-only",
+    errorPolicy: "all",
     onError: (err) =>
       dispatchToast.error(
         `There was an error loading the task: ${err.message}`,
@@ -70,8 +71,7 @@ export const Task = () => {
   // @ts-expect-error: FIXME. This comment was added by an automated script.
   const attributed = annotation?.issues?.length > 0;
   const isDisplayTask = executionTasksFull != null;
-
-  if (error) {
+  if (error && !task) {
     return <PageDoesNotExist />;
   }
 


### PR DESCRIPTION
DEVPROD-6860

### Description
Allow Task page rendering and populating task analytics metadata even if `task.Annotations` is unavailable due to a permission error. The [SuspectedIssues](https://github.com/evergreen-ci/ui/blob/afd1d715aa6f89e8f3a8f5efecb1678c8bc3ca18/apps/spruce/src/pages/task/taskTabs/buildBaronAndAnnotations/Issues/Issues.tsx#L43), [BuildBaronContent](https://github.com/evergreen-ci/spruce/blob/b3372e60a8e06456701c0d906fe483647b07504b/src/pages/task/taskTabs/buildBaronAndAnnotations/BuildBaronContent.tsx#L64), and [Issues](https://github.com/evergreen-ci/ui/blob/afd1d715aa6f89e8f3a8f5efecb1678c8bc3ca18/apps/spruce/src/pages/task/taskTabs/buildBaronAndAnnotations/Issues/Issues.tsx#L43) components all handle empty data. 