### PR TITLE
DEVPROD-9697 Update eslint sort rules so that evg-ui packages are not treated as external deps

### DIFF
--- a/apps/parsley/src/components/Search/SearchBar/index.tsx
+++ b/apps/parsley/src/components/Search/SearchBar/index.tsx
@@ -1,11 +1,11 @@
 import { KeyboardEvent, useRef, useState } from "react";
 import styled from "@emotion/styled";
-import { TextInputWithGlyph } from "@evg-ui/lib/components/TextInputWithGlyph";
 import IconButton from "@leafygreen-ui/icon-button";
 import { palette } from "@leafygreen-ui/palette";
 import { Option, Select } from "@leafygreen-ui/select";
 import Tooltip from "@leafygreen-ui/tooltip";
 import debounce from "lodash.debounce";
+import { TextInputWithGlyph } from "@evg-ui/lib/components/TextInputWithGlyph";
 import { useLogWindowAnalytics } from "analytics";
 import Icon from "components/Icon";
 import { SearchBarActions } from "constants/enums";

--- a/apps/parsley/src/hooks/useQueryParam/index.ts
+++ b/apps/parsley/src/hooks/useQueryParam/index.ts
@@ -1,7 +1,7 @@
 import { useCallback, useMemo } from "react";
-import { conditionalToArray } from "@evg-ui/lib/utils/array";
 import { ParseOptions } from "query-string";
 import { useNavigate, useSearchParams } from "react-router-dom";
+import { conditionalToArray } from "@evg-ui/lib/utils/array";
 import { QueryParams } from "constants/queryParams";
 import { parseQueryString, stringifyQuery } from "utils/query-string";
 

--- a/apps/parsley/src/pages/LogDrop/ParseLogSelect/index.tsx
+++ b/apps/parsley/src/pages/LogDrop/ParseLogSelect/index.tsx
@@ -1,10 +1,10 @@
 import { useState } from "react";
 import styled from "@emotion/styled";
-import { size } from "@evg-ui/lib/constants/tokens";
 import Button from "@leafygreen-ui/button";
 import { Option, Select } from "@leafygreen-ui/select";
 import { InlineCode, InlineCodeProps, Label } from "@leafygreen-ui/typography";
 import Cookie from "js-cookie";
+import { size } from "@evg-ui/lib/constants/tokens";
 import { LAST_SELECTED_LOG_TYPE } from "constants/cookies";
 import { LogRenderingTypes } from "constants/enums";
 

--- a/apps/parsley/src/snapshot.test.ts
+++ b/apps/parsley/src/snapshot.test.ts
@@ -1,7 +1,7 @@
-import { projectAnnotations } from "@evg-ui/storybook-addon";
 import { composeStories, setProjectAnnotations } from "@storybook/react";
 import { expect } from "vitest";
 import path from "path";
+import { projectAnnotations } from "@evg-ui/storybook-addon";
 import { act, render, stubGetClientRects } from "test_utils";
 import { CustomMeta, CustomStoryObj } from "test_utils/types";
 import * as previewAnnotations from "../.storybook/preview";

--- a/apps/spruce/src/components/SearchableDropdown/index.tsx
+++ b/apps/spruce/src/components/SearchableDropdown/index.tsx
@@ -7,9 +7,9 @@ import {
   useMemo,
 } from "react";
 import styled from "@emotion/styled";
-import { TextInputWithGlyph } from "@evg-ui/lib/components/TextInputWithGlyph";
 import { palette } from "@leafygreen-ui/palette";
 import { Label } from "@leafygreen-ui/typography";
+import { TextInputWithGlyph } from "@evg-ui/lib/components/TextInputWithGlyph";
 import Dropdown from "components/Dropdown";
 import Icon from "components/Icon";
 import { size } from "constants/tokens";

