### PR TITLE
DEVPROD-5141: Write commit.txt file on deploy

### DIFF
--- a/packages/deploy-utils/src/build-and-push/build-and-push.test.ts
+++ b/packages/deploy-utils/src/build-and-push/build-and-push.test.ts
@@ -1,9 +1,14 @@
 import { execSync } from "child_process";
+import { writeFileSync } from "fs";
 import { buildAndPush } from ".";
 import { pushToS3 } from "../utils/s3";
 
 vi.mock("child_process", () => ({
   execSync: vi.fn(),
+}));
+
+vi.mock("fs", () => ({
+  writeFileSync: vi.fn(),
 }));
 
 vi.mock("../utils/s3", () => ({
@@ -16,9 +21,16 @@ describe("buildAndPush", () => {
   });
 
   it("calls pushToS3 function when BUCKET is defined", () => {
+    vi.mocked(execSync).mockImplementationOnce(vi.fn());
+    vi.mocked(execSync).mockReturnValueOnce("commitHash");
     buildAndPush("bucket-name");
     expect(vi.mocked(pushToS3)).toHaveBeenCalledOnce();
     expect(vi.mocked(pushToS3)).toHaveBeenCalledWith("bucket-name");
+    expect(vi.mocked(writeFileSync)).toHaveBeenCalledOnce();
+    expect(vi.mocked(writeFileSync)).toHaveBeenCalledWith(
+      "dist/commit.txt",
+      "commitHash",
+    );
   });
 
   it("fails when yarn build fails", () => {

--- a/packages/deploy-utils/src/build-and-push/index.ts
+++ b/packages/deploy-utils/src/build-and-push/index.ts
@@ -1,4 +1,6 @@
 import { execSync } from "child_process";
+import { writeFileSync } from "fs";
+import { getCurrentCommit } from "../utils/git";
 import { pushToS3 } from "../utils/s3";
 
 /**
@@ -7,6 +9,9 @@ import { pushToS3 } from "../utils/s3";
  */
 export const buildAndPush = (bucket: string) => {
   execSync(`yarn build`, { stdio: "inherit" });
+
+  const currentCommit = getCurrentCommit();
+  writeFileSync("dist/commit.txt", currentCommit);
 
   pushToS3(bucket);
 };


### PR DESCRIPTION
Fix for DEVPROD-5141
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? -->

### Description
<!-- add description, context, thought process, etc -->
- Write commit.txt file on staging/beta/prod deploys. I opted to include it on non-production since this makes it more testable and keeps the workflows more similar.

### Testing
<!-- add a description of how you tested it -->
- Just deployed to beta at https://spruce-beta.corp.mongodb.com/commit.txt
- This will fix (at least some of) the broken waterfall tests. Tests that look for these files to be deployed are still currently broken.