### PR TITLE
DEVPROD-5141: Fix commit check for prod deploy

### DIFF
--- a/apps/parsley/src/gql/generated/types.ts
+++ b/apps/parsley/src/gql/generated/types.ts
@@ -622,6 +622,17 @@ export type GeneralSubscription = {
   triggerData?: Maybe<Scalars["StringMap"]["output"]>;
 };
 
+export type GitHubDynamicTokenPermissionGroup = {
+  __typename?: "GitHubDynamicTokenPermissionGroup";
+  name: Scalars["String"]["output"];
+  permissions: Scalars["StringMap"]["output"];
+};
+
+export type GitHubDynamicTokenPermissionGroupInput = {
+  name: Scalars["String"]["input"];
+  permissions: Scalars["StringMap"]["input"];
+};
+
 export type GitTag = {
   __typename?: "GitTag";
   pusher: Scalars["String"]["output"];
@@ -1690,6 +1701,7 @@ export type Project = {
   gitTagAuthorizedUsers?: Maybe<Array<Scalars["String"]["output"]>>;
   gitTagVersionsEnabled?: Maybe<Scalars["Boolean"]["output"]>;
   githubChecksEnabled?: Maybe<Scalars["Boolean"]["output"]>;
+  githubDynamicTokenPermissionGroups: Array<GitHubDynamicTokenPermissionGroup>;
   githubTriggerAliases?: Maybe<Array<Scalars["String"]["output"]>>;
   hidden?: Maybe<Scalars["Boolean"]["output"]>;
   id: Scalars["String"]["output"];
@@ -1827,6 +1839,9 @@ export type ProjectInput = {
   gitTagAuthorizedUsers?: InputMaybe<Array<Scalars["String"]["input"]>>;
   gitTagVersionsEnabled?: InputMaybe<Scalars["Boolean"]["input"]>;
   githubChecksEnabled?: InputMaybe<Scalars["Boolean"]["input"]>;
+  githubDynamicTokenPermissionGroups?: InputMaybe<
+    Array<GitHubDynamicTokenPermissionGroupInput>
+  >;
   githubTriggerAliases?: InputMaybe<Array<Scalars["String"]["input"]>>;
   id: Scalars["String"]["input"];
   identifier?: InputMaybe<Scalars["String"]["input"]>;
@@ -1904,6 +1919,8 @@ export enum ProjectSettingsSection {
   Containers = "CONTAINERS",
   General = "GENERAL",
   GithubAndCommitQueue = "GITHUB_AND_COMMIT_QUEUE",
+  GithubAppSettings = "GITHUB_APP_SETTINGS",
+  GithubPermissions = "GITHUB_PERMISSIONS",
   Notifications = "NOTIFICATIONS",
   PatchAliases = "PATCH_ALIASES",
   PeriodicBuilds = "PERIODIC_BUILDS",

--- a/packages/deploy-utils/src/utils/git/get-current-deployed-commit.test.ts
+++ b/packages/deploy-utils/src/utils/git/get-current-deployed-commit.test.ts
@@ -1,0 +1,57 @@
+import Stream from "stream";
+import { tagIsValid } from ".";
+
+describe("getCurrentDeployedCommit without mocking https requests", () => {
+  it("fetches the commit from spruce", async () => {
+    const { getCurrentlyDeployedCommit } = await import(
+      "./get-current-deployed-commit"
+    );
+    expect(await getCurrentlyDeployedCommit("spruce")).toHaveLength(40);
+  });
+
+  it("fetches the commit from parsley", async () => {
+    const { getCurrentlyDeployedCommit } = await import(
+      "./get-current-deployed-commit"
+    );
+    expect(await getCurrentlyDeployedCommit("parsley")).toHaveLength(40);
+  });
+});
+
+describe("when get request fails", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.doMock("https", () => ({
+      default: vi.fn(),
+      get: vi.fn().mockImplementation((_, cb) => {
+        const s = new Stream();
+        cb(s);
+        s.emit("error", new Error("invalid"));
+      }),
+    }));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.doUnmock("https");
+  });
+
+  it("gets a local spruce tag", async () => {
+    const { getCurrentlyDeployedCommit } = await import(
+      "./get-current-deployed-commit"
+    );
+    const app = "spruce";
+    const commit = await getCurrentlyDeployedCommit(app);
+    expect(commit).not.toHaveLength(40);
+    expect(tagIsValid(app, commit)).toBe(true);
+  });
+
+  it("gets a local parsley tag", async () => {
+    const { getCurrentlyDeployedCommit } = await import(
+      "./get-current-deployed-commit"
+    );
+    const app = "parsley";
+    const commit = await getCurrentlyDeployedCommit(app);
+    expect(commit).not.toHaveLength(40);
+    expect(tagIsValid(app, commit)).toBe(true);
+  });
+});

--- a/packages/deploy-utils/src/utils/git/get-current-deployed-commit.ts
+++ b/packages/deploy-utils/src/utils/git/get-current-deployed-commit.ts
@@ -1,5 +1,5 @@
 import { get } from "https";
-import { getLatestTag } from ".";
+import { getLatestTag, tagIsValid } from ".";
 import { DeployableApp } from "../types";
 
 /**
@@ -47,9 +47,11 @@ export const getCurrentlyDeployedCommit = async (app: DeployableApp) => {
     }
   }
 
-  const commitIsCorrectLength = commit?.length === 40;
+  commit = commit?.trim();
 
-  if (commitIsCorrectLength) {
+  const commitIsValid = commit?.length === 40 || tagIsValid(app, commit);
+
+  if (commitIsValid) {
     return commit;
   }
   throw new Error("No valid commit found");

--- a/packages/deploy-utils/src/utils/git/git.test.ts
+++ b/packages/deploy-utils/src/utils/git/git.test.ts
@@ -71,10 +71,8 @@ describe("getCurrentlyDeployedCommit", () => {
 
   it("returns a valid local commit", async () => {
     vi.mocked(get).mockImplementation(errorMock);
-    vi.mocked(execSync).mockReturnValue(validCommitString);
-    expect(await getCurrentlyDeployedCommit("spruce")).toEqual(
-      validCommitString,
-    );
+    vi.mocked(execSync).mockReturnValue("spruce/v1.0.0");
+    expect(await getCurrentlyDeployedCommit("spruce")).toEqual("spruce/v1.0.0");
     expect(vi.mocked(execSync)).toHaveBeenCalledOnce();
   });
 

--- a/packages/deploy-utils/src/utils/git/tag.test.ts
+++ b/packages/deploy-utils/src/utils/git/tag.test.ts
@@ -5,7 +5,7 @@ describe("tagIsValid", () => {
     expect(tagIsValid("parsley", "parsley/v1.2.3")).toEqual(true);
   });
 
-  it("should not match on the wrong app's tag tag", () => {
+  it("should not match on the wrong app's tag", () => {
     expect(tagIsValid("parsley", "spruce/v1.2.3")).toEqual(false);
   });
 });

--- a/packages/deploy-utils/src/utils/git/tag.test.ts
+++ b/packages/deploy-utils/src/utils/git/tag.test.ts
@@ -1,31 +1,25 @@
-import { getLatestTag } from ".";
-import { DeployableApp } from "../types";
+import { getLatestTag, tagIsValid } from ".";
+
+describe("tagIsValid", () => {
+  it("should match on a known valid tag", () => {
+    expect(tagIsValid("parsley", "parsley/v1.2.3")).toEqual(true);
+  });
+
+  it("should not match on the wrong app's tag tag", () => {
+    expect(tagIsValid("parsley", "spruce/v1.2.3")).toEqual(false);
+  });
+});
 
 describe("getLatestTag", () => {
-  const currentlyDeployedTagRegex = (app: DeployableApp) =>
-    new RegExp(`${app}/v\\d+.\\d+.\\d+`);
-
-  it("currentlyDeployedTagRegex should match on a known valid tag", () => {
-    const tag = currentlyDeployedTagRegex("parsley").test("parsley/v1.2.3");
-    expect(tag).toBeTruthy();
-  });
-
-  it("currentlyDeployedTagRegex should not match on the wrong app's tag tag", () => {
-    const tag = currentlyDeployedTagRegex("parsley").test("spruce/v1.2.3");
-    expect(tag).toBeFalsy();
-  });
-
   it("should return the latest spruce tag", () => {
     const app = "spruce";
     const latestTag = getLatestTag(app);
-    const latestTagIsTag = currentlyDeployedTagRegex(app).test(latestTag);
-    expect(latestTagIsTag).toBeTruthy();
+    expect(tagIsValid(app, latestTag)).toEqual(true);
   });
 
   it("should return the latest parsley tag", () => {
     const app = "parsley";
     const latestTag = getLatestTag(app);
-    const latestTagIsTag = currentlyDeployedTagRegex(app).test(latestTag);
-    expect(latestTagIsTag).toBeTruthy();
+    expect(tagIsValid(app, latestTag)).toEqual(true);
   });
 });

--- a/packages/deploy-utils/src/utils/git/tag.ts
+++ b/packages/deploy-utils/src/utils/git/tag.ts
@@ -87,10 +87,20 @@ const pushTags = () => {
   }
 };
 
+/**
+ * tagIsValid asserts whether a given string matches a tag for a specified app
+ * @param app - app with which tag is associated
+ * @param matchString - string to test against
+ * @returns - boolean indicating whether matchString is a valid tag
+ */
+const tagIsValid = (app: DeployableApp, matchString: string) =>
+  new RegExp(`${app}/v\\d+.\\d+.\\d+`).test(matchString);
+
 export {
   createTagAndPush,
   deleteTag,
   getLatestTag,
   getTagFromCommit,
   pushTags,
+  tagIsValid,
 };


### PR DESCRIPTION
DEVPROD-5141 - Fix bug introduced in #210 blocking new deploy script from working
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? -->

### Description
<!-- add description, context, thought process, etc -->
- Fix string check: commit fetched from remote file was not being trimmed and so was not 40 characters
- Also validate tag correctly if local commit is used, since it would not be 40 characters

### Testing
<!-- add a description of how you tested it -->
- Add unit tests