### PR TITLE
DEVPROD-9751 Fix label not being shown for Failing command

### DIFF
--- a/apps/parsley/src/gql/generated/types.ts
+++ b/apps/parsley/src/gql/generated/types.ts
@@ -879,14 +879,14 @@ export type Image = {
   __typename?: "Image";
   ami: Scalars["String"]["output"];
   distros: Array<Distro>;
-  events: Array<ImageEvent>;
+  events: ImageEventsPayload;
   id: Scalars["String"]["output"];
   kernel: Scalars["String"]["output"];
   lastDeployed: Scalars["Time"]["output"];
   latestTask?: Maybe<Task>;
   name: Scalars["String"]["output"];
-  packages: Array<Package>;
-  toolchains: Array<Toolchain>;
+  packages: ImagePackagesPayload;
+  toolchains: ImageToolchainsPayload;
   versionId: Scalars["String"]["output"];
 };
 
@@ -942,6 +942,26 @@ export enum ImageEventType {
   Package = "PACKAGE",
   Toolchain = "TOOLCHAIN",
 }
+
+export type ImageEventsPayload = {
+  __typename?: "ImageEventsPayload";
+  count: Scalars["Int"]["output"];
+  eventLogEntries: Array<ImageEvent>;
+};
+
+export type ImagePackagesPayload = {
+  __typename?: "ImagePackagesPayload";
+  data: Array<Package>;
+  filteredCount: Scalars["Int"]["output"];
+  totalCount: Scalars["Int"]["output"];
+};
+
+export type ImageToolchainsPayload = {
+  __typename?: "ImageToolchainsPayload";
+  data: Array<Toolchain>;
+  filteredCount: Scalars["Int"]["output"];
+  totalCount: Scalars["Int"]["output"];
+};
 
 export type InstanceTag = {
   __typename?: "InstanceTag";
@@ -1570,6 +1590,7 @@ export type Patch = {
   createTime?: Maybe<Scalars["Time"]["output"]>;
   description: Scalars["String"]["output"];
   duration?: Maybe<PatchDuration>;
+  generatedTaskCounts: Scalars["Map"]["output"];
   githash: Scalars["String"]["output"];
   hidden: Scalars["Boolean"]["output"];
   id: Scalars["ID"]["output"];
@@ -3231,6 +3252,7 @@ export type Version = {
   errors: Array<Scalars["String"]["output"]>;
   externalLinksForMetadata: Array<ExternalLinkForMetadata>;
   finishTime?: Maybe<Scalars["Time"]["output"]>;
+  generatedTaskCounts: Scalars["Map"]["output"];
   gitTags?: Maybe<Array<GitTag>>;
   id: Scalars["String"]["output"];
   ignored: Scalars["Boolean"]["output"];

--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -885,8 +885,8 @@ export type Image = {
   lastDeployed: Scalars["Time"]["output"];
   latestTask?: Maybe<Task>;
   name: Scalars["String"]["output"];
-  packages: Array<Package>;
-  toolchains: Array<Toolchain>;
+  packages: ImagePackagesPayload;
+  toolchains: ImageToolchainsPayload;
   versionId: Scalars["String"]["output"];
 };
 
@@ -947,6 +947,20 @@ export type ImageEventsPayload = {
   __typename?: "ImageEventsPayload";
   count: Scalars["Int"]["output"];
   eventLogEntries: Array<ImageEvent>;
+};
+
+export type ImagePackagesPayload = {
+  __typename?: "ImagePackagesPayload";
+  data: Array<Package>;
+  filteredCount: Scalars["Int"]["output"];
+  totalCount: Scalars["Int"]["output"];
+};
+
+export type ImageToolchainsPayload = {
+  __typename?: "ImageToolchainsPayload";
+  data: Array<Toolchain>;
+  filteredCount: Scalars["Int"]["output"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type InstanceTag = {
@@ -1576,6 +1590,7 @@ export type Patch = {
   createTime?: Maybe<Scalars["Time"]["output"]>;
   description: Scalars["String"]["output"];
   duration?: Maybe<PatchDuration>;
+  generatedTaskCounts: Scalars["Map"]["output"];
   githash: Scalars["String"]["output"];
   hidden: Scalars["Boolean"]["output"];
   id: Scalars["ID"]["output"];
@@ -3237,6 +3252,7 @@ export type Version = {
   errors: Array<Scalars["String"]["output"]>;
   externalLinksForMetadata: Array<ExternalLinkForMetadata>;
   finishTime?: Maybe<Scalars["Time"]["output"]>;
+  generatedTaskCounts: Scalars["Map"]["output"];
   gitTags?: Maybe<Array<GitTag>>;
   id: Scalars["String"]["output"];
   ignored: Scalars["Boolean"]["output"];

--- a/apps/spruce/src/pages/task/metadata/__snapshots__/Metadata_ContainerizedTask.storyshot
+++ b/apps/spruce/src/pages/task/metadata/__snapshots__/Metadata_ContainerizedTask.storyshot
@@ -96,9 +96,10 @@
           class="css-1spnncu-Item-wordBreakCss e1ul56zb0 leafygreen-ui-1tb6tuo"
         >
           <b
-            class="css-60sdmx-StyledBody ebphozh0"
+            class="css-11k78l8-DetailsDescription"
           >
-            Failing Command: 
+            Failing Command:
+             
           </b>
           Long description that requires use of the inline definition component. This would include details ab...
            

--- a/apps/spruce/src/pages/task/metadata/__snapshots__/Metadata_ContainerizedTask.storyshot
+++ b/apps/spruce/src/pages/task/metadata/__snapshots__/Metadata_ContainerizedTask.storyshot
@@ -96,10 +96,9 @@
           class="css-1spnncu-Item-wordBreakCss e1ul56zb0 leafygreen-ui-1tb6tuo"
         >
           <b
-            class="css-11k78l8-DetailsDescription"
+            class="css-qyvtrs-StyledB ebphozh0"
           >
-            Failing Command:
-             
+            Failing Command: 
           </b>
           Long description that requires use of the inline definition component. This would include details ab...
            

--- a/apps/spruce/src/pages/task/metadata/__snapshots__/Metadata_Default.storyshot
+++ b/apps/spruce/src/pages/task/metadata/__snapshots__/Metadata_Default.storyshot
@@ -96,9 +96,10 @@
           class="css-1spnncu-Item-wordBreakCss e1ul56zb0 leafygreen-ui-1tb6tuo"
         >
           <b
-            class="css-60sdmx-StyledBody ebphozh0"
+            class="css-11k78l8-DetailsDescription"
           >
-            Failing Command: 
+            Failing Command:
+             
           </b>
           Long description that requires use of the inline definition component. This would include details ab...
            

--- a/apps/spruce/src/pages/task/metadata/__snapshots__/Metadata_Default.storyshot
+++ b/apps/spruce/src/pages/task/metadata/__snapshots__/Metadata_Default.storyshot
@@ -96,10 +96,9 @@
           class="css-1spnncu-Item-wordBreakCss e1ul56zb0 leafygreen-ui-1tb6tuo"
         >
           <b
-            class="css-11k78l8-DetailsDescription"
+            class="css-qyvtrs-StyledB ebphozh0"
           >
-            Failing Command:
-             
+            Failing Command: 
           </b>
           Long description that requires use of the inline definition component. This would include details ab...
            

--- a/apps/spruce/src/pages/task/metadata/__snapshots__/Metadata_WithAbortMessage.storyshot
+++ b/apps/spruce/src/pages/task/metadata/__snapshots__/Metadata_WithAbortMessage.storyshot
@@ -96,9 +96,10 @@
           class="css-1spnncu-Item-wordBreakCss e1ul56zb0 leafygreen-ui-1tb6tuo"
         >
           <b
-            class="css-60sdmx-StyledBody ebphozh0"
+            class="css-11k78l8-DetailsDescription"
           >
-            Failing Command: 
+            Failing Command:
+             
           </b>
           Long description that requires use of the inline definition component. This would include details ab...
            

--- a/apps/spruce/src/pages/task/metadata/__snapshots__/Metadata_WithAbortMessage.storyshot
+++ b/apps/spruce/src/pages/task/metadata/__snapshots__/Metadata_WithAbortMessage.storyshot
@@ -96,10 +96,9 @@
           class="css-1spnncu-Item-wordBreakCss e1ul56zb0 leafygreen-ui-1tb6tuo"
         >
           <b
-            class="css-11k78l8-DetailsDescription"
+            class="css-qyvtrs-StyledB ebphozh0"
           >
-            Failing Command:
-             
+            Failing Command: 
           </b>
           Long description that requires use of the inline definition component. This would include details ab...
            

--- a/apps/spruce/src/pages/task/metadata/__snapshots__/Metadata_WithDependencies.storyshot
+++ b/apps/spruce/src/pages/task/metadata/__snapshots__/Metadata_WithDependencies.storyshot
@@ -96,9 +96,10 @@
           class="css-1spnncu-Item-wordBreakCss e1ul56zb0 leafygreen-ui-1tb6tuo"
         >
           <b
-            class="css-60sdmx-StyledBody ebphozh0"
+            class="css-11k78l8-DetailsDescription"
           >
-            Failing Command: 
+            Failing Command:
+             
           </b>
           Long description that requires use of the inline definition component. This would include details ab...
            
@@ -166,7 +167,7 @@
         </a>
       </p>
       <div
-        class="css-5f1fjg-DependsOnContainer ebphozh3"
+        class="css-5f1fjg-DependsOnContainer ebphozh2"
         data-cy="depends-on-container"
       >
         <div>

--- a/apps/spruce/src/pages/task/metadata/__snapshots__/Metadata_WithDependencies.storyshot
+++ b/apps/spruce/src/pages/task/metadata/__snapshots__/Metadata_WithDependencies.storyshot
@@ -96,10 +96,9 @@
           class="css-1spnncu-Item-wordBreakCss e1ul56zb0 leafygreen-ui-1tb6tuo"
         >
           <b
-            class="css-11k78l8-DetailsDescription"
+            class="css-qyvtrs-StyledB ebphozh0"
           >
-            Failing Command:
-             
+            Failing Command: 
           </b>
           Long description that requires use of the inline definition component. This would include details ab...
            
@@ -167,7 +166,7 @@
         </a>
       </p>
       <div
-        class="css-5f1fjg-DependsOnContainer ebphozh2"
+        class="css-5f1fjg-DependsOnContainer ebphozh3"
         data-cy="depends-on-container"
       >
         <div>

--- a/apps/spruce/src/pages/task/metadata/index.tsx
+++ b/apps/spruce/src/pages/task/metadata/index.tsx
@@ -1,6 +1,5 @@
 import { useState, useRef } from "react";
 import { ApolloError } from "@apollo/client";
-import { css } from "@emotion/react";
 import styled from "@emotion/styled";
 import { GuideCue } from "@leafygreen-ui/guide-cue";
 import { palette } from "@leafygreen-ui/palette";
@@ -487,13 +486,7 @@ const DetailsDescription = ({
   return (
     <MetadataItem>
       {isFailingTask ? (
-        <b
-          css={css`
-            color: ${red.base};
-          `}
-        >
-          Failing Command:{" "}
-        </b>
+        <StyledB>Failing Command: </StyledB>
       ) : (
         <span>Command: </span>
       )}
@@ -544,4 +537,8 @@ const HoneycombLinkContainer = styled.span`
 const OOMTrackerMessage = styled(MetadataItem)`
   color: ${red.dark2};
   font-weight: 500;
+`;
+
+const StyledB = styled.b`
+  color: ${red.base};
 `;

--- a/apps/spruce/src/pages/task/metadata/index.tsx
+++ b/apps/spruce/src/pages/task/metadata/index.tsx
@@ -1,5 +1,6 @@
 import { useState, useRef } from "react";
 import { ApolloError } from "@apollo/client";
+import { css } from "@emotion/react";
 import styled from "@emotion/styled";
 import { GuideCue } from "@leafygreen-ui/guide-cue";
 import { palette } from "@leafygreen-ui/palette";
@@ -34,6 +35,7 @@ import { TaskQuery } from "gql/generated/types";
 import { useDateFormat } from "hooks";
 import { TaskStatus } from "types/task";
 import { string } from "utils";
+import { isFailedTaskStatus } from "utils/statuses";
 import { AbortMessage } from "./AbortMessage";
 import { DependsOn } from "./DependsOn";
 import ETATimer from "./ETATimer";
@@ -470,19 +472,28 @@ const DetailsDescription = ({
   status: string;
 }) => {
   const MAX_CHAR = 100;
-
-  const fullText =
-    status === TaskStatus.Failed
-      ? `${processFailingCommand(description, isContainerTask)}`
-      : `Command: ${description}`;
+  const isFailingTask = isFailedTaskStatus(status);
+  const fullText = isFailingTask
+    ? `${processFailingCommand(description, isContainerTask)}`
+    : `${description}`;
   const shouldTruncate = fullText.length > MAX_CHAR;
   const truncatedText = fullText.substring(0, MAX_CHAR).concat("...");
 
   return (
     <MetadataItem>
+      {isFailingTask ? (
+        <b
+          css={css`
+            color: ${red.base};
+          `}
+        >
+          Failing Command:{" "}
+        </b>
+      ) : (
+        <span>Command: </span>
+      )}
       {shouldTruncate ? (
         <>
-          <StyledBody>Failing Command: </StyledBody>
           {truncatedText}{" "}
           <ExpandedText
             align="right"
@@ -528,8 +539,4 @@ const HoneycombLinkContainer = styled.span`
 const OOMTrackerMessage = styled(MetadataItem)`
   color: ${red.dark2};
   font-weight: 500;
-`;
-
-const StyledBody = styled.b`
-  color: ${red.base};
 `;


### PR DESCRIPTION
DEVPROD-9751

### Description
Forgot to move the label out of the component body for longer descriptions

### Screenshots
<img width="300" alt="image" src="https://github.com/user-attachments/assets/ac2ebb8d-650b-4aa3-90bd-03180a9f5292">

