### PR TITLE
DEVPROD-8373 Update spruce and parsley analytics attributes to use dot notation

### DIFF
--- a/apps/parsley/src/analytics/loadingPage/useLogDownloadAnalytics.ts
+++ b/apps/parsley/src/analytics/loadingPage/useLogDownloadAnalytics.ts
@@ -6,14 +6,14 @@ type Action =
   | {
       name: "System Event log downloaded";
       duration: number;
-      type: LogTypes;
-      fileSize: number;
+      "log.type": LogTypes;
+      "log.size": number;
     }
   | {
       name: "System Event log download failed";
       duration: number;
-      type: LogTypes;
-      fileSize: number;
+      "log.type": LogTypes;
+      "log.size": number;
     }
   | {
       name: "System Event log download incomplete";

--- a/apps/parsley/src/analytics/logDrop/useLogDropAnalytics.ts
+++ b/apps/parsley/src/analytics/logDrop/useLogDropAnalytics.ts
@@ -3,12 +3,12 @@ import { AnalyticsIdentifier } from "analytics/types";
 import { LogTypes } from "constants/enums";
 
 type Action =
-  | { name: "Clicked file upload link"; hasLogs: boolean }
+  | { name: "Clicked file upload link"; "has.logs": boolean }
   | { name: "Used file dropper to upload file" }
   | {
       name: "System Event processed uploaded log file";
-      logType: LogTypes;
-      fileSize?: number;
+      "log.type": LogTypes;
+      "file.size"?: number;
     };
 
 export const useLogDropAnalytics = () =>

--- a/apps/parsley/src/analytics/logWindow/useLogWindowAnalytics.ts
+++ b/apps/parsley/src/analytics/logWindow/useLogWindowAnalytics.ts
@@ -4,10 +4,10 @@ import { DIRECTION } from "context/LogContext/types";
 import { Filter } from "types/logs";
 
 type Action =
-  | { name: "Created new filter"; filterExpression: string }
-  | { name: "Deleted filter"; filterExpression: string }
+  | { name: "Created new filter"; "filter.expression": string }
+  | { name: "Deleted filter"; "filter.expression": string }
   | { name: "Toggled filter active state"; active: boolean }
-  | { name: "Used project filters"; filters: Filter[] }
+  | { name: "Used project filters"; "filter.expressions": string[] }
   | { name: "Created bookmark" }
   | { name: "Created new share line" }
   | { name: "Deleted share line" }
@@ -19,22 +19,22 @@ type Action =
   | { name: "Clicked copy share lines to clipboard button" }
   | { name: "Used range limit for search" }
   | { name: "Changed existing filter"; before: Filter; after: Filter }
-  | { name: "Created new highlight"; highlightExpression: string }
-  | { name: "Deleted existing highlight"; highlightExpression: string }
-  | { name: "Used search"; searchExpression: string }
+  | { name: "Created new highlight"; "highlight.expression": string }
+  | { name: "Deleted existing highlight"; "highlight.expression": string }
+  | { name: "Used search"; "search.expression": string }
   | { name: "Used search suggestion"; suggestion: string }
   | {
       name: "Toggled expanded lines";
       option: "All" | "Five";
-      lineCount: number;
+      "line.count": number;
       open: true;
     }
   | { name: "Toggled expanded lines"; open: false }
   | { name: "Used search result pagination"; direction: DIRECTION }
   | {
       name: "Toggled section";
-      sectionName: string;
-      sectionType: "command" | "function";
+      "section.name": string;
+      "section.type": "command" | "function";
       open: boolean;
     };
 

--- a/apps/parsley/src/components/LogRow/SectionHeader/index.tsx
+++ b/apps/parsley/src/components/LogRow/SectionHeader/index.tsx
@@ -37,8 +37,8 @@ const SectionHeader: React.FC<SectionHeaderProps> = ({
           sendEvent({
             name: "Toggled section",
             open: !open,
-            sectionName: functionName,
-            sectionType: "function",
+            "section.name": functionName,
+            "section.type": "function",
           });
           sectioning.toggleFunctionSection({ functionID, isOpen: !open });
         }}

--- a/apps/parsley/src/components/LogRow/SkippedLinesRow/index.tsx
+++ b/apps/parsley/src/components/LogRow/SkippedLinesRow/index.tsx
@@ -40,7 +40,7 @@ const SkippedLinesRow: React.FC<SkippedLinesRowProps> = ({
       startTransition(() => expandLines([[start, lineEndInclusive]]));
     }
     sendEvent({
-      lineCount: canExpandFive ? SKIP_NUMBER * 2 : numSkipped,
+      "line.count": canExpandFive ? SKIP_NUMBER * 2 : numSkipped,
       name: "Toggled expanded lines",
       open: true,
       option: "Five",
@@ -50,7 +50,7 @@ const SkippedLinesRow: React.FC<SkippedLinesRowProps> = ({
   const expandAll = () => {
     startTransition(() => expandLines([[start, lineEndInclusive]]));
     sendEvent({
-      lineCount: numSkipped,
+      "line.count": numSkipped,
       name: "Toggled expanded lines",
       open: true,
       option: "All",

--- a/apps/parsley/src/components/LogRow/SubsectionHeader/index.tsx
+++ b/apps/parsley/src/components/LogRow/SubsectionHeader/index.tsx
@@ -33,8 +33,8 @@ const SubsectionHeader: React.FC<SectionHeaderProps> = ({
           sendEvent({
             name: "Toggled section",
             open: !open,
-            sectionName: commandName,
-            sectionType: "command",
+            "section.name": commandName,
+            "section.type": "command",
           });
           sectioning.toggleCommandSection({
             commandID,

--- a/apps/parsley/src/components/NavBar/UploadLink/index.tsx
+++ b/apps/parsley/src/components/NavBar/UploadLink/index.tsx
@@ -19,7 +19,7 @@ const UploadLink: React.FC<UploadLinkProps> = ({ clearLogs, hasLogs }) => {
   const { sendEvent } = useLogDropAnalytics();
   const handleClick = useCallback(() => {
     if (hasLogs) {
-      sendEvent({ hasLogs: true, name: "Clicked file upload link" });
+      sendEvent({ "has.logs": true, name: "Clicked file upload link" });
       setOpen(true);
     } else {
       leaveBreadcrumb(
@@ -27,7 +27,7 @@ const UploadLink: React.FC<UploadLinkProps> = ({ clearLogs, hasLogs }) => {
         { from: pathname, hasLogs: false, to: "/upload" },
         SentryBreadcrumb.Navigation,
       );
-      sendEvent({ hasLogs: false, name: "Clicked file upload link" });
+      sendEvent({ "has.logs": false, name: "Clicked file upload link" });
       navigate(routes.upload);
     }
   }, [hasLogs, pathname, sendEvent, navigate]);

--- a/apps/parsley/src/components/ProjectFiltersModal/index.tsx
+++ b/apps/parsley/src/components/ProjectFiltersModal/index.tsx
@@ -59,7 +59,7 @@ const ProjectFiltersModal: React.FC<ProjectFiltersModalProps> = ({
       SentryBreadcrumb.User,
     );
     sendEvent({
-      filters: state.selectedFilters,
+      "filter.expressions": state.selectedFilters.map((f) => f.expression),
       name: "Used project filters",
     });
     setOpen(false);

--- a/apps/parsley/src/components/Search/index.tsx
+++ b/apps/parsley/src/components/Search/index.tsx
@@ -88,7 +88,7 @@ const Search: React.FC = () => {
               },
             ]);
           }
-          sendEvent({ filterExpression: value, name: "Created new filter" });
+          sendEvent({ "filter.expression": value, name: "Created new filter" });
           leaveBreadcrumb(
             "Added filter",
             { filterExpression: value },
@@ -101,7 +101,7 @@ const Search: React.FC = () => {
           setSearch("");
           setHighlights([...highlights, value]);
           sendEvent({
-            highlightExpression: value,
+            "highlight.expression": value,
             name: "Created new highlight",
           });
           leaveBreadcrumb(
@@ -118,7 +118,7 @@ const Search: React.FC = () => {
 
   const handleOnChange = (value: string) => {
     setSearch(value);
-    sendEvent({ name: "Used search", searchExpression: value });
+    sendEvent({ name: "Used search", "search.expression": value });
     leaveBreadcrumb(
       "Applied search",
       { searchExpression: value },

--- a/apps/parsley/src/components/SidePanel/NavGroup/FilterNavGroup/index.tsx
+++ b/apps/parsley/src/components/SidePanel/NavGroup/FilterNavGroup/index.tsx
@@ -36,7 +36,10 @@ const FilterNavGroup: React.FC<FilterNavGroupProps> = ({
       { filterExpression },
       SentryBreadcrumb.User,
     );
-    sendEvent({ filterExpression, name: "Deleted filter" });
+    sendEvent({
+      "filter.expression": filterExpression,
+      name: "Deleted filter",
+    });
   };
 
   const editFilter = (

--- a/apps/parsley/src/components/SidePanel/NavGroup/HighlightNavGroup/index.tsx
+++ b/apps/parsley/src/components/SidePanel/NavGroup/HighlightNavGroup/index.tsx
@@ -15,7 +15,7 @@ const HighlightNavGroup: React.FC = () => {
     const newHighlights = highlights.filter((h) => h !== highlightName);
     setHighlights(newHighlights);
     sendEvent({
-      highlightExpression: highlightName,
+      "highlight.expression": highlightName,
       name: "Deleted existing highlight",
     });
   };

--- a/apps/parsley/src/gql/generated/types.ts
+++ b/apps/parsley/src/gql/generated/types.ts
@@ -885,6 +885,7 @@ export type Image = {
   lastDeployed: Scalars["Time"]["output"];
   latestTask?: Maybe<Task>;
   name: Scalars["String"]["output"];
+  operatingSystem: ImageOperatingSystemPayload;
   packages: ImagePackagesPayload;
   toolchains: ImageToolchainsPayload;
   versionId: Scalars["String"]["output"];
@@ -897,6 +898,14 @@ export type Image = {
 export type ImageEventsArgs = {
   limit: Scalars["Int"]["input"];
   page: Scalars["Int"]["input"];
+};
+
+/**
+ * Image is returned by the image query.
+ * It contains information about an image.
+ */
+export type ImageOperatingSystemArgs = {
+  opts: OperatingSystemOpts;
 };
 
 /**
@@ -947,6 +956,13 @@ export type ImageEventsPayload = {
   __typename?: "ImageEventsPayload";
   count: Scalars["Int"]["output"];
   eventLogEntries: Array<ImageEvent>;
+};
+
+export type ImageOperatingSystemPayload = {
+  __typename?: "ImageOperatingSystemPayload";
+  data: Array<OsInfo>;
+  filteredCount: Scalars["Int"]["output"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type ImagePackagesPayload = {
@@ -1512,10 +1528,22 @@ export type NotificationsInput = {
   spawnHostOutcome?: InputMaybe<Scalars["String"]["input"]>;
 };
 
+export type OsInfo = {
+  __typename?: "OSInfo";
+  name: Scalars["String"]["output"];
+  version: Scalars["String"]["output"];
+};
+
 export type OomTrackerInfo = {
   __typename?: "OomTrackerInfo";
   detected: Scalars["Boolean"]["output"];
   pids?: Maybe<Array<Scalars["Int"]["output"]>>;
+};
+
+export type OperatingSystemOpts = {
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  name?: InputMaybe<Scalars["String"]["input"]>;
+  page?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export enum OverallocatedRule {

--- a/apps/parsley/src/hooks/useLogDownloader/index.ts
+++ b/apps/parsley/src/hooks/useLogDownloader/index.ts
@@ -125,9 +125,9 @@ const useLogDownloader = ({
           setError(err.message);
           sendEvent({
             duration: Date.now() - timeStart,
-            fileSize: getFileSize(),
+            "log.size": getFileSize(),
+            "log.type": logType,
             name: "System Event log download failed",
-            type: logType,
           });
         })
         .finally(() => {
@@ -142,9 +142,9 @@ const useLogDownloader = ({
           );
           sendEvent({
             duration: Date.now() - timeStart,
-            fileSize: getFileSize(),
+            "log.size": getFileSize(),
+            "log.type": logType,
             name: "System Event log downloaded",
-            type: logType,
           });
           setIsLoading(false);
         });

--- a/apps/parsley/src/pages/LogDrop/FileDropper.tsx
+++ b/apps/parsley/src/pages/LogDrop/FileDropper.tsx
@@ -66,8 +66,8 @@ const FileDropper: React.FC = () => {
                   SentryBreadcrumb.UI,
                 );
                 sendEvent({
-                  fileSize: logLines?.length,
-                  logType,
+                  "file.size": logLines?.length,
+                  "log.type": logType,
                   name: "System Event processed uploaded log file",
                 });
                 setFileName(state.file.name);

--- a/apps/spruce/src/analytics/distroSettings/useDistroSettingsAnalytics.ts
+++ b/apps/spruce/src/analytics/distroSettings/useDistroSettingsAnalytics.ts
@@ -5,8 +5,8 @@ import { slugs } from "constants/routes";
 
 type Action =
   | { name: "Saved distro"; section: string }
-  | { name: "Created new distro"; newDistroId: string }
-  | { name: "Clicked duplicate distro"; newDistroId: string };
+  | { name: "Created new distro"; "distro.id": string }
+  | { name: "Clicked duplicate distro"; "distro.id": string };
 
 export const useDistroSettingsAnalytics = () => {
   const { [slugs.distroId]: distroId } = useParams();

--- a/apps/spruce/src/analytics/hostsTable/useHostsTableAnalytics.ts
+++ b/apps/spruce/src/analytics/hostsTable/useHostsTableAnalytics.ts
@@ -7,7 +7,7 @@ type Action =
   | { name: "Changed page size"; "page.size": number }
   | { name: "Clicked restart jasper button" }
   | { name: "Clicked reprovision host button" }
-  | { name: "Clicked update host status button"; status: string };
+  | { name: "Clicked update host status button"; "host.status": string };
 
 export const useHostsTableAnalytics = (isHostPage?: boolean) =>
   useAnalyticsRoot<Action, AnalyticsIdentifier>(

--- a/apps/spruce/src/analytics/hostsTable/useHostsTableAnalytics.ts
+++ b/apps/spruce/src/analytics/hostsTable/useHostsTableAnalytics.ts
@@ -2,9 +2,9 @@ import { useAnalyticsRoot } from "@evg-ui/lib/analytics/hooks";
 import { AnalyticsIdentifier } from "analytics/types";
 
 type Action =
-  | { name: "Filtered hosts table"; filterBy: string | string[] }
+  | { name: "Filtered hosts table"; "filter.by": string | string[] }
   | { name: "Sorted hosts table" }
-  | { name: "Changed page size"; pageSize: number }
+  | { name: "Changed page size"; "page.size": number }
   | { name: "Clicked restart jasper button" }
   | { name: "Clicked reprovision host button" }
   | { name: "Clicked update host status button"; status: string };

--- a/apps/spruce/src/analytics/joblogs/useJobLogsAnalytics.ts
+++ b/apps/spruce/src/analytics/joblogs/useJobLogsAnalytics.ts
@@ -4,12 +4,12 @@ import { AnalyticsIdentifier } from "analytics/types";
 type Action =
   | {
       name: "Clicked complete logs link";
-      buildId?: string;
-      taskId?: string;
+      "build.id"?: string;
+      "task.id"?: string;
       execution?: number;
-      groupID?: string;
+      "group.id"?: string;
     }
-  | { name: "Clicked Parsley test log link"; buildId?: string };
+  | { name: "Clicked Parsley test log link"; "build.id"?: string };
 
 export const useJobLogsAnalytics = (isLogkeeper: boolean) =>
   useAnalyticsRoot<Action, AnalyticsIdentifier>("JobLogs", {

--- a/apps/spruce/src/analytics/patch/usePatchAnalytics.ts
+++ b/apps/spruce/src/analytics/patch/usePatchAnalytics.ts
@@ -11,11 +11,11 @@ import { PATCH } from "gql/queries";
 type Action =
   | {
       name: "Filtered downstream tasks table";
-      filterBy: string | string[];
+      "filter.by": string | string[];
     }
   | {
       name: "Sorted downstream tasks table";
-      sortBy: TaskSortCategory | TaskSortCategory[];
+      "sort.by": TaskSortCategory | TaskSortCategory[];
     }
   | { name: "Toggled patch visibility"; hidden: boolean }
   | { name: "Clicked patch reconfigure link" };

--- a/apps/spruce/src/analytics/patch/usePatchAnalytics.ts
+++ b/apps/spruce/src/analytics/patch/usePatchAnalytics.ts
@@ -17,7 +17,7 @@ type Action =
       name: "Sorted downstream tasks table";
       "sort.by": TaskSortCategory | TaskSortCategory[];
     }
-  | { name: "Toggled patch visibility"; hidden: boolean }
+  | { name: "Toggled patch visibility"; "patch.hidden": boolean }
   | { name: "Clicked patch reconfigure link" };
 
 export const usePatchAnalytics = (id: string) => {

--- a/apps/spruce/src/analytics/patches/useProjectPatchesAnalytics.ts
+++ b/apps/spruce/src/analytics/patches/useProjectPatchesAnalytics.ts
@@ -5,13 +5,13 @@ import { slugs } from "constants/routes";
 
 type Action =
   | { name: "Changed page size" }
-  | { name: "Changed project"; projectIdentifier: string }
+  | { name: "Changed project"; "project.identifier": string }
   | { name: "Clicked patch link" }
   | {
       name: "Filtered for patches";
-      filterBy: string;
-      includeHidden: boolean;
-      includeCommitQueue: boolean;
+      "filter.by": string;
+      "filter.include.hidden": boolean;
+      "filter.include.commit.queue": boolean;
     };
 
 export const useProjectPatchesAnalytics = () => {

--- a/apps/spruce/src/analytics/patches/useProjectPatchesAnalytics.ts
+++ b/apps/spruce/src/analytics/patches/useProjectPatchesAnalytics.ts
@@ -10,8 +10,8 @@ type Action =
   | {
       name: "Filtered for patches";
       "filter.by": string;
-      "filter.include.hidden": boolean;
-      "filter.include.commit.queue": boolean;
+      "filter.hidden": boolean;
+      "filter.commit_queue": boolean;
     };
 
 export const useProjectPatchesAnalytics = () => {

--- a/apps/spruce/src/analytics/patches/useUserPatchesAnalytics.ts
+++ b/apps/spruce/src/analytics/patches/useUserPatchesAnalytics.ts
@@ -6,9 +6,9 @@ type Action =
   | { name: "Clicked patch link" }
   | {
       name: "Filtered for patches";
-      filterBy: string;
-      includeHidden: boolean;
-      includeCommitQueue: boolean;
+      "filter.by": string;
+      "filter.include.hidden": boolean;
+      "filter.include.commit.queue": boolean;
     };
 
 export const useUserPatchesAnalytics = () =>

--- a/apps/spruce/src/analytics/patches/useUserPatchesAnalytics.ts
+++ b/apps/spruce/src/analytics/patches/useUserPatchesAnalytics.ts
@@ -7,8 +7,8 @@ type Action =
   | {
       name: "Filtered for patches";
       "filter.by": string;
-      "filter.include.hidden": boolean;
-      "filter.include.commit.queue": boolean;
+      "filter.hidden": boolean;
+      "filter.commit_queue": boolean;
     };
 
 export const useUserPatchesAnalytics = () =>

--- a/apps/spruce/src/analytics/preferences/usePreferencesAnalytics.ts
+++ b/apps/spruce/src/analytics/preferences/usePreferencesAnalytics.ts
@@ -1,13 +1,12 @@
 import { useAnalyticsRoot } from "@evg-ui/lib/analytics/hooks";
 import { AnalyticsIdentifier } from "analytics/types";
-import { UpdateUserSettingsMutationVariables } from "gql/generated/types";
 
 type Action =
   | { name: "Changed tab"; tab: string }
-  | { name: "Saved profile info"; params: UpdateUserSettingsMutationVariables }
-  | { name: "Saved notifications"; params: UpdateUserSettingsMutationVariables }
+  | { name: "Saved profile info" }
+  | { name: "Saved notification preferences" }
   | { name: "Deleted subscriptions" }
-  | { name: "Clicked CLI download link"; downloadName: string }
+  | { name: "Clicked CLI download link"; "download.name": string }
   | { name: "Clicked download auth file" }
   | { name: "Clicked reset API key" }
   | { name: "Created new public key" }

--- a/apps/spruce/src/analytics/projectHealth/useProjectHealthAnalytics.ts
+++ b/apps/spruce/src/analytics/projectHealth/useProjectHealthAnalytics.ts
@@ -35,9 +35,9 @@ type Action =
       "project.id": string;
       "project.identifier": string;
     } // "Commit chart"
-  | { name: "Toggled chart view option"; viewOption: string } // "Commit chart"
+  | { name: "Toggled chart view option"; "view.option": string } // "Commit chart"
   | { name: "Toggled folded commit"; toggle: "open" | "close" } // "Variant history" | "Task history"
-  | { name: "Toggled icon view mode"; iconView: ProjectHealthView } // "Commit chart"
+  | { name: "Toggled icon view mode"; "icon.view": ProjectHealthView } // "Commit chart"
   | { name: "Toggled task icon legend"; open: boolean } // "Task history" | "Variant history" | "Commit chart"
   | { name: "Viewed commit chart label tooltip" } // "Commit chart"
   | { name: "Viewed git commit search modal" } // "Commit chart"

--- a/apps/spruce/src/analytics/projectHealth/useProjectHealthAnalytics.ts
+++ b/apps/spruce/src/analytics/projectHealth/useProjectHealthAnalytics.ts
@@ -1,9 +1,6 @@
 import { useAnalyticsRoot } from "@evg-ui/lib/analytics/hooks";
 import { AnalyticsIdentifier } from "analytics/types";
-import {
-  ProjectHealthView,
-  SaveSubscriptionForUserMutationVariables,
-} from "gql/generated/types";
+import { ProjectHealthView } from "gql/generated/types";
 
 // The comments below are used to indicate which pageType the action is relevant to (e.g. "Commit chart")
 type pageType = "Commit chart" | "Task history" | "Variant history";
@@ -11,18 +8,19 @@ type Action =
   | { name: "Changed page"; direction: "previous" | "next" } // "Commit chart"
   | { name: "Changed project"; project: string } // "Commit chart"
   | { name: "Clicked column header" } // "Task history" | "Variant history"
-  | { name: "Clicked task cell"; taskStatus: string } // "Task history" | "Variant history"
+  | { name: "Clicked task cell"; "task.status": string } // "Task history" | "Variant history"
   | {
       name: "Clicked commit label";
       link: "jira" | "githash" | "upstream project";
-      commitType: "active" | "inactive";
+      "commit.type": "active" | "inactive";
     } // "Task history" | "Variant history" | "Commit chart"
   | { name: "Clicked grouped task status badge"; statuses: string[] }
   | { name: "Clicked task status icon"; status: string } // "Commit chart"
   | { name: "Clicked variant label" } // "Commit chart"
   | {
       name: "Created notification";
-      subscription: SaveSubscriptionForUserMutationVariables["subscription"];
+      "subscription.type": string;
+      "subscription.trigger": string;
     } // "Commit chart"
   | { name: "Deleted a badge" } // "Variant history" | "Task history" | "Commit chart"
   | { name: "Deleted all badges" } // "Variant history" | "Task history" | "Commit chart"
@@ -34,8 +32,8 @@ type Action =
   | { name: "Filtered for git commit"; commit: string } // "Commit chart"
   | {
       name: "Redirected to project identifier";
-      projectId: string;
-      projectIdentifier: string;
+      "project.id": string;
+      "project.identifier": string;
     } // "Commit chart"
   | { name: "Toggled chart view option"; viewOption: string } // "Commit chart"
   | { name: "Toggled folded commit"; toggle: "open" | "close" } // "Variant history" | "Task history"

--- a/apps/spruce/src/analytics/projectSettings/useProjectSettingsAnalytics.ts
+++ b/apps/spruce/src/analytics/projectSettings/useProjectSettingsAnalytics.ts
@@ -9,25 +9,25 @@ type Action =
   | { name: "Clicked default section to repo button"; section: string }
   | {
       name: "Clicked attach project to repo button";
-      repoOwner: string;
-      repoName: string;
+      "repo.owner": string;
+      "repo.name": string;
     }
   | {
       name: "Clicked detach project from repo button";
-      repoOwner: string;
-      repoName: string;
+      "repo.owner": string;
+      "repo.name": string;
     }
   | {
       name: "Clicked move project to new repo button";
-      repoOwner: string;
-      repoName: string;
+      "repo.owner": string;
+      "repo.name": string;
     }
   | { name: "Created new project" }
-  | { name: "Created duplicate project from project"; projectIdToCopy: string }
+  | { name: "Created duplicate project from project"; "project.id": string }
   | {
       name: "Redirected to project identifier";
-      projectId: string;
-      projectIdentifier: string;
+      "project.id": string;
+      "project.identifier": string;
     };
 
 export const useProjectSettingsAnalytics = () => {

--- a/apps/spruce/src/analytics/spawn/useSpawnAnalytics.ts
+++ b/apps/spruce/src/analytics/spawn/useSpawnAnalytics.ts
@@ -3,19 +3,23 @@ import { AnalyticsIdentifier } from "analytics/types";
 
 type Action =
   | { name: "Clicked copy SSH command button" }
-  | { name: "Changed host status"; status: string }
+  | { name: "Changed host status"; "host.status": string }
   | { name: "Toggled spawn host details panel"; expanded: boolean }
   | { name: "Viewed spawn host modal" }
-  | { name: "Viewed edit spawn host modal"; "host.id": string; status: string }
+  | {
+      name: "Viewed edit spawn host modal";
+      "host.id": string;
+      "host.status": string;
+    }
   | {
       name: "Changed spawn host settings";
     }
   | {
       name: "Created a spawn host";
-      "is.volume.migration": boolean;
-      "is.workstation": boolean;
-      "distro.id": string;
-      "no.expire": boolean;
+      "host.is.volume.migration": boolean;
+      "host.is.workstation": boolean;
+      "host.distro.id": string;
+      "host.is.unexpirable": boolean;
     }
   | { name: "Viewed spawn volume modal" }
   | {
@@ -29,11 +33,11 @@ type Action =
       name: "Created a volume";
       "volume.type": string;
       "volume.size": number;
-      "volume.no.expire": boolean;
+      "volume.is.unexpirable": boolean;
     }
   | {
       name: "Changed spawn volume settings";
-      "volume.no.expire": boolean;
+      "volume.is.unexpirable": boolean;
     }
   | { name: "Clicked open IDE button" }
   | { name: "Changed tab"; tab: string };

--- a/apps/spruce/src/analytics/spawn/useSpawnAnalytics.ts
+++ b/apps/spruce/src/analytics/spawn/useSpawnAnalytics.ts
@@ -1,41 +1,39 @@
 import { useAnalyticsRoot } from "@evg-ui/lib/analytics/hooks";
 import { AnalyticsIdentifier } from "analytics/types";
-import {
-  EditSpawnHostMutationVariables,
-  SpawnHostMutationVariables,
-  SpawnVolumeMutationVariables,
-  UpdateVolumeMutationVariables,
-} from "gql/generated/types";
 
 type Action =
   | { name: "Clicked copy SSH command button" }
   | { name: "Changed host status"; status: string }
   | { name: "Toggled spawn host details panel"; expanded: boolean }
   | { name: "Viewed spawn host modal" }
-  | { name: "Viewed edit spawn host modal"; hostId: string; status: string }
+  | { name: "Viewed edit spawn host modal"; "host.id": string; status: string }
   | {
       name: "Changed spawn host settings";
-      params: EditSpawnHostMutationVariables;
     }
   | {
       name: "Created a spawn host";
-      isMigration: boolean;
-      params: Omit<
-        SpawnHostMutationVariables["spawnHostInput"],
-        "publicKey" | "userDataScript" | "setUpScript"
-      >;
+      "is.volume.migration": boolean;
+      "is.workstation": boolean;
+      "distro.id": string;
+      "no.expire": boolean;
     }
   | { name: "Viewed spawn volume modal" }
-  | { name: "Changed mounted volume on host"; volumeId: string; hostId: string }
-  | { name: "Deleted a volume"; volumeId: string }
-  | { name: "Changed unmounted volume on host"; volumeId: string }
+  | {
+      name: "Changed mounted volume on host";
+      "volume.id": string;
+      "host.id": string;
+    }
+  | { name: "Deleted a volume"; "volume.id": string }
+  | { name: "Changed unmounted volume on host"; "volume.id": string }
   | {
       name: "Created a volume";
-      params: SpawnVolumeMutationVariables["spawnVolumeInput"];
+      "volume.type": string;
+      "volume.size": number;
+      "volume.no.expire": boolean;
     }
   | {
       name: "Changed spawn volume settings";
-      params: UpdateVolumeMutationVariables["updateVolumeInput"];
+      "volume.no.expire": boolean;
     }
   | { name: "Clicked open IDE button" }
   | { name: "Changed tab"; tab: string };

--- a/apps/spruce/src/analytics/task/useAnnotationAnalytics.ts
+++ b/apps/spruce/src/analytics/task/useAnnotationAnalytics.ts
@@ -20,8 +20,14 @@ type Action =
       name: "Clicked annotation link";
       target: "Jira ticket link";
     }
-  | { name: "Deleted annotation"; type: "Issue" | "Suspected Issue" }
-  | { name: "Created task annotation"; type: "Issue" | "Suspected Issue" };
+  | {
+      name: "Deleted annotation";
+      "annotation.type": "Issue" | "Suspected Issue";
+    }
+  | {
+      name: "Created task annotation";
+      "annotation.type": "Issue" | "Suspected Issue";
+    };
 
 export const useAnnotationAnalytics = () => {
   const { [slugs.taskId]: taskId } = useParams();

--- a/apps/spruce/src/analytics/task/useTaskAnalytics.ts
+++ b/apps/spruce/src/analytics/task/useTaskAnalytics.ts
@@ -4,7 +4,6 @@ import { useAnalyticsRoot } from "@evg-ui/lib/analytics/hooks";
 import { AnalyticsIdentifier } from "analytics/types";
 import { slugs } from "constants/routes";
 import {
-  SaveSubscriptionForUserMutationVariables,
   TaskQuery,
   TaskQueryVariables,
   TaskSortCategory,
@@ -45,25 +44,30 @@ type Action =
   | { name: "Changed page size" }
   | { name: "Changed tab"; tab: string }
   | { name: "Changed execution" }
-  | { name: "Clicked log link"; logType: LogTypes; logViewer: LogViewer }
-  | { name: "Clicked test log link"; logViewer: LogViewer; testStatus: string }
-  | { name: "Clicked annotation link"; linkText: string }
-  | { name: "Changed log preview type"; logType: LogTypes }
+  | { name: "Clicked log link"; "log.type": LogTypes; "log.viewer": LogViewer }
+  | {
+      name: "Clicked test log link";
+      "log.viewer": LogViewer;
+      "test.status": string;
+    }
+  | { name: "Clicked annotation link"; "link.text": string }
+  | { name: "Changed log preview type"; "log.type": LogTypes }
   | { name: "Viewed notification modal" }
   | {
       name: "Created notification";
-      subscription: SaveSubscriptionForUserMutationVariables["subscription"];
+      "subscription.type": string;
+      "subscription.trigger": string;
     }
   | { name: "Clicked see history link" }
-  | { name: "Clicked metadata link"; linkType: string }
+  | { name: "Clicked metadata link"; "link.type": string }
   | {
       name: "Clicked task file link";
-      parsleyAvailable: boolean;
-      fileName: string;
+      "parsley.available": boolean;
+      "file.name": string;
     }
   | {
       name: "Clicked task file Parsley link";
-      fileName: string;
+      "file.name": string;
     }
   | { name: "Clicked relevant commit"; type: CommitType };
 

--- a/apps/spruce/src/analytics/task/useTaskAnalytics.ts
+++ b/apps/spruce/src/analytics/task/useTaskAnalytics.ts
@@ -16,30 +16,30 @@ import { RequiredQueryParams, LogTypes } from "types/task";
 
 type LogViewer = "raw" | "html" | "parsley";
 type Action =
-  | { name: "Filtered tests table"; filterBy: string | string[] }
+  | { name: "Filtered tests table"; "filter.by": string | string[] }
   | {
       name: "Sorted tests table";
-      sortBy: TestSortCategory | TestSortCategory[];
+      "sort.by": TestSortCategory | TestSortCategory[];
     }
   | {
       name: "Sorted execution tasks table";
-      sortBy: TaskSortCategory | TaskSortCategory[];
+      "sort.by": TaskSortCategory | TaskSortCategory[];
     }
   | {
       name: "Clicked restart task button";
-      isDisplayTask: false;
+      "task.is.display_task": false;
     }
   | {
       name: "Clicked restart task button";
       allTasks: boolean;
-      isDisplayTask: true;
+      "task.is.display_task": true;
     }
   | {
       name: "Clicked execution tasks table link";
     }
   | { name: "Clicked schedule task button" }
   | { name: "Clicked abort task button" }
-  | { name: "Changed task priority"; priority: number }
+  | { name: "Changed task priority"; "task.priority": number }
   | { name: "Clicked unschedule task button" }
   | { name: "Changed page size" }
   | { name: "Changed tab"; tab: string }

--- a/apps/spruce/src/analytics/version/useVersionAnalytics.ts
+++ b/apps/spruce/src/analytics/version/useVersionAnalytics.ts
@@ -2,7 +2,6 @@ import { useQuery } from "@apollo/client";
 import { useAnalyticsRoot } from "@evg-ui/lib/analytics/hooks";
 import { AnalyticsIdentifier } from "analytics/types";
 import {
-  SaveSubscriptionForUserMutationVariables,
   VersionQuery,
   VersionQueryVariables,
   TaskSortCategory,
@@ -12,9 +11,10 @@ import { VERSION } from "gql/queries";
 type Action =
   | {
       name: "Created notification";
-      subscription: SaveSubscriptionForUserMutationVariables["subscription"];
+      "subscription.type": string;
+      "subscription.trigger": string;
     }
-  | { name: "Changed page size"; pageSize: number }
+  | { name: "Changed page size"; "page.size": number }
   | { name: "Changed tab"; tab: string }
   | { name: "Clicked metadata base commit link" }
   | { name: "Filtered by build variant group" }
@@ -25,12 +25,12 @@ type Action =
     }
   | { name: "Clicked metadata previous version link" }
   | { name: "Clicked metadata project patches link" }
-  | { name: "Clicked task table task link"; taskId: string }
+  | { name: "Clicked task table task link"; "task.id": string }
   | { name: "Deleted all filters" }
   | { name: "Clicked enqueue tasks button" }
-  | { name: "Filtered downstream tasks table"; filterBy: string | string[] }
-  | { name: "Filtered tasks table"; filterBy: string | string[] }
-  | { name: "Filtered task duration table"; filterBy: string | string[] }
+  | { name: "Filtered downstream tasks table"; "filter.by": string | string[] }
+  | { name: "Filtered tasks table"; "filter.by": string | string[] }
+  | { name: "Filtered task duration table"; "filter.by": string | string[] }
   | { name: "Viewed notification modal" }
   | { name: "Viewed schedule tasks modal" }
   | { name: "Clicked restart tasks button"; abort: boolean }
@@ -47,7 +47,7 @@ type Action =
     }
   | {
       name: "Sorted downstream tasks table";
-      sortBy: TaskSortCategory | TaskSortCategory[];
+      "sort.by": TaskSortCategory | TaskSortCategory[];
     }
   | { name: "Toggled display task expansion"; expanded: boolean }
   | { name: "Clicked unschedule tasks button"; abort: boolean };

--- a/apps/spruce/src/analytics/version/useVersionAnalytics.ts
+++ b/apps/spruce/src/analytics/version/useVersionAnalytics.ts
@@ -36,10 +36,10 @@ type Action =
   | { name: "Clicked restart tasks button"; abort: boolean }
   | { name: "Clicked schedule tasks button" }
   | { name: "Clicked patch reconfigure link" }
-  | { name: "Changed version priority"; priority: number }
+  | { name: "Changed version priority"; "version.priority": number }
   | {
       name: "Sorted tasks table";
-      sortBy:
+      "sort.by":
         | TaskSortCategory.BaseStatus
         | TaskSortCategory.Name
         | TaskSortCategory.Status

--- a/apps/spruce/src/components/Hosts/UpdateStatusModal.tsx
+++ b/apps/spruce/src/components/Hosts/UpdateStatusModal.tsx
@@ -73,7 +73,7 @@ export const UpdateStatusModal: React.FC<Props> = ({
   const onClickUpdate = () => {
     hostsTableAnalytics.sendEvent({
       name: "Clicked update host status button",
-      status,
+      "host.status": status,
     });
     updateHostStatus({ variables: { hostIds, status, notes } });
   };

--- a/apps/spruce/src/components/PatchActionButtons/SetPatchVisibility.tsx
+++ b/apps/spruce/src/components/PatchActionButtons/SetPatchVisibility.tsx
@@ -37,7 +37,10 @@ export const SetPatchVisibility: React.FC<Props> = ({
   return (
     <MenuItem
       onClick={() => {
-        sendEvent({ name: "Toggled patch visibility", hidden: !isPatchHidden });
+        sendEvent({
+          name: "Toggled patch visibility",
+          "patch.hidden": !isPatchHidden,
+        });
         setPatchVisibility({
           variables: { patchIds: [patchId], hidden: !isPatchHidden },
         });

--- a/apps/spruce/src/components/PatchActionButtons/addNotification/PatchNotificationModal.tsx
+++ b/apps/spruce/src/components/PatchActionButtons/addNotification/PatchNotificationModal.tsx
@@ -25,7 +25,11 @@ export const PatchNotificationModal: React.FC<ModalProps> = ({
       // @ts-expect-error: FIXME. This comment was added by an automated script.
       resourceId={versionId}
       sendAnalyticsEvent={(subscription) =>
-        sendEvent({ name: "Created notification", subscription })
+        sendEvent({
+          name: "Created notification",
+          "subscription.type": subscription.subscriber.type || "",
+          "subscription.trigger": subscription.trigger || "",
+        })
       }
       subscriptionMethods={versionSubscriptionMethods}
       triggers={versionTriggers}

--- a/apps/spruce/src/components/PatchesPage/index.tsx
+++ b/apps/spruce/src/components/PatchesPage/index.tsx
@@ -64,9 +64,9 @@ export const PatchesPage: React.FC<Props> = ({
       sendAnalyticsEvent: (filterBy: string) =>
         analytics.sendEvent({
           name: "Filtered for patches",
-          filterBy,
-          includeHidden: includeHiddenCheckboxChecked,
-          includeCommitQueue: isCommitQueueCheckboxChecked,
+          "filter.by": filterBy,
+          "filter.include.hidden": includeHiddenCheckboxChecked,
+          "filter.include.commit.queue": isCommitQueueCheckboxChecked,
         }),
     });
   usePageTitle(pageTitle);
@@ -78,9 +78,9 @@ export const PatchesPage: React.FC<Props> = ({
     Cookies.set(cookie, e.target.checked ? "true" : "false");
     analytics.sendEvent({
       name: "Filtered for patches",
-      filterBy: filterInput,
-      includeHidden: includeHiddenCheckboxChecked,
-      includeCommitQueue: e.target.checked,
+      "filter.by": filterInput,
+      "filter.include.hidden": includeHiddenCheckboxChecked,
+      "filter.include.commit.queue": e.target.checked,
     });
   };
 
@@ -91,9 +91,9 @@ export const PatchesPage: React.FC<Props> = ({
     Cookies.set(INCLUDE_HIDDEN_PATCHES, e.target.checked ? "true" : "false");
     analytics.sendEvent({
       name: "Filtered for patches",
-      filterBy: filterInput,
-      includeHidden: e.target.checked,
-      includeCommitQueue: isCommitQueueCheckboxChecked,
+      "filter.by": filterInput,
+      "filter.include.hidden": e.target.checked,
+      "filter.include.commit.queue": isCommitQueueCheckboxChecked,
     });
   };
 

--- a/apps/spruce/src/components/PatchesPage/index.tsx
+++ b/apps/spruce/src/components/PatchesPage/index.tsx
@@ -65,8 +65,8 @@ export const PatchesPage: React.FC<Props> = ({
         analytics.sendEvent({
           name: "Filtered for patches",
           "filter.by": filterBy,
-          "filter.include.hidden": includeHiddenCheckboxChecked,
-          "filter.include.commit.queue": isCommitQueueCheckboxChecked,
+          "filter.hidden": includeHiddenCheckboxChecked,
+          "filter.commit_queue": isCommitQueueCheckboxChecked,
         }),
     });
   usePageTitle(pageTitle);
@@ -79,8 +79,8 @@ export const PatchesPage: React.FC<Props> = ({
     analytics.sendEvent({
       name: "Filtered for patches",
       "filter.by": filterInput,
-      "filter.include.hidden": includeHiddenCheckboxChecked,
-      "filter.include.commit.queue": e.target.checked,
+      "filter.hidden": includeHiddenCheckboxChecked,
+      "filter.commit_queue": e.target.checked,
     });
   };
 
@@ -92,8 +92,8 @@ export const PatchesPage: React.FC<Props> = ({
     analytics.sendEvent({
       name: "Filtered for patches",
       "filter.by": filterInput,
-      "filter.include.hidden": e.target.checked,
-      "filter.include.commit.queue": isCommitQueueCheckboxChecked,
+      "filter.hidden": e.target.checked,
+      "filter.commit_queue": isCommitQueueCheckboxChecked,
     });
   };
 

--- a/apps/spruce/src/components/SetPriority/index.tsx
+++ b/apps/spruce/src/components/SetPriority/index.tsx
@@ -82,11 +82,17 @@ const SetPriority: React.FC<SetPriorityProps> = ({
   const onConfirm = () => {
     if (taskId) {
       setTaskPriority({ variables: { taskId, priority } });
-      sendTaskEvent({ name: "Changed task priority", priority });
+      sendTaskEvent({
+        name: "Changed task priority",
+        "task.priority": priority,
+      });
     } else {
       // @ts-expect-error: FIXME. This comment was added by an automated script.
       setVersionPriority({ variables: { versionId, priority } });
-      sendVersionEvent({ name: "Changed version priority", priority });
+      sendVersionEvent({
+        name: "Changed version priority",
+        "version.priority": priority,
+      });
     }
   };
 

--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -885,6 +885,7 @@ export type Image = {
   lastDeployed: Scalars["Time"]["output"];
   latestTask?: Maybe<Task>;
   name: Scalars["String"]["output"];
+  operatingSystem: ImageOperatingSystemPayload;
   packages: ImagePackagesPayload;
   toolchains: ImageToolchainsPayload;
   versionId: Scalars["String"]["output"];
@@ -897,6 +898,14 @@ export type Image = {
 export type ImageEventsArgs = {
   limit: Scalars["Int"]["input"];
   page: Scalars["Int"]["input"];
+};
+
+/**
+ * Image is returned by the image query.
+ * It contains information about an image.
+ */
+export type ImageOperatingSystemArgs = {
+  opts: OperatingSystemOpts;
 };
 
 /**
@@ -947,6 +956,13 @@ export type ImageEventsPayload = {
   __typename?: "ImageEventsPayload";
   count: Scalars["Int"]["output"];
   eventLogEntries: Array<ImageEvent>;
+};
+
+export type ImageOperatingSystemPayload = {
+  __typename?: "ImageOperatingSystemPayload";
+  data: Array<OsInfo>;
+  filteredCount: Scalars["Int"]["output"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type ImagePackagesPayload = {
@@ -1512,10 +1528,22 @@ export type NotificationsInput = {
   spawnHostOutcome?: InputMaybe<Scalars["String"]["input"]>;
 };
 
+export type OsInfo = {
+  __typename?: "OSInfo";
+  name: Scalars["String"]["output"];
+  version: Scalars["String"]["output"];
+};
+
 export type OomTrackerInfo = {
   __typename?: "OomTrackerInfo";
   detected: Scalars["Boolean"]["output"];
   pids?: Maybe<Array<Scalars["Int"]["output"]>>;
+};
+
+export type OperatingSystemOpts = {
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  name?: InputMaybe<Scalars["String"]["input"]>;
+  page?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export enum OverallocatedRule {

--- a/apps/spruce/src/pages/ProjectPatches.tsx
+++ b/apps/spruce/src/pages/ProjectPatches.tsx
@@ -69,7 +69,7 @@ export const ProjectPatches = () => {
             onSubmit={(p) => {
               analytics.sendEvent({
                 name: "Changed project",
-                projectIdentifier: p,
+                "project.identifier": p,
               });
             }}
           />

--- a/apps/spruce/src/pages/commits/ActiveCommits/index.tsx
+++ b/apps/spruce/src/pages/commits/ActiveCommits/index.tsx
@@ -29,21 +29,21 @@ export const ActiveCommitLabel: React.FC<ActiveCommitLabelProps> = ({
       onClickGithash={() => {
         sendEvent({
           name: "Clicked commit label",
-          commitType: "active",
+          "commit.type": "active",
           link: "githash",
         });
       }}
       onClickJiraTicket={() => {
         sendEvent({
           name: "Clicked commit label",
-          commitType: "active",
+          "commit.type": "active",
           link: "jira",
         });
       }}
       onClickUpstreamProject={() => {
         sendEvent({
           name: "Clicked commit label",
-          commitType: "active",
+          "commit.type": "active",
           link: "upstream project",
         });
       }}

--- a/apps/spruce/src/pages/commits/CommitChart/ChartToggle.tsx
+++ b/apps/spruce/src/pages/commits/CommitChart/ChartToggle.tsx
@@ -25,7 +25,7 @@ export const ChartToggle: React.FC<{
     onChangeChartType(chartType);
     sendEvent({
       name: "Toggled chart view option",
-      viewOption: chartType,
+      "view.option": chartType,
     });
   };
   return (

--- a/apps/spruce/src/pages/commits/InactiveCommits/index.tsx
+++ b/apps/spruce/src/pages/commits/InactiveCommits/index.tsx
@@ -146,7 +146,7 @@ const CommitCopy: React.FC<CommitCopyProps> = ({ isTooltip, v }) => {
           onClick={() =>
             sendEvent({
               name: "Clicked commit label",
-              commitType: "inactive",
+              "commit.type": "inactive",
               link: "githash",
             })
           }
@@ -163,7 +163,7 @@ const CommitCopy: React.FC<CommitCopyProps> = ({ isTooltip, v }) => {
         {jiraLinkify(message, jiraHost, () => {
           sendEvent({
             name: "Clicked commit label",
-            commitType: "inactive",
+            "commit.type": "inactive",
             link: "jira",
           });
         })}{" "}

--- a/apps/spruce/src/pages/commits/ViewToggle.tsx
+++ b/apps/spruce/src/pages/commits/ViewToggle.tsx
@@ -52,7 +52,7 @@ export const ViewToggle: React.FC<Props> = ({ identifier }) => {
     setView(value);
     sendEvent({
       name: "Toggled icon view mode",
-      iconView: value,
+      "icon.view": value,
     });
   };
 

--- a/apps/spruce/src/pages/commits/WaterfallMenu/AddNotification.tsx
+++ b/apps/spruce/src/pages/commits/WaterfallMenu/AddNotification.tsx
@@ -37,7 +37,11 @@ export const AddNotification: React.FC<AddNotificationProps> = ({
         // @ts-expect-error: FIXME. This comment was added by an automated script.
         resourceId={projectIdentifier}
         sendAnalyticsEvent={(subscription) =>
-          sendEvent({ name: "Created notification", subscription })
+          sendEvent({
+            name: "Created notification",
+            "subscription.type": subscription.subscriber.type || "",
+            "subscription.trigger": subscription.trigger || "",
+          })
         }
         subscriptionMethods={subscriptionMethods}
         triggers={waterfallTriggers}

--- a/apps/spruce/src/pages/commits/index.tsx
+++ b/apps/spruce/src/pages/commits/index.tsx
@@ -73,8 +73,8 @@ const Commits = () => {
   const sendAnalyticsEvent = (id: string, identifier: string) => {
     sendEvent({
       name: "Redirected to project identifier",
-      projectId: id,
-      projectIdentifier: identifier,
+      "project.id": id,
+      "project.identifier": identifier,
     });
   };
   const { isRedirecting } = useProjectRedirect({

--- a/apps/spruce/src/pages/distroSettings/NewDistro/CopyModal.tsx
+++ b/apps/spruce/src/pages/distroSettings/NewDistro/CopyModal.tsx
@@ -54,7 +54,7 @@ export const CopyModal: React.FC<Props> = ({ handleClose, open }) => {
     });
     sendEvent({
       name: "Clicked duplicate distro",
-      newDistroId: formState.newDistroId,
+      "distro.id": formState.newDistroId,
     });
     handleClose();
   };

--- a/apps/spruce/src/pages/distroSettings/NewDistro/CreateModal.tsx
+++ b/apps/spruce/src/pages/distroSettings/NewDistro/CreateModal.tsx
@@ -51,7 +51,7 @@ export const CreateModal: React.FC<Props> = ({ handleClose, open }) => {
     });
     sendEvent({
       name: "Created new distro",
-      newDistroId: formState.newDistroId,
+      "distro.id": formState.newDistroId,
     });
     handleClose();
   };

--- a/apps/spruce/src/pages/host/HostTable.tsx
+++ b/apps/spruce/src/pages/host/HostTable.tsx
@@ -36,7 +36,10 @@ export const HostTable: React.FC<{
 
   const handlePageSizeChange = (pageSize: number): void => {
     setLimit(pageSize);
-    hostsTableAnalytics.sendEvent({ name: "Changed page size", pageSize });
+    hostsTableAnalytics.sendEvent({
+      name: "Changed page size",
+      "page.size": pageSize,
+    });
   };
 
   const columns: LGColumnDef<HostEvent>[] = useMemo(

--- a/apps/spruce/src/pages/hosts/HostsTable.tsx
+++ b/apps/spruce/src/pages/hosts/HostsTable.tsx
@@ -85,7 +85,7 @@ export const HostsTable: React.FC<Props> = ({
     setQueryParams(updatedParams);
     sendEvent({
       name: "Filtered hosts table",
-      filterBy: Object.keys(filterState),
+      "filter.by": Object.keys(filterState),
     });
   };
 

--- a/apps/spruce/src/pages/hosts/index.tsx
+++ b/apps/spruce/src/pages/hosts/index.tsx
@@ -91,7 +91,10 @@ const Hosts: React.FC = () => {
 
   const handlePageSizeChange = (pageSize: number): void => {
     setLimit(pageSize);
-    hostsTableAnalytics.sendEvent({ name: "Changed page size", pageSize });
+    hostsTableAnalytics.sendEvent({
+      name: "Changed page size",
+      "page.size": pageSize,
+    });
   };
 
   // UPDATE STATUS MODAL VISIBILITY STATE

--- a/apps/spruce/src/pages/jobLogs/JobLogsTable.tsx
+++ b/apps/spruce/src/pages/jobLogs/JobLogsTable.tsx
@@ -41,7 +41,7 @@ export const JobLogsTable: React.FC<JobLogsTableProps> = ({
             onClick={() => {
               sendEvent({
                 name: "Clicked Parsley test log link",
-                buildId,
+                "build.id": buildId,
               });
             }}
             hideExternalIcon

--- a/apps/spruce/src/pages/jobLogs/Metadata.tsx
+++ b/apps/spruce/src/pages/jobLogs/Metadata.tsx
@@ -33,10 +33,10 @@ export const Metadata: React.FC<{
           onClick={() => {
             sendEvent({
               name: "Clicked complete logs link",
-              buildId: metadata.buildId,
-              taskId: metadata.taskId,
+              "build.id": metadata.buildId,
+              "task.id": metadata.taskId,
               execution: metadata.execution,
-              groupID: metadata.groupID,
+              "group.id": metadata.groupID,
             });
           }}
         >

--- a/apps/spruce/src/pages/preferences/preferencesTabs/NotificationsTab.tsx
+++ b/apps/spruce/src/pages/preferences/preferencesTabs/NotificationsTab.tsx
@@ -69,8 +69,7 @@ export const NotificationsTab: React.FC = () => {
       },
     };
     sendEvent({
-      name: "Saved notifications",
-      params: variables,
+      name: "Saved notification preferences",
     });
     try {
       await updateUserSettings({

--- a/apps/spruce/src/pages/preferences/preferencesTabs/ProfileTab.tsx
+++ b/apps/spruce/src/pages/preferences/preferencesTabs/ProfileTab.tsx
@@ -101,13 +101,6 @@ export const ProfileTab: React.FC = () => {
     });
     sendEvent({
       name: "Saved profile info",
-      params: {
-        userSettings: {
-          timezone: formState.timezone,
-          region: formState.region,
-          dateFormat: formState.dateFormat,
-        },
-      },
     });
   };
 

--- a/apps/spruce/src/pages/preferences/preferencesTabs/cliTab/DownloadCard.tsx
+++ b/apps/spruce/src/pages/preferences/preferencesTabs/cliTab/DownloadCard.tsx
@@ -95,7 +95,7 @@ const CliDownloadBox: React.FC<CliDownloadBoxProps> = ({
         onClick={() => {
           sendEvent({
             name: "Clicked CLI download link",
-            downloadName: title,
+            "download.name": title,
           });
         }}
         // @ts-expect-error: FIXME. This comment was added by an automated script.
@@ -124,8 +124,7 @@ const ExpandableLinkContents: React.FC<ExpandableLinkContentsProps> = ({
           onClick={() => {
             sendEvent({
               name: "Clicked CLI download link",
-              // @ts-expect-error: FIXME. This comment was added by an automated script.
-              downloadName: binary.displayName,
+              "download.name": binary.displayName || "",
             });
           }}
           key={`link_${binary.url}`}

--- a/apps/spruce/src/pages/projectSettings/CopyProjectModal.tsx
+++ b/apps/spruce/src/pages/projectSettings/CopyProjectModal.tsx
@@ -96,7 +96,7 @@ export const CopyProjectModal: React.FC<Props> = ({
     });
     sendEvent({
       name: "Created duplicate project from project",
-      projectIdToCopy: id,
+      "project.id": id,
     });
     handleClose();
   };

--- a/apps/spruce/src/pages/projectSettings/index.tsx
+++ b/apps/spruce/src/pages/projectSettings/index.tsx
@@ -90,8 +90,8 @@ const ProjectSettings: React.FC = () => {
     sendAnalyticsEvent: (projectId: string, identifier: string) => {
       sendEvent({
         name: "Redirected to project identifier",
-        projectId,
-        projectIdentifier: identifier,
+        "project.id": projectId,
+        "project.identifier": identifier,
       });
     },
   });

--- a/apps/spruce/src/pages/projectSettings/tabs/GeneralTab/Fields/AttachDetachModal.tsx
+++ b/apps/spruce/src/pages/projectSettings/tabs/GeneralTab/Fields/AttachDetachModal.tsx
@@ -80,15 +80,15 @@ export const AttachDetachModal: React.FC<ModalProps> = ({
           attachProjectToRepo();
           sendEvent({
             name: "Clicked attach project to repo button",
-            repoOwner,
-            repoName,
+            "repo.owner": repoOwner,
+            "repo.name": repoName,
           });
         } else {
           detachProjectFromRepo();
           sendEvent({
             name: "Clicked detach project from repo button",
-            repoOwner,
-            repoName,
+            "repo.owner": repoOwner,
+            "repo.name": repoName,
           });
         }
         handleClose();

--- a/apps/spruce/src/pages/projectSettings/tabs/GeneralTab/Fields/MoveRepoModal.tsx
+++ b/apps/spruce/src/pages/projectSettings/tabs/GeneralTab/Fields/MoveRepoModal.tsx
@@ -78,8 +78,8 @@ export const MoveRepoModal: React.FC<ModalProps> = ({
         });
         sendEvent({
           name: "Clicked move project to new repo button",
-          repoOwner: newOwner,
-          repoName: newRepo,
+          "repo.owner": newOwner,
+          "repo.name": newRepo,
         });
         handleClose();
       }}

--- a/apps/spruce/src/pages/spawn/spawnHost/EditSpawnHostButton.tsx
+++ b/apps/spruce/src/pages/spawn/spawnHost/EditSpawnHostButton.tsx
@@ -40,7 +40,7 @@ export const EditSpawnHostButton: React.FC<EditSpawnHostButtonProps> = ({
                 setOpenModal(true);
                 spawnAnalytics.sendEvent({
                   name: "Viewed edit spawn host modal",
-                  hostId: host.id,
+                  "host.id": host.id,
                   status: host.status,
                 });
               }}

--- a/apps/spruce/src/pages/spawn/spawnHost/EditSpawnHostButton.tsx
+++ b/apps/spruce/src/pages/spawn/spawnHost/EditSpawnHostButton.tsx
@@ -41,7 +41,7 @@ export const EditSpawnHostButton: React.FC<EditSpawnHostButtonProps> = ({
                 spawnAnalytics.sendEvent({
                   name: "Viewed edit spawn host modal",
                   "host.id": host.id,
-                  status: host.status,
+                  "host.status": host.status,
                 });
               }}
             >

--- a/apps/spruce/src/pages/spawn/spawnHost/EditSpawnHostModal.tsx
+++ b/apps/spruce/src/pages/spawn/spawnHost/EditSpawnHostModal.tsx
@@ -27,7 +27,6 @@ import { EDIT_SPAWN_HOST } from "gql/mutations";
 import { useUserTimeZone } from "hooks";
 import { HostStatus } from "types/host";
 import { MyHost } from "types/spawn";
-import { omit } from "utils/object";
 
 interface EditSpawnHostModalProps {
   visible?: boolean;
@@ -169,11 +168,6 @@ export const EditSpawnHostModal: React.FC<EditSpawnHostModalProps> = ({
   const onSubmit = () => {
     sendEvent({
       name: "Changed spawn host settings",
-      params: {
-        // @ts-expect-error: FIXME. This comment was added by an automated script.
-        hostId: host.id,
-        ...omit(mutationParams, ["publicKey"]),
-      },
     });
     editSpawnHostMutation({
       variables: {

--- a/apps/spruce/src/pages/spawn/spawnHost/SpawnHostActionButton.tsx
+++ b/apps/spruce/src/pages/spawn/spawnHost/SpawnHostActionButton.tsx
@@ -77,7 +77,7 @@ export const SpawnHostActionButton: React.FC<{ host: MyHost }> = ({ host }) => {
   });
 
   const handleClick = (a: SpawnHostStatusActions, shouldKeepOff?: boolean) => {
-    spawnAnalytics.sendEvent({ name: "Changed host status", status: a });
+    spawnAnalytics.sendEvent({ name: "Changed host status", "host.status": a });
     updateSpawnHostStatus({
       variables: {
         updateSpawnHostStatusInput: {

--- a/apps/spruce/src/pages/spawn/spawnHost/spawnHostButton/SpawnHostModal.tsx
+++ b/apps/spruce/src/pages/spawn/spawnHost/spawnHostButton/SpawnHostModal.tsx
@@ -142,7 +142,7 @@ export const SpawnHostModal: React.FC<SpawnHostModalProps> = ({
       "is.volume.migration": false,
       "is.workstation": selectedDistro?.isVirtualWorkStation || false,
       "distro.id": selectedDistro?.name || "",
-      "no.expire": mutationInput?.noExpiration || false,
+      "host.is.unexpirable": mutationInput?.noExpiration || false,
     });
     spawnHostMutation({
       variables: { spawnHostInput: mutationInput },

--- a/apps/spruce/src/pages/spawn/spawnHost/spawnHostButton/SpawnHostModal.tsx
+++ b/apps/spruce/src/pages/spawn/spawnHost/spawnHostButton/SpawnHostModal.tsx
@@ -139,9 +139,9 @@ export const SpawnHostModal: React.FC<SpawnHostModalProps> = ({
     });
     spawnAnalytics.sendEvent({
       name: "Created a spawn host",
-      "is.volume.migration": false,
-      "is.workstation": selectedDistro?.isVirtualWorkStation || false,
-      "distro.id": selectedDistro?.name || "",
+      "host.is.volume.migration": false,
+      "host.is.workstation": selectedDistro?.isVirtualWorkStation || false,
+      "host.distro.id": selectedDistro?.name || "",
       "host.is.unexpirable": mutationInput?.noExpiration || false,
     });
     spawnHostMutation({

--- a/apps/spruce/src/pages/spawn/spawnHost/spawnHostButton/SpawnHostModal.tsx
+++ b/apps/spruce/src/pages/spawn/spawnHost/spawnHostButton/SpawnHostModal.tsx
@@ -26,7 +26,6 @@ import {
 import { SPAWN_HOST } from "gql/mutations";
 import { SPAWN_TASK } from "gql/queries";
 import { useUserTimeZone } from "hooks";
-import { omit } from "utils/object";
 import { getString, parseQueryString } from "utils/queryString";
 
 interface SpawnHostModalProps {
@@ -140,13 +139,10 @@ export const SpawnHostModal: React.FC<SpawnHostModalProps> = ({
     });
     spawnAnalytics.sendEvent({
       name: "Created a spawn host",
-      isMigration: false,
-      // @ts-expect-error: FIXME. This comment was added by an automated script.
-      params: omit(mutationInput, [
-        "publicKey",
-        "userDataScript",
-        "setUpScript",
-      ]),
+      "is.volume.migration": false,
+      "is.workstation": selectedDistro?.isVirtualWorkStation || false,
+      "distro.id": selectedDistro?.name || "",
+      "no.expire": mutationInput?.noExpiration || false,
     });
     spawnHostMutation({
       variables: { spawnHostInput: mutationInput },

--- a/apps/spruce/src/pages/spawn/spawnVolume/SpawnVolumeModal.tsx
+++ b/apps/spruce/src/pages/spawn/spawnVolume/SpawnVolumeModal.tsx
@@ -54,7 +54,7 @@ export const SpawnVolumeModal: React.FC<SpawnVolumeModalProps> = ({
       name: "Created a volume",
       "volume.type": mutationInput.type,
       "volume.size": mutationInput.size,
-      "volume.no.expire": mutationInput.noExpiration || false,
+      "volume.is.unexpirable": mutationInput.noExpiration || false,
     });
     spawnVolumeMutation({
       variables: { spawnVolumeInput: mutationInput },

--- a/apps/spruce/src/pages/spawn/spawnVolume/SpawnVolumeModal.tsx
+++ b/apps/spruce/src/pages/spawn/spawnVolume/SpawnVolumeModal.tsx
@@ -52,7 +52,9 @@ export const SpawnVolumeModal: React.FC<SpawnVolumeModalProps> = ({
     const mutationInput = formToGql({ formData: formState });
     spawnAnalytics.sendEvent({
       name: "Created a volume",
-      params: mutationInput,
+      "volume.type": mutationInput.type,
+      "volume.size": mutationInput.size,
+      "volume.no.expire": mutationInput.noExpiration || false,
     });
     spawnVolumeMutation({
       variables: { spawnVolumeInput: mutationInput },

--- a/apps/spruce/src/pages/spawn/spawnVolume/spawnVolumeTableActions/DeleteVolumeButton.tsx
+++ b/apps/spruce/src/pages/spawn/spawnVolume/spawnVolumeTableActions/DeleteVolumeButton.tsx
@@ -45,7 +45,7 @@ export const DeleteVolumeButton: React.FC<Props> = ({ volume }) => {
       onConfirm={() => {
         spawnAnalytics.sendEvent({
           name: "Deleted a volume",
-          volumeId: volume.id,
+          "volume.id": volume.id,
         });
         removeVolume({ variables: { volumeId: volume.id } });
       }}

--- a/apps/spruce/src/pages/spawn/spawnVolume/spawnVolumeTableActions/EditVolumeModal.tsx
+++ b/apps/spruce/src/pages/spawn/spawnVolume/spawnVolumeTableActions/EditVolumeModal.tsx
@@ -67,7 +67,7 @@ export const EditVolumeModal: React.FC<Props> = ({
     const mutationInput = formToGql(initialState, formState, volume.id);
     spawnAnalytics.sendEvent({
       name: "Changed spawn volume settings",
-      "volume.no.expire": mutationInput.noExpiration,
+      "volume.is.unexpirable": mutationInput.noExpiration,
     });
     updateVolumeMutation({
       variables: { updateVolumeInput: mutationInput },

--- a/apps/spruce/src/pages/spawn/spawnVolume/spawnVolumeTableActions/EditVolumeModal.tsx
+++ b/apps/spruce/src/pages/spawn/spawnVolume/spawnVolumeTableActions/EditVolumeModal.tsx
@@ -67,7 +67,7 @@ export const EditVolumeModal: React.FC<Props> = ({
     const mutationInput = formToGql(initialState, formState, volume.id);
     spawnAnalytics.sendEvent({
       name: "Changed spawn volume settings",
-      params: mutationInput,
+      "volume.no.expire": mutationInput.noExpiration,
     });
     updateVolumeMutation({
       variables: { updateVolumeInput: mutationInput },

--- a/apps/spruce/src/pages/spawn/spawnVolume/spawnVolumeTableActions/MigrateVolumeModal.tsx
+++ b/apps/spruce/src/pages/spawn/spawnVolume/spawnVolumeTableActions/MigrateVolumeModal.tsx
@@ -18,7 +18,6 @@ import {
 import { MIGRATE_VOLUME } from "gql/mutations";
 import { AZToRegion } from "pages/spawn/utils";
 import { TableVolume } from "types/spawn";
-import { omit } from "utils/object";
 import { initialState, Page, reducer } from "./migrateVolumeReducer";
 
 interface MigrateVolumeModalProps {
@@ -107,13 +106,10 @@ export const MigrateVolumeModal: React.FC<MigrateVolumeModalProps> = ({
     });
     sendEvent({
       name: "Created a spawn host",
-      isMigration: true,
-      // @ts-expect-error: FIXME. This comment was added by an automated script.
-      params: omit(mutationInput, [
-        "publicKey",
-        "userDataScript",
-        "setUpScript",
-      ]),
+      "is.volume.migration": true,
+      "distro.id": mutationInput?.distroId || "",
+      "no.expire": mutationInput?.noExpiration || false,
+      "is.workstation": mutationInput?.isVirtualWorkStation || false,
     });
     migrateVolumeMutation({
       variables: {

--- a/apps/spruce/src/pages/spawn/spawnVolume/spawnVolumeTableActions/MigrateVolumeModal.tsx
+++ b/apps/spruce/src/pages/spawn/spawnVolume/spawnVolumeTableActions/MigrateVolumeModal.tsx
@@ -106,10 +106,10 @@ export const MigrateVolumeModal: React.FC<MigrateVolumeModalProps> = ({
     });
     sendEvent({
       name: "Created a spawn host",
-      "is.volume.migration": true,
-      "distro.id": mutationInput?.distroId || "",
-      "no.expire": mutationInput?.noExpiration || false,
-      "is.workstation": mutationInput?.isVirtualWorkStation || false,
+      "host.is.volume.migration": true,
+      "host.distro.id": mutationInput?.distroId || "",
+      "host.is.unexpirable": mutationInput?.noExpiration || false,
+      "host.is.workstation": mutationInput?.isVirtualWorkStation || false,
     });
     migrateVolumeMutation({
       variables: {

--- a/apps/spruce/src/pages/spawn/spawnVolume/spawnVolumeTableActions/MountVolumeModal.tsx
+++ b/apps/spruce/src/pages/spawn/spawnVolume/spawnVolumeTableActions/MountVolumeModal.tsx
@@ -48,8 +48,8 @@ export const MountVolumeModal: React.FC<Props> = ({
       onConfirm={() => {
         spawnAnalytics.sendEvent({
           name: "Changed mounted volume on host",
-          volumeId: volume.id,
-          hostId: selectedHostId,
+          "volume.id": volume.id,
+          "host.id": selectedHostId,
         });
         attachVolume({
           variables: {

--- a/apps/spruce/src/pages/spawn/spawnVolume/spawnVolumeTableActions/UnmountButton.tsx
+++ b/apps/spruce/src/pages/spawn/spawnVolume/spawnVolumeTableActions/UnmountButton.tsx
@@ -68,7 +68,7 @@ export const UnmountButton: React.FC<Props> = ({ volume }) => {
           onConfirm={() => {
             spawnAnalytics.sendEvent({
               name: "Changed unmounted volume on host",
-              volumeId: volume.id,
+              "volume.id": volume.id,
             });
             detachVolume({ variables: { volumeId: volume.id } });
           }}

--- a/apps/spruce/src/pages/task/ActionButtons.tsx
+++ b/apps/spruce/src/pages/task/ActionButtons.tsx
@@ -311,7 +311,7 @@ export const ActionButtons: React.FC<Props> = ({
                 taskAnalytics.sendEvent({
                   name: "Clicked restart task button",
                   allTasks: true,
-                  isDisplayTask: true,
+                  "task.is.display_task": true,
                 });
               }}
             >
@@ -324,7 +324,7 @@ export const ActionButtons: React.FC<Props> = ({
                 taskAnalytics.sendEvent({
                   name: "Clicked restart task button",
                   allTasks: false,
-                  isDisplayTask: true,
+                  "task.is.display_task": true,
                 });
               }}
             >
@@ -343,7 +343,7 @@ export const ActionButtons: React.FC<Props> = ({
               restartTask({ variables: { taskId, failedOnly: false } });
               taskAnalytics.sendEvent({
                 name: "Clicked restart task button",
-                isDisplayTask: false,
+                "task.is.display_task": false,
               });
             }}
           >

--- a/apps/spruce/src/pages/task/actionButtons/TaskNotificationModal.tsx
+++ b/apps/spruce/src/pages/task/actionButtons/TaskNotificationModal.tsx
@@ -24,7 +24,11 @@ export const TaskNotificationModal: React.FC<ModalProps> = ({
       // @ts-expect-error: FIXME. This comment was added by an automated script.
       resourceId={taskId}
       sendAnalyticsEvent={(subscription) =>
-        taskAnalytics.sendEvent({ name: "Created notification", subscription })
+        taskAnalytics.sendEvent({
+          name: "Created notification",
+          "subscription.type": subscription.subscriber.type || "",
+          "subscription.trigger": subscription.trigger || "",
+        })
       }
       subscriptionMethods={taskSubscriptionMethods}
       triggers={taskTriggers}

--- a/apps/spruce/src/pages/task/metadata/index.tsx
+++ b/apps/spruce/src/pages/task/metadata/index.tsx
@@ -127,7 +127,7 @@ export const Metadata: React.FC<Props> = ({ error, loading, task, taskId }) => {
           onClick={() =>
             taskAnalytics.sendEvent({
               name: "Clicked metadata link",
-              linkType: "build variant link",
+              "link.type": "build variant link",
             })
           }
         >
@@ -143,7 +143,7 @@ export const Metadata: React.FC<Props> = ({ error, loading, task, taskId }) => {
           onClick={() =>
             taskAnalytics.sendEvent({
               name: "Clicked metadata link",
-              linkType: "project link",
+              "link.type": "project link",
             })
           }
         >
@@ -226,7 +226,7 @@ export const Metadata: React.FC<Props> = ({ error, loading, task, taskId }) => {
             onClick={() =>
               taskAnalytics.sendEvent({
                 name: "Clicked metadata link",
-                linkType: "base commit",
+                "link.type": "base commit",
               })
             }
             to={getTaskRoute(baseTaskId)}
@@ -258,7 +258,7 @@ export const Metadata: React.FC<Props> = ({ error, loading, task, taskId }) => {
             onClick={() =>
               taskAnalytics.sendEvent({
                 name: "Clicked metadata link",
-                linkType: "display task link",
+                "link.type": "display task link",
               })
             }
           >
@@ -274,7 +274,7 @@ export const Metadata: React.FC<Props> = ({ error, loading, task, taskId }) => {
             onClick={() =>
               taskAnalytics.sendEvent({
                 name: "Clicked metadata link",
-                linkType: "distro link",
+                "link.type": "distro link",
               })
             }
             to={getDistroSettingsRoute(distroId)}
@@ -295,7 +295,7 @@ export const Metadata: React.FC<Props> = ({ error, loading, task, taskId }) => {
             onClick={() =>
               taskAnalytics.sendEvent({
                 name: "Clicked metadata link",
-                linkType: "host link",
+                "link.type": "host link",
               })
             }
           >
@@ -312,7 +312,7 @@ export const Metadata: React.FC<Props> = ({ error, loading, task, taskId }) => {
             onClick={() =>
               taskAnalytics.sendEvent({
                 name: "Clicked metadata link",
-                linkType: "pod link",
+                "link.type": "pod link",
               })
             }
           >
@@ -338,7 +338,7 @@ export const Metadata: React.FC<Props> = ({ error, loading, task, taskId }) => {
             onClick={() =>
               taskAnalytics.sendEvent({
                 name: "Clicked metadata link",
-                linkType: "spawn host link",
+                "link.type": "spawn host link",
               })
             }
           >
@@ -355,7 +355,7 @@ export const Metadata: React.FC<Props> = ({ error, loading, task, taskId }) => {
               onClick={() =>
                 taskAnalytics.sendEvent({
                   name: "Clicked metadata link",
-                  linkType: "annotation link",
+                  "link.type": "annotation link",
                 })
               }
             >
@@ -427,7 +427,7 @@ export const Metadata: React.FC<Props> = ({ error, loading, task, taskId }) => {
                 onHideCue();
                 taskAnalytics.sendEvent({
                   name: "Clicked metadata link",
-                  linkType: "honeycomb trace link",
+                  "link.type": "honeycomb trace link",
                 });
               }}
               hideExternalIcon={false}
@@ -447,7 +447,7 @@ export const Metadata: React.FC<Props> = ({ error, loading, task, taskId }) => {
                 onHideCue();
                 taskAnalytics.sendEvent({
                   name: "Clicked metadata link",
-                  linkType: "honeycomb metrics link",
+                  "link.type": "honeycomb metrics link",
                 });
               }}
               hideExternalIcon={false}

--- a/apps/spruce/src/pages/task/taskTabs/ExecutionTasksTable.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/ExecutionTasksTable.tsx
@@ -81,7 +81,7 @@ export const ExecutionTasksTable: React.FC<Props> = ({
     sendAnalyticsEvents: (sorter: SortingState) =>
       sendEvent({
         name: "Sorted execution tasks table",
-        sortBy: sorter.map(({ id }) => id as TaskSortCategory),
+        "sort.by": sorter.map(({ id }) => id as TaskSortCategory),
       }),
   });
 

--- a/apps/spruce/src/pages/task/taskTabs/FileTable/GroupedFileTable/index.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/FileTable/GroupedFileTable/index.tsx
@@ -32,8 +32,8 @@ const columns = (
             onClick={() => {
               taskAnalytics.sendEvent({
                 name: "Clicked task file link",
-                parsleyAvailable: value.row.original.urlParsley !== null,
-                fileName,
+                "parsley.available": value.row.original.urlParsley !== null,
+                "file.name": fileName,
               });
             }}
           >
@@ -50,7 +50,7 @@ const columns = (
                 onClick={() => {
                   taskAnalytics.sendEvent({
                     name: "Clicked task file Parsley link",
-                    fileName,
+                    "file.name": fileName,
                   });
                 }}
               >

--- a/apps/spruce/src/pages/task/taskTabs/Logs.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/Logs.tsx
@@ -58,7 +58,7 @@ export const Logs: React.FC<Props> = ({ execution, logLinks, taskId }) => {
     updateQueryParams({ [QueryParams.LogType]: nextLogType });
     sendEvent({
       name: "Changed log preview type",
-      logType: nextLogType,
+      "log.type": nextLogType,
     });
   };
 
@@ -109,8 +109,8 @@ export const Logs: React.FC<Props> = ({ execution, logLinks, taskId }) => {
                 onClick={() =>
                   sendEvent({
                     name: "Clicked log link",
-                    logType: currentLog,
-                    logViewer: "parsley",
+                    "log.type": currentLog,
+                    "log.viewer": "parsley",
                   })
                 }
               >
@@ -127,8 +127,8 @@ export const Logs: React.FC<Props> = ({ execution, logLinks, taskId }) => {
                 onClick={() =>
                   sendEvent({
                     name: "Clicked log link",
-                    logType: currentLog,
-                    logViewer: "html",
+                    "log.type": currentLog,
+                    "log.viewer": "html",
                   })
                 }
               >
@@ -145,8 +145,8 @@ export const Logs: React.FC<Props> = ({ execution, logLinks, taskId }) => {
                 onClick={() =>
                   sendEvent({
                     name: "Clicked log link",
-                    logType: currentLog,
-                    logViewer: "raw",
+                    "log.type": currentLog,
+                    "log.viewer": "raw",
                   })
                 }
               >

--- a/apps/spruce/src/pages/task/taskTabs/TestsTable.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/TestsTable.tsx
@@ -107,7 +107,7 @@ export const TestsTable: React.FC<TestsTableProps> = ({ task }) => {
     setQueryParams(updatedParams);
     sendEvent({
       name: "Filtered tests table",
-      filterBy: Object.keys(filterState),
+      "filter.by": Object.keys(filterState),
     });
   };
 
@@ -116,7 +116,7 @@ export const TestsTable: React.FC<TestsTableProps> = ({ task }) => {
     sendAnalyticsEvents: (sorter: SortingState) =>
       sendEvent({
         name: "Sorted tests table",
-        sortBy: sorter.map(({ id }) => id as TestSortCategory),
+        "sort.by": sorter.map(({ id }) => id as TestSortCategory),
       }),
   });
 

--- a/apps/spruce/src/pages/task/taskTabs/buildBaronAndAnnotations/AddIssueModal/index.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/buildBaronAndAnnotations/AddIssueModal/index.tsx
@@ -61,7 +61,7 @@ export const AddIssueModal: React.FC<Props> = ({
       closeModal();
       annotationAnalytics.sendEvent({
         name: "Created task annotation",
-        type: isIssue ? "Issue" : "Suspected Issue",
+        "annotation.type": isIssue ? "Issue" : "Suspected Issue",
       });
     },
     onError(error) {

--- a/apps/spruce/src/pages/task/taskTabs/buildBaronAndAnnotations/AnnotationTicketsList/index.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/buildBaronAndAnnotations/AnnotationTicketsList/index.tsx
@@ -80,7 +80,7 @@ const AnnotationTicketsList: React.FC<AnnotationTicketsListProps> = ({
 
     annotationAnalytics.sendEvent({
       name: "Deleted annotation",
-      type: isIssue ? "Issue" : "Suspected Issue",
+      "annotation.type": isIssue ? "Issue" : "Suspected Issue",
     });
   };
 

--- a/apps/spruce/src/pages/task/taskTabs/testsTable/LogsColumn.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/testsTable/LogsColumn.tsx
@@ -39,8 +39,8 @@ export const LogsColumn: React.FC<Props> = ({ task, testResult }) => {
           onClick={() =>
             sendEvent({
               name: "Clicked test log link",
-              logViewer: "parsley",
-              testStatus: status,
+              "log.viewer": "parsley",
+              "test.status": status,
             })
           }
         >
@@ -57,8 +57,8 @@ export const LogsColumn: React.FC<Props> = ({ task, testResult }) => {
           onClick={() =>
             sendEvent({
               name: "Clicked test log link",
-              logViewer: "html",
-              testStatus: status,
+              "log.viewer": "html",
+              "test.status": status,
             })
           }
         >
@@ -75,8 +75,8 @@ export const LogsColumn: React.FC<Props> = ({ task, testResult }) => {
           onClick={() =>
             sendEvent({
               name: "Clicked test log link",
-              logViewer: "raw",
-              testStatus: status,
+              "log.viewer": "raw",
+              "test.status": status,
             })
           }
         >

--- a/apps/spruce/src/pages/taskHistory/TaskHistoryRow/index.tsx
+++ b/apps/spruce/src/pages/taskHistory/TaskHistoryRow/index.tsx
@@ -34,33 +34,33 @@ const TaskHistoryRow: React.FC<Props> = ({ data, index }) => {
         sendEvent({
           name: "Clicked commit label",
           link: "githash",
-          commitType: "active",
+          "commit.type": "active",
         }),
       onClickFoldedGithash: () =>
         sendEvent({
           name: "Clicked commit label",
           link: "githash",
-          commitType: "inactive",
+          "commit.type": "inactive",
         }),
       onClickUpstreamProject: () => {
         sendEvent({
           name: "Clicked commit label",
           link: "upstream project",
-          commitType: "active",
+          "commit.type": "active",
         });
       },
       onClickJiraTicket: () => {
         sendEvent({
           name: "Clicked commit label",
           link: "jira",
-          commitType: "active",
+          "commit.type": "active",
         });
       },
       onClickFoldedJiraTicket: () => {
         sendEvent({
           name: "Clicked commit label",
           link: "jira",
-          commitType: "inactive",
+          "commit.type": "inactive",
         });
       },
       // @ts-expect-error: FIXME. This comment was added by an automated script.
@@ -112,7 +112,7 @@ const generateColumns = (
             onClick={({ taskStatus }) => {
               sendEvent({
                 name: "Clicked task cell",
-                taskStatus,
+                "task.status": taskStatus,
               });
             }}
             inactive={inactive}

--- a/apps/spruce/src/pages/variantHistory/VariantHistoryRow.tsx
+++ b/apps/spruce/src/pages/variantHistory/VariantHistoryRow.tsx
@@ -34,40 +34,40 @@ const VariantHistoryRow: React.FC<Props> = ({ data, index }) => {
         sendEvent({
           name: "Clicked commit label",
           link: "githash",
-          commitType: "active",
+          "commit.type": "active",
         }),
       onClickFoldedGithash: () =>
         sendEvent({
           name: "Clicked commit label",
           link: "githash",
-          commitType: "inactive",
+          "commit.type": "inactive",
         }),
       onClickUpstreamProject: () => {
         sendEvent({
           name: "Clicked commit label",
           link: "upstream project",
-          commitType: "active",
+          "commit.type": "active",
         });
       },
       onClickFoldedUpstreamProject: () => {
         sendEvent({
           name: "Clicked commit label",
           link: "upstream project",
-          commitType: "inactive",
+          "commit.type": "inactive",
         });
       },
       onClickJiraTicket: () => {
         sendEvent({
           name: "Clicked commit label",
           link: "jira",
-          commitType: "active",
+          "commit.type": "active",
         });
       },
       onClickFoldedJiraTicket: () => {
         sendEvent({
           name: "Clicked commit label",
           link: "jira",
-          commitType: "inactive",
+          "commit.type": "inactive",
         });
       },
       // @ts-expect-error: FIXME. This comment was added by an automated script.
@@ -115,7 +115,7 @@ const generateColumns = (
             onClick={({ taskStatus }) => {
               sendEvent({
                 name: "Clicked task cell",
-                taskStatus,
+                "task.status": taskStatus,
               });
             }}
             inactive={inactive}

--- a/apps/spruce/src/pages/version/TaskDuration.tsx
+++ b/apps/spruce/src/pages/version/TaskDuration.tsx
@@ -97,7 +97,7 @@ const TaskDuration: React.FC<Props> = ({ taskCount }) => {
         onPageSizeChange={(l) => {
           versionAnalytics.sendEvent({
             name: "Changed page size",
-            pageSize: l,
+            "page.size": l,
           });
         }}
       />
@@ -121,7 +121,7 @@ const TaskDuration: React.FC<Props> = ({ taskCount }) => {
             onPageSizeChange={(l) => {
               versionAnalytics.sendEvent({
                 name: "Changed page size",
-                pageSize: l,
+                "page.size": l,
               });
             }}
           />

--- a/apps/spruce/src/pages/version/Tasks.tsx
+++ b/apps/spruce/src/pages/version/Tasks.tsx
@@ -100,7 +100,7 @@ export const Tasks: React.FC<Props> = ({ taskCount }) => {
           onPageSizeChange={(l) => {
             versionAnalytics.sendEvent({
               name: "Changed page size",
-              pageSize: l,
+              "page.size": l,
             });
           }}
         />

--- a/apps/spruce/src/pages/version/downstreamTasks/DownstreamTasksTable.tsx
+++ b/apps/spruce/src/pages/version/downstreamTasks/DownstreamTasksTable.tsx
@@ -76,7 +76,7 @@ export const DownstreamTasksTable: React.FC<DownstreamTasksTableProps> = ({
     });
     sendEvent({
       name: "Filtered downstream tasks table",
-      filterBy: Object.keys(filterState),
+      "filter.by": Object.keys(filterState),
     });
   };
 
@@ -88,7 +88,7 @@ export const DownstreamTasksTable: React.FC<DownstreamTasksTableProps> = ({
     dispatch({ type: "setSorts", sorts: updatedSorts });
     sendEvent({
       name: "Sorted downstream tasks table",
-      sortBy: sortingState.map(({ id }) => id as TaskSortCategory),
+      "sort.by": sortingState.map(({ id }) => id as TaskSortCategory),
     });
   };
 

--- a/apps/spruce/src/pages/version/taskDuration/TaskDurationTable.tsx
+++ b/apps/spruce/src/pages/version/taskDuration/TaskDurationTable.tsx
@@ -75,7 +75,7 @@ export const TaskDurationTable: React.FC<Props> = ({
     setQueryParams(updatedParams);
     sendEvent({
       name: "Filtered task duration table",
-      filterBy: Object.keys(filterState),
+      "filter.by": Object.keys(filterState),
     });
   };
 

--- a/apps/spruce/src/pages/version/tasks/PatchTasksTable.tsx
+++ b/apps/spruce/src/pages/version/tasks/PatchTasksTable.tsx
@@ -36,7 +36,7 @@ export const PatchTasksTable: React.FC<Props> = ({
   const filterHookProps = {
     resetPage: true,
     sendAnalyticsEvent: (filterBy: string) =>
-      sendEvent({ name: "Filtered tasks table", filterBy }),
+      sendEvent({ name: "Filtered tasks table", "filter.by": filterBy }),
   };
   const currentStatusesFilter = useStatusesFilter({
     urlParam: PatchTasksQueryParams.Statuses,
@@ -109,7 +109,7 @@ export const PatchTasksTable: React.FC<Props> = ({
       onClickTaskLink={(taskId) =>
         sendEvent({
           name: "Clicked task table task link",
-          taskId,
+          "task.id": taskId,
         })
       }
       onColumnHeaderClick={(sortField) =>

--- a/apps/spruce/src/pages/version/tasks/PatchTasksTable.tsx
+++ b/apps/spruce/src/pages/version/tasks/PatchTasksTable.tsx
@@ -115,7 +115,7 @@ export const PatchTasksTable: React.FC<Props> = ({
       onColumnHeaderClick={(sortField) =>
         sendEvent({
           name: "Sorted tasks table",
-          sortBy: sortField,
+          "sort.by": sortField,
         })
       }
       taskNameInputProps={taskNameInputProps}


### PR DESCRIPTION
DEVPROD-8373

### Description
This PR updates all of the remaining spruce and parsley analytics attributes to utilize dot notation which is recommended/required by OTEL. Also removes the usage of complex structs since those are not supported. 
In a future PR I will introduce strict typescript enforcement of structs so that they are not complex.

Sorry for the large number of files changed the changes are small.

**Have you have updated the analytics documentation if necessary?**  
Yes

### Evergreen PR
<!-- link to a corresponding Evergreen PR if applicable -->
