### PR TITLE
DEVPROD-928: Parallelize Spruce e2e tasks

### DIFF
--- a/.evergreen/generate.yml
+++ b/.evergreen/generate.yml
@@ -23,8 +23,8 @@ tasks:
   - name: generate-tasks
     commands:
       - func: run-generate-tasks
+      - func: attach-generated
       - command: generate.tasks
         params:
           files:
             - ui/.evergreen/generate-tasks.json
-      - func: attach-generated

--- a/.evergreen/scripts/generate-tasks.js
+++ b/.evergreen/scripts/generate-tasks.js
@@ -1,6 +1,7 @@
 import { execSync } from "child_process";
 import { writeFileSync } from "fs";
 import { join, parse } from "path";
+import { getSpecs } from "./parallelize-e2e.js";
 
 // This file is written in plain JS because it makes the generator super fast. No need to install TypeScript.
 
@@ -8,6 +9,7 @@ const Tasks = {
   CheckCodegen: "check_codegen",
   Compile: "compile",
   E2E: "e2e",
+  E2EParallel: "e2e_parallel",
   Lint: "lint",
   Snapshots: "snapshots",
   Storybook: "storybook",
@@ -39,7 +41,7 @@ const TASK_MAPPING = {
   spruce: [
     Tasks.CheckCodegen,
     Tasks.Compile,
-    Tasks.E2E,
+    Tasks.E2EParallel,
     Tasks.Lint,
     Tasks.Snapshots,
     Tasks.Storybook,
@@ -114,6 +116,27 @@ const targetsFromChangedFiles = (files) => {
   return Array.from(targets);
 };
 
+const generateE2E = (bv) => {
+  const specs = getSpecs(`./apps/${bv}/cypress/integration`);
+  return specs.map((spec, i) => {
+    return {
+      name: `e2e_${bv}_${i}`,
+      commands: [
+        { func: "setup-mongodb" },
+        { func: "run-make-background", vars: { target: "local-evergreen" } },
+        { func: "symlink" },
+        { func: "seed-bucket-data" },
+        { func: "run-logkeeper" },
+        { func: "yarn-build" },
+        { func: "yarn-preview" },
+        { func: "wait-for-evergreen" },
+        { func: "yarn-verify-backend" },
+        { func: "yarn-cypress", vars: { cypress_spec: spec } },
+      ],
+    };
+  });
+};
+
 /**
  * generateTasks generates an object indicating build variants and tasks to run based on changed files.
  * @returns an Evergreen-compliant generate.tasks object.
@@ -124,11 +147,35 @@ const generateTasks = () => {
     changes.length === 0
       ? Object.keys(TASK_MAPPING)
       : targetsFromChangedFiles(changes);
-  const buildvariants = targets.map((bv) => ({
-    name: bv,
-    tasks: TASK_MAPPING[bv].map((name) => ({ name })),
-  }));
-  return { buildvariants };
+
+  const tasks = [];
+  const buildvariants = targets.map((bv) => {
+    const bvTasks = [];
+    const displayTasks = [];
+    TASK_MAPPING[bv].forEach((name) => {
+      if (name === Tasks.E2EParallel) {
+        // Make display tasks
+        const e2eTasks = generateE2E(bv);
+        tasks.push(...e2eTasks);
+        bvTasks.push(...e2eTasks.map(({ name }) => ({ name }))),
+          displayTasks.push({
+            name: Tasks.E2EParallel,
+            execution_tasks: e2eTasks.map(({ name }) => name),
+          });
+      } else {
+        bvTasks.push({ name });
+      }
+    });
+    const variant = {
+      name: bv,
+      tasks: bvTasks,
+      display_tasks: displayTasks,
+    };
+
+    return variant;
+  });
+
+  return { buildvariants, tasks };
 };
 
 const main = () => {

--- a/.evergreen/scripts/generate-tasks.js
+++ b/.evergreen/scripts/generate-tasks.js
@@ -161,11 +161,11 @@ const generateTasks = () => {
         // Make display tasks
         const e2eTasks = generateParallelE2ETasks(bv);
         tasks.push(...e2eTasks);
-        bvTasks.push(...e2eTasks.map(({ name }) => ({ name }))),
-          displayTasks.push({
-            name: Tasks.E2EParallel,
-            execution_tasks: e2eTasks.map(({ name }) => name),
-          });
+        bvTasks.push(...e2eTasks.map(({ name }) => ({ name })));
+        displayTasks.push({
+          name: Tasks.E2EParallel,
+          execution_tasks: e2eTasks.map(({ name }) => name),
+        });
       } else {
         bvTasks.push({ name });
       }

--- a/.evergreen/scripts/parallelize-e2e.js
+++ b/.evergreen/scripts/parallelize-e2e.js
@@ -3,6 +3,12 @@ import { join } from "path";
 
 const PARALLEL_COUNT = 4;
 
+/**
+ *  getDirSize calculates the size of a directory at a given path, optionally including the size of its subdirectories.
+ * @param {string} dirPath - string representing the root directory path
+ * @param {boolean} [includeNestedDirs=true] - boolean indicating whether to recurse and calculate size of nested directories
+ * @returns {number} - directory size in bytes
+ */
 const getDirSize = (dirPath, includeNestedDirs = true) => {
   let size = 0;
   const files = readdirSync(dirPath);
@@ -21,6 +27,11 @@ const getDirSize = (dirPath, includeNestedDirs = true) => {
   return size;
 };
 
+/**
+ * getDirs creates a list of all subdirectories located under dirPath
+ * @param {string} dirPath - string representing the root directory path
+ * @returns {Array.<string>} - array of subdir paths
+ */
 const getDirs = (dirPath) => {
   const files = readdirSync(dirPath);
 
@@ -32,11 +43,17 @@ const getDirs = (dirPath) => {
     });
 };
 
+/**
+ * getDirSizes creates a map of directory sizes. The keys represent each subdirectory within dirPath, and the value represents the directory's size. An entry is also added for the root directory size (i.e. the size of all files at root, omitting subdirectories)
+ * @param {string} dirPath - string representing the root directory path
+ * @returns {Object.<string, number>} - mapping of subdirectory path to its size
+ */
 const getDirSizes = (dirPath) => {
   const makeRelative = (d) => d.substring(d.indexOf("cypress"));
 
   const dirSizeMap = {};
   const dirs = getDirs(dirPath);
+
   dirs.forEach((dir) => {
     const size = getDirSize(dir);
     dirSizeMap[`${makeRelative(dir)}/**/*.ts`] = size;
@@ -46,10 +63,20 @@ const getDirSizes = (dirPath) => {
   return dirSizeMap;
 };
 
-const sortDirSizes = (dirSizeMap) => {
-  return Object.entries(dirSizeMap).sort((a, b) => b[1] - a[1]);
-};
+/**
+ * sortDirSizes sorts the {[filepath]: size} map returned by getDirSizes in descending order.
+ * @param {Object.<string, number>} dirSizeMap - map of filepath to size
+ * @returns {Object.<string, number>} - sorted map
+ */
+const sortDirSizes = (dirSizeMap) =>
+  Object.entries(dirSizeMap).sort((a, b) => b[1] - a[1]);
 
+/**
+ * bucketSpecs splits the Cypress spec paths into n=bucketCount buckets. By iterating through the sorted list and round robin-ing the specs into each bucket, we attempt to make the bucket file sizes roughly even, since file size can function as a rough heuristic of how long a spec takes to run on Cypress.
+ * @param {Object.<string, number>} specs - sorted map of {[filepath]: size} as returned by sortDirSizes
+ * @param {number} bucketCount - integer representing number of buckets
+ * @returns {Array.<Array.<string>>} - array of length bucketCount, with each array entry containing an array of filepaths
+ */
 const bucketSpecs = (specs, bucketCount) => {
   const buckets = Array.from(Array(bucketCount), () => []);
 
@@ -61,6 +88,11 @@ const bucketSpecs = (specs, bucketCount) => {
   return buckets;
 };
 
+/**
+ * getSpecs attempts to split the Cypress specs located at dirPath into n similarly-sized groups. It returns an array of strings listing spec files. Each string should be an argument for the "--spec" option in a separate Cypress run.
+ * @param {string} dirPath - string representing the root Cypress integration test path
+ * @returns {Array.<string>} - array of comma-separated specs. Each array entry represents the specs to be run in a parallelized execution task.
+ */
 export const getSpecs = (dirPath) => {
   const dirSizes = getDirSizes(dirPath);
   const sorted = sortDirSizes(dirSizes);

--- a/.evergreen/scripts/parallelize-e2e.js
+++ b/.evergreen/scripts/parallelize-e2e.js
@@ -1,0 +1,69 @@
+import { readdirSync, statSync } from "fs";
+import { join } from "path";
+
+const PARALLEL_COUNT = 4;
+
+const getDirSize = (dirPath, includeNestedDirs = true) => {
+  let size = 0;
+  const files = readdirSync(dirPath);
+
+  files.forEach((file) => {
+    const filePath = join(dirPath, file);
+    const stats = statSync(filePath);
+
+    if (stats.isFile()) {
+      size += stats.size;
+    } else if (stats.isDirectory() && includeNestedDirs) {
+      size += getDirSize(filePath);
+    }
+  });
+
+  return size;
+};
+
+const getDirs = (dirPath) => {
+  const files = readdirSync(dirPath);
+
+  return files
+    .map((file) => join(dirPath, file))
+    .filter((filePath) => {
+      const stats = statSync(filePath);
+      return stats.isDirectory();
+    });
+};
+
+const getDirSizes = (dirPath) => {
+  const makeRelative = (d) => d.substring(d.indexOf("cypress"));
+
+  const dirSizeMap = {};
+  const dirs = getDirs(dirPath);
+  dirs.forEach((dir) => {
+    const size = getDirSize(dir);
+    dirSizeMap[`${makeRelative(dir)}/**/*.ts`] = size;
+  });
+  // Specifically add root tests with no wildcard directory regex
+  dirSizeMap[`${makeRelative(dirPath)}/*.ts`] = getDirSize(dirPath, false);
+  return dirSizeMap;
+};
+
+const sortDirSizes = (dirSizeMap) => {
+  return Object.entries(dirSizeMap).sort((a, b) => b[1] - a[1]);
+};
+
+const bucketSpecs = (specs, bucketCount) => {
+  const buckets = Array.from(Array(bucketCount), () => []);
+
+  specs.forEach((spec, i) => {
+    const bucketIndex = i % bucketCount;
+    buckets[bucketIndex].push(spec[0]);
+  });
+
+  return buckets;
+};
+
+export const getSpecs = (dirPath) => {
+  const dirSizes = getDirSizes(dirPath);
+  const sorted = sortDirSizes(dirSizes);
+  const buckets = bucketSpecs(sorted, PARALLEL_COUNT);
+  return buckets.map((specs) => specs.join());
+};

--- a/.evergreen/scripts/parallelize-e2e.js
+++ b/.evergreen/scripts/parallelize-e2e.js
@@ -44,11 +44,11 @@ const getDirs = (dirPath) => {
 };
 
 /**
- * getDirSizes creates a map of directory sizes. The keys represent each subdirectory within dirPath, and the value represents the directory's size. An entry is also added for the root directory size (i.e. the size of all files at root, omitting subdirectories)
+ * getCypressDirSizes creates a map of directory sizes. The keys represent each subdirectory within dirPath, and the value represents the directory's size. An entry is also added for the root directory size (i.e. the size of all files at root, omitting subdirectories)
  * @param {string} dirPath - string representing the root directory path
  * @returns {Object.<string, number>} - mapping of subdirectory path to its size
  */
-const getDirSizes = (dirPath) => {
+const getCypressDirSizes = (dirPath) => {
   const makeRelative = (d) => d.substring(d.indexOf("cypress"));
 
   const dirSizeMap = {};
@@ -64,7 +64,7 @@ const getDirSizes = (dirPath) => {
 };
 
 /**
- * sortDirSizes sorts the {[filepath]: size} map returned by getDirSizes in descending order.
+ * sortDirSizes sorts the {[filepath]: size} map returned by getCypressDirSizes in descending order.
  * @param {Object.<string, number>} dirSizeMap - map of filepath to size
  * @returns {Object.<string, number>} - sorted map
  */
@@ -94,7 +94,7 @@ const bucketSpecs = (specs, bucketCount) => {
  * @returns {Array.<string>} - array of comma-separated specs. Each array entry represents the specs to be run in a parallelized execution task.
  */
 export const getSpecs = (dirPath) => {
-  const dirSizes = getDirSizes(dirPath);
+  const dirSizes = getCypressDirSizes(dirPath);
   const sorted = sortDirSizes(dirSizes);
   const buckets = bucketSpecs(sorted, PARALLEL_COUNT);
   return buckets.map((specs) => specs.join());

--- a/.evergreen/shared.yml
+++ b/.evergreen/shared.yml
@@ -259,6 +259,7 @@ tasks:
       - func: symlink
       - func: yarn-build
 
+  # Updates to e2e should likely also be applied to e2e_parallel in the task generator.
   - name: e2e
     commands:
       - func: setup-mongodb

--- a/.evergreen/shared.yml
+++ b/.evergreen/shared.yml
@@ -166,7 +166,7 @@ functions:
       script: |
         ${PREPARE_SHELL}
         # Allow spec filtering for an intentional patch.
-        if [[ "${requester}" == "patch" ]]; then
+        if [[ "${cypress_spec}" != "" ]]; then
           yarn cy:run --reporter junit --spec "${cypress_spec}"
         else
           yarn cy:run --reporter junit


### PR DESCRIPTION
DEVPROD-928
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? -->

### Description
<!-- add description, context, thought process, etc -->
- Parallelize Spruce e2e tests. This brings the wait time down from ~25 to ~10-12 minutes 😱 
  - Programmatically bucket specs into N groups; I went with 4 groups for now but this is easy to play with. The buckets should have the same-ish size so that we don't have hugely different runtimes. To do this, the spec directories are sorted by size and then distributed into buckets. We could implement a smarter algorithm if this became a pain point.
  - One consequence of programmatic bucketing is that the base status for each execution task is not necessarily meaningful. However, I don't anticipate that being a huge problem since the parent e2e_parallel base status is still correct and it's quite easy to see which test is failing. I think the reduced maintenance of not having to manually bucket tests is a good tradeoff.
- Don't parallelize Parsley: the comparatively short runtime combined with the significant setup time for e2e tests meant that there was basically no time difference (see a run [here](https://spruce.mongodb.com/task/evergreen_ui_parsley_display_e2e_parallel_patch_2f696a40d7b1fea4a86fc8dee7ecc2b94c995cbf_66bb6d59896b850007fd183d_24_08_13_14_27_39?execution=0&sortBy=STATUS&sortDir=ASC)). We can always revisit this if Parsley gets significantly longer, or try it with a different parallelization number.
- Opened a separate ticket for parallelizing Evergreen's downstream Spruce task (DEVPROD-9875). This will probably require making a new generator so I opted to split up the work.