### PR TITLE
DEVPROD-7910: Fix unresponsive notifications page bug

### DIFF
--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -1987,6 +1987,7 @@ export type Query = {
   host?: Maybe<Host>;
   hostEvents: HostEvents;
   hosts: HostsResponse;
+  images: Array<Scalars["String"]["output"]>;
   instanceTypes: Array<Scalars["String"]["output"]>;
   logkeeperBuildMetadata: LogkeeperBuild;
   mainlineCommits?: Maybe<MainlineCommits>;

--- a/apps/spruce/src/pages/preferences/preferencesTabs/notificationTab/UserSubscriptions.tsx
+++ b/apps/spruce/src/pages/preferences/preferencesTabs/notificationTab/UserSubscriptions.tsx
@@ -43,6 +43,24 @@ import { getResourceRoute } from "./utils";
 const { gray } = palette;
 
 export const UserSubscriptions: React.FC<{}> = () => {
+  const subscriptions = useSubscriptionData();
+  return (
+    <>
+      <SettingsCardTitle>Manage subscriptions</SettingsCardTitle>
+      <SettingsCard>
+        {!subscriptions?.length ? (
+          "No subscriptions found."
+        ) : (
+          <SubscriptionsTable subscriptions={subscriptions} />
+        )}
+      </SettingsCard>
+    </>
+  );
+};
+
+const SubscriptionsTable: React.FC<{
+  subscriptions: GeneralSubscription[];
+}> = ({ subscriptions }) => {
   const dispatchToast = useToastContext();
   const spruceConfig = useSpruceConfig();
   const jiraHost = spruceConfig?.jira?.host;
@@ -65,9 +83,6 @@ export const UserSubscriptions: React.FC<{}> = () => {
       );
     },
   });
-
-  const subscriptions = useSubscriptionData();
-
   const [columnFilters, setColumnFilters] = useState([]);
   const [rowSelection, setRowSelection] = useState({});
 
@@ -198,52 +213,43 @@ export const UserSubscriptions: React.FC<{}> = () => {
 
   return (
     <>
-      <SettingsCardTitle>Manage subscriptions</SettingsCardTitle>
-      <SettingsCard>
-        {!subscriptions?.length ? (
-          "No subscriptions found."
-        ) : (
-          <>
-            <InteractiveWrapper>
-              <Button
-                data-cy="delete-some-button"
-                disabled={Object.entries(rowSelection).length === 0}
-                leftGlyph={<Icon glyph="Trash" />}
-                onClick={onDeleteSubscriptions}
-                size="small"
-              >
-                Delete
-                {Object.entries(rowSelection).length
-                  ? ` (${Object.entries(rowSelection).length})`
-                  : ""}
-              </Button>
-              <PaginationWrapper>
-                <Pagination
-                  itemsPerPage={table.getState().pagination.pageSize}
-                  onItemsPerPageOptionChange={(value: string) => {
-                    table.setPageSize(Number(value));
-                  }}
-                  numTotalItems={subscriptions.length}
-                  currentPage={table.getState().pagination.pageIndex + 1}
-                  onCurrentPageOptionChange={(value: string) => {
-                    table.setPageIndex(Number(value) - 1);
-                  }}
-                  onBackArrowClick={() => table.previousPage()}
-                  onForwardArrowClick={() => table.nextPage()}
-                />
-              </PaginationWrapper>
-            </InteractiveWrapper>
-            <BaseTable
-              data-cy-row="subscription-row"
-              table={table}
-              shouldAlternateRowColor
-            />
-            <TableFooter>
-              <ClearSubscriptions />
-            </TableFooter>
-          </>
-        )}
-      </SettingsCard>
+      <InteractiveWrapper>
+        <Button
+          data-cy="delete-some-button"
+          disabled={Object.entries(rowSelection).length === 0}
+          leftGlyph={<Icon glyph="Trash" />}
+          onClick={onDeleteSubscriptions}
+          size="small"
+        >
+          Delete
+          {Object.entries(rowSelection).length
+            ? ` (${Object.entries(rowSelection).length})`
+            : ""}
+        </Button>
+        <PaginationWrapper>
+          <Pagination
+            itemsPerPage={table.getState().pagination.pageSize}
+            onItemsPerPageOptionChange={(value: string) => {
+              table.setPageSize(Number(value));
+            }}
+            numTotalItems={subscriptions.length}
+            currentPage={table.getState().pagination.pageIndex + 1}
+            onCurrentPageOptionChange={(value: string) => {
+              table.setPageIndex(Number(value) - 1);
+            }}
+            onBackArrowClick={() => table.previousPage()}
+            onForwardArrowClick={() => table.nextPage()}
+          />
+        </PaginationWrapper>
+      </InteractiveWrapper>
+      <BaseTable
+        data-cy-row="subscription-row"
+        table={table}
+        shouldAlternateRowColor
+      />
+      <TableFooter>
+        <ClearSubscriptions />
+      </TableFooter>
     </>
   );
 };


### PR DESCRIPTION
DEVPROD-7910
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? -->

### Description
<!-- add description, context, thought process, etc -->
On the notifications page, making any change while not having any individual subscriptions would cause the page to become unresponsive. This was a result of the internal Tanstack table within the subscriptions table attempting to perform operations while empty. The easiest way to get around this is just to split out the table into a separate component that is not rendered if the user has no subscriptions. 

### Testing
<!-- add a description of how you tested it -->
Editing the page with no subscriptions is successful