### PR TITLE
DEVPROD-7394: Fix styles for long filter expressions

### DIFF
--- a/apps/parsley/src/components/Accordion/__snapshots__/Accordion_Default.storyshot
+++ b/apps/parsley/src/components/Accordion/__snapshots__/Accordion_Default.storyshot
@@ -1,27 +1,38 @@
 <div>
   <div>
     <div
-      class="css-16i4gmg-AccordionToggle e1bamyem4"
+      class="css-vntv7t-AccordionToggle e1bamyem4"
       data-cy="accordion-toggle"
       role="button"
     >
-      <svg
-        aria-label="Chevron Right Icon"
-        class="leafygreen-ui-jc2z8v css-lltsma-AccordionIcon e1bamyem3"
-        fill="none"
-        height="14"
-        role="img"
-        viewBox="0 0 16 16"
-        width="14"
-        xmlns="http://www.w3.org/2000/svg"
+      <button
+        aria-disabled="false"
+        aria-labelledby="Expand or collapse filter"
+        class="css-lltsma-AccordionIcon e1bamyem3 leafygreen-ui-tcjr3n"
+        tabindex="0"
       >
-        <path
-          clip-rule="evenodd"
-          d="M5.364 14.364a1 1 0 0 0 1.414 0l4.95-4.95.707-.707a1 1 0 0 0 0-1.414l-.707-.707-4.95-4.95a1 1 0 0 0-1.414 0l-.707.707a1 1 0 0 0 0 1.414L8.899 8l-4.242 4.243a1 1 0 0 0 0 1.414l.707.707Z"
-          fill="currentColor"
-          fill-rule="evenodd"
-        />
-      </svg>
+        <div
+          class="leafygreen-ui-xhlipt"
+        >
+          <svg
+            aria-label="Chevron Right Icon"
+            class="leafygreen-ui-jc2z8v"
+            fill="none"
+            height="16"
+            role="img"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              clip-rule="evenodd"
+              d="M5.364 14.364a1 1 0 0 0 1.414 0l4.95-4.95.707-.707a1 1 0 0 0 0-1.414l-.707-.707-4.95-4.95a1 1 0 0 0-1.414 0l-.707.707a1 1 0 0 0 0 1.414L8.899 8l-4.242 4.243a1 1 0 0 0 0 1.414l.707.707Z"
+              fill="currentColor"
+              fill-rule="evenodd"
+            />
+          </svg>
+        </div>
+      </button>
       <span>
         Accordion
       </span>

--- a/apps/parsley/src/components/Accordion/index.tsx
+++ b/apps/parsley/src/components/Accordion/index.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import styled from "@emotion/styled";
 import Icon from "@leafygreen-ui/icon";
+import IconButton from "@leafygreen-ui/icon-button";
 import { palette } from "@leafygreen-ui/palette";
 import { size } from "constants/tokens";
 
