### PR TITLE
DEVPROD-9282: Add button to delete GitHub app credentials

### DIFF
--- a/apps/parsley/src/gql/generated/types.ts
+++ b/apps/parsley/src/gql/generated/types.ts
@@ -882,6 +882,7 @@ export type Image = {
   id: Scalars["String"]["output"];
   kernel: Scalars["String"]["output"];
   lastDeployed: Scalars["Time"]["output"];
+  latestTask?: Maybe<Task>;
   name: Scalars["String"]["output"];
   packages: Array<Package>;
   toolchains: Array<Toolchain>;

--- a/apps/spruce/cypress/integration/projectSettings/github_app_settings.ts
+++ b/apps/spruce/cypress/integration/projectSettings/github_app_settings.ts
@@ -20,38 +20,50 @@ describe("GitHub app settings", () => {
     saveButtonEnabled(false);
   });
 
-  // TODO: Add test for deletion in DEVPROD-9282.
+  it("should be able to delete & save app credentials", () => {
+    cy.dataCy("github-app-id-input").as("appId");
+    cy.dataCy("github-private-key-input").as("privateKey");
 
-  it("should be able to save app credentials", () => {
-    cy.visit(getAppSettingsRoute("logkeeper"));
-    cy.contains("Token Permission Restrictions");
+    // Delete GitHub app credentials.
+    cy.dataCy("delete-app-credentials-button").should("be.visible");
+    cy.dataCy("delete-app-credentials-button").click();
+    cy.dataCy("delete-github-credentials-modal").should("be.visible");
+    cy.dataCy("delete-github-credentials-modal")
+      .find("button")
+      .contains("Delete")
+      .parent()
+      .click();
+    cy.validateToast("success");
 
     cy.dataCy("github-app-credentials-banner").should("be.visible");
-    cy.dataCy("github-app-id-input").type("12345");
-    cy.dataCy("github-private-key-input").type("secret");
+    cy.get("@appId").should("have.value", "");
+    cy.get("@privateKey").should("have.value", "");
+    cy.get("@appId").should("have.attr", "aria-disabled", "false");
+    cy.get("@privateKey").should("have.attr", "aria-disabled", "false");
+
+    cy.reload();
+    cy.dataCy("github-app-credentials-banner").should("be.visible");
+    cy.get("@appId").should("have.value", "");
+    cy.get("@privateKey").should("have.value", "");
+
+    // Add GitHub app credentials.
+    cy.get("@appId").type("12345");
+    cy.get("@privateKey").type("secret");
     cy.dataCy("save-settings-button").scrollIntoView();
     saveButtonEnabled(true);
     clickSave();
     cy.validateToast("success", "Successfully updated project");
 
     cy.dataCy("github-app-credentials-banner").should("not.exist");
-    cy.dataCy("github-app-id-input").should("have.value", "12345");
-    cy.dataCy("github-private-key-input").should("have.value", "{REDACTED}");
-    cy.dataCy("github-app-id-input").should(
-      "have.attr",
-      "aria-disabled",
-      "true",
-    );
-    cy.dataCy("github-private-key-input").should(
-      "have.attr",
-      "aria-disabled",
-      "true",
-    );
+    cy.get("@appId").should("have.value", "12345");
+    cy.get("@privateKey").should("have.value", "{REDACTED}");
+    cy.get("@appId").should("have.attr", "aria-disabled", "true");
+    cy.get("@privateKey").should("have.attr", "aria-disabled", "true");
 
     cy.reload();
     cy.dataCy("github-app-credentials-banner").should("not.exist");
-    cy.dataCy("github-app-id-input").should("have.value", "12345");
-    cy.dataCy("github-private-key-input").should("have.value", "{REDACTED}");
+    cy.get("@appId").should("have.value", "12345");
+    cy.get("@privateKey").should("have.value", "{REDACTED}");
   });
 
   it("should be able to save different permission groups for requesters, then return to defaults", () => {

--- a/apps/spruce/src/components/ConfirmationModal.tsx
+++ b/apps/spruce/src/components/ConfirmationModal.tsx
@@ -1,7 +1,8 @@
 import styled from "@emotion/styled";
-import Modal from "@leafygreen-ui/confirmation-modal";
+import Modal, { Variant } from "@leafygreen-ui/confirmation-modal";
 import { zIndex } from "constants/tokens";
 
 export const ConfirmationModal = styled(Modal)`
   z-index: ${zIndex.modal};
 `;
+export { Variant };

--- a/apps/spruce/src/components/ConfirmationModal.tsx
+++ b/apps/spruce/src/components/ConfirmationModal.tsx
@@ -2,7 +2,7 @@ import styled from "@emotion/styled";
 import Modal, { Variant } from "@leafygreen-ui/confirmation-modal";
 import { zIndex } from "constants/tokens";
 
-export const ConfirmationModal = styled(Modal)`
+const ConfirmationModal = styled(Modal)`
   z-index: ${zIndex.modal};
 `;
-export { Variant };
+export { ConfirmationModal, Variant };

--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -882,6 +882,7 @@ export type Image = {
   id: Scalars["String"]["output"];
   kernel: Scalars["String"]["output"];
   lastDeployed: Scalars["Time"]["output"];
+  latestTask?: Maybe<Task>;
   name: Scalars["String"]["output"];
   packages: Array<Package>;
   toolchains: Array<Toolchain>;
@@ -4876,6 +4877,18 @@ export type DeleteDistroMutationVariables = Exact<{
 export type DeleteDistroMutation = {
   __typename?: "Mutation";
   deleteDistro: { __typename?: "DeleteDistroPayload"; deletedDistroId: string };
+};
+
+export type DeleteGithubAppCredentialsMutationVariables = Exact<{
+  projectId: Scalars["String"]["input"];
+}>;
+
+export type DeleteGithubAppCredentialsMutation = {
+  __typename?: "Mutation";
+  deleteGithubAppCredentials?: {
+    __typename?: "DeleteGithubAppCredentialsPayload";
+    oldAppId: number;
+  } | null;
 };
 
 export type DeleteProjectMutationVariables = Exact<{

--- a/apps/spruce/src/gql/mutations/delete-github-app-credentials.graphql
+++ b/apps/spruce/src/gql/mutations/delete-github-app-credentials.graphql
@@ -1,0 +1,5 @@
+mutation DeleteGithubAppCredentials($projectId: String!) {
+  deleteGithubAppCredentials(opts: { projectId: $projectId }) {
+    oldAppId
+  }
+}

--- a/apps/spruce/src/gql/mutations/index.ts
+++ b/apps/spruce/src/gql/mutations/index.ts
@@ -13,6 +13,7 @@ import CREATE_PUBLIC_KEY from "./create-public-key.graphql";
 import DEACTIVATE_STEPBACK_TASK from "./deactivate-stepback-task.graphql";
 import DEFAULT_SECTION_TO_REPO from "./default-section-to-repo.graphql";
 import DELETE_DISTRO from "./delete-distro.graphql";
+import DELETE_GITHUB_APP_CREDENTIALS from "./delete-github-app-credentials.graphql";
 import DELETE_PROJECT from "./delete-project.graphql";
 import DELETE_SUBSCRIPTIONS from "./delete-subscriptions.graphql";
 import DETACH_PROJECT_FROM_REPO from "./detach-project-from-repo.graphql";
@@ -73,6 +74,7 @@ export {
   DEACTIVATE_STEPBACK_TASK,
   DEFAULT_SECTION_TO_REPO,
   DELETE_DISTRO,
+  DELETE_GITHUB_APP_CREDENTIALS,
   DELETE_PROJECT,
   DELETE_SUBSCRIPTIONS,
   DETACH_PROJECT_FROM_REPO,

--- a/apps/spruce/src/pages/projectSettings/Tabs.tsx
+++ b/apps/spruce/src/pages/projectSettings/Tabs.tsx
@@ -282,6 +282,8 @@ export const ProjectSettingsTabs: React.FC<Props> = ({
                 }
                 // @ts-expect-error: FIXME. This comment was added by an automated script.
                 identifier={identifier}
+                // @ts-expect-error: FIXME. This comment was added by an automated script.
+                projectId={projectId}
               />
             }
           />

--- a/apps/spruce/src/pages/projectSettings/tabs/GithubAppSettingsTab/AppSettingsTab.tsx
+++ b/apps/spruce/src/pages/projectSettings/tabs/GithubAppSettingsTab/AppSettingsTab.tsx
@@ -11,6 +11,7 @@ export const AppSettingsTab: React.FC<TabProps> = ({
   githubPermissionGroups,
   identifier,
   projectData,
+  projectId,
 }) => {
   const initialFormState = projectData;
   const isAppDefined =
@@ -23,8 +24,9 @@ export const AppSettingsTab: React.FC<TabProps> = ({
         githubPermissionGroups,
         identifier,
         isAppDefined,
+        projectId,
       }),
-    [githubPermissionGroups, identifier, isAppDefined],
+    [githubPermissionGroups, identifier, isAppDefined, projectId],
   );
 
   return (

--- a/apps/spruce/src/pages/projectSettings/tabs/GithubAppSettingsTab/FieldTemplates.tsx
+++ b/apps/spruce/src/pages/projectSettings/tabs/GithubAppSettingsTab/FieldTemplates.tsx
@@ -1,50 +1,10 @@
 import { useRef } from "react";
 import styled from "@emotion/styled";
-import Banner from "@leafygreen-ui/banner";
-import InlineDefinition from "@leafygreen-ui/inline-definition";
 import { useLeafyGreenTable, LGColumnDef } from "@leafygreen-ui/table";
-import { Body } from "@leafygreen-ui/typography";
-import { ArrayFieldTemplateProps, Field } from "@rjsf/core";
-import { StyledLink } from "components/styles";
+import { ArrayFieldTemplateProps } from "@rjsf/core";
 import { BaseTable } from "components/Table/BaseTable";
-import { githubAppCredentialsDocumentationUrl } from "constants/externalResources";
-import {
-  requesterToTitle,
-  requesterToDescription,
-  Requester,
-} from "constants/requesters";
 import { tableColumnOffset } from "constants/tokens";
 import { Unpacked } from "types/utils";
-
-export const RequesterTypeField: Field = ({
-  formData,
-}: {
-  formData: Requester;
-}) =>
-  requesterToDescription[formData] ? (
-    <InlineDefinition definition={requesterToDescription[formData]}>
-      {requesterToTitle[formData]}
-    </InlineDefinition>
-  ) : (
-    <Body>{requesterToTitle[formData]}</Body>
-  );
-
-export const GithubAppActions: Field = ({ uiSchema }) => {
-  const {
-    options: { isAppDefined },
-  } = uiSchema;
-
-  // TODO DEVPROD-9282: Add delete button.
-  return isAppDefined ? null : (
-    <Banner variant="warning" data-cy="github-app-credentials-banner">
-      App ID and Key must be saved in order for token permissions restrictions
-      to take effect. <br />
-      <StyledLink href={githubAppCredentialsDocumentationUrl}>
-        GitHub App Documentation
-      </StyledLink>
-    </Banner>
-  );
-};
 
 type ArrayItem = Unpacked<ArrayFieldTemplateProps["items"]>;
 

--- a/apps/spruce/src/pages/projectSettings/tabs/GithubAppSettingsTab/Fields/GithubAppActions.test.tsx
+++ b/apps/spruce/src/pages/projectSettings/tabs/GithubAppSettingsTab/Fields/GithubAppActions.test.tsx
@@ -1,0 +1,95 @@
+import { MockedProvider } from "@apollo/client/testing";
+import { FieldProps } from "@rjsf/core";
+import { RenderFakeToastContext } from "context/toast/__mocks__";
+import {
+  DeleteGithubAppCredentialsMutation,
+  DeleteGithubAppCredentialsMutationVariables,
+} from "gql/generated/types";
+import { DELETE_GITHUB_APP_CREDENTIALS } from "gql/mutations";
+import { renderWithRouterMatch as render, screen, userEvent } from "test_utils";
+import { ApolloMock } from "types/gql";
+import { GithubAppActions } from ".";
+
+const Field = ({ isAppDefined }: { isAppDefined: boolean }) => (
+  <MockedProvider mocks={[deleteAppCredentialsMock]}>
+    <GithubAppActions
+      {...({} as unknown as FieldProps)}
+      uiSchema={{
+        options: {
+          projectId: "evergreen",
+          isAppDefined,
+        },
+      }}
+    />
+  </MockedProvider>
+);
+
+describe("githubAppActions", () => {
+  describe("app is not defined", () => {
+    it("renders the banner and not the button", () => {
+      const { Component } = RenderFakeToastContext(
+        <Field isAppDefined={false} />,
+      );
+      render(<Component />);
+      expect(
+        screen.getByDataCy("github-app-credentials-banner"),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByDataCy("delete-app-credentials-button"),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("app is defined", () => {
+    it("renders the button and not the banner", () => {
+      const { Component } = RenderFakeToastContext(<Field isAppDefined />);
+      render(<Component />);
+      expect(
+        screen.getByDataCy("delete-app-credentials-button"),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByDataCy("github-app-credentials-banner"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("can delete the credentials via the modal", async () => {
+      const user = userEvent.setup();
+
+      const { Component, dispatchToast } = RenderFakeToastContext(
+        <Field isAppDefined />,
+      );
+      render(<Component />);
+      await user.click(screen.getByDataCy("delete-app-credentials-button"));
+      expect(
+        screen.getByDataCy("delete-github-credentials-modal"),
+      ).toBeInTheDocument();
+      const deleteButton = screen.getByRole("button", {
+        name: "Delete",
+      });
+      expect(deleteButton).toBeEnabled();
+      await user.click(deleteButton);
+      expect(dispatchToast.success).toHaveBeenCalledWith(
+        "GitHub app credentials were successfully deleted.",
+      );
+    });
+  });
+});
+
+const deleteAppCredentialsMock: ApolloMock<
+  DeleteGithubAppCredentialsMutation,
+  DeleteGithubAppCredentialsMutationVariables
+> = {
+  request: {
+    query: DELETE_GITHUB_APP_CREDENTIALS,
+    variables: {
+      projectId: "evergreen",
+    },
+  },
+  result: {
+    data: {
+      deleteGithubAppCredentials: {
+        oldAppId: 12344,
+      },
+    },
+  },
+};

--- a/apps/spruce/src/pages/projectSettings/tabs/GithubAppSettingsTab/Fields/GithubAppActions.tsx
+++ b/apps/spruce/src/pages/projectSettings/tabs/GithubAppSettingsTab/Fields/GithubAppActions.tsx
@@ -1,0 +1,88 @@
+import { useState } from "react";
+import { useMutation } from "@apollo/client";
+import Banner from "@leafygreen-ui/banner";
+import Button from "@leafygreen-ui/button";
+import { Field } from "@rjsf/core";
+import { ConfirmationModal } from "components/ConfirmationModal";
+import { StyledLink } from "components/styles";
+import { githubAppCredentialsDocumentationUrl } from "constants/externalResources";
+import { useToastContext } from "context/toast";
+import {
+  DeleteGithubAppCredentialsMutation,
+  DeleteGithubAppCredentialsMutationVariables,
+} from "gql/generated/types";
+import { DELETE_GITHUB_APP_CREDENTIALS } from "gql/mutations";
+
+const DeleteAppCredentialsButton: React.FC<{
+  ["data-cy"]: string;
+  projectId: string;
+}> = ({ "data-cy": dataCy, projectId }) => {
+  const [open, setOpen] = useState(false);
+  const dispatchToast = useToastContext();
+
+  const [deleteGithubAppCredentials, { loading }] = useMutation<
+    DeleteGithubAppCredentialsMutation,
+    DeleteGithubAppCredentialsMutationVariables
+  >(DELETE_GITHUB_APP_CREDENTIALS, {
+    onCompleted: () => {
+      dispatchToast.success(
+        "GitHub app credentials were successfully deleted.",
+      );
+    },
+    onError: (err) => {
+      dispatchToast.error(
+        `There was an error deleting GitHub app credentials: ${err.message}`,
+      );
+    },
+    refetchQueries: ["ProjectSettings"],
+  });
+
+  return (
+    <>
+      <ConfirmationModal
+        buttonText="Delete"
+        data-cy="delete-github-credentials-modal"
+        onCancel={() => setOpen(false)}
+        onConfirm={() => {
+          deleteGithubAppCredentials({ variables: { projectId } });
+          setOpen(false);
+        }}
+        open={open}
+        submitDisabled={loading}
+        title="Delete GitHub app credentials?"
+        variant="danger"
+      >
+        <p>
+          Confirm that you want to remove the GitHub app credentials associated
+          with this project.
+        </p>
+      </ConfirmationModal>
+      <Button data-cy={dataCy} onClick={() => setOpen(true)}>
+        Delete key
+      </Button>
+    </>
+  );
+};
+
+const GithubAppActions: Field = ({ uiSchema }) => {
+  const {
+    options: { isAppDefined, projectId },
+  } = uiSchema;
+
+  return isAppDefined ? (
+    <DeleteAppCredentialsButton
+      data-cy="delete-app-credentials-button"
+      projectId={projectId}
+    />
+  ) : (
+    <Banner data-cy="github-app-credentials-banner" variant="warning">
+      App ID and Key must be saved in order for token permissions restrictions
+      to take effect. <br />
+      <StyledLink href={githubAppCredentialsDocumentationUrl}>
+        GitHub App Documentation
+      </StyledLink>
+    </Banner>
+  );
+};
+
+export default GithubAppActions;

--- a/apps/spruce/src/pages/projectSettings/tabs/GithubAppSettingsTab/Fields/GithubAppActions.tsx
+++ b/apps/spruce/src/pages/projectSettings/tabs/GithubAppSettingsTab/Fields/GithubAppActions.tsx
@@ -1,9 +1,12 @@
 import { useState } from "react";
 import { useMutation } from "@apollo/client";
-import Banner from "@leafygreen-ui/banner";
-import Button from "@leafygreen-ui/button";
+import Banner, { Variant as BannerVariant } from "@leafygreen-ui/banner";
+import Button, { Variant as ButtonVariant } from "@leafygreen-ui/button";
 import { Field } from "@rjsf/core";
-import { ConfirmationModal } from "components/ConfirmationModal";
+import {
+  ConfirmationModal,
+  Variant as ModalVariant,
+} from "components/ConfirmationModal";
 import { StyledLink } from "components/styles";
 import { githubAppCredentialsDocumentationUrl } from "constants/externalResources";
 import { useToastContext } from "context/toast";
@@ -31,7 +34,7 @@ const DeleteAppCredentialsButton: React.FC<{
     },
     onError: (err) => {
       dispatchToast.error(
-        `There was an error deleting GitHub app credentials: ${err.message}`,
+        `There was an error deleting the GitHub app credentials: ${err.message}`,
       );
     },
     refetchQueries: ["ProjectSettings"],
@@ -50,14 +53,18 @@ const DeleteAppCredentialsButton: React.FC<{
         open={open}
         submitDisabled={loading}
         title="Delete GitHub app credentials?"
-        variant="danger"
+        variant={ModalVariant.Danger}
       >
         <p>
           Confirm that you want to remove the GitHub app credentials associated
           with this project.
         </p>
       </ConfirmationModal>
-      <Button data-cy={dataCy} onClick={() => setOpen(true)}>
+      <Button
+        data-cy={dataCy}
+        onClick={() => setOpen(true)}
+        variant={ButtonVariant.Danger}
+      >
         Delete key
       </Button>
     </>
@@ -75,12 +82,17 @@ const GithubAppActions: Field = ({ uiSchema }) => {
       projectId={projectId}
     />
   ) : (
-    <Banner data-cy="github-app-credentials-banner" variant="warning">
-      App ID and Key must be saved in order for token permissions restrictions
+    <Banner
+      data-cy="github-app-credentials-banner"
+      variant={BannerVariant.Warning}
+    >
+      App ID and key must be saved in order for token permissions restrictions
       to take effect. <br />
+      For more information, see the{" "}
       <StyledLink href={githubAppCredentialsDocumentationUrl}>
         GitHub App Documentation
       </StyledLink>
+      .
     </Banner>
   );
 };

--- a/apps/spruce/src/pages/projectSettings/tabs/GithubAppSettingsTab/Fields/RequesterTypeField.tsx
+++ b/apps/spruce/src/pages/projectSettings/tabs/GithubAppSettingsTab/Fields/RequesterTypeField.tsx
@@ -1,0 +1,19 @@
+import InlineDefinition from "@leafygreen-ui/inline-definition";
+import { Body } from "@leafygreen-ui/typography";
+import { Field } from "@rjsf/core";
+import {
+  requesterToTitle,
+  requesterToDescription,
+  Requester,
+} from "constants/requesters";
+
+const RequesterTypeField: Field = ({ formData }: { formData: Requester }) =>
+  requesterToDescription[formData] ? (
+    <InlineDefinition definition={requesterToDescription[formData]}>
+      {requesterToTitle[formData]}
+    </InlineDefinition>
+  ) : (
+    <Body>{requesterToTitle[formData]}</Body>
+  );
+
+export default RequesterTypeField;

--- a/apps/spruce/src/pages/projectSettings/tabs/GithubAppSettingsTab/Fields/index.tsx
+++ b/apps/spruce/src/pages/projectSettings/tabs/GithubAppSettingsTab/Fields/index.tsx
@@ -1,0 +1,4 @@
+import GithubAppActions from "./GithubAppActions";
+import RequesterTypeField from "./RequesterTypeField";
+
+export { GithubAppActions, RequesterTypeField };

--- a/apps/spruce/src/pages/projectSettings/tabs/GithubAppSettingsTab/getFormSchema.tsx
+++ b/apps/spruce/src/pages/projectSettings/tabs/GithubAppSettingsTab/getFormSchema.tsx
@@ -13,11 +13,8 @@ import {
 } from "constants/routes";
 import { size } from "constants/tokens";
 import { GitHubDynamicTokenPermissionGroup } from "gql/generated/types";
-import {
-  ArrayFieldTemplate,
-  RequesterTypeField,
-  GithubAppActions,
-} from "./FieldTemplates";
+import { GithubAppActions, RequesterTypeField } from "./Fields";
+import { ArrayFieldTemplate } from "./FieldTemplates";
 
 /** All permissions group is the default if no permission group is set. */
 const allPermissionsGroup = "";
@@ -29,10 +26,12 @@ export const getFormSchema = ({
   githubPermissionGroups,
   identifier,
   isAppDefined,
+  projectId,
 }: {
   githubPermissionGroups: GitHubDynamicTokenPermissionGroup[];
   identifier: string;
   isAppDefined: boolean;
+  projectId: string;
 }): ReturnType<GetFormSchema> => ({
   fields: {},
   schema: {
@@ -113,16 +112,18 @@ export const getFormSchema = ({
         appId: {
           "ui:data-cy": "github-app-id-input",
           "ui:disabled": isAppDefined,
+          "ui:elementWrapperCSS": appFieldCss,
         },
         privateKey: {
           "ui:data-cy": "github-private-key-input",
           "ui:disabled": isAppDefined,
+          "ui:elementWrapperCSS": appFieldCss,
         },
       },
       actions: {
         "ui:field": GithubAppActions,
         "ui:showLabel": false,
-        options: { isAppDefined },
+        options: { isAppDefined, projectId },
       },
     },
     tokenPermissionRestrictions: {
@@ -158,14 +159,14 @@ export const getFormSchema = ({
           "ui:ObjectFieldTemplate": FieldRow,
           requesterType: {
             "ui:field": RequesterTypeField,
-            "ui:elementWrapperCSS": fieldCss,
+            "ui:elementWrapperCSS": tokenFieldCss,
             "ui:showLabel": false,
           },
           permissionGroup: {
             "ui:allowDeselect": false,
             "ui:ariaLabelledBy": "Permission Group",
             "ui:data-cy": "permission-group-input",
-            "ui:elementWrapperCSS": fieldCss,
+            "ui:elementWrapperCSS": tokenFieldCss,
             "ui:sizeVariant": "small",
           },
         },
@@ -174,8 +175,12 @@ export const getFormSchema = ({
   },
 });
 
-const fieldCss = css`
+const tokenFieldCss = css`
   margin: ${size.xs} 0;
+`;
+
+const appFieldCss = css`
+  max-width: unset;
 `;
 
 const StyledDescription = styled.span`

--- a/apps/spruce/src/pages/projectSettings/tabs/GithubAppSettingsTab/types.ts
+++ b/apps/spruce/src/pages/projectSettings/tabs/GithubAppSettingsTab/types.ts
@@ -19,4 +19,5 @@ export type TabProps = {
   identifier: string;
   githubPermissionGroups: GitHubDynamicTokenPermissionGroup[];
   projectData: AppSettingsFormState;
+  projectId: string;
 };


### PR DESCRIPTION
DEVPROD-9282
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? -->

### Description
Following the Figma designs, add button to delete GitHub credentials (because they are greyed out and uneditable after save).

### Screenshots
<!-- add screenshots of visible changes -->
<img width="491" alt="Screenshot 2024-07-31 at 9 34 03 AM" src="https://github.com/user-attachments/assets/2e2c6be7-370b-4efd-8a2a-93bfdb453ef7">
<img width="426" alt="Screenshot 2024-07-31 at 9 34 20 AM" src="https://github.com/user-attachments/assets/f8ee7626-28aa-40ab-895d-ff3000e2df36">


### Testing
- Jest tests for `DeleteAppCredentialsButton`
- Cypress tests for the actual deletion action
