### PR TITLE
DEVPROD-8356: Create outline for new GitHub tabs on project settings page

### DIFF
--- a/apps/parsley/src/gql/generated/types.ts
+++ b/apps/parsley/src/gql/generated/types.ts
@@ -622,6 +622,17 @@ export type GeneralSubscription = {
   triggerData?: Maybe<Scalars["StringMap"]["output"]>;
 };
 
+export type GitHubDynamicTokenPermissionGroup = {
+  __typename?: "GitHubDynamicTokenPermissionGroup";
+  name: Scalars["String"]["output"];
+  permissions: Scalars["StringMap"]["output"];
+};
+
+export type GitHubDynamicTokenPermissionGroupInput = {
+  name: Scalars["String"]["input"];
+  permissions: Scalars["StringMap"]["input"];
+};
+
 export type GitTag = {
   __typename?: "GitTag";
   pusher: Scalars["String"]["output"];
@@ -1690,6 +1701,7 @@ export type Project = {
   gitTagAuthorizedUsers?: Maybe<Array<Scalars["String"]["output"]>>;
   gitTagVersionsEnabled?: Maybe<Scalars["Boolean"]["output"]>;
   githubChecksEnabled?: Maybe<Scalars["Boolean"]["output"]>;
+  githubDynamicTokenPermissionGroups: Array<GitHubDynamicTokenPermissionGroup>;
   githubTriggerAliases?: Maybe<Array<Scalars["String"]["output"]>>;
   hidden?: Maybe<Scalars["Boolean"]["output"]>;
   id: Scalars["String"]["output"];
@@ -1827,6 +1839,9 @@ export type ProjectInput = {
   gitTagAuthorizedUsers?: InputMaybe<Array<Scalars["String"]["input"]>>;
   gitTagVersionsEnabled?: InputMaybe<Scalars["Boolean"]["input"]>;
   githubChecksEnabled?: InputMaybe<Scalars["Boolean"]["input"]>;
+  githubDynamicTokenPermissionGroups?: InputMaybe<
+    Array<GitHubDynamicTokenPermissionGroupInput>
+  >;
   githubTriggerAliases?: InputMaybe<Array<Scalars["String"]["input"]>>;
   id: Scalars["String"]["input"];
   identifier?: InputMaybe<Scalars["String"]["input"]>;
@@ -1904,6 +1919,8 @@ export enum ProjectSettingsSection {
   Containers = "CONTAINERS",
   General = "GENERAL",
   GithubAndCommitQueue = "GITHUB_AND_COMMIT_QUEUE",
+  GithubAppSettings = "GITHUB_APP_SETTINGS",
+  GithubPermissions = "GITHUB_PERMISSIONS",
   Notifications = "NOTIFICATIONS",
   PatchAliases = "PATCH_ALIASES",
   PeriodicBuilds = "PERIODIC_BUILDS",

--- a/apps/spruce/src/constants/featureFlags.ts
+++ b/apps/spruce/src/constants/featureFlags.ts
@@ -1,0 +1,3 @@
+import { isProduction } from "utils/environmentVariables";
+
+export const showGitHubAccessTokenProject = !isProduction();

--- a/apps/spruce/src/constants/routes.ts
+++ b/apps/spruce/src/constants/routes.ts
@@ -43,6 +43,8 @@ export enum ProjectSettingsTabRoutes {
   EventLog = "event-log",
   Containers = "containers",
   ViewsAndFilters = "views-and-filters",
+  AppSettings = "app-settings",
+  PermissionGroups = "permission-groups",
 }
 
 export enum DistroSettingsTabRoutes {

--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -622,6 +622,17 @@ export type GeneralSubscription = {
   triggerData?: Maybe<Scalars["StringMap"]["output"]>;
 };
 
+export type GitHubDynamicTokenPermissionGroup = {
+  __typename?: "GitHubDynamicTokenPermissionGroup";
+  name: Scalars["String"]["output"];
+  permissions: Scalars["StringMap"]["output"];
+};
+
+export type GitHubDynamicTokenPermissionGroupInput = {
+  name: Scalars["String"]["input"];
+  permissions: Scalars["StringMap"]["input"];
+};
+
 export type GitTag = {
   __typename?: "GitTag";
   pusher: Scalars["String"]["output"];
@@ -1690,6 +1701,7 @@ export type Project = {
   gitTagAuthorizedUsers?: Maybe<Array<Scalars["String"]["output"]>>;
   gitTagVersionsEnabled?: Maybe<Scalars["Boolean"]["output"]>;
   githubChecksEnabled?: Maybe<Scalars["Boolean"]["output"]>;
+  githubDynamicTokenPermissionGroups: Array<GitHubDynamicTokenPermissionGroup>;
   githubTriggerAliases?: Maybe<Array<Scalars["String"]["output"]>>;
   hidden?: Maybe<Scalars["Boolean"]["output"]>;
   id: Scalars["String"]["output"];
@@ -1827,6 +1839,9 @@ export type ProjectInput = {
   gitTagAuthorizedUsers?: InputMaybe<Array<Scalars["String"]["input"]>>;
   gitTagVersionsEnabled?: InputMaybe<Scalars["Boolean"]["input"]>;
   githubChecksEnabled?: InputMaybe<Scalars["Boolean"]["input"]>;
+  githubDynamicTokenPermissionGroups?: InputMaybe<
+    Array<GitHubDynamicTokenPermissionGroupInput>
+  >;
   githubTriggerAliases?: InputMaybe<Array<Scalars["String"]["input"]>>;
   id: Scalars["String"]["input"];
   identifier?: InputMaybe<Scalars["String"]["input"]>;
@@ -1904,6 +1919,8 @@ export enum ProjectSettingsSection {
   Containers = "CONTAINERS",
   General = "GENERAL",
   GithubAndCommitQueue = "GITHUB_AND_COMMIT_QUEUE",
+  GithubAppSettings = "GITHUB_APP_SETTINGS",
+  GithubPermissions = "GITHUB_PERMISSIONS",
   Notifications = "NOTIFICATIONS",
   PatchAliases = "PATCH_ALIASES",
   PeriodicBuilds = "PERIODIC_BUILDS",

--- a/apps/spruce/src/pages/projectSettings/Header.tsx
+++ b/apps/spruce/src/pages/projectSettings/Header.tsx
@@ -9,6 +9,7 @@ import { size } from "constants/tokens";
 import { getTabTitle } from "./getTabTitle";
 import { HeaderButtons } from "./HeaderButtons";
 import {
+  projectOnlyTabs,
   WritableProjectSettingsTabs,
   WritableProjectSettingsType,
 } from "./tabs/types";
@@ -31,12 +32,13 @@ export const Header: React.FC<Props> = ({
   const saveable = Object.values(WritableProjectSettingsTabs).includes(
     tab as WritableProjectSettingsType,
   );
+  const showRepoLink = !projectOnlyTabs.has(tab);
 
   return (
     <Container>
       <TitleContainer>
         <H2 data-cy="project-settings-tab-title">{title}</H2>
-        {projectType === ProjectType.AttachedProject && (
+        {projectType === ProjectType.AttachedProject && showRepoLink && (
           <StyledRouterLink
             // @ts-expect-error: FIXME. This comment was added by an automated script.
             to={getProjectSettingsRoute(attachedRepoId, tab)}

--- a/apps/spruce/src/pages/projectSettings/HeaderButtons.tsx
+++ b/apps/spruce/src/pages/projectSettings/HeaderButtons.tsx
@@ -32,6 +32,8 @@ const defaultToRepoDisabled: Set<WritableProjectSettingsType> = new Set([
   ProjectSettingsTabRoutes.Plugins,
   ProjectSettingsTabRoutes.Containers,
   ProjectSettingsTabRoutes.ViewsAndFilters,
+  ProjectSettingsTabRoutes.AppSettings,
+  ProjectSettingsTabRoutes.PermissionGroups,
 ]);
 
 interface Props {
@@ -184,6 +186,10 @@ const mapRouteToSection: Record<
   [ProjectSettingsTabRoutes.Containers]: ProjectSettingsSection.Containers,
   [ProjectSettingsTabRoutes.ViewsAndFilters]:
     ProjectSettingsSection.ViewsAndFilters,
+  [ProjectSettingsTabRoutes.AppSettings]:
+    ProjectSettingsSection.GithubAppSettings,
+  [ProjectSettingsTabRoutes.PermissionGroups]:
+    ProjectSettingsSection.GithubPermissions,
 };
 
 const ButtonRow = styled.div`

--- a/apps/spruce/src/pages/projectSettings/Tabs.tsx
+++ b/apps/spruce/src/pages/projectSettings/Tabs.tsx
@@ -1,12 +1,15 @@
 import { useEffect, useMemo } from "react";
 import styled from "@emotion/styled";
 import { Navigate, Route, Routes, useParams } from "react-router-dom";
+import { showGitHubAccessTokenProject } from "constants/featureFlags";
 import { ProjectSettingsTabRoutes, slugs } from "constants/routes";
 import { ProjectSettingsQuery, RepoSettingsQuery } from "gql/generated/types";
 import useScrollToAnchor from "hooks/useScrollToAnchor";
 import { useProjectSettingsContext } from "./Context";
 import { Header } from "./Header";
 import { NavigationModal } from "./NavigationModal";
+import { AppSettingsTab } from "./tabs/GithubAppSettingsTab/AppSettingsTab";
+import { PermissionGroupsTab } from "./tabs/GithubPermissionGroupsTab/PermissionGroupsTab";
 import {
   AccessTab,
   ContainersTab,
@@ -264,6 +267,30 @@ export const ProjectSettingsTabs: React.FC<Props> = ({
             />
           }
         />
+        {showGitHubAccessTokenProject && (
+          <Route
+            path={ProjectSettingsTabRoutes.AppSettings}
+            element={
+              <AppSettingsTab
+                projectData={
+                  tabData[ProjectSettingsTabRoutes.AppSettings].projectData
+                }
+              />
+            }
+          />
+        )}
+        {showGitHubAccessTokenProject && (
+          <Route
+            path={ProjectSettingsTabRoutes.PermissionGroups}
+            element={
+              <PermissionGroupsTab
+                projectData={
+                  tabData[ProjectSettingsTabRoutes.AppSettings].projectData
+                }
+              />
+            }
+          />
+        )}
         <Route
           path={ProjectSettingsTabRoutes.EventLog}
           element={

--- a/apps/spruce/src/pages/projectSettings/getTabTitle.ts
+++ b/apps/spruce/src/pages/projectSettings/getTabTitle.ts
@@ -42,6 +42,12 @@ export const getTabTitle = (
       [ProjectSettingsTabRoutes.Plugins]: {
         title: "Plugins",
       },
+      [ProjectSettingsTabRoutes.AppSettings]: {
+        title: "GitHub App Settings",
+      },
+      [ProjectSettingsTabRoutes.PermissionGroups]: {
+        title: "GitHub Permission Groups",
+      },
       [ProjectSettingsTabRoutes.EventLog]: {
         title: "Event Log",
       },

--- a/apps/spruce/src/pages/projectSettings/index.tsx
+++ b/apps/spruce/src/pages/projectSettings/index.tsx
@@ -12,6 +12,7 @@ import {
   SideNavItem,
   PageWrapper,
 } from "components/styles";
+import { showGitHubAccessTokenProject } from "constants/featureFlags";
 import {
   ProjectSettingsTabRoutes,
   getProjectSettingsRoute,
@@ -121,8 +122,8 @@ const ProjectSettings: React.FC = () => {
   }
 
   const sharedProps = {
-    projectIdentifier,
-    currentTab: tab,
+    projectIdentifier: projectIdentifier ?? "",
+    currentTab: tab ?? ProjectSettingsTabRoutes.General,
   };
   const project =
     projectType === ProjectType.Repo
@@ -167,67 +168,66 @@ const ProjectSettings: React.FC = () => {
         </ButtonsContainer>
 
         <SideNavGroup>
-          {/* @ts-expect-error: FIXME. This comment was added by an automated script. */}
           <ProjectSettingsNavItem
             {...sharedProps}
             tab={ProjectSettingsTabRoutes.General}
           />
-          {/* @ts-expect-error: FIXME. This comment was added by an automated script. */}
           <ProjectSettingsNavItem
             {...sharedProps}
             tab={ProjectSettingsTabRoutes.Access}
           />
-          {/* @ts-expect-error: FIXME. This comment was added by an automated script. */}
           <ProjectSettingsNavItem
             {...sharedProps}
             tab={ProjectSettingsTabRoutes.Variables}
           />
-          {/* @ts-expect-error: FIXME. This comment was added by an automated script. */}
           <ProjectSettingsNavItem
             {...sharedProps}
             tab={ProjectSettingsTabRoutes.GithubCommitQueue}
           />
-          {/* @ts-expect-error: FIXME. This comment was added by an automated script. */}
           <ProjectSettingsNavItem
             {...sharedProps}
             tab={ProjectSettingsTabRoutes.Notifications}
           />
-          {/* @ts-expect-error: FIXME. This comment was added by an automated script. */}
           <ProjectSettingsNavItem
             {...sharedProps}
             tab={ProjectSettingsTabRoutes.PatchAliases}
           />
-          {/* @ts-expect-error: FIXME. This comment was added by an automated script. */}
           <ProjectSettingsNavItem
             {...sharedProps}
             tab={ProjectSettingsTabRoutes.VirtualWorkstation}
           />
-          {/* @ts-expect-error: FIXME. This comment was added by an automated script. */}
           <ProjectSettingsNavItem
             {...sharedProps}
             tab={ProjectSettingsTabRoutes.Containers}
           />
-          {/* @ts-expect-error: FIXME. This comment was added by an automated script. */}
           <ProjectSettingsNavItem
             {...sharedProps}
             tab={ProjectSettingsTabRoutes.ViewsAndFilters}
           />
-          {/* @ts-expect-error: FIXME. This comment was added by an automated script. */}
           <ProjectSettingsNavItem
             {...sharedProps}
             tab={ProjectSettingsTabRoutes.ProjectTriggers}
           />
-          {/* @ts-expect-error: FIXME. This comment was added by an automated script. */}
           <ProjectSettingsNavItem
             {...sharedProps}
             tab={ProjectSettingsTabRoutes.PeriodicBuilds}
           />
-          {/* @ts-expect-error: FIXME. This comment was added by an automated script. */}
           <ProjectSettingsNavItem
             {...sharedProps}
             tab={ProjectSettingsTabRoutes.Plugins}
           />
-          {/* @ts-expect-error: FIXME. This comment was added by an automated script. */}
+          {showGitHubAccessTokenProject && projectType !== ProjectType.Repo && (
+            <ProjectSettingsNavItem
+              {...sharedProps}
+              tab={ProjectSettingsTabRoutes.AppSettings}
+            />
+          )}
+          {showGitHubAccessTokenProject && projectType !== ProjectType.Repo && (
+            <ProjectSettingsNavItem
+              {...sharedProps}
+              tab={ProjectSettingsTabRoutes.PermissionGroups}
+            />
+          )}
           <ProjectSettingsNavItem
             {...sharedProps}
             tab={ProjectSettingsTabRoutes.EventLog}

--- a/apps/spruce/src/pages/projectSettings/tabs/GithubAppSettingsTab/AppSettingsTab.tsx
+++ b/apps/spruce/src/pages/projectSettings/tabs/GithubAppSettingsTab/AppSettingsTab.tsx
@@ -1,0 +1,21 @@
+import { useMemo } from "react";
+import { ProjectSettingsTabRoutes } from "constants/routes";
+import { BaseTab } from "../BaseTab";
+import { getFormSchema } from "./getFormSchema";
+import { TabProps } from "./types";
+
+const tab = ProjectSettingsTabRoutes.AppSettings;
+
+export const AppSettingsTab: React.FC<TabProps> = ({ projectData }) => {
+  const initialFormState = projectData;
+
+  const formSchema = useMemo(() => getFormSchema(), []);
+
+  return (
+    <BaseTab
+      initialFormState={initialFormState}
+      formSchema={formSchema}
+      tab={tab}
+    />
+  );
+};

--- a/apps/spruce/src/pages/projectSettings/tabs/GithubAppSettingsTab/getFormSchema.tsx
+++ b/apps/spruce/src/pages/projectSettings/tabs/GithubAppSettingsTab/getFormSchema.tsx
@@ -1,0 +1,19 @@
+import { GetFormSchema } from "components/SpruceForm";
+
+export const getFormSchema = (): ReturnType<GetFormSchema> => ({
+  fields: {},
+  schema: {
+    type: "object" as "object",
+    properties: {
+      appCredentials: {
+        type: "object" as "object",
+        title: "App Credentials",
+      },
+      tokenPermissionRestrictions: {
+        type: "object" as "object",
+        title: "Token Permission Restrictions",
+      },
+    },
+  },
+  uiSchema: {},
+});

--- a/apps/spruce/src/pages/projectSettings/tabs/GithubAppSettingsTab/transformers.ts
+++ b/apps/spruce/src/pages/projectSettings/tabs/GithubAppSettingsTab/transformers.ts
@@ -1,0 +1,20 @@
+import { ProjectSettingsTabRoutes } from "constants/routes";
+import { ProjectSettingsQuery } from "gql/generated/types";
+import { FormToGqlFunction, GqlToFormFunction } from "../types";
+
+type Tab = ProjectSettingsTabRoutes.AppSettings;
+
+export const gqlToForm = ((data: ProjectSettingsQuery["projectSettings"]) => {
+  if (!data) return null;
+
+  return {};
+  // @ts-expect-error: FIXME. This comment was added by an automated script.
+}) satisfies GqlToFormFunction<Tab>;
+
+export const formToGql = ((_formState, isRepo, id) => ({
+  ...(isRepo ? { repoId: id } : { projectId: id }),
+  projectRef: {
+    // @ts-expect-error: FIXME. This comment was added by an automated script.
+    id,
+  },
+})) satisfies FormToGqlFunction<Tab>;

--- a/apps/spruce/src/pages/projectSettings/tabs/GithubAppSettingsTab/types.ts
+++ b/apps/spruce/src/pages/projectSettings/tabs/GithubAppSettingsTab/types.ts
@@ -1,0 +1,5 @@
+export interface AppSettingsFormState {}
+
+export type TabProps = {
+  projectData: AppSettingsFormState;
+};

--- a/apps/spruce/src/pages/projectSettings/tabs/GithubPermissionGroupsTab/PermissionGroupsTab.tsx
+++ b/apps/spruce/src/pages/projectSettings/tabs/GithubPermissionGroupsTab/PermissionGroupsTab.tsx
@@ -1,0 +1,21 @@
+import { useMemo } from "react";
+import { ProjectSettingsTabRoutes } from "constants/routes";
+import { BaseTab } from "../BaseTab";
+import { getFormSchema } from "./getFormSchema";
+import { TabProps } from "./types";
+
+const tab = ProjectSettingsTabRoutes.PermissionGroups;
+
+export const PermissionGroupsTab: React.FC<TabProps> = ({ projectData }) => {
+  const initialFormState = projectData;
+
+  const formSchema = useMemo(() => getFormSchema(), []);
+
+  return (
+    <BaseTab
+      initialFormState={initialFormState}
+      formSchema={formSchema}
+      tab={tab}
+    />
+  );
+};

--- a/apps/spruce/src/pages/projectSettings/tabs/GithubPermissionGroupsTab/getFormSchema.tsx
+++ b/apps/spruce/src/pages/projectSettings/tabs/GithubPermissionGroupsTab/getFormSchema.tsx
@@ -1,0 +1,15 @@
+import { GetFormSchema } from "components/SpruceForm";
+
+export const getFormSchema = (): ReturnType<GetFormSchema> => ({
+  fields: {},
+  schema: {
+    type: "object" as "object",
+    properties: {
+      permissionGroups: {
+        type: "object" as "object",
+        title: "Permission Groups",
+      },
+    },
+  },
+  uiSchema: {},
+});

--- a/apps/spruce/src/pages/projectSettings/tabs/GithubPermissionGroupsTab/transformers.ts
+++ b/apps/spruce/src/pages/projectSettings/tabs/GithubPermissionGroupsTab/transformers.ts
@@ -1,0 +1,20 @@
+import { ProjectSettingsTabRoutes } from "constants/routes";
+import { ProjectSettingsQuery } from "gql/generated/types";
+import { FormToGqlFunction, GqlToFormFunction } from "../types";
+
+type Tab = ProjectSettingsTabRoutes.AppSettings;
+
+export const gqlToForm = ((data: ProjectSettingsQuery["projectSettings"]) => {
+  if (!data) return null;
+
+  return {};
+  // @ts-expect-error: FIXME. This comment was added by an automated script.
+}) satisfies GqlToFormFunction<Tab>;
+
+export const formToGql = ((_formState, isRepo, id) => ({
+  ...(isRepo ? { repoId: id } : { projectId: id }),
+  projectRef: {
+    // @ts-expect-error: FIXME. This comment was added by an automated script.
+    id,
+  },
+})) satisfies FormToGqlFunction<Tab>;

--- a/apps/spruce/src/pages/projectSettings/tabs/GithubPermissionGroupsTab/types.ts
+++ b/apps/spruce/src/pages/projectSettings/tabs/GithubPermissionGroupsTab/types.ts
@@ -1,0 +1,5 @@
+export interface PermissionGroupsFormState {}
+
+export type TabProps = {
+  projectData: PermissionGroupsFormState;
+};

--- a/apps/spruce/src/pages/projectSettings/tabs/transformers.ts
+++ b/apps/spruce/src/pages/projectSettings/tabs/transformers.ts
@@ -2,7 +2,9 @@ import { ProjectSettingsTabRoutes } from "constants/routes";
 import * as access from "./AccessTab/transformers";
 import * as containers from "./ContainersTab/transformers";
 import * as general from "./GeneralTab/transformers";
+import * as appSettings from "./GithubAppSettingsTab/transformers";
 import * as githubCommitQueue from "./GithubCommitQueueTab/transformers";
+import * as permissionGroups from "./GithubPermissionGroupsTab/transformers";
 import * as notifications from "./NotificationsTab/transformers";
 import * as patchAliases from "./PatchAliasesTab/transformers";
 import * as periodicBuilds from "./PeriodicBuildsTab/transformers";
@@ -43,6 +45,10 @@ export const gqlToFormMap: {
   [ProjectSettingsTabRoutes.Containers]: containers.gqlToForm,
   // @ts-expect-error: FIXME. This comment was added by an automated script.
   [ProjectSettingsTabRoutes.ViewsAndFilters]: viewsAndFilters.gqlToForm,
+  // @ts-expect-error: FIXME. This comment was added by an automated script.
+  [ProjectSettingsTabRoutes.AppSettings]: appSettings.gqlToForm,
+  // @ts-expect-error: FIXME. This comment was added by an automated script.
+  [ProjectSettingsTabRoutes.PermissionGroups]: permissionGroups.gqlToForm,
 };
 
 export const formToGqlMap: {
@@ -72,4 +78,8 @@ export const formToGqlMap: {
   [ProjectSettingsTabRoutes.Containers]: containers.formToGql,
   // @ts-expect-error: FIXME. This comment was added by an automated script.
   [ProjectSettingsTabRoutes.ViewsAndFilters]: viewsAndFilters.formToGql,
+  // @ts-expect-error: FIXME. This comment was added by an automated script.
+  [ProjectSettingsTabRoutes.AppSettings]: appSettings.formToGql,
+  // @ts-expect-error: FIXME. This comment was added by an automated script.
+  [ProjectSettingsTabRoutes.PermissionGroups]: permissionGroups.formToGql,
 };

--- a/apps/spruce/src/pages/projectSettings/tabs/types.ts
+++ b/apps/spruce/src/pages/projectSettings/tabs/types.ts
@@ -8,7 +8,9 @@ import {
 import { AccessFormState } from "./AccessTab/types";
 import { ContainersFormState } from "./ContainersTab/types";
 import { GeneralFormState } from "./GeneralTab/types";
+import { AppSettingsFormState } from "./GithubAppSettingsTab/types";
 import { GCQFormState } from "./GithubCommitQueueTab/types";
+import { PermissionGroupsFormState } from "./GithubPermissionGroupsTab/types";
 import { NotificationsFormState } from "./NotificationsTab/types";
 import { PatchAliasesFormState } from "./PatchAliasesTab/types";
 import { PeriodicBuildsFormState } from "./PeriodicBuildsTab/types";
@@ -24,7 +26,6 @@ export type FormStateMap = {
     [ProjectSettingsTabRoutes.Access]: AccessFormState;
     [ProjectSettingsTabRoutes.Containers]: ContainersFormState;
     [ProjectSettingsTabRoutes.General]: GeneralFormState;
-    [ProjectSettingsTabRoutes.GithubCommitQueue]: GCQFormState;
     [ProjectSettingsTabRoutes.Notifications]: NotificationsFormState;
     [ProjectSettingsTabRoutes.PatchAliases]: PatchAliasesFormState;
     [ProjectSettingsTabRoutes.PeriodicBuilds]: PeriodicBuildsFormState;
@@ -33,6 +34,9 @@ export type FormStateMap = {
     [ProjectSettingsTabRoutes.Variables]: VariablesFormState;
     [ProjectSettingsTabRoutes.ViewsAndFilters]: ViewsFormState;
     [ProjectSettingsTabRoutes.VirtualWorkstation]: VWFormState;
+    [ProjectSettingsTabRoutes.GithubCommitQueue]: GCQFormState;
+    [ProjectSettingsTabRoutes.AppSettings]: AppSettingsFormState;
+    [ProjectSettingsTabRoutes.PermissionGroups]: PermissionGroupsFormState;
   }[T];
 };
 
@@ -61,3 +65,8 @@ export { WritableProjectSettingsTabs };
 
 export type WritableProjectSettingsType =
   (typeof WritableProjectSettingsTabs)[keyof typeof WritableProjectSettingsTabs];
+
+export const projectOnlyTabs: Set<ProjectSettingsTabRoutes> = new Set([
+  ProjectSettingsTabRoutes.AppSettings,
+  ProjectSettingsTabRoutes.PermissionGroups,
+]);


### PR DESCRIPTION
DEVPROD-8356

### Description
This PR creates an outline for the new tabs on the project settings page. The tabs don't have any functionality or real content yet, that will be added in follow up PRs.

The tabs will not be added for repos at this point in time.

### Screenshots

<img width="1035" alt="Screenshot 2024-07-03 at 10 57 29 AM" src="https://github.com/evergreen-ci/ui/assets/47064971/83943516-074c-44b7-b5d1-2de6f1433125">