@@ -68,11 +69,11 @@ const Accordion: React.FC<AccordionProps> = ({
         role="button"
       >
         <AccordionIcon
-          fill={gray.dark1}
-          glyph="ChevronRight"
+          aria-labelledby="Expand or collapse filter"
           open={accordionOpen}
-          size="small"
-        />
+        >
+          <Icon fill={gray.dark1} glyph="ChevronRight" />
+        </AccordionIcon>
         {titleComp}
       </AccordionToggle>
       {subtitle && <SubtitleContainer>{subtitle}</SubtitleContainer>}
@@ -90,16 +91,15 @@ const Accordion: React.FC<AccordionProps> = ({
 
 const AccordionToggle = styled.div`
   display: flex;
-  align-items: center;
   gap: 2px;
   :hover {
     cursor: pointer;
   }
 `;
 
-const AccordionIcon = styled(Icon)<{ open: boolean }>`
+const AccordionIcon = styled(IconButton)<{ open: boolean }>`
   flex-shrink: 0;
-  transform: ${({ open }): string => (open ? "rotate(90deg)" : "unset")};
+  transform: ${({ open }) => (open ? "rotate(90deg)" : "unset")};
   transition-property: transform;
   transition-duration: 150ms;
 `;

--- a/apps/parsley/src/components/SidePanel/NavGroup/FilterNavGroup/FilterGroup/__snapshots__/FilterGroup_Default.storyshot
+++ b/apps/parsley/src/components/SidePanel/NavGroup/FilterNavGroup/FilterGroup/__snapshots__/FilterGroup_Default.storyshot
@@ -1,39 +1,51 @@
 <div>
   <div>
     <div
-      class="css-16i4gmg-AccordionToggle e1bamyem4"
+      class="css-vntv7t-AccordionToggle e1bamyem4"
       data-cy="accordion-toggle"
       role="button"
     >
-      <svg
-        aria-label="Chevron Right Icon"
-        class="leafygreen-ui-jc2z8v css-7x45r8-AccordionIcon e1bamyem3"
-        fill="none"
-        height="14"
+      <button
+        aria-disabled="false"
+        aria-labelledby="Expand or collapse filter"
+        class="css-7x45r8-AccordionIcon e1bamyem3 leafygreen-ui-tcjr3n"
         open=""
-        role="img"
-        viewBox="0 0 16 16"
-        width="14"
-        xmlns="http://www.w3.org/2000/svg"
+        tabindex="0"
       >
-        <path
-          clip-rule="evenodd"
-          d="M5.364 14.364a1 1 0 0 0 1.414 0l4.95-4.95.707-.707a1 1 0 0 0 0-1.414l-.707-.707-4.95-4.95a1 1 0 0 0-1.414 0l-.707.707a1 1 0 0 0 0 1.414L8.899 8l-4.242 4.243a1 1 0 0 0 0 1.414l.707.707Z"
-          fill="currentColor"
-          fill-rule="evenodd"
-        />
-      </svg>
+        <div
+          class="leafygreen-ui-xhlipt"
+        >
+          <svg
+            aria-label="Chevron Right Icon"
+            class="leafygreen-ui-jc2z8v"
+            fill="none"
+            height="16"
+            role="img"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              clip-rule="evenodd"
+              d="M5.364 14.364a1 1 0 0 0 1.414 0l4.95-4.95.707-.707a1 1 0 0 0 0-1.414l-.707-.707-4.95-4.95a1 1 0 0 0-1.414 0l-.707.707a1 1 0 0 0 0 1.414L8.899 8l-4.242 4.243a1 1 0 0 0 0 1.414l.707.707Z"
+              fill="currentColor"
+              fill-rule="evenodd"
+            />
+          </svg>
+        </div>
+      </button>
       <div
-        class="css-1kr6vj4-AccordionTitle e12rc5wm5"
+        class="css-ze06g-AccordionTitle e12rc5wm6"
       >
         <p
-          class="leafygreen-ui-1miy0xp"
+          aria-expanded="true"
+          class="css-1foaoyi-FilterExpression e12rc5wm4 leafygreen-ui-1tb6tuo"
           id=":r0:"
         >
           Some Filter Expression
         </p>
         <div
-          class="css-1sof2u0-IconButtonContainer e12rc5wm3"
+          class="css-1yy8s1m-IconButtonContainer e12rc5wm3"
         >
           <button
             aria-checked="true"
@@ -118,7 +130,7 @@
         class="css-1nylm8s-ContentsContainer e1bamyem1"
       >
         <div
-          class="css-2ra843-AccordionContent e12rc5wm4"
+          class="css-2ra843-AccordionContent e12rc5wm5"
         >
           <div
             class="leafygreen-ui-ozfao7 css-7tm8v2-StyledSegmentedControl e12rc5wm0"

--- a/apps/parsley/src/components/SidePanel/NavGroup/FilterNavGroup/FilterGroup/index.tsx
+++ b/apps/parsley/src/components/SidePanel/NavGroup/FilterNavGroup/FilterGroup/index.tsx
@@ -9,7 +9,7 @@ import {
 } from "@leafygreen-ui/segmented-control";
 import TextInput from "@leafygreen-ui/text-input";
 import Toggle from "@leafygreen-ui/toggle";
-import { Body, Error } from "@leafygreen-ui/typography";
+import { Body, BodyProps, Error } from "@leafygreen-ui/typography";
 import { useLogWindowAnalytics } from "analytics";
 import Accordion from "components/Accordion";
 import Icon from "components/Icon";
@@ -88,9 +88,13 @@ const FilterGroup: React.FC<FilterGroupProps> = ({
               <Error>{validationMessage}</Error>
             </IconWithTooltip>
           )}
-          <Body id={id} weight="medium">
+          <FilterExpression
+            aria-expanded={openAccordion}
+            expanded={openAccordion}
+            id={id}
+          >
             {expression}
-          </Body>
+          </FilterExpression>
           <IconButtonContainer>
             <Toggle
               aria-label={visible ? "Hide filter" : "Show filter"}
@@ -212,7 +216,7 @@ const FilterGroup: React.FC<FilterGroupProps> = ({
 
 const AccordionTitle = styled.div`
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   gap: ${size.xxs};
   overflow: hidden;
 `;
@@ -224,9 +228,18 @@ const AccordionContent = styled.div`
   padding-right: ${size.xxs};
 `;
 
+const FilterExpression = styled(Body)<{ expanded: boolean } & BodyProps>`
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: ${({ expanded }) => (expanded ? "unset" : 1)};
+  overflow: hidden;
+  font-weight: medium;
+  margin-top: ${size.xxs};
+`;
+
 const IconButtonContainer = styled.div`
-  position: absolute;
-  right: 0;
+  display: flex;
+  align-items: center;
 `;
 
 const StyledTextInput = styled(TextInput)`

--- a/apps/parsley/src/components/SidePanel/__snapshots__/SidePanel_Default.storyshot
+++ b/apps/parsley/src/components/SidePanel/__snapshots__/SidePanel_Default.storyshot
@@ -95,39 +95,51 @@
                     >
                       <div>
                         <div
-                          class="css-16i4gmg-AccordionToggle e1bamyem4"
+                          class="css-vntv7t-AccordionToggle e1bamyem4"
                           data-cy="accordion-toggle"
                           role="button"
                         >
-                          <svg
-                            aria-label="Chevron Right Icon"
-                            class="leafygreen-ui-jc2z8v css-7x45r8-AccordionIcon e1bamyem3"
-                            fill="none"
-                            height="14"
+                          <button
+                            aria-disabled="false"
+                            aria-labelledby="Expand or collapse filter"
+                            class="css-7x45r8-AccordionIcon e1bamyem3 leafygreen-ui-tcjr3n"
                             open=""
-                            role="img"
-                            viewBox="0 0 16 16"
-                            width="14"
-                            xmlns="http://www.w3.org/2000/svg"
+                            tabindex="0"
                           >
-                            <path
-                              clip-rule="evenodd"
-                              d="M5.364 14.364a1 1 0 0 0 1.414 0l4.95-4.95.707-.707a1 1 0 0 0 0-1.414l-.707-.707-4.95-4.95a1 1 0 0 0-1.414 0l-.707.707a1 1 0 0 0 0 1.414L8.899 8l-4.242 4.243a1 1 0 0 0 0 1.414l.707.707Z"
-                              fill="currentColor"
-                              fill-rule="evenodd"
-                            />
-                          </svg>
+                            <div
+                              class="leafygreen-ui-xhlipt"
+                            >
+                              <svg
+                                aria-label="Chevron Right Icon"
+                                class="leafygreen-ui-jc2z8v"
+                                fill="none"
+                                height="16"
+                                role="img"
+                                viewBox="0 0 16 16"
+                                width="16"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M5.364 14.364a1 1 0 0 0 1.414 0l4.95-4.95.707-.707a1 1 0 0 0 0-1.414l-.707-.707-4.95-4.95a1 1 0 0 0-1.414 0l-.707.707a1 1 0 0 0 0 1.414L8.899 8l-4.242 4.243a1 1 0 0 0 0 1.414l.707.707Z"
+                                  fill="currentColor"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </div>
+                          </button>
                           <div
-                            class="css-1kr6vj4-AccordionTitle e12rc5wm5"
+                            class="css-ze06g-AccordionTitle e12rc5wm6"
                           >
                             <p
-                              class="leafygreen-ui-1miy0xp"
+                              aria-expanded="true"
+                              class="css-1foaoyi-FilterExpression e12rc5wm4 leafygreen-ui-1tb6tuo"
                               id=":r1:"
                             >
                               active filter
                             </p>
                             <div
-                              class="css-1sof2u0-IconButtonContainer e12rc5wm3"
+                              class="css-1yy8s1m-IconButtonContainer e12rc5wm3"
                             >
                               <button
                                 aria-checked="true"
@@ -212,7 +224,7 @@
                             class="css-1nylm8s-ContentsContainer e1bamyem1"
                           >
                             <div
-                              class="css-2ra843-AccordionContent e12rc5wm4"
+                              class="css-2ra843-AccordionContent e12rc5wm5"
                             >
                               <div
                                 class="leafygreen-ui-ozfao7 css-7tm8v2-StyledSegmentedControl e12rc5wm0"


### PR DESCRIPTION
DEVPROD-7394
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? -->

### Description
Fix filter styles where the formatting is messed up. It looks like this right now on production:

<img width="282" alt="Screenshot 2024-08-22 at 1 20 50 PM" src="https://github.com/user-attachments/assets/1f7da9b7-1378-4d69-9978-443fde77e946">

### Screenshots
(After consulting with Will on the design.)

https://github.com/user-attachments/assets/bc81a7f0-0933-4901-85b4-8ac086b5447d
