### PR TITLE
DEVPROD-8159: Prevent Version Metadata Panel from accessing undefined

### DIFF
--- a/apps/spruce/src/gql/client/cache.ts
+++ b/apps/spruce/src/gql/client/cache.ts
@@ -13,6 +13,9 @@ export const cache = new InMemoryCache({
         repoEvents: {
           keyArgs: ["$id"],
         },
+        hasVersion: {
+          keyArgs: ["$patchId"],
+        },
       },
     },
     GeneralSubscription: {

--- a/apps/spruce/src/pages/Version.tsx
+++ b/apps/spruce/src/pages/Version.tsx
@@ -44,12 +44,6 @@ export const VersionPage: React.FC = () => {
   const [redirectURL, setRedirectURL] = useState(undefined);
   const [isLoadingData, setIsLoadingData] = useState(true);
 
-  // Reset state when version ID changes.
-  useEffect(() => {
-    setIsLoadingData(true);
-    setRedirectURL(undefined);
-  }, [versionId]);
-
   // This query is used to fetch the version data.
   const [getVersion, { data: versionData, error: versionError }] = useLazyQuery<
     VersionQuery,

--- a/apps/spruce/src/pages/Version.tsx
+++ b/apps/spruce/src/pages/Version.tsx
@@ -45,7 +45,6 @@ export const VersionPage: React.FC = () => {
   const [isLoadingData, setIsLoadingData] = useState(true);
 
   // Reset state when version ID changes.
-  // This triggers a re-fetch of the HasVersion query.
   useEffect(() => {
     setIsLoadingData(true);
     setRedirectURL(undefined);

--- a/apps/spruce/src/pages/Version.tsx
+++ b/apps/spruce/src/pages/Version.tsx
@@ -44,6 +44,13 @@ export const VersionPage: React.FC = () => {
   const [redirectURL, setRedirectURL] = useState(undefined);
   const [isLoadingData, setIsLoadingData] = useState(true);
 
+  // Reset state when version ID changes.
+  // This triggers a re-fetch of the HasVersion query.
+  useEffect(() => {
+    setIsLoadingData(true);
+    setRedirectURL(undefined);
+  }, [versionId]);
+
   // This query is used to fetch the version data.
   const [getVersion, { data: versionData, error: versionError }] = useLazyQuery<
     VersionQuery,


### PR DESCRIPTION
DEVPROD-8159

### Description
In-app navigation to the version page from a version page results in the Version Metadata panel processing an undefined version object. Resetting the version page state when the versionID URL field changes properly gates page rendering until new data is fetched. 
I'm unable to edit the diagram but this case is basically captured by the diagram entry statement "User Visits /version/{id}".

You can recreate this issue by clicking Previous Commit on this [page](https://spruce.mongodb.com/version/mongodb_mongo_v5.0_809167cbc5a70e1418d8090a7bb6a44395163c7a/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC).