### PR TITLE
DEVPROD-7838: Fix 422 error in CreateDuplicateProjectButton

### DIFF
--- a/apps/spruce/src/pages/projectSettings/CreateDuplicateProjectButton.tsx
+++ b/apps/spruce/src/pages/projectSettings/CreateDuplicateProjectButton.tsx
@@ -42,6 +42,7 @@ export const CreateDuplicateProjectButton: React.FC<Props> = ({
     UserProjectSettingsPermissionsQueryVariables
   >(USER_PROJECT_SETTINGS_PERMISSIONS, {
     variables: { projectIdentifier: id },
+    skip: !id,
   });
 
   const {


### PR DESCRIPTION
DEVPROD-7838

### Description
Fix 422 query error that originates from the Duplicate button.

### Testing
* Before change, you can consistently see a single 422 failed request in the network tab. After change, there is no failed request in the network tab.