### PR TITLE
DEVPROD-4046: Trim lines split between chunks

### DIFF
--- a/apps/parsley/src/utils/streams/index.ts
+++ b/apps/parsley/src/utils/streams/index.ts
@@ -37,7 +37,19 @@ const decodeStream = async (stream: ReadableStream, lineSizeLimit?: number) => {
       const lastIndex = result.length - 1;
       const lastLine = result[lastIndex];
       // Concatenate the last line with the first line of the "lines" array
-      result[lastIndex] = lastLine + lines[0];
+      if (
+        !lineSizeLimit ||
+        lastLine.length + lines[0].length <= lineSizeLimit
+      ) {
+        result[lastIndex] = lastLine + lines[0];
+      } else {
+        // If concatenating the line would exceed the limit, trim it
+        result[lastIndex] = trimLogLineToMaxSize(
+          lastLine + lines[0],
+          lineSizeLimit,
+        );
+        trimmedLines = true;
+      }
       // Remove the first line from the "lines" array
       lines.shift();
     }

--- a/apps/parsley/src/utils/streams/streams.test.ts
+++ b/apps/parsley/src/utils/streams/streams.test.ts
@@ -24,12 +24,23 @@ describe("decodeStream", () => {
   it("should trim a line if it is longer than the line limit", async () => {
     const readableStream = createReadableStream([
       "Hello World!\n",
-      "The\n",
-      "Quick brown fox jumped over the lazy dog",
+      "The\nQ",
+      "uick brown fox jumped over the lazy dog",
     ]);
     const { result, trimmedLines } = await decodeStream(readableStream, 5);
     expect(trimmedLines).toBe(true);
     expect(result).toStrictEqual(["Hello…", "The", "Quick…"]);
+  });
+
+  it("should handle a line that is longer than the line limit spread over multiple chunks", async () => {
+    const readableStream = createReadableStream([
+      "One\nThis is a single",
+      "line that is too lon",
+      "g\nNew",
+    ]);
+    const { result, trimmedLines } = await decodeStream(readableStream, 5);
+    expect(trimmedLines).toBe(true);
+    expect(result).toStrictEqual(["One", "This …", "New"]);
   });
 });
 


### PR DESCRIPTION
DEVPROD-4046

### Description
<!-- add description, context, thought process, etc -->
The current approach to trimming lines failed to catch any long lines split over multiple chunks. When concatenating the first line with the previously processed line, check whether their combined length is too long and trim if so.

### Testing
<!-- add a description of how you tested it -->
- Add unit test that fails without code changes
- Log linked in ticket now shows warning toast and trims correctly