### PR TITLE
DEVPROD-8684: Clarify volume expiration policy in spawn volume table

### DIFF
--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -879,14 +879,14 @@ export type Image = {
   __typename?: "Image";
   ami: Scalars["String"]["output"];
   distros: Array<Distro>;
-  events: Array<ImageEvent>;
+  events: ImageEventsPayload;
   id: Scalars["String"]["output"];
   kernel: Scalars["String"]["output"];
   lastDeployed: Scalars["Time"]["output"];
   latestTask?: Maybe<Task>;
   name: Scalars["String"]["output"];
-  packages: Array<Package>;
-  toolchains: Array<Toolchain>;
+  packages: ImagePackagesPayload;
+  toolchains: ImageToolchainsPayload;
   versionId: Scalars["String"]["output"];
 };
 
@@ -942,6 +942,26 @@ export enum ImageEventType {
   Package = "PACKAGE",
   Toolchain = "TOOLCHAIN",
 }
+
+export type ImageEventsPayload = {
+  __typename?: "ImageEventsPayload";
+  count: Scalars["Int"]["output"];
+  eventLogEntries: Array<ImageEvent>;
+};
+
+export type ImagePackagesPayload = {
+  __typename?: "ImagePackagesPayload";
+  data: Array<Package>;
+  filteredCount: Scalars["Int"]["output"];
+  totalCount: Scalars["Int"]["output"];
+};
+
+export type ImageToolchainsPayload = {
+  __typename?: "ImageToolchainsPayload";
+  data: Array<Toolchain>;
+  filteredCount: Scalars["Int"]["output"];
+  totalCount: Scalars["Int"]["output"];
+};
 
 export type InstanceTag = {
   __typename?: "InstanceTag";
@@ -1570,6 +1590,7 @@ export type Patch = {
   createTime?: Maybe<Scalars["Time"]["output"]>;
   description: Scalars["String"]["output"];
   duration?: Maybe<PatchDuration>;
+  generatedTaskCounts: Scalars["Map"]["output"];
   githash: Scalars["String"]["output"];
   hidden: Scalars["Boolean"]["output"];
   id: Scalars["ID"]["output"];
@@ -3231,6 +3252,7 @@ export type Version = {
   errors: Array<Scalars["String"]["output"]>;
   externalLinksForMetadata: Array<ExternalLinkForMetadata>;
   finishTime?: Maybe<Scalars["Time"]["output"]>;
+  generatedTaskCounts: Scalars["Map"]["output"];
   gitTags?: Maybe<Array<GitTag>>;
   id: Scalars["String"]["output"];
   ignored: Scalars["Boolean"]["output"];

--- a/apps/spruce/src/pages/spawn/spawnVolume/SpawnVolumeTable.tsx
+++ b/apps/spruce/src/pages/spawn/spawnVolume/SpawnVolumeTable.tsx
@@ -1,9 +1,8 @@
 import { useMemo, useRef } from "react";
 import styled from "@emotion/styled";
+import { InfoSprinkle } from "@leafygreen-ui/info-sprinkle";
 import { LeafyGreenTableRow, useLeafyGreenTable } from "@leafygreen-ui/table";
-import Tooltip from "@leafygreen-ui/tooltip";
 import { formatDistanceToNow } from "date-fns";
-import Icon from "components/Icon";
 import { DoesNotExpire } from "components/Spawn";
 import { StyledRouterLink, WordBreak } from "components/styles";
 import { BaseTable } from "components/Table/BaseTable";
@@ -122,16 +121,11 @@ const columns = [
         <>
           {isUnexpirable ? DoesNotExpire : formatDistanceToNow(expiration)}
           {!isUnexpirable && row.original.hostID && (
-            <Tooltip
-              trigger={
-                <IconContainer>
-                  <Icon glyph="InfoWithCircle" />
-                </IconContainer>
-              }
-              triggerEvent="hover"
-            >
-              Expiration is not applicable to mounted volumes.
-            </Tooltip>
+            <InfoContainer>
+              <InfoSprinkle>
+                Expiration is not applicable to mounted volumes.
+              </InfoSprinkle>
+            </InfoContainer>
           )}
         </>
       );
@@ -144,8 +138,7 @@ const columns = [
   },
 ];
 
-const IconContainer = styled.span`
-  margin-left: ${size.xxs};
-  top: 2px;
-  vertical-align: text-top;
+const InfoContainer = styled.div`
+  position: relative;
+  left: ${size.xxs};
 `;

--- a/apps/spruce/src/pages/spawn/spawnVolume/SpawnVolumeTable.tsx
+++ b/apps/spruce/src/pages/spawn/spawnVolume/SpawnVolumeTable.tsx
@@ -1,10 +1,14 @@
 import { useMemo, useRef } from "react";
+import styled from "@emotion/styled";
 import { LeafyGreenTableRow, useLeafyGreenTable } from "@leafygreen-ui/table";
+import Tooltip from "@leafygreen-ui/tooltip";
 import { formatDistanceToNow } from "date-fns";
+import Icon from "components/Icon";
 import { DoesNotExpire } from "components/Spawn";
 import { StyledRouterLink, WordBreak } from "components/styles";
 import { BaseTable } from "components/Table/BaseTable";
 import { getSpawnHostRoute } from "constants/routes";
+import { size } from "constants/tokens";
 import { useQueryParam } from "hooks/useQueryParam";
 import { MyVolume, QueryParams, TableVolume } from "types/spawn";
 import { SpawnVolumeCard } from "./SpawnVolumeCard";
@@ -113,9 +117,24 @@ const columns = [
     cell: ({ getValue, row }) => {
       const expiration = getValue();
       const { noExpiration } = row.original;
-      return noExpiration || !expiration
-        ? DoesNotExpire
-        : formatDistanceToNow(expiration);
+      const isUnexpirable = noExpiration || !expiration;
+      return (
+        <>
+          {isUnexpirable ? DoesNotExpire : formatDistanceToNow(expiration)}
+          {!isUnexpirable && row.original.hostID && (
+            <Tooltip
+              trigger={
+                <IconContainer>
+                  <Icon glyph="InfoWithCircle" />
+                </IconContainer>
+              }
+              triggerEvent="hover"
+            >
+              Expiration is not applicable to mounted volumes.
+            </Tooltip>
+          )}
+        </>
+      );
     },
   },
   {
@@ -124,3 +143,9 @@ const columns = [
     cell: ({ row }) => <SpawnVolumeTableActions volume={row.original} />,
   },
 ];
+
+const IconContainer = styled.span`
+  margin-left: ${size.xxs};
+  top: 2px;
+  vertical-align: text-top;
+`;


### PR DESCRIPTION
DEVPROD-8684

### Description
Clarify expiration policy with a tooltip when a volume is mounted and expirable. 

### Screenshots
<img width="287" alt="Screenshot 2024-08-13 at 3 43 37 PM" src="https://github.com/user-attachments/assets/7a81b4cb-c30a-4d2e-9076-8d41171c4f42">

