### PR TITLE
DEVPROD-5295: Fix type error

### DIFF
--- a/apps/parsley/src/utils/logRow/logRow.test.ts
+++ b/apps/parsley/src/utils/logRow/logRow.test.ts
@@ -77,6 +77,7 @@ describe("includesLineNumber", () => {
         isOpen: true,
         range: { end: 10, start: 1 },
         rowType: RowType.SubsectionHeader,
+        step: "1.1 of 4",
       };
       expect(includesLineNumber(logLine, 9)).toBe(true);
       expect(includesLineNumber(logLine, 3)).toBe(true);
@@ -91,6 +92,7 @@ describe("includesLineNumber", () => {
         isOpen: true,
         range: { end: 10, start: 1 },
         rowType: RowType.SubsectionHeader,
+        step: "1.1 of 4",
       };
       expect(includesLineNumber(logLine, 11)).toBe(false);
       expect(includesLineNumber(logLine, 10)).toBe(false);


### PR DESCRIPTION
DEVPROD-5295
This fixes a type error introduced in [this](https://spruce.mongodb.com/version/evergreen_ui_db3e6af4878b518493a472b2a67886b82be56cd0/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) mainline commit
