### PR TITLE
DEVPROD-8537: Require minimum length for image field

### DIFF
--- a/apps/spruce/src/pages/distroSettings/tabs/GeneralTab/getFormSchema.ts
+++ b/apps/spruce/src/pages/distroSettings/tabs/GeneralTab/getFormSchema.ts
@@ -28,6 +28,7 @@ export const getFormSchema = (
             type: "string" as "string",
             title: "Image",
             default: "",
+            minLength: 1,
           },
         },
       },


### PR DESCRIPTION
DEVPROD-8537
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? -->

### Description
Require minimum length for the distro's `image_id` field. I have checked the distros on staging & production and filled in this field where it was missing.
