### PR TITLE
Docs: Add codeowners and label prompt

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @evergreen-ci/evg-ui

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,5 @@
 DEVPROD-NNNNN
+<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? -->
 
 ### Description
 <!-- add description, context, thought process, etc -->


### PR DESCRIPTION
### Description
<!-- add description, context, thought process, etc -->
Add CODEOWNERS file which will automatically tag evg-ui as the reviewer for PRs in this repo. According to the [docs](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#about-code-owners) the reviewer will not be tagged if the PR is opened as a draft, and will be added when the PR is converted to "ready for review"

Also add prompt to PR template about labels!