### PR TITLE
DEVPROD-791 bump z-index on task icon tooltip to fix overlap on segmented control.

### DIFF
--- a/apps/parsley/src/gql/generated/types.ts
+++ b/apps/parsley/src/gql/generated/types.ts
@@ -882,6 +882,7 @@ export type Image = {
   id: Scalars["String"]["output"];
   kernel: Scalars["String"]["output"];
   lastDeployed: Scalars["Time"]["output"];
+  latestTask?: Maybe<Task>;
   name: Scalars["String"]["output"];
   packages: Array<Package>;
   toolchains: Array<Toolchain>;

--- a/apps/spruce/src/components/TaskStatusIconLegend/index.tsx
+++ b/apps/spruce/src/components/TaskStatusIconLegend/index.tsx
@@ -49,7 +49,8 @@ export const TaskStatusIconLegend: React.FC = () => {
         justify="end"
         active={isActive}
         usePortal
-        popoverZIndex={zIndex.popover}
+        // In some cases, the z-index of the popover needs to be higher than the rest of the app due to some components having a higher z-index.
+        popoverZIndex={zIndex.modal}
       >
         <StyledPopoverContainer>
           <TitleContainer>

--- a/apps/spruce/src/components/TaskStatusIconLegend/index.tsx
+++ b/apps/spruce/src/components/TaskStatusIconLegend/index.tsx
@@ -50,7 +50,7 @@ export const TaskStatusIconLegend: React.FC = () => {
         active={isActive}
         usePortal
         // In some cases, the z-index of the popover needs to be higher than the rest of the app due to some components having a higher z-index.
-        popoverZIndex={zIndex.modal}
+        popoverZIndex={zIndex.tooltip}
       >
         <StyledPopoverContainer>
           <TitleContainer>

--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -882,6 +882,7 @@ export type Image = {
   id: Scalars["String"]["output"];
   kernel: Scalars["String"]["output"];
   lastDeployed: Scalars["Time"]["output"];
+  latestTask?: Maybe<Task>;
   name: Scalars["String"]["output"];
   packages: Array<Package>;
   toolchains: Array<Toolchain>;


### PR DESCRIPTION
DEVPROD-791

### Description
The `@leafygreen-ui/segemented-control` component uses a `z-index:3` property which causes the component to occasionally overlap the task icon tooltip. https://github.com/mongodb/leafygreen-ui/blob/6834540cba85e3d09b2d337df8f0c28ddd96ceec/packages/segmented-control/src/SegmentedControlOption/SegmentedControlOption.styles.ts#L93

### Screenshots

![image](https://github.com/user-attachments/assets/c0bd3f66-b1f2-4a7e-b873-311ab214636c)


