### PR TITLE
DEVPROD-7054: Omit changes tab for GitHub merge queue patches

### DIFF
--- a/apps/spruce/src/components/CodeChanges/index.tsx
+++ b/apps/spruce/src/components/CodeChanges/index.tsx
@@ -1,13 +1,7 @@
 import { useQuery } from "@apollo/client";
 import styled from "@emotion/styled";
 import Button from "@leafygreen-ui/button";
-import {
-  Body,
-  BodyProps,
-  Description,
-  Subtitle,
-  SubtitleProps,
-} from "@leafygreen-ui/typography";
+import { Body, BodyProps, Description } from "@leafygreen-ui/typography";
 import { Skeleton } from "antd";
 import { CodeChangesBadge } from "components/CodeChangesBadge";
 import { CodeChangesTable } from "components/CodeChangesTable";
@@ -45,7 +39,8 @@ export const CodeChanges: React.FC<CodeChangesProps> = ({ patchId }) => {
   if (!moduleCodeChanges.length) {
     return (
       <Title className="cy-no-code-changes">
-        Code changes do not exist, or are too large to display.
+        No code changes were applied, or the code changes are too large to
+        display.
       </Title>
     );
   }
@@ -126,9 +121,9 @@ const StyledButton = styled(Button)`
   margin-right: ${size.xs};
 `;
 
-const Title = styled(Subtitle)<SubtitleProps>`
-  font-weight: normal;
+const Title = styled(Body)<BodyProps>`
   margin-right: ${size.s};
+  margin-left: ${size.s};
   margin-bottom: ${size.s};
 `;
 

--- a/apps/spruce/src/pages/Version.tsx
+++ b/apps/spruce/src/pages/Version.tsx
@@ -160,7 +160,6 @@ export const VersionPage: React.FC = () => {
   } = version || {};
   const {
     canEnqueueToCommitQueue,
-    childPatches,
     commitQueuePosition = null,
     patchNumber,
   } = patch || {};
@@ -229,11 +228,8 @@ export const VersionPage: React.FC = () => {
         <PageLayout>
           <PageContent>
             <VersionTabs
-              childPatches={childPatches}
               // @ts-expect-error: FIXME. This comment was added by an automated script.
-              isPatch={version?.isPatch}
-              // @ts-expect-error: FIXME. This comment was added by an automated script.
-              taskCount={version?.taskCount}
+              version={version}
             />
           </PageContent>
         </PageLayout>


### PR DESCRIPTION
DEVPROD-7054
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? -->

### Description
Apparently the GitHub merge queue API is not capable of returning the changes included in the patches, so there will never be any changes to show. This PR makes it so that we don't show the changes tab for GitHub merge queue patches.

### Screenshots
<!-- add screenshots of visible changes -->
<img width="624" alt="Screenshot 2024-08-28 at 4 40 20 PM" src="https://github.com/user-attachments/assets/a0a3a9d1-ef9b-4881-bfb0-830c03667a68">