--- a/apps/spruce/src/components/Spawn/utils/hostUptime.ts
+++ b/apps/spruce/src/components/Spawn/utils/hostUptime.ts
@@ -1,4 +1,3 @@
-import { arraySymmetricDifference } from "@evg-ui/lib/utils/array";
 import { setToUTCMidnight } from "@leafygreen-ui/date-utils";
 import {
   isAfter,
@@ -7,6 +6,7 @@ import {
   isTomorrow,
   parse,
 } from "date-fns";
+import { arraySymmetricDifference } from "@evg-ui/lib/utils/array";
 import { ValidateProps } from "components/SpruceForm";
 import { days } from "constants/fieldMaps";
 import { SleepScheduleInput } from "gql/generated/types";

--- a/apps/spruce/src/components/TextInputWithValidation/index.tsx
+++ b/apps/spruce/src/components/TextInputWithValidation/index.tsx
@@ -1,10 +1,10 @@
 import { useState, forwardRef } from "react";
+import IconButton from "@leafygreen-ui/icon-button";
+import { palette } from "@leafygreen-ui/palette";
 import {
   TextInputWithGlyph,
   TextInputWithGlyphProps,
 } from "@evg-ui/lib/components/TextInputWithGlyph";
-import IconButton from "@leafygreen-ui/icon-button";
-import { palette } from "@leafygreen-ui/palette";
 import Icon from "components/Icon";
 import IconTooltip from "components/IconTooltip";
 

--- a/apps/spruce/src/hooks/useQueryParam/index.ts
+++ b/apps/spruce/src/hooks/useQueryParam/index.ts
@@ -1,6 +1,6 @@
 import { useCallback, useMemo } from "react";
-import { conditionalToArray } from "@evg-ui/lib/utils/array";
 import { useSearchParams } from "react-router-dom";
+import { conditionalToArray } from "@evg-ui/lib/utils/array";
 import {
   parseQueryStringAsValue as parseQueryString,
   stringifyQueryAsValue as stringifyQuery,

--- a/apps/spruce/src/snapshot.test.ts
+++ b/apps/spruce/src/snapshot.test.ts
@@ -1,7 +1,7 @@
-import { projectAnnotations } from "@evg-ui/storybook-addon";
 import { composeStories, setProjectAnnotations } from "@storybook/react";
 import { expect } from "vitest";
 import path from "path";
+import { projectAnnotations } from "@evg-ui/storybook-addon";
 import { act, render, stubGetClientRects } from "test_utils";
 import { CustomMeta, CustomStoryObj } from "test_utils/types";
 import * as previewAnnotations from "../.storybook/preview";

--- a/packages/deploy-utils/src/email/index.ts
+++ b/packages/deploy-utils/src/email/index.ts
@@ -1,6 +1,6 @@
-import { toSentenceCase } from "@evg-ui/lib/utils/string";
 import { execSync } from "child_process";
 import { readFileSync } from "fs";
+import { toSentenceCase } from "@evg-ui/lib/utils/string";
 import { getAppToDeploy, isRunningOnCI, isTest } from "../utils/environment";
 import {
   COMMIT_LENGTH,

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -196,6 +196,11 @@ module.exports = {
           },
           {
             group: "internal",
+            pattern: "@evg-ui/**",
+            position: "before",
+          },
+          {
+            group: "internal",
             pattern:
               "(analytics|components|constants|context|gql|hoc|hooks|pages|types|utils)/**",
             position: "before",

--- a/packages/lib/src/snapshot.test.ts
+++ b/packages/lib/src/snapshot.test.ts
@@ -1,4 +1,3 @@
-import { projectAnnotations } from "@evg-ui/storybook-addon";
 import {
   composeStories,
   Meta,
@@ -9,6 +8,7 @@ import {
 import { act, render } from "@testing-library/react";
 import { expect } from "vitest";
 import path from "path";
+import { projectAnnotations } from "@evg-ui/storybook-addon";
 
 setProjectAnnotations([projectAnnotations]);
 


### PR DESCRIPTION
DEVPROD-9697

### Description
While working on a separate feature I noticed that `@evg-ui` dependencies were being sorted above internal deps and being sorted as if it was an external dependency. I split out this change to make the change sooner. 
