### PR TITLE
DEVPROD-7661: Add links to image pages on Distro Settings page

### DIFF
--- a/apps/spruce/cypress/integration/distroSettings/navigation.ts
+++ b/apps/spruce/cypress/integration/distroSettings/navigation.ts
@@ -14,11 +14,28 @@ describe("distroSettings/navigation", () => {
       cy.location("pathname").should("not.contain", "localhost");
       cy.location("pathname").should("contain", "rhel71-power8-large");
     });
-    it("navigates to the task queue for the selected distro", () => {
+
+    it("can navigate to the task queue for the selected distro", () => {
       cy.dataCy("navitem-task-queue-link").should(
         "have.attr",
         "href",
         "/task-queue/localhost",
+      );
+    });
+
+    it("can navigate to the image build information for the selected distro", () => {
+      cy.dataCy("navitem-image-build-information-link").should(
+        "have.attr",
+        "href",
+        "/image/ubuntu2204/build-information",
+      );
+    });
+
+    it("can navigate to the image event log for the selected distro", () => {
+      cy.dataCy("navitem-image-event-log-link").should(
+        "have.attr",
+        "href",
+        "/image/ubuntu2204/event-log",
       );
     });
 

--- a/apps/spruce/src/pages/distroSettings/index.tsx
+++ b/apps/spruce/src/pages/distroSettings/index.tsx
@@ -10,10 +10,13 @@ import {
   PageWrapper,
 } from "components/styles";
 import { SideNavItemLink } from "components/styles/SideNav";
+import { showImageVisibilityPage } from "constants/featureFlags";
 import {
   DistroSettingsTabRoutes,
   getDistroSettingsRoute,
+  getImageRoute,
   getTaskQueueRoute,
+  ImageTabRoutes,
   slugs,
 } from "constants/routes";
 import { size } from "constants/tokens";
@@ -89,6 +92,28 @@ const DistroSettings: React.FC = () => {
           >
             Task Queue
           </SideNavItemLink>
+          {showImageVisibilityPage && (
+            <SideNavItemLink
+              to={getImageRoute(
+                data?.distro?.imageId ?? "",
+                ImageTabRoutes.BuildInformation,
+              )}
+              data-cy="navitem-image-build-information-link"
+            >
+              Image Build Information
+            </SideNavItemLink>
+          )}
+          {showImageVisibilityPage && (
+            <SideNavItemLink
+              to={getImageRoute(
+                data?.distro?.imageId ?? "",
+                ImageTabRoutes.EventLog,
+              )}
+              data-cy="navitem-image-event-log-link"
+            >
+              Image Event Log
+            </SideNavItemLink>
+          )}
         </SideNavGroup>
       </SideNav>
       <PageWrapper data-cy="distro-settings-page">


### PR DESCRIPTION
DEVPROD-7661
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? -->

### Description
<!-- add description, context, thought process, etc -->
Show links to image pages on distro pages (hidden on production).

### Screenshots
<img width="945" alt="Screenshot 2024-08-23 at 3 55 44 PM" src="https://github.com/user-attachments/assets/0c7dd381-9bd2-4899-b6f5-7fdbd9e01947">

### Testing
- Cypress tests
