### PR TITLE
DEVPROD-7027: Fix off-by-1 date error

### DIFF
--- a/packages/deploy-utils/package.json
+++ b/packages/deploy-utils/package.json
@@ -8,7 +8,7 @@
     "eslint:fix": "yarn eslint:strict --fix",
     "eslint:staged": "STRICT=1 eslint",
     "eslint:strict": "STRICT=1 eslint .",
-    "test": "vitest"
+    "test": "TZ=UTC vitest"
   },
   "dependencies": {
     "@evg-ui/lib": "*",

--- a/packages/deploy-utils/src/email/email.test.ts
+++ b/packages/deploy-utils/src/email/email.test.ts
@@ -13,7 +13,7 @@ vi.mock("../utils/environment", async (importOriginal) => ({
 
 describe("formatDate", () => {
   it("correctly formats a date", () => {
-    const d = new Date(2024, 1, 23);
+    const d = new Date("2024-01-23");
     expect(formatDate(d)).toEqual("2024-01-23");
   });
 });
@@ -62,7 +62,7 @@ describe("makeEmail", async () => {
     vi.stubEnv("CI", "true");
     vi.stubEnv("DEPLOYS_EMAIL", "foo@mongodb.com");
     vi.stubEnv("AUTHOR_EMAIL", "sender@mongodb.com");
-    vi.useFakeTimers().setSystemTime(new Date(2020, 6, 22));
+    vi.useFakeTimers().setSystemTime(new Date("2020-06-22"));
     expect(makeEmail(defaultArgs)).toStrictEqual({
       body: "<ul><li>commit‘s a</li><li>commit b</li></ul><p><b>To revert, rerun task from previous release tag (spruce/v0.0.1)</b></p>",
       from: "sender@mongodb.com",
@@ -76,7 +76,7 @@ describe("makeEmail", async () => {
     vi.stubEnv("DEPLOYS_EMAIL", "foo@mongodb.com");
     vi.stubEnv("AUTHOR_EMAIL", "sender@mongodb.com");
     vi.spyOn(shellUtils, "execTrim").mockReturnValue("git.email@mongodb.com");
-    vi.useFakeTimers().setSystemTime(new Date(2020, 6, 22));
+    vi.useFakeTimers().setSystemTime(new Date("2020-06-22"));
     expect(makeEmail(defaultArgs)).toStrictEqual({
       body: "<ul><li>commit‘s a</li><li>commit b</li></ul><p><b>To revert, rerun task from previous release tag (spruce/v0.0.1)</b></p>",
       from: "git.email@mongodb.com",
@@ -89,7 +89,7 @@ describe("makeEmail", async () => {
     vi.stubEnv("CI", "true");
     vi.stubEnv("DEPLOYS_EMAIL", "foo@mongodb.com");
     vi.stubEnv("AUTHOR_EMAIL", "sender@mongodb.com");
-    vi.useFakeTimers().setSystemTime(new Date(2020, 6, 22));
+    vi.useFakeTimers().setSystemTime(new Date("2020-06-22"));
     expect(
       makeEmail({
         ...defaultArgs,
@@ -107,7 +107,7 @@ describe("makeEmail", async () => {
     vi.stubEnv("CI", "true");
     vi.stubEnv("DEPLOYS_EMAIL", "foo@mongodb.com");
     vi.stubEnv("AUTHOR_EMAIL", "sender@mongodb.com");
-    vi.useFakeTimers().setSystemTime(new Date(2020, 6, 22));
+    vi.useFakeTimers().setSystemTime(new Date("2020-06-22"));
     expect(
       makeEmail({
         ...defaultArgs,
@@ -138,7 +138,7 @@ describe("sendEmail", () => {
     vi.stubEnv("DEPLOYS_EMAIL", "foo@mongodb.com");
     vi.stubEnv("EXECUTION", "0");
     vi.mocked(getAppToDeploy).mockReturnValue("spruce");
-    vi.useFakeTimers().setSystemTime(new Date(2020, 6, 22));
+    vi.useFakeTimers().setSystemTime(new Date("2020-06-22"));
   });
 
   afterEach(() => {

--- a/packages/deploy-utils/src/email/email.test.ts
+++ b/packages/deploy-utils/src/email/email.test.ts
@@ -3,8 +3,6 @@ import { getAppToDeploy } from "../utils/environment";
 import * as shellUtils from "../utils/shell";
 import { findEvergreen, formatDate } from "./utils";
 
-const mockCommit = "0000011111222223333344444555556666677777";
-
 vi.mock("../utils/environment", async (importOriginal) => ({
   // @ts-expect-error
   ...(await importOriginal()),
@@ -124,10 +122,10 @@ describe("makeEmail", async () => {
 
 describe("sendEmail", () => {
   const emailCommandRegex =
-    /^(evergreen|(~\/evergreen -c .evergreen.yml))(\s+)notify email -f sender@mongodb.com -r foo@mongodb.com -s '2020-06-22 Spruce Deploy to (spruce\/v\d+.\d+.\d+|[0-9a-f]{40})' -b '<ul>(<li>(.*)<\/li>)*<\/ul><p><b>To revert, rerun task from previous release tag \(spruce\/v\d+.\d+.\d+\)<\/b><\/p>'$/;
+    /^(evergreen|(~\/evergreen -c .evergreen.yml))(\s+)notify email -f sender@mongodb.com -r foo@mongodb.com -s '2020-06-22 Spruce Deploy to (spruce\/v\d+.\d+.\d+|[0-9a-f]{7})' -b '<ul>(<li>(.*)<\/li>)*<\/ul><p><b>To revert, rerun task from previous release tag \(spruce\/v\d+.\d+.\d+\)<\/b><\/p>'$/;
 
   const revertEmailRegex =
-    /^(evergreen|~\/evergreen)( -c .evergreen.yml)?(\s+)notify email -f sender@mongodb.com -r foo@mongodb.com -s '2020-06-22 Spruce Deploy to (spruce\/v\d+.\d+.\d+|[0-9a-f]{40}) \(Revert\)' -b '<ul>(<li>(.*)<\/li>)*<\/ul>'$/;
+    /^(evergreen|~\/evergreen)( -c .evergreen.yml)?(\s+)notify email -f sender@mongodb.com -r foo@mongodb.com -s '2020-06-22 Spruce Deploy to (spruce\/v\d+.\d+.\d+|[0-9a-f]{7}) \(Revert\)' -b '<ul>(<li>(.*)<\/li>)*<\/ul>'$/;
 
   beforeEach(() => {
     vi.unstubAllEnvs();
@@ -148,12 +146,12 @@ describe("sendEmail", () => {
 
   describe("validate regexes", () => {
     it("matches on a non-revert email", () => {
-      const emailCmd = `evergreen notify email -f sender@mongodb.com -r foo@mongodb.com -s '2020-06-22 Spruce Deploy to ${mockCommit}' -b '<ul><li>123abc commit message</li></ul><p><b>To revert, rerun task from previous release tag (spruce/v0.1.2)</b></p>'`;
+      const emailCmd = `evergreen notify email -f sender@mongodb.com -r foo@mongodb.com -s '2020-06-22 Spruce Deploy to 1234567' -b '<ul><li>123abc commit message</li></ul><p><b>To revert, rerun task from previous release tag (spruce/v0.1.2)</b></p>'`;
       expect(emailCmd).toEqual(expect.stringMatching(emailCommandRegex));
     });
 
     it("matches on a revert email", () => {
-      const emailCmd = `~/evergreen -c .evergreen.yml notify email -f sender@mongodb.com -r foo@mongodb.com -s '2020-06-22 Spruce Deploy to ${mockCommit} (Revert)' -b '<ul><li>123abc commit message</li></ul>'`;
+      const emailCmd = `~/evergreen -c .evergreen.yml notify email -f sender@mongodb.com -r foo@mongodb.com -s '2020-06-22 Spruce Deploy to 1234567 (Revert)' -b '<ul><li>123abc commit message</li></ul>'`;
       expect(emailCmd).toEqual(expect.stringMatching(revertEmailRegex));
     });
   });

--- a/packages/deploy-utils/src/email/index.ts
+++ b/packages/deploy-utils/src/email/index.ts
@@ -3,6 +3,7 @@ import { execSync } from "child_process";
 import { readFileSync } from "fs";
 import { getAppToDeploy, isRunningOnCI, isTest } from "../utils/environment";
 import {
+  COMMIT_LENGTH,
   getCommitMessages,
   getCurrentCommit,
   getLatestTag,
@@ -125,7 +126,11 @@ export const makeEmail = ({
     })
     .join("");
 
-  const subject = `${formatDate(new Date())} ${toSentenceCase(app)} Deploy to ${commitToDeploy}${isRevert ? " (Revert)" : ""}`;
+  const commitLabel =
+    commitToDeploy.length === COMMIT_LENGTH
+      ? commitToDeploy.substring(0, 7)
+      : commitToDeploy;
+  const subject = `${formatDate(new Date())} ${toSentenceCase(app)} Deploy to ${commitLabel}${isRevert ? " (Revert)" : ""}`;
   const body = `<ul>${commitsHTML}</ul>${previousTag ? `<p><b>To revert, rerun task from previous release tag (${previousTag})</b></p>` : ""}`;
 
   return { body, from, recipients, subject };

--- a/packages/deploy-utils/src/email/utils.ts
+++ b/packages/deploy-utils/src/email/utils.ts
@@ -1,14 +1,11 @@
 import { execSync } from "child_process";
 
-const pad = (dateOrMonth: number) => dateOrMonth.toString().padStart(2, "0");
-
 /**
- * formatDate creates a readable string from a given date
+ * formatDate creates a readable string from a given date.
  * @param d - date
- * @returns - date string in format "year-month-day"
+ * @returns - date string in format "YYYY-MM-DD"
  */
-export const formatDate = (d: Date) =>
-  `${d.getFullYear()}-${pad(d.getMonth())}-${pad(d.getDate())}`;
+export const formatDate = (d: Date) => d.toISOString().split("T")[0];
 
 const commandExists = (commandName: string) => {
   try {

--- a/packages/deploy-utils/src/utils/git/get-current-deployed-commit.ts
+++ b/packages/deploy-utils/src/utils/git/get-current-deployed-commit.ts
@@ -1,8 +1,6 @@
 import { get } from "https";
-import { getLatestTag, tagIsValid } from ".";
+import { COMMIT_LENGTH, getLatestTag, tagIsValid } from ".";
 import { DeployableApp } from "../types";
-
-const COMMIT_LENGTH = 40;
 
 /**
  * getRemotePreviousCommit fetches the commit hash currently deployed to the given app

--- a/packages/deploy-utils/src/utils/git/index.ts
+++ b/packages/deploy-utils/src/utils/git/index.ts
@@ -3,6 +3,8 @@ import { resolve } from "path";
 import { execTrim } from "../shell";
 import { DeployableApp } from "../types";
 
+const COMMIT_LENGTH = 40;
+
 /**
  * `push` is a helper function that pushes commits to the remote.
  */
@@ -84,6 +86,7 @@ export { getCurrentlyDeployedCommit } from "./get-current-deployed-commit";
 export {
   assertMainBranch,
   assertWorkingDirectoryClean,
+  COMMIT_LENGTH,
   getCommitMessages,
   getCurrentCommit,
   getGitRoot,


### PR DESCRIPTION
DEVPROD-7027
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? -->

### Description
<!-- add description, context, thought process, etc -->
- Fix off-by-1 error in deploy emails. It was caused by [`getDate()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getDate) being 0-indexed even though the other 2 `get` functions I used are not... 🙄 I switched to trimming an ISO string because I think it's less error-prone.
- Also shorten commit hash in subject line as previous deploy emails used

### Testing
<!-- add a description of how you tested it -->
- Update tests and run them in UTC for consistency across machines