### PR TITLE
DEVPROD-6861: Show error toast when fetching Task.taskLogs

### DIFF
--- a/apps/spruce/src/pages/task/taskTabs/logs/LogTypes.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/logs/LogTypes.tsx
@@ -7,6 +7,7 @@ import { useParams, useLocation } from "react-router-dom";
 import { DEFAULT_POLL_INTERVAL } from "constants/index";
 import { slugs } from "constants/routes";
 import { size, fontSize } from "constants/tokens";
+import { useToastContext } from "context/toast";
 import {
   TaskEventLogsQuery,
   TaskEventLogsQueryVariables,
@@ -53,7 +54,7 @@ export const AllLog: React.FC<Props> = (props) => {
   const location = useLocation();
   const parsed = parseQueryString(location.search);
   const selectedExecution = Number(parsed[RequiredQueryParams.Execution]);
-
+  const dispatchToast = useToastContext();
   const { data, error, loading, refetch, startPolling, stopPolling } = useQuery<
     AllLogsQuery,
     AllLogsQueryVariables
@@ -61,6 +62,11 @@ export const AllLog: React.FC<Props> = (props) => {
     // @ts-expect-error: FIXME. This comment was added by an automated script.
     variables: { id: taskId, execution: selectedExecution },
     pollInterval: DEFAULT_POLL_INTERVAL,
+    onError(err) {
+      dispatchToast.error(
+        `There was an error loading all logs: ${err.message}`,
+      );
+    },
   });
   usePolling({ startPolling, stopPolling, refetch });
 
@@ -83,6 +89,7 @@ export const EventLog: React.FC<Props> = (props) => {
   const location = useLocation();
   const parsed = parseQueryString(location.search);
   const selectedExecution = Number(parsed[RequiredQueryParams.Execution]);
+  const dispatchToast = useToastContext();
   const { data, error, loading, refetch, startPolling, stopPolling } = useQuery<
     TaskEventLogsQuery,
     TaskEventLogsQueryVariables
@@ -90,6 +97,11 @@ export const EventLog: React.FC<Props> = (props) => {
     // @ts-expect-error: FIXME. This comment was added by an automated script.
     variables: { id: taskId, execution: selectedExecution },
     pollInterval: DEFAULT_POLL_INTERVAL,
+    onError(err) {
+      dispatchToast.error(
+        `There was an error loading event logs: ${err.message}`,
+      );
+    },
   });
   usePolling({ startPolling, stopPolling, refetch });
 
@@ -116,6 +128,7 @@ export const SystemLog: React.FC<Props> = (props) => {
   const location = useLocation();
   const parsed = parseQueryString(location.search);
   const selectedExecution = Number(parsed[RequiredQueryParams.Execution]);
+  const dispatchToast = useToastContext();
   const { data, error, loading, refetch, startPolling, stopPolling } = useQuery<
     SystemLogsQuery,
     SystemLogsQueryVariables
@@ -123,6 +136,11 @@ export const SystemLog: React.FC<Props> = (props) => {
     // @ts-expect-error: FIXME. This comment was added by an automated script.
     variables: { id: taskId, execution: selectedExecution },
     pollInterval: DEFAULT_POLL_INTERVAL,
+    onError(err) {
+      dispatchToast.error(
+        `There was an error loading system logs: ${err.message}`,
+      );
+    },
   });
   usePolling({ startPolling, stopPolling, refetch });
 
@@ -144,6 +162,7 @@ export const AgentLog: React.FC<Props> = (props) => {
   const location = useLocation();
   const parsed = parseQueryString(location.search);
   const selectedExecution = Number(parsed[RequiredQueryParams.Execution]);
+  const dispatchToast = useToastContext();
   const { data, error, loading, refetch, startPolling, stopPolling } = useQuery<
     AgentLogsQuery,
     AgentLogsQueryVariables
@@ -151,6 +170,11 @@ export const AgentLog: React.FC<Props> = (props) => {
     // @ts-expect-error: FIXME. This comment was added by an automated script.
     variables: { id: taskId, execution: selectedExecution },
     pollInterval: DEFAULT_POLL_INTERVAL,
+    onError(err) {
+      dispatchToast.error(
+        `There was an error loading agent logs: ${err.message}`,
+      );
+    },
   });
   usePolling({ startPolling, stopPolling, refetch });
 
@@ -172,6 +196,7 @@ export const TaskLog: React.FC<Props> = (props) => {
   const location = useLocation();
   const parsed = parseQueryString(location.search);
   const selectedExecution = Number(parsed[RequiredQueryParams.Execution]);
+  const dispatchToast = useToastContext();
   const { data, error, loading, refetch, startPolling, stopPolling } = useQuery<
     TaskLogsQuery,
     TaskLogsQueryVariables
@@ -179,6 +204,11 @@ export const TaskLog: React.FC<Props> = (props) => {
     // @ts-expect-error: FIXME. This comment was added by an automated script.
     variables: { id: taskId, execution: selectedExecution },
     pollInterval: DEFAULT_POLL_INTERVAL,
+    onError(err) {
+      dispatchToast.error(
+        `There was an error loading task logs: ${err.message}`,
+      );
+    },
   });
   usePolling({ startPolling, stopPolling, refetch });
 


### PR DESCRIPTION
DEVPROD-6861

https://github.com/evergreen-ci/evergreen/pull/8105 introduces a permissions check for the `Task.taskLogs` GQL field and this PR surfaces those errors in the UI when they occur. 