### PR TITLE
DEVPROD-9069 Highlight failing command more prominently

### DIFF
--- a/apps/spruce/src/gql/mocks/taskData.ts
+++ b/apps/spruce/src/gql/mocks/taskData.ts
@@ -16,7 +16,7 @@ export const taskQuery: TaskQuery = {
     displayTask: null,
     details: {
       description:
-        "Long description that requirese use of the inline definition component. This would include details about where the task failed.",
+        "Long description that requires use of the inline definition component. This would include details about where the task failed.",
       diskDevices: [],
       oomTracker: {
         detected: false,

--- a/apps/spruce/src/pages/task/metadata/__snapshots__/Metadata_ContainerizedTask.storyshot
+++ b/apps/spruce/src/pages/task/metadata/__snapshots__/Metadata_ContainerizedTask.storyshot
@@ -96,7 +96,7 @@
           class="css-1spnncu-Item-wordBreakCss e1ul56zb0 leafygreen-ui-1tb6tuo"
         >
           <b
-            class="css-jgxcgw-StyledBody ebphozh0"
+            class="css-60sdmx-StyledBody ebphozh0"
           >
             Failing Command: 
           </b>

--- a/apps/spruce/src/pages/task/metadata/__snapshots__/Metadata_ContainerizedTask.storyshot
+++ b/apps/spruce/src/pages/task/metadata/__snapshots__/Metadata_ContainerizedTask.storyshot
@@ -100,7 +100,7 @@
           >
             Failing Command: 
           </b>
-          Long description that requirese use of the inline definition component. This would include details a...
+          Long description that requires use of the inline definition component. This would include details ab...
            
           <span
             class="leafygreen-ui-vm4wms"

--- a/apps/spruce/src/pages/task/metadata/__snapshots__/Metadata_ContainerizedTask.storyshot
+++ b/apps/spruce/src/pages/task/metadata/__snapshots__/Metadata_ContainerizedTask.storyshot
@@ -92,8 +92,15 @@
         class="css-1spnncu-Item-wordBreakCss e1ul56zb0 leafygreen-ui-1tb6tuo"
         data-cy="task-metadata-description"
       >
-        <span>
-          Failing command: Long description that requirese use of the inline definition component. This would ...
+        <p
+          class="css-1spnncu-Item-wordBreakCss e1ul56zb0 leafygreen-ui-1tb6tuo"
+        >
+          <b
+            class="css-jgxcgw-StyledBody ebphozh0"
+          >
+            Failing Command: 
+          </b>
+          Long description that requirese use of the inline definition component. This would include details a...
            
           <span
             class="leafygreen-ui-vm4wms"
@@ -105,7 +112,7 @@
               more
             </small>
           </span>
-        </span>
+        </p>
       </p>
       <p
         class="css-1spnncu-Item-wordBreakCss e1ul56zb0 leafygreen-ui-1tb6tuo"

--- a/apps/spruce/src/pages/task/metadata/__snapshots__/Metadata_Default.storyshot
+++ b/apps/spruce/src/pages/task/metadata/__snapshots__/Metadata_Default.storyshot
@@ -96,7 +96,7 @@
           class="css-1spnncu-Item-wordBreakCss e1ul56zb0 leafygreen-ui-1tb6tuo"
         >
           <b
-            class="css-jgxcgw-StyledBody ebphozh0"
+            class="css-60sdmx-StyledBody ebphozh0"
           >
             Failing Command: 
           </b>

--- a/apps/spruce/src/pages/task/metadata/__snapshots__/Metadata_Default.storyshot
+++ b/apps/spruce/src/pages/task/metadata/__snapshots__/Metadata_Default.storyshot
@@ -100,7 +100,7 @@
           >
             Failing Command: 
           </b>
-          Long description that requirese use of the inline definition component. This would include details a...
+          Long description that requires use of the inline definition component. This would include details ab...
            
           <span
             class="leafygreen-ui-vm4wms"

--- a/apps/spruce/src/pages/task/metadata/__snapshots__/Metadata_Default.storyshot
+++ b/apps/spruce/src/pages/task/metadata/__snapshots__/Metadata_Default.storyshot
@@ -92,8 +92,15 @@
         class="css-1spnncu-Item-wordBreakCss e1ul56zb0 leafygreen-ui-1tb6tuo"
         data-cy="task-metadata-description"
       >
-        <span>
-          Failing command: Long description that requirese use of the inline definition component. This would ...
+        <p
+          class="css-1spnncu-Item-wordBreakCss e1ul56zb0 leafygreen-ui-1tb6tuo"
+        >
+          <b
+            class="css-jgxcgw-StyledBody ebphozh0"
+          >
+            Failing Command: 
+          </b>
+          Long description that requirese use of the inline definition component. This would include details a...
            
           <span
             class="leafygreen-ui-vm4wms"
@@ -105,7 +112,7 @@
               more
             </small>
           </span>
-        </span>
+        </p>
       </p>
       <p
         class="css-1spnncu-Item-wordBreakCss e1ul56zb0 leafygreen-ui-1tb6tuo"

--- a/apps/spruce/src/pages/task/metadata/__snapshots__/Metadata_WithAbortMessage.storyshot
+++ b/apps/spruce/src/pages/task/metadata/__snapshots__/Metadata_WithAbortMessage.storyshot
@@ -96,7 +96,7 @@
           class="css-1spnncu-Item-wordBreakCss e1ul56zb0 leafygreen-ui-1tb6tuo"
         >
           <b
-            class="css-jgxcgw-StyledBody ebphozh0"
+            class="css-60sdmx-StyledBody ebphozh0"
           >
             Failing Command: 
           </b>

--- a/apps/spruce/src/pages/task/metadata/__snapshots__/Metadata_WithAbortMessage.storyshot
+++ b/apps/spruce/src/pages/task/metadata/__snapshots__/Metadata_WithAbortMessage.storyshot
@@ -100,7 +100,7 @@
           >
             Failing Command: 
           </b>
-          Long description that requirese use of the inline definition component. This would include details a...
+          Long description that requires use of the inline definition component. This would include details ab...
            
           <span
             class="leafygreen-ui-vm4wms"

--- a/apps/spruce/src/pages/task/metadata/__snapshots__/Metadata_WithAbortMessage.storyshot
+++ b/apps/spruce/src/pages/task/metadata/__snapshots__/Metadata_WithAbortMessage.storyshot
@@ -92,8 +92,15 @@
         class="css-1spnncu-Item-wordBreakCss e1ul56zb0 leafygreen-ui-1tb6tuo"
         data-cy="task-metadata-description"
       >
-        <span>
-          Failing command: Long description that requirese use of the inline definition component. This would ...
+        <p
+          class="css-1spnncu-Item-wordBreakCss e1ul56zb0 leafygreen-ui-1tb6tuo"
+        >
+          <b
+            class="css-jgxcgw-StyledBody ebphozh0"
+          >
+            Failing Command: 
+          </b>
+          Long description that requirese use of the inline definition component. This would include details a...
            
           <span
             class="leafygreen-ui-vm4wms"
@@ -105,7 +112,7 @@
               more
             </small>
           </span>
-        </span>
+        </p>
       </p>
       <p
         class="css-1spnncu-Item-wordBreakCss e1ul56zb0 leafygreen-ui-1tb6tuo"

--- a/apps/spruce/src/pages/task/metadata/__snapshots__/Metadata_WithDependencies.storyshot
+++ b/apps/spruce/src/pages/task/metadata/__snapshots__/Metadata_WithDependencies.storyshot
@@ -96,7 +96,7 @@
           class="css-1spnncu-Item-wordBreakCss e1ul56zb0 leafygreen-ui-1tb6tuo"
         >
           <b
-            class="css-jgxcgw-StyledBody ebphozh0"
+            class="css-60sdmx-StyledBody ebphozh0"
           >
             Failing Command: 
           </b>

--- a/apps/spruce/src/pages/task/metadata/__snapshots__/Metadata_WithDependencies.storyshot
+++ b/apps/spruce/src/pages/task/metadata/__snapshots__/Metadata_WithDependencies.storyshot
@@ -100,7 +100,7 @@
           >
             Failing Command: 
           </b>
-          Long description that requirese use of the inline definition component. This would include details a...
+          Long description that requires use of the inline definition component. This would include details ab...
            
           <span
             class="leafygreen-ui-vm4wms"

--- a/apps/spruce/src/pages/task/metadata/__snapshots__/Metadata_WithDependencies.storyshot
+++ b/apps/spruce/src/pages/task/metadata/__snapshots__/Metadata_WithDependencies.storyshot
@@ -92,8 +92,15 @@
         class="css-1spnncu-Item-wordBreakCss e1ul56zb0 leafygreen-ui-1tb6tuo"
         data-cy="task-metadata-description"
       >
-        <span>
-          Failing command: Long description that requirese use of the inline definition component. This would ...
+        <p
+          class="css-1spnncu-Item-wordBreakCss e1ul56zb0 leafygreen-ui-1tb6tuo"
+        >
+          <b
+            class="css-jgxcgw-StyledBody ebphozh0"
+          >
+            Failing Command: 
+          </b>
+          Long description that requirese use of the inline definition component. This would include details a...
            
           <span
             class="leafygreen-ui-vm4wms"
@@ -105,7 +112,7 @@
               more
             </small>
           </span>
-        </span>
+        </p>
       </p>
       <p
         class="css-1spnncu-Item-wordBreakCss e1ul56zb0 leafygreen-ui-1tb6tuo"
@@ -159,7 +166,7 @@
         </a>
       </p>
       <div
-        class="css-5f1fjg-DependsOnContainer ebphozh2"
+        class="css-5f1fjg-DependsOnContainer ebphozh3"
         data-cy="depends-on-container"
       >
         <div>

--- a/apps/spruce/src/pages/task/metadata/index.tsx
+++ b/apps/spruce/src/pages/task/metadata/index.tsx
@@ -482,7 +482,7 @@ const DetailsDescription = ({
     <MetadataItem>
       {shouldTruncate ? (
         <>
-          <StyledBody weight="medium">Failing Command: </StyledBody>
+          <StyledBody>Failing Command: </StyledBody>
           {truncatedText}{" "}
           <ExpandedText
             align="right"

--- a/apps/spruce/src/pages/task/metadata/index.tsx
+++ b/apps/spruce/src/pages/task/metadata/index.tsx
@@ -532,6 +532,4 @@ const OOMTrackerMessage = styled(MetadataItem)`
 
 const StyledBody = styled.b`
   color: ${red.base};
-  display: inline;
-  font-weight: bold;
 `;

--- a/apps/spruce/src/pages/task/metadata/index.tsx
+++ b/apps/spruce/src/pages/task/metadata/index.tsx
@@ -473,18 +473,16 @@ const DetailsDescription = ({
 
   const fullText =
     status === TaskStatus.Failed
-      ? `Failing command: ${processFailingCommand(
-          description,
-          isContainerTask,
-        )}`
+      ? `${processFailingCommand(description, isContainerTask)}`
       : `Command: ${description}`;
   const shouldTruncate = fullText.length > MAX_CHAR;
   const truncatedText = fullText.substring(0, MAX_CHAR).concat("...");
 
   return (
-    <span>
+    <MetadataItem>
       {shouldTruncate ? (
         <>
+          <StyledBody weight="medium">Failing Command: </StyledBody>
           {truncatedText}{" "}
           <ExpandedText
             align="right"
@@ -497,7 +495,7 @@ const DetailsDescription = ({
       ) : (
         fullText
       )}
-    </span>
+    </MetadataItem>
   );
 };
 
@@ -530,4 +528,10 @@ const HoneycombLinkContainer = styled.span`
 const OOMTrackerMessage = styled(MetadataItem)`
   color: ${red.dark2};
   font-weight: 500;
+`;
+
+const StyledBody = styled.b`
+  color: ${red.base};
+  display: inline;
+  font-weight: bold;
 `;


### PR DESCRIPTION
DEVPROD-9069

### Description
Users had difficulty identifying the failing command when looking at a task page. This PR aims to highlight the failing command in the task metadata more prominently.
### Screenshots
<img width="421" alt="image" src="https://github.com/user-attachments/assets/291d8784-d14f-469b-be4f-b880c1b324e2">

https://www.figma.com/design/ZUhP5FPvKe67XZvpbpctt8/EXPO-3972%3A--Highlighting-Failing-Command?node-id=1-474&t=eYWPcitcmiYrxHaH-0