### PR TITLE
DEVPROD-7846: Fix 422 errors on Project Health page

### DIFF
--- a/apps/parsley/src/gql/generated/types.ts
+++ b/apps/parsley/src/gql/generated/types.ts
@@ -395,7 +395,7 @@ export type Distro = {
   homeVolumeSettings: HomeVolumeSettings;
   hostAllocatorSettings: HostAllocatorSettings;
   iceCreamSettings: IceCreamSettings;
-  imageId?: Maybe<Scalars["String"]["output"]>;
+  imageId: Scalars["String"]["output"];
   isCluster: Scalars["Boolean"]["output"];
   isVirtualWorkStation: Scalars["Boolean"]["output"];
   mountpoints?: Maybe<Array<Scalars["String"]["output"]>>;
@@ -461,7 +461,7 @@ export type DistroInput = {
   homeVolumeSettings: HomeVolumeSettingsInput;
   hostAllocatorSettings: HostAllocatorSettingsInput;
   iceCreamSettings: IceCreamSettingsInput;
-  imageId?: InputMaybe<Scalars["String"]["input"]>;
+  imageId: Scalars["String"]["input"];
   isCluster: Scalars["Boolean"]["input"];
   isVirtualWorkStation: Scalars["Boolean"]["input"];
   mountpoints?: InputMaybe<Array<Scalars["String"]["input"]>>;
@@ -847,6 +847,19 @@ export type IceCreamSettings = {
 export type IceCreamSettingsInput = {
   configPath: Scalars["String"]["input"];
   schedulerHost: Scalars["String"]["input"];
+};
+
+/**
+ * Image is returned by the image query.
+ * It contains information about an image.
+ */
+export type Image = {
+  __typename?: "Image";
+  ami: Scalars["String"]["output"];
+  kernel: Scalars["String"]["output"];
+  lastDeployed: Scalars["Time"]["output"];
+  name: Scalars["String"]["output"];
+  versionId: Scalars["String"]["output"];
 };
 
 export type InstanceTag = {
@@ -1989,6 +2002,7 @@ export type Query = {
   host?: Maybe<Host>;
   hostEvents: HostEvents;
   hosts: HostsResponse;
+  image?: Maybe<Image>;
   images: Array<Scalars["String"]["output"]>;
   instanceTypes: Array<Scalars["String"]["output"]>;
   logkeeperBuildMetadata: LogkeeperBuild;
@@ -2081,6 +2095,10 @@ export type QueryHostsArgs = {
   sortDir?: InputMaybe<SortDirection>;
   startedBy?: InputMaybe<Scalars["String"]["input"]>;
   statuses?: InputMaybe<Array<Scalars["String"]["input"]>>;
+};
+
+export type QueryImageArgs = {
+  imageId: Scalars["String"]["input"];
 };
 
 export type QueryLogkeeperBuildMetadataArgs = {
@@ -2595,6 +2613,7 @@ export type Task = {
   hasCedarResults: Scalars["Boolean"]["output"];
   hostId?: Maybe<Scalars["String"]["output"]>;
   id: Scalars["String"]["output"];
+  imageId: Scalars["String"]["output"];
   ingestTime?: Maybe<Scalars["Time"]["output"]>;
   isPerfPluginEnabled: Scalars["Boolean"]["output"];
   latestExecution: Scalars["Int"]["output"];

--- a/apps/spruce/src/components/Banners/RepotrackerBanner.tsx
+++ b/apps/spruce/src/components/Banners/RepotrackerBanner.tsx
@@ -37,6 +37,7 @@ export const RepotrackerBanner: React.FC<RepotrackerBannerProps> = ({
     RepotrackerErrorQueryVariables
   >(REPOTRACKER_ERROR, {
     variables: { projectIdentifier },
+    skip: !projectIdentifier,
   });
   const hasRepotrackerError =
     repotrackerData?.project?.repotrackerError?.exists ?? false;

--- a/apps/spruce/src/components/PatchesPage/ListArea/testData.ts
+++ b/apps/spruce/src/components/PatchesPage/ListArea/testData.ts
@@ -12,6 +12,7 @@ const patchData = {
   id: "667b2f7f7a878200076f23d1",
   projectIdentifier: "evergreen-ui",
   projectMetadata: {
+    id: "123456",
     owner: "evergreen-ci",
     repo: "ui",
   },

--- a/apps/spruce/src/components/TupleSelect/__snapshots__/TupleSelect_Default.storyshot
+++ b/apps/spruce/src/components/TupleSelect/__snapshots__/TupleSelect_Default.storyshot
@@ -78,6 +78,7 @@
       >
         <div
           aria-label="Build Variant"
+          aria-labelledby="Build Variant"
           class="leafygreen-ui-1br9h7w"
           data-lgid="lg-text_input"
         >
@@ -94,7 +95,7 @@
                 aria-describedby=""
                 aria-disabled="false"
                 aria-invalid="false"
-                aria-label="Build Variant"
+                aria-labelledby="Build Variant"
                 autocomplete="on"
                 class="lg-ui-form-field-input-0000 leafygreen-ui-1ago99h"
                 data-cy="tuple-select-input"

--- a/apps/spruce/src/components/TupleSelect/index.tsx
+++ b/apps/spruce/src/components/TupleSelect/index.tsx
@@ -31,7 +31,8 @@ const TupleSelect: React.FC<TupleSelectProps> = ({
     onSubmit({ category: selected, value: input });
   };
 
-  const selectedOption = options.find((o) => o.value === selected);
+  const selectedOption =
+    options.find((o) => o.value === selected) ?? options[0];
 
   return (
     <Container>
@@ -58,11 +59,10 @@ const TupleSelect: React.FC<TupleSelectProps> = ({
         </GroupedSelect>
         <GroupedTextInput
           id="filter-input"
-          // @ts-expect-error: FIXME. This comment was added by an automated script.
           aria-label={selectedOption.displayName}
+          aria-labelledby={selectedOption.displayName}
           data-cy="tuple-select-input"
           type="text" // Chrome will overlay a clear "x" button on the input if type is not set to 'search'
-          // @ts-expect-error: FIXME. This comment was added by an automated script.
           placeholder={selectedOption.placeHolderText}
           validator={validator}
           validatorErrorMessage={validatorErrorMessage}

--- a/apps/spruce/src/components/TupleSelectWithRegexConditional/__snapshots__/TupleSelectWithRegexConditional_WithConditional.storyshot
+++ b/apps/spruce/src/components/TupleSelectWithRegexConditional/__snapshots__/TupleSelectWithRegexConditional_WithConditional.storyshot
@@ -157,6 +157,7 @@
       >
         <div
           aria-label="Build Variant"
+          aria-labelledby="Build Variant"
           class="leafygreen-ui-1br9h7w"
           data-lgid="lg-text_input"
         >
@@ -173,7 +174,7 @@
                 aria-describedby=""
                 aria-disabled="false"
                 aria-invalid="false"
-                aria-label="Build Variant"
+                aria-labelledby="Build Variant"
                 autocomplete="on"
                 class="lg-ui-form-field-input-0000 leafygreen-ui-1ago99h"
                 data-cy="tuple-select-input"

--- a/apps/spruce/src/gql/client/cache.ts
+++ b/apps/spruce/src/gql/client/cache.ts
@@ -53,7 +53,7 @@ export const cache = new InMemoryCache({
       keyFields: false,
     },
     Project: {
-      keyFields: false,
+      keyFields: ["id"],
     },
     User: {
       keyFields: ["userId"],

--- a/apps/spruce/src/gql/client/cache.ts
+++ b/apps/spruce/src/gql/client/cache.ts
@@ -52,9 +52,6 @@ export const cache = new InMemoryCache({
     ProjectAlias: {
       keyFields: false,
     },
-    Project: {
-      keyFields: ["id"],
-    },
     User: {
       keyFields: ["userId"],
     },

--- a/apps/spruce/src/gql/fragments/patchesPage.graphql
+++ b/apps/spruce/src/gql/fragments/patchesPage.graphql
@@ -13,6 +13,7 @@ fragment PatchesPagePatches on Patches {
     id
     projectIdentifier
     projectMetadata {
+      id
       owner
       repo
     }

--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -395,7 +395,7 @@ export type Distro = {
   homeVolumeSettings: HomeVolumeSettings;
   hostAllocatorSettings: HostAllocatorSettings;
   iceCreamSettings: IceCreamSettings;
-  imageId?: Maybe<Scalars["String"]["output"]>;
+  imageId: Scalars["String"]["output"];
   isCluster: Scalars["Boolean"]["output"];
   isVirtualWorkStation: Scalars["Boolean"]["output"];
   mountpoints?: Maybe<Array<Scalars["String"]["output"]>>;
@@ -461,7 +461,7 @@ export type DistroInput = {
   homeVolumeSettings: HomeVolumeSettingsInput;
   hostAllocatorSettings: HostAllocatorSettingsInput;
   iceCreamSettings: IceCreamSettingsInput;
-  imageId?: InputMaybe<Scalars["String"]["input"]>;
+  imageId: Scalars["String"]["input"];
   isCluster: Scalars["Boolean"]["input"];
   isVirtualWorkStation: Scalars["Boolean"]["input"];
   mountpoints?: InputMaybe<Array<Scalars["String"]["input"]>>;
@@ -847,6 +847,19 @@ export type IceCreamSettings = {
 export type IceCreamSettingsInput = {
   configPath: Scalars["String"]["input"];
   schedulerHost: Scalars["String"]["input"];
+};
+
+/**
+ * Image is returned by the image query.
+ * It contains information about an image.
+ */
+export type Image = {
+  __typename?: "Image";
+  ami: Scalars["String"]["output"];
+  kernel: Scalars["String"]["output"];
+  lastDeployed: Scalars["Time"]["output"];
+  name: Scalars["String"]["output"];
+  versionId: Scalars["String"]["output"];
 };
 
 export type InstanceTag = {
@@ -1989,6 +2002,7 @@ export type Query = {
   host?: Maybe<Host>;
   hostEvents: HostEvents;
   hosts: HostsResponse;
+  image?: Maybe<Image>;
   images: Array<Scalars["String"]["output"]>;
   instanceTypes: Array<Scalars["String"]["output"]>;
   logkeeperBuildMetadata: LogkeeperBuild;
@@ -2081,6 +2095,10 @@ export type QueryHostsArgs = {
   sortDir?: InputMaybe<SortDirection>;
   startedBy?: InputMaybe<Scalars["String"]["input"]>;
   statuses?: InputMaybe<Array<Scalars["String"]["input"]>>;
+};
+
+export type QueryImageArgs = {
+  imageId: Scalars["String"]["input"];
 };
 
 export type QueryLogkeeperBuildMetadataArgs = {
@@ -2595,6 +2613,7 @@ export type Task = {
   hasCedarResults: Scalars["Boolean"]["output"];
   hostId?: Maybe<Scalars["String"]["output"]>;
   id: Scalars["String"]["output"];
+  imageId: Scalars["String"]["output"];
   ingestTime?: Maybe<Scalars["Time"]["output"]>;
   isPerfPluginEnabled: Scalars["Boolean"]["output"];
   latestExecution: Scalars["Int"]["output"];
@@ -3486,6 +3505,7 @@ export type PatchesPagePatchesFragment = {
     status: string;
     projectMetadata?: {
       __typename?: "Project";
+      id: string;
       owner: string;
       repo: string;
     } | null;
@@ -5793,7 +5813,7 @@ export type DistroQuery = {
     containerPool: string;
     disabled: boolean;
     disableShallowClone: boolean;
-    imageId?: string | null;
+    imageId: string;
     isCluster: boolean;
     isVirtualWorkStation: boolean;
     mountpoints?: Array<string> | null;
@@ -7197,6 +7217,7 @@ export type ProjectPatchesQuery = {
         status: string;
         projectMetadata?: {
           __typename?: "Project";
+          id: string;
           owner: string;
           repo: string;
         } | null;
@@ -8767,6 +8788,7 @@ export type UserPatchesQuery = {
         status: string;
         projectMetadata?: {
           __typename?: "Project";
+          id: string;
           owner: string;
           repo: string;
         } | null;

--- a/apps/spruce/src/pages/commits/ViewToggle.tsx
+++ b/apps/spruce/src/pages/commits/ViewToggle.tsx
@@ -38,6 +38,7 @@ export const ViewToggle: React.FC<Props> = ({ identifier }) => {
     ProjectHealthViewQueryVariables
   >(PROJECT_HEALTH_VIEW, {
     variables: { identifier },
+    skip: !identifier,
   });
 
   useEffect(() => {


### PR DESCRIPTION
DEVPROD-7846
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? -->

### Description
Fix 422 errors on the Project Health page. They could be seen on the network tab in Firefox:

<img width="542" alt="Screenshot 2024-07-18 at 10 47 02 AM" src="https://github.com/user-attachments/assets/0393f52f-9219-45bb-9a1a-490cd0e59d42">

They no longer show up after applying the changes in this PR.

I also saw some cache errors for these queries so I tried to fix them:

<img width="363" alt="Screenshot 2024-07-18 at 10 57 11 AM" src="https://github.com/user-attachments/assets/a7246381-70d7-4863-9ede-a2a4746fd1fb">