### PR TITLE
DEVPROD-4250: Resolve host_section e2e test flake

### DIFF
--- a/apps/spruce/cypress/integration/distroSettings/host_section.ts
+++ b/apps/spruce/cypress/integration/distroSettings/host_section.ts
@@ -52,7 +52,7 @@ describe("host section", () => {
       cy.validateToast("success", "Updated distro.");
     });
 
-    it("updates mountpoints", () => {
+    it("updates mountpoints", { retries: { runMode: 2 } }, () => {
       cy.contains("button", "Add Mountpoint").click();
       cy.getInputByLabel("Mountpoint").type("/data");
 

--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -879,7 +879,7 @@ export type Image = {
   __typename?: "Image";
   ami: Scalars["String"]["output"];
   distros: Array<Distro>;
-  events: Array<ImageEvent>;
+  events: ImageEventsPayload;
   id: Scalars["String"]["output"];
   kernel: Scalars["String"]["output"];
   lastDeployed: Scalars["Time"]["output"];
@@ -942,6 +942,12 @@ export enum ImageEventType {
   Package = "PACKAGE",
   Toolchain = "TOOLCHAIN",
 }
+
+export type ImageEventsPayload = {
+  __typename?: "ImageEventsPayload";
+  count: Scalars["Int"]["output"];
+  eventLogEntries: Array<ImageEvent>;
+};
 
 export type InstanceTag = {
   __typename?: "InstanceTag";


### PR DESCRIPTION
DEVPROD-425

### Description
I ran the `distroSettings/host_section` spec [100 times](https://spruce.mongodb.com/task/evergreen_ui_spruce_e2e_patch_15134b20786c8ee05a57a0f609bf976388f3b448_66b1193e32c17e00071dc0cf_24_08_05_18_26_17/files?execution=0) and found that it failed the "updates mountpoint" button test 6 times (6% flake rate). This test fails because clicking the "Add Mountpoint" button fails dispatch a callback. The element is not disabled and the element is clickable. Looking at the video, the events happen extremely fast and you can see the blue outline showing that element is selected as soon as the fade-in animation runs. I believe Cypress is clicking on the RJSF component before it can fully register JS callbacks because there is no repaint visible in .25x speed and no network requests are required to render the click result. 
To solve this, I enabled a 2nd retry for this test. I don't think it's worth to introduce a mechanism to wait on the render because it doesn't fail frequently enough to warrant slowing the test suite down. There is a 6% chance that the second retry will occur and a 99.6% [binomial probability](https://statisticshelper.com/binomial-probability-calculator/) that test will succeed after 2 trials.

### Screenshots

Uploading addMountpointFail.mov…

