### PR TITLE
DEVPROD-7659: Support global filter on Event Log page

### DIFF
--- a/apps/spruce/cypress/integration/image/event_log.ts
+++ b/apps/spruce/cypress/integration/image/event_log.ts
@@ -10,7 +10,7 @@ describe("event log page", () => {
     );
   });
 
-  it("should show no events when filtering for a nonexistent item", () => {
+  it("should show no events when filtering by name for a nonexistent item", () => {
     cy.visit("/image/ubuntu2204/event-log");
     cy.dataCy("image-event-log-card").should("have.length", IMAGE_EVENT_LIMIT);
     cy.dataCy("image-event-log-name-filter").first().click();
@@ -20,5 +20,12 @@ describe("event log page", () => {
       .within(() => {
         cy.dataCy("image-event-log-table-row").should("have.length", 0);
       });
+  });
+
+  it("should show no events when global filtering for a nonexistent item", () => {
+    cy.visit("/image/ubuntu2204/event-log");
+    cy.dataCy("image-event-log-card").should("have.length", IMAGE_EVENT_LIMIT);
+    cy.get('input[placeholder="Global search by name"]').type("bogus{enter}");
+    cy.dataCy("image-event-log-table-row").should("have.length", 0);
   });
 });

--- a/apps/spruce/cypress/integration/image/event_log.ts
+++ b/apps/spruce/cypress/integration/image/event_log.ts
@@ -25,7 +25,7 @@ describe("event log page", () => {
   it("should show no events when global filtering for a nonexistent item", () => {
     cy.visit("/image/ubuntu2204/event-log");
     cy.dataCy("image-event-log-card").should("have.length", IMAGE_EVENT_LIMIT);
-    cy.get('input[placeholder="Global search by name"]').type("bogus{enter}");
+    cy.dataCy("event-log-global-search").type("bogus{enter}");
     cy.dataCy("image-event-log-table-row").should("have.length", 0);
   });
 });

--- a/apps/spruce/src/pages/image/ImageEventLog/ImageEventLog.tsx
+++ b/apps/spruce/src/pages/image/ImageEventLog/ImageEventLog.tsx
@@ -1,5 +1,7 @@
+import { useState } from "react";
 import styled from "@emotion/styled";
 import Card from "@leafygreen-ui/card";
+import { SearchInput } from "@leafygreen-ui/search-input";
 import { Subtitle } from "@leafygreen-ui/typography";
 import { LoadingButton } from "components/Buttons";
 import { size } from "constants/tokens";
@@ -20,11 +22,26 @@ export const ImageEventLog: React.FC<ImageEventLogProps> = ({
   handleFetchMore,
   loading,
 }) => {
+  const [globalFilter, setGlobalFilter] = useState("");
+  const handleGlobalFilterChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setGlobalFilter(e.target.value);
+  };
+
   const allEventsFetchedCopy =
     events.length > 0 ? "No more events to show." : "No events to show.";
 
   return (
     <Container>
+      <SearchContainer>
+        <SearchInput
+          aria-labelledby="event-log-global-search"
+          value={globalFilter}
+          onChange={handleGlobalFilterChange}
+          placeholder="Global search by name"
+          data-cy="global-search-input"
+        />
+      </SearchContainer>
+
       {events.map((event) => {
         const { amiAfter, amiBefore, entries, timestamp } = event;
         return (
@@ -37,7 +54,10 @@ export const ImageEventLog: React.FC<ImageEventLogProps> = ({
               amiBefore={amiBefore ?? ""}
               timestamp={timestamp}
             />
-            <ImageEventLogTable entries={entries} />
+            <ImageEventLogTable
+              entries={entries}
+              globalFilterQuery={globalFilter}
+            />
           </ImageEventLogCard>
         );
       })}
@@ -61,6 +81,10 @@ const Container = styled.div`
   flex-direction: column;
   align-items: center;
   gap: ${size.l};
+`;
+
+const SearchContainer = styled.div`
+  align-self: flex-start;
 `;
 
 const ImageEventLogCard = styled(Card)`

--- a/apps/spruce/src/pages/image/ImageEventLog/ImageEventLog.tsx
+++ b/apps/spruce/src/pages/image/ImageEventLog/ImageEventLog.tsx
@@ -22,9 +22,9 @@ export const ImageEventLog: React.FC<ImageEventLogProps> = ({
   handleFetchMore,
   loading,
 }) => {
-  const [globalFilter, setGlobalFilter] = useState("");
-  const handleGlobalFilterChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setGlobalFilter(e.target.value);
+  const [globalSearch, setGlobalSearch] = useState("");
+  const handleGlobalSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setGlobalSearch(e.target.value);
   };
 
   const allEventsFetchedCopy =
@@ -35,10 +35,9 @@ export const ImageEventLog: React.FC<ImageEventLogProps> = ({
       <SearchContainer>
         <SearchInput
           aria-labelledby="event-log-global-search"
-          value={globalFilter}
-          onChange={handleGlobalFilterChange}
+          value={globalSearch}
+          onChange={handleGlobalSearchChange}
           placeholder="Global search by name"
-          data-cy="global-search-input"
         />
       </SearchContainer>
 
@@ -54,10 +53,7 @@ export const ImageEventLog: React.FC<ImageEventLogProps> = ({
               amiBefore={amiBefore ?? ""}
               timestamp={timestamp}
             />
-            <ImageEventLogTable
-              entries={entries}
-              globalFilterQuery={globalFilter}
-            />
+            <ImageEventLogTable entries={entries} globalFilter={globalSearch} />
           </ImageEventLogCard>
         );
       })}

--- a/apps/spruce/src/pages/image/ImageEventLog/ImageEventLog.tsx
+++ b/apps/spruce/src/pages/image/ImageEventLog/ImageEventLog.tsx
@@ -81,6 +81,7 @@ const Container = styled.div`
 
 const SearchContainer = styled.div`
   align-self: flex-start;
+  width: 421px;
 `;
 
 const ImageEventLogCard = styled(Card)`

--- a/apps/spruce/src/pages/image/ImageEventLog/ImageEventLog.tsx
+++ b/apps/spruce/src/pages/image/ImageEventLog/ImageEventLog.tsx
@@ -41,7 +41,6 @@ export const ImageEventLog: React.FC<ImageEventLogProps> = ({
           data-cy="event-log-global-search"
         />
       </SearchContainer>
-
       {events.map((event) => {
         const { amiAfter, amiBefore, entries, timestamp } = event;
         return (

--- a/apps/spruce/src/pages/image/ImageEventLog/ImageEventLog.tsx
+++ b/apps/spruce/src/pages/image/ImageEventLog/ImageEventLog.tsx
@@ -38,6 +38,7 @@ export const ImageEventLog: React.FC<ImageEventLogProps> = ({
           value={globalSearch}
           onChange={handleGlobalSearchChange}
           placeholder="Global search by name"
+          data-cy="event-log-global-search"
         />
       </SearchContainer>
 
@@ -81,7 +82,7 @@ const Container = styled.div`
 
 const SearchContainer = styled.div`
   align-self: flex-start;
-  width: 421px;
+  width: 420px;
 `;
 
 const ImageEventLogCard = styled(Card)`

--- a/apps/spruce/src/pages/image/ImageEventLog/ImageEventLogTable.tsx
+++ b/apps/spruce/src/pages/image/ImageEventLog/ImageEventLogTable.tsx
@@ -56,10 +56,12 @@ const imageEventTypeTreeData = [
 
 interface ImageEventLogTableProps {
   entries: ImageEventEntry[];
+  globalFilterQuery: string;
 }
 
 export const ImageEventLogTable: React.FC<ImageEventLogTableProps> = ({
   entries,
+  globalFilterQuery,
 }) => {
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
   const tableContainerRef = useRef<HTMLDivElement>(null);
@@ -73,9 +75,12 @@ export const ImageEventLogTable: React.FC<ImageEventLogTableProps> = ({
     onColumnFiltersChange: setColumnFilters,
     state: {
       columnFilters,
+      globalFilter: globalFilterQuery,
     },
     getFilteredRowModel: getFilteredRowModel(),
     getFacetedUniqueValues: getFacetedUniqueValues(),
+    enableGlobalFilter: true,
+    globalFilterFn: filterFns.includesString,
   });
 
   const hasFilters = columnFilters.length > 0;

--- a/apps/spruce/src/pages/image/ImageEventLog/ImageEventLogTable.tsx
+++ b/apps/spruce/src/pages/image/ImageEventLog/ImageEventLogTable.tsx
@@ -56,12 +56,12 @@ const imageEventTypeTreeData = [
 
 interface ImageEventLogTableProps {
   entries: ImageEventEntry[];
-  globalFilterQuery: string;
+  globalFilter: string;
 }
 
 export const ImageEventLogTable: React.FC<ImageEventLogTableProps> = ({
   entries,
-  globalFilterQuery,
+  globalFilter,
 }) => {
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
   const tableContainerRef = useRef<HTMLDivElement>(null);
@@ -75,7 +75,7 @@ export const ImageEventLogTable: React.FC<ImageEventLogTableProps> = ({
     onColumnFiltersChange: setColumnFilters,
     state: {
       columnFilters,
-      globalFilter: globalFilterQuery,
+      globalFilter,
     },
     getFilteredRowModel: getFilteredRowModel(),
     getFacetedUniqueValues: getFacetedUniqueValues(),

--- a/apps/spruce/src/pages/image/ImageEventLog/ImageEventLogTable.tsx
+++ b/apps/spruce/src/pages/image/ImageEventLog/ImageEventLogTable.tsx
@@ -83,7 +83,7 @@ export const ImageEventLogTable: React.FC<ImageEventLogTableProps> = ({
     globalFilterFn: filterFns.includesString,
   });
 
-  const hasFilters = columnFilters.length > 0;
+  const hasFilters = columnFilters.length > 0 || globalFilter;
 
   const emptyMessage = hasFilters
     ? "No data to display"

--- a/apps/spruce/src/pages/image/tabs/EventLogTab/EventLogTab.test.tsx
+++ b/apps/spruce/src/pages/image/tabs/EventLogTab/EventLogTab.test.tsx
@@ -380,6 +380,48 @@ describe("image event log page", async () => {
       expect(rows).toHaveLength(3);
     });
   });
+
+  it("supports global filter for existing entries", async () => {
+    const user = userEvent.setup();
+    const { Component } = RenderFakeToastContext(
+      <EventLogTab imageId="ubuntu2204" />,
+    );
+    render(<Component />, { wrapper });
+    await waitFor(() => {
+      expect(screen.queryAllByDataCy("image-event-log-card")).toHaveLength(5);
+    });
+    const searchBar = screen.getByPlaceholderText("Global search by name");
+
+    // Filter for golang.
+    await user.type(searchBar, "golang{enter}");
+    expect(searchBar).toHaveValue("golang");
+    await waitFor(() => {
+      expect(screen.queryAllByDataCy("image-event-log-table-row")).toHaveLength(
+        1,
+      );
+    });
+  });
+
+  it("supports global filter for non-existent entries", async () => {
+    const user = userEvent.setup();
+    const { Component } = RenderFakeToastContext(
+      <EventLogTab imageId="ubuntu2204" />,
+    );
+    render(<Component />, { wrapper });
+    await waitFor(() => {
+      expect(screen.queryAllByDataCy("image-event-log-card")).toHaveLength(5);
+    });
+    const searchBar = screen.getByPlaceholderText("Global search by name");
+
+    // Filter for non-existent entry.
+    await user.type(searchBar, "blahblah{enter}");
+    expect(searchBar).toHaveValue("blahblah");
+    await waitFor(() => {
+      expect(screen.queryAllByDataCy("image-event-log-table-row")).toHaveLength(
+        0,
+      );
+    });
+  });
 });
 
 const imageEventsMock: ApolloMock<ImageEventsQuery, ImageEventsQueryVariables> =

--- a/apps/spruce/src/pages/image/tabs/EventLogTab/EventLogTab.test.tsx
+++ b/apps/spruce/src/pages/image/tabs/EventLogTab/EventLogTab.test.tsx
@@ -113,8 +113,12 @@ describe("image event log page", async () => {
       within(cards[0]).queryByDataCy("image-event-log-empty-message"),
     ).toBeNull();
 
+    expect(
+      within(cards[1]).queryByDataCy("image-event-log-empty-message"),
+    ).toBeNull();
+
     // Expects cards to contain the empty message.
-    for (let i = 1; i <= 4; i++) {
+    for (let i = 2; i <= 4; i++) {
       const emptyMessageElement = within(cards[i]).getByDataCy(
         "image-event-log-empty-message",
       );
@@ -397,7 +401,7 @@ describe("image event log page", async () => {
     expect(searchBar).toHaveValue("golang");
     await waitFor(() => {
       expect(screen.queryAllByDataCy("image-event-log-table-row")).toHaveLength(
-        1,
+        2,
       );
     });
   });
@@ -479,7 +483,16 @@ const imageEventsMock: ApolloMock<ImageEventsQuery, ImageEventsQueryVariables> =
                 __typename: "ImageEvent",
                 amiAfter: "ami-03e245926032896f9",
                 amiBefore: "ami-03e24592603281234",
-                entries: [],
+                entries: [
+                  {
+                    __typename: "ImageEventEntry",
+                    type: ImageEventType.Toolchain,
+                    name: "golang",
+                    before: "go1.20.14",
+                    after: "",
+                    action: ImageEventEntryAction.Deleted,
+                  },
+                ],
                 timestamp: new Date("2023-08-07T17:57:00-04:00"),
               },
               {


### PR DESCRIPTION
DEVPROD-7659
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? -->

### Description
<!-- add description, context, thought process, etc -->
Add a search bar at the top of the Event Log page as a global filter. The global filter can be applied on the client side (LeafyGreen table should have built-in fields to support it).

### Screenshots
<!-- add screenshots of visible changes -->
![GlobalSearch](https://github.com/user-attachments/assets/c3dd5e15-3ac2-4c70-a2a3-82963a9f8d30)

### Testing
<!-- add a description of how you tested it -->
Added Jest and Cypress tests. 

<!-- Have you have updated the analytics documentation if necessary?  
https://docs.google.com/spreadsheets/d/1s4_nq8ZiphXp5Uq_-9HT6GPqz-KOyaq6HuvmXYaSNzg/edit?usp=sharing -->
