### PR TITLE
DEVPROD-7652: Create new route for image pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@ node_modules
 
 .env-cmdrc.json
 
+# misc
+.DS_Store
+
 # artifacts
 bin
 build

--- a/apps/spruce/src/components/Content/index.tsx
+++ b/apps/spruce/src/components/Content/index.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/order
 import { Route, Routes, Navigate } from "react-router-dom";
 import {
   DistroSettingsRedirect,
@@ -6,7 +5,6 @@ import {
   UserPatchesRedirect,
   WaterfallCommitsRedirect,
 } from "components/Redirects";
-// eslint-disable-next-line import/order
 import { redirectRoutes, routes, slugs } from "constants/routes";
 import { CommitQueue } from "pages/CommitQueue";
 import { Commits } from "pages/Commits";
@@ -29,7 +27,6 @@ import { TaskQueue } from "pages/TaskQueue";
 import { UserPatches } from "pages/UserPatches";
 import { VariantHistory } from "pages/VariantHistory";
 import { VersionPage } from "pages/Version";
-
 import { Layout } from "./Layout";
 
 export const Content: React.FC = () => (

--- a/apps/spruce/src/components/Content/index.tsx
+++ b/apps/spruce/src/components/Content/index.tsx
@@ -1,3 +1,4 @@
+// eslint-disable-next-line import/order
 import { Route, Routes, Navigate } from "react-router-dom";
 import {
   DistroSettingsRedirect,
@@ -5,6 +6,7 @@ import {
   UserPatchesRedirect,
   WaterfallCommitsRedirect,
 } from "components/Redirects";
+// eslint-disable-next-line import/order
 import { redirectRoutes, routes, slugs } from "constants/routes";
 import { CommitQueue } from "pages/CommitQueue";
 import { Commits } from "pages/Commits";
@@ -13,6 +15,7 @@ import { Container } from "pages/Container";
 import { Distro } from "pages/Distro";
 import { Host } from "pages/Host";
 import { Hosts } from "pages/Hosts";
+import { Image } from "pages/Image";
 import { JobLogs } from "pages/JobLogs";
 import { MyPatches } from "pages/MyPatches";
 import { PageDoesNotExist } from "pages/NotFound";
@@ -26,6 +29,7 @@ import { TaskQueue } from "pages/TaskQueue";
 import { UserPatches } from "pages/UserPatches";
 import { VariantHistory } from "pages/VariantHistory";
 import { VersionPage } from "pages/Version";
+
 import { Layout } from "./Layout";
 
 export const Content: React.FC = () => (
@@ -52,6 +56,9 @@ export const Content: React.FC = () => (
       />
       <Route path={routes.host} element={<Host />} />
       <Route path={routes.hosts} element={<Hosts />} />
+      <Route path={`${routes.image}/*`} element={<Image />}>
+        <Route path={`:${slugs.tab}`} element={null} />
+      </Route>
       <Route path={routes.jobLogs} element={null}>
         <Route path={`:${slugs.buildId}`} element={<JobLogs isLogkeeper />}>
           <Route path={`:${slugs.groupId}`} element={null} />

--- a/apps/spruce/src/components/Content/index.tsx
+++ b/apps/spruce/src/components/Content/index.tsx
@@ -27,6 +27,7 @@ import { TaskQueue } from "pages/TaskQueue";
 import { UserPatches } from "pages/UserPatches";
 import { VariantHistory } from "pages/VariantHistory";
 import { VersionPage } from "pages/Version";
+import { isProduction } from "utils/environmentVariables";
 import { Layout } from "./Layout";
 
 export const Content: React.FC = () => (
@@ -53,9 +54,11 @@ export const Content: React.FC = () => (
       />
       <Route path={routes.host} element={<Host />} />
       <Route path={routes.hosts} element={<Hosts />} />
-      <Route path={`${routes.image}/*`} element={<Image />}>
-        <Route path={`:${slugs.tab}`} element={null} />
-      </Route>
+      {!isProduction() && (
+        <Route path={`${routes.image}/*`} element={<Image />}>
+          <Route path={`:${slugs.tab}`} element={null} />
+        </Route>
+      )}
       <Route path={routes.jobLogs} element={null}>
         <Route path={`:${slugs.buildId}`} element={<JobLogs isLogkeeper />}>
           <Route path={`:${slugs.groupId}`} element={null} />

--- a/apps/spruce/src/constants/routes.ts
+++ b/apps/spruce/src/constants/routes.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/order
 import { getGithubCommitUrl } from "constants/externalResources";
 import { TestStatus, HistoryQueryParams } from "types/history";
 import { PatchTab } from "types/patch";

--- a/apps/spruce/src/constants/routes.ts
+++ b/apps/spruce/src/constants/routes.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line import/order
 import { getGithubCommitUrl } from "constants/externalResources";
 import { TestStatus, HistoryQueryParams } from "types/history";
 import { PatchTab } from "types/patch";
@@ -22,6 +23,11 @@ export enum PreferencesTabRoutes {
   CLI = "cli",
   NewUI = "newUI",
   PublicKeys = "publickeys",
+}
+
+export enum ImageTabRoutes {
+  BuildInformation = "build-information",
+  Events = "events",
 }
 
 export enum ProjectSettingsTabRoutes {
@@ -57,6 +63,7 @@ const paths = {
   distros: "/distros",
   host: "/host",
   hosts: "/hosts",
+  image: "/image",
   jobLogs: "/job-logs",
   login: "/login",
   patch: "/patch",
@@ -79,6 +86,7 @@ export enum slugs {
   distroId = "distroId",
   groupId = "groupId",
   hostId = "hostId",
+  imageId = "imageId",
   patchId = "patchId",
   projectIdentifier = "projectIdentifier",
   tab = "tab",
@@ -94,6 +102,7 @@ export const idSlugs = [
   slugs.podId,
   slugs.distroId,
   slugs.hostId,
+  slugs.imageId,
   slugs.patchId,
   slugs.projectIdentifier,
   slugs.taskId,
@@ -116,6 +125,7 @@ export const routes = {
   distroSettings: `${paths.distro}/:${slugs.distroId}/${PageNames.Settings}`,
   host: `${paths.host}/:${slugs.hostId}`,
   hosts: paths.hosts,
+  image: `${paths.image}/:${slugs.imageId}`,
   jobLogs: paths.jobLogs,
   login: paths.login,
   myPatches: `${paths.user}/${PageNames.Patches}`,
@@ -257,6 +267,12 @@ export const getProjectPatchesRoute = (projectIdentifier: string) =>
   `${paths.project}/${encodeURIComponent(projectIdentifier)}/${
     PageNames.Patches
   }`;
+
+export const getImageRoute = (imageId: string, tab?: ImageTabRoutes) => {
+  const encodedImageId = encodeURIComponent(imageId);
+  const root = `${paths.image}/${encodedImageId}`;
+  return tab ? `${root}/${tab}` : `${root}/${ImageTabRoutes.BuildInformation}`;
+};
 
 export const getProjectSettingsRoute = (
   projectId: string,

--- a/apps/spruce/src/constants/routes.ts
+++ b/apps/spruce/src/constants/routes.ts
@@ -27,7 +27,7 @@ export enum PreferencesTabRoutes {
 
 export enum ImageTabRoutes {
   BuildInformation = "build-information",
-  Events = "events",
+  EventLog = "event-log",
 }
 
 export enum ProjectSettingsTabRoutes {

--- a/apps/spruce/src/pages/Image.tsx
+++ b/apps/spruce/src/pages/Image.tsx
@@ -1,0 +1,3 @@
+import { loadable } from "components/SpruceLoader";
+
+export const Image = loadable(() => import("./image/index"));

--- a/apps/spruce/src/pages/image/index.tsx
+++ b/apps/spruce/src/pages/image/index.tsx
@@ -1,3 +1,3 @@
-const Image: React.FC = () => <div>hi</div>;
+const Image: React.FC = () => <div>{}</div>;
 
 export default Image;

--- a/apps/spruce/src/pages/image/index.tsx
+++ b/apps/spruce/src/pages/image/index.tsx
@@ -1,0 +1,3 @@
+const Image: React.FC = () => <div>hi</div>;
+
+export default Image;


### PR DESCRIPTION
DEVPROD-7652

### Description
Created new route for image pages at /image/imageID/:tab with tabs of build-information and events. 

### Screenshots
![DEVPROD-7652](https://github.com/evergreen-ci/ui/assets/80068149/395eef31-af24-45a3-bfe8-f7783e7d6dba)
