### PR TITLE
DEVPROD-9904 Switch GitHub app private key from input to textarea

### DIFF
--- a/apps/spruce/cypress/integration/projectSettings/github_app_settings.ts
+++ b/apps/spruce/cypress/integration/projectSettings/github_app_settings.ts
@@ -58,7 +58,7 @@ describe("GitHub app settings", () => {
     cy.get("@appId").should("have.value", "12345");
     cy.get("@privateKey").should("have.value", "{REDACTED}");
     cy.get("@appId").should("have.attr", "aria-disabled", "true");
-    cy.get("@privateKey").should("have.attr", "disabled", "");
+    cy.get("@privateKey").should("have.attr", "disabled");
 
     cy.reload();
     cy.dataCy("github-app-credentials-banner").should("not.exist");

--- a/apps/spruce/cypress/integration/projectSettings/github_app_settings.ts
+++ b/apps/spruce/cypress/integration/projectSettings/github_app_settings.ts
@@ -39,7 +39,7 @@ describe("GitHub app settings", () => {
     cy.get("@appId").should("have.value", "");
     cy.get("@privateKey").should("have.value", "");
     cy.get("@appId").should("have.attr", "aria-disabled", "false");
-    cy.get("@privateKey").should("have.attr", "aria-disabled", "false");
+    cy.get("@privateKey").should("not.have.attr", "disabled");
 
     cy.reload();
     cy.dataCy("github-app-credentials-banner").should("be.visible");
@@ -58,7 +58,7 @@ describe("GitHub app settings", () => {
     cy.get("@appId").should("have.value", "12345");
     cy.get("@privateKey").should("have.value", "{REDACTED}");
     cy.get("@appId").should("have.attr", "aria-disabled", "true");
-    cy.get("@privateKey").should("have.attr", "aria-disabled", "true");
+    cy.get("@privateKey").should("have.attr", "disabled", "");
 
     cy.reload();
     cy.dataCy("github-app-credentials-banner").should("not.exist");

--- a/apps/spruce/src/pages/projectSettings/tabs/GithubAppSettingsTab/getFormSchema.tsx
+++ b/apps/spruce/src/pages/projectSettings/tabs/GithubAppSettingsTab/getFormSchema.tsx
@@ -118,6 +118,7 @@ export const getFormSchema = ({
           "ui:data-cy": "github-private-key-input",
           "ui:disabled": isAppDefined,
           "ui:elementWrapperCSS": appFieldCss,
+          "ui:widget": "textarea",
         },
       },
       actions: {


### PR DESCRIPTION
DEVPROD-9904
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
GitHub app private keys need the new line characters to be valid. Instead of having users manually add new line characters, and then escaping them ourselves, it's better to change it to a textarea so the new line characters are preserved.

### Screenshots
<!-- add screenshots of visible changes -->
<img width="774" alt="Screenshot 2024-08-15 at 12 27 15 PM" src="https://github.com/user-attachments/assets/684e0960-ecb5-4b8e-935c-fcc3ed6ecb13">

### Testing
Ran locally and then saved it with the textarea, the keys are successfully saved with the new lines. With the input, they were not.