### PR TITLE
DEVPROD-9691: Consider file deletions when generating CI tasks

### DIFF
--- a/.evergreen/scripts/generate-tasks.js
+++ b/.evergreen/scripts/generate-tasks.js
@@ -74,7 +74,7 @@ const whatChanged = () => {
   const mergeBase = getMergeBase();
   try {
     const diffFiles = execSync(
-      `git diff ${mergeBase} --name-only --diff-filter=d`,
+      `git diff ${mergeBase} --name-only`,
     )
       .toString()
       .trim();


### PR DESCRIPTION
DEVPROD-9691
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? -->

### Description
Stop excluding file deletions when generating CI tasks. The file deletions were being filtered out by the parameter [`--diff-filter=d`](https://git-scm.com/docs/git-diff#Documentation/git-diff.txt---diff-filterACDMRTUXB82308203).

Running the commands, you can see that deletions were being explicitly excluded before:

<img width="758" alt="Screenshot 2024-08-21 at 2 22 15 PM" src="https://github.com/user-attachments/assets/c5b80551-6425-420b-9a62-bdaf1b41a5c4">

### Testing
* [Patch](https://spruce.mongodb.com/version/66c63249ad024100079cab88/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) where deletions were excluded — no tasks generated
* [Patch](https://spruce.mongodb.com/version/66c632bd9e3b5600075f991c/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) where deletions were included — tasks were generated