### PR TITLE
DEVPROD-9642: Ingest TaskEndDetail.failingCommand GQL field

### DIFF
--- a/apps/parsley/src/gql/generated/types.ts
+++ b/apps/parsley/src/gql/generated/types.ts
@@ -2777,6 +2777,7 @@ export type TaskEndDetail = {
   __typename?: "TaskEndDetail";
   description?: Maybe<Scalars["String"]["output"]>;
   diskDevices: Array<Scalars["String"]["output"]>;
+  failingCommand?: Maybe<Scalars["String"]["output"]>;
   oomTracker: OomTrackerInfo;
   status: Scalars["String"]["output"];
   timedOut?: Maybe<Scalars["Boolean"]["output"]>;
@@ -3476,6 +3477,7 @@ export type TaskQuery = {
     details?: {
       __typename?: "TaskEndDetail";
       description?: string | null;
+      failingCommand?: string | null;
       status: string;
     } | null;
     logs: {

--- a/apps/parsley/src/gql/queries/get-task.graphql
+++ b/apps/parsley/src/gql/queries/get-task.graphql
@@ -5,6 +5,7 @@ query Task($taskId: String!, $execution: Int) {
     ...BaseTask
     details {
       description
+      failingCommand
       status
     }
     logs {

--- a/apps/parsley/src/hooks/useTaskQuery/index.ts
+++ b/apps/parsley/src/hooks/useTaskQuery/index.ts
@@ -26,6 +26,7 @@ type TaskType = BaseTaskFragment & {
   details?:
     | {
         description?: string | null | undefined;
+        failingCommand?: string | null | undefined;
         status: string;
       }
     | null

--- a/apps/parsley/src/pages/LogView/LoadingPage/useResolveLogURLAndRenderingType.ts
+++ b/apps/parsley/src/pages/LogView/LoadingPage/useResolveLogURLAndRenderingType.ts
@@ -190,7 +190,7 @@ export const useResolveLogURLAndRenderingType = ({
           });
       renderingType = LogRenderingTypes.Default;
 
-      // This is for backwards compatbility with older task logs that don't details.failingCommand (adjust in DEVPROD-9689)
+      // TODO DEVPROD-9689: Parsley should not examine TaskEndDetail.description GQL type to determine failing log line
       const potentialFailingCommand =
         task?.details?.failingCommand || task?.details?.description;
       failingCommand =

--- a/apps/parsley/src/pages/LogView/LoadingPage/useResolveLogURLAndRenderingType.ts
+++ b/apps/parsley/src/pages/LogView/LoadingPage/useResolveLogURLAndRenderingType.ts
@@ -189,9 +189,13 @@ export const useResolveLogURLAndRenderingType = ({
             text: false,
           });
       renderingType = LogRenderingTypes.Default;
+
+      // This is for backwards compatbility with older task logs that don't details.failingCommand (adjust in DEVPROD-9689)
+      const potentialFailingCommand =
+        task?.details?.failingCommand || task?.details?.description;
       failingCommand =
-        task?.details?.status === "failed" && task?.details?.description
-          ? task.details.description
+        task?.details?.status === "failed" && potentialFailingCommand
+          ? potentialFailingCommand
           : "";
       break;
     }

--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -2777,6 +2777,7 @@ export type TaskEndDetail = {
   __typename?: "TaskEndDetail";
   description?: Maybe<Scalars["String"]["output"]>;
   diskDevices: Array<Scalars["String"]["output"]>;
+  failingCommand?: Maybe<Scalars["String"]["output"]>;
   oomTracker: OomTrackerInfo;
   status: Scalars["String"]["output"];
   timedOut?: Maybe<Scalars["Boolean"]["output"]>;
@@ -8843,6 +8844,7 @@ export type TaskQuery = {
       __typename?: "TaskEndDetail";
       description?: string | null;
       diskDevices: Array<string>;
+      failingCommand?: string | null;
       status: string;
       timedOut?: boolean | null;
       timeoutType?: string | null;

--- a/apps/spruce/src/gql/mocks/taskData.ts
+++ b/apps/spruce/src/gql/mocks/taskData.ts
@@ -15,6 +15,7 @@ export const taskQuery: TaskQuery = {
     executionTasksFull: null,
     displayTask: null,
     details: {
+      failingCommand: "",
       description:
         "Long description that requires use of the inline definition component. This would include details about where the task failed.",
       diskDevices: [],

--- a/apps/spruce/src/gql/queries/task.graphql
+++ b/apps/spruce/src/gql/queries/task.graphql
@@ -47,6 +47,7 @@ query Task($taskId: String!, $execution: Int) {
     details {
       description
       diskDevices
+      failingCommand
       oomTracker {
         detected
         pids

--- a/apps/spruce/src/pages/task/metadata/index.tsx
+++ b/apps/spruce/src/pages/task/metadata/index.tsx
@@ -234,15 +234,17 @@ export const Metadata: React.FC<Props> = ({ error, loading, task, taskId }) => {
           </InlineCode>
         </MetadataItem>
       )}
-      {details?.description && (
-        <MetadataItem data-cy="task-metadata-description">
-          <DetailsDescription
-            description={details.description}
-            isContainerTask={isContainerTask}
-            status={details?.status}
-          />
-        </MetadataItem>
-      )}
+      {details?.description ||
+        (details?.failingCommand && (
+          <MetadataItem data-cy="task-metadata-description">
+            <DetailsDescription
+              description={details?.description ?? ""}
+              failingCommand={details?.failingCommand ?? ""}
+              isContainerTask={isContainerTask}
+              status={details?.status}
+            />
+          </MetadataItem>
+        ))}
       {details?.timeoutType && details?.timeoutType !== "" && (
         <MetadataItem>Timeout type: {details?.timeoutType}</MetadataItem>
       )}
@@ -462,19 +464,22 @@ export const Metadata: React.FC<Props> = ({ error, loading, task, taskId }) => {
 
 const DetailsDescription = ({
   description,
+  failingCommand,
   isContainerTask,
   status,
 }: {
   description: string;
+  failingCommand: string;
   isContainerTask: boolean;
   status: string;
 }) => {
   const MAX_CHAR = 100;
 
+  const baseCopy = description || failingCommand;
   const fullText =
     status === TaskStatus.Failed
-      ? `${processFailingCommand(description, isContainerTask)}`
-      : `Command: ${description}`;
+      ? `${processFailingCommand(baseCopy, isContainerTask)}`
+      : `Command: ${baseCopy}`;
   const shouldTruncate = fullText.length > MAX_CHAR;
   const truncatedText = fullText.substring(0, MAX_CHAR).concat("...");
 

--- a/apps/spruce/src/pages/task/metadata/index.tsx
+++ b/apps/spruce/src/pages/task/metadata/index.tsx
@@ -234,17 +234,16 @@ export const Metadata: React.FC<Props> = ({ error, loading, task, taskId }) => {
           </InlineCode>
         </MetadataItem>
       )}
-      {details?.description ||
-        (details?.failingCommand && (
-          <MetadataItem data-cy="task-metadata-description">
-            <DetailsDescription
-              description={details?.description ?? ""}
-              failingCommand={details?.failingCommand ?? ""}
-              isContainerTask={isContainerTask}
-              status={details?.status}
-            />
-          </MetadataItem>
-        ))}
+      {(details?.description || details?.failingCommand) && (
+        <MetadataItem data-cy="task-metadata-description">
+          <DetailsDescription
+            description={details?.description ?? ""}
+            failingCommand={details?.failingCommand ?? ""}
+            isContainerTask={isContainerTask}
+            status={details?.status}
+          />
+        </MetadataItem>
+      )}
       {details?.timeoutType && details?.timeoutType !== "" && (
         <MetadataItem>Timeout type: {details?.timeoutType}</MetadataItem>
       )}


### PR DESCRIPTION
DEVPROD-9642

### Description
Ingest the failing command and use it in the Task Metadata panel as a backup value and in Parsley to find the failing log line. 

### Evergreen PR
https://github.com/evergreen-ci/evergreen/pull/8166
