### PR TITLE
DEVPROD-7027: Fix email bug

### DIFF
--- a/packages/deploy-utils/src/email/email.test.ts
+++ b/packages/deploy-utils/src/email/email.test.ts
@@ -124,7 +124,7 @@ describe("makeEmail", async () => {
 
 describe("sendEmail", () => {
   const emailCommandRegex =
-    /^(evergreen|~\/evergreen)( -c .evergreen.yml)?(\s+)notify email -f sender@mongodb.com -r foo@mongodb.com -s '2020-06-22 Spruce Deploy to (spruce\/v\d+.\d+.\d+|[0-9a-f]{40})' -b '<ul>(<li>(.*)<\/li>)*<\/ul><p><b>To revert, rerun task from previous release tag \(spruce\/v\d+.\d+.\d+\)<\/b><\/p>'$/;
+    /^(evergreen|(~\/evergreen -c .evergreen.yml))(\s+)notify email -f sender@mongodb.com -r foo@mongodb.com -s '2020-06-22 Spruce Deploy to (spruce\/v\d+.\d+.\d+|[0-9a-f]{40})' -b '<ul>(<li>(.*)<\/li>)*<\/ul><p><b>To revert, rerun task from previous release tag \(spruce\/v\d+.\d+.\d+\)<\/b><\/p>'$/;
 
   const revertEmailRegex =
     /^(evergreen|~\/evergreen)( -c .evergreen.yml)?(\s+)notify email -f sender@mongodb.com -r foo@mongodb.com -s '2020-06-22 Spruce Deploy to (spruce\/v\d+.\d+.\d+|[0-9a-f]{40}) \(Revert\)' -b '<ul>(<li>(.*)<\/li>)*<\/ul>'$/;

--- a/packages/deploy-utils/src/email/utils.ts
+++ b/packages/deploy-utils/src/email/utils.ts
@@ -32,7 +32,7 @@ export const findEvergreen = () => {
     return { evgExecutable: "evergreen", credentials: "" };
   }
   if (commandExists("~/evergreen")) {
-    return { evgExecutable: "evergreen", credentials: "-c .evergreen.yml" };
+    return { evgExecutable: "~/evergreen", credentials: "-c .evergreen.yml" };
   }
   return null;
 };


### PR DESCRIPTION
DEVPROD-7027
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? -->

### Description
<!-- add description, context, thought process, etc -->
- Fix mistake where wrong path to command was returned when searching for the Evergreen executable. This led to failures sending today's deploy email ([Parsley](https://spruce.mongodb.com/task/evergreen_ui_parsley_deploy_parsley_prod__parsley_v2.1.34_24_07_15_18_07_14?execution=0), [Spruce](https://spruce.mongodb.com/version/evergreen_ui_spruce_v4.1.48_66956595233b000007ce4f9a/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC))

### Testing
<!-- add a description of how you tested it -->
- Ran patch without these changes and with improved tests and tests [failed](https://spruce.mongodb.com/task/evergreen_ui_deploy_utils_test_patch_cb12b0296cfbdb636293caa471c3a5013be3ef61_6695828e6065e50007ab64f9_24_07_15_20_12_05/logs?execution=0)