### PR TITLE
DEVPROD-10353 Update metadata panels on spruce to use new bold label design

### DIFF
--- a/apps/spruce/src/pages/configurePatch/configurePatchCore/__snapshots__/ConfigurePatchCore_ConfigureTasksDefault.storyshot
+++ b/apps/spruce/src/pages/configurePatch/configurePatchCore/__snapshots__/ConfigurePatchCore_ConfigureTasksDefault.storyshot
@@ -95,19 +95,33 @@
           <p
             class="css-1spnncu-Item-wordBreakCss e1ul56zb1 leafygreen-ui-1tb6tuo"
           >
-            Submitted by: 
+            <b
+              class="css-1xk67r-MetadataLabel e1ul56zb0"
+            >
+              Submitted by:
+            </b>
+             
             mohamed.khelif
           </p>
           <p
             class="css-1spnncu-Item-wordBreakCss e1ul56zb1 leafygreen-ui-1tb6tuo"
           >
-            Submitted at: 
+            <b
+              class="css-1xk67r-MetadataLabel e1ul56zb0"
+            >
+              Submitted at:
+            </b>
+             
             2020-08-28T15:00:17Z
           </p>
           <p
             class="css-1spnncu-Item-wordBreakCss e1ul56zb1 leafygreen-ui-1tb6tuo"
           >
-            Project:
+            <b
+              class="css-1xk67r-MetadataLabel e1ul56zb0"
+            >
+              Project:
+            </b>
              
             <a
               class="lg-ui-0001 css-1gw3cuq-StyledLink leafygreen-ui-sv8tvj"

--- a/apps/spruce/src/pages/configurePatch/configurePatchCore/index.tsx
+++ b/apps/spruce/src/pages/configurePatch/configurePatchCore/index.tsx
@@ -10,6 +10,7 @@ import { CodeChanges } from "components/CodeChanges";
 import {
   MetadataCard,
   MetadataItem,
+  MetadataLabel,
   MetadataTitle,
 } from "components/MetadataCard";
 import {
@@ -188,14 +189,16 @@ const ConfigurePatchCore: React.FC<ConfigurePatchCoreProps> = ({ patch }) => {
       </FlexRow>
       <PageLayout hasSider>
         <PageSider>
-          {/* @ts-expect-error: FIXME. This comment was added by an automated script. */}
-          <MetadataCard error={null}>
+          <MetadataCard>
             <MetadataTitle>Patch Metadata</MetadataTitle>
-            <MetadataItem>Submitted by: {author}</MetadataItem>
-            {/* @ts-expect-error: FIXME. This comment was added by an automated script. */}
-            <MetadataItem>Submitted at: {time.submittedAt}</MetadataItem>
             <MetadataItem>
-              Project:{" "}
+              <MetadataLabel>Submitted by:</MetadataLabel> {author}
+            </MetadataItem>
+            <MetadataItem>
+              <MetadataLabel>Submitted at:</MetadataLabel> {time?.submittedAt}
+            </MetadataItem>
+            <MetadataItem>
+              <MetadataLabel>Project:</MetadataLabel>{" "}
               <StyledRouterLink to={getProjectPatchesRoute(projectIdentifier)}>
                 {projectIdentifier}
               </StyledRouterLink>

--- a/apps/spruce/src/pages/container/Metadata/index.tsx
+++ b/apps/spruce/src/pages/container/Metadata/index.tsx
@@ -3,6 +3,7 @@ import { InlineCode } from "@leafygreen-ui/typography";
 import {
   MetadataCard,
   MetadataItem,
+  MetadataLabel,
   MetadataTitle,
 } from "components/MetadataCard";
 import { StyledRouterLink, WordBreak } from "components/styles";
@@ -33,19 +34,30 @@ const Metadata: React.FC<{
       <MetadataTitle>Container Details</MetadataTitle>
       {runningTaskId !== "" && (
         <MetadataItem>
-          Running Task:{" "}
+          <MetadataLabel>Running Task:</MetadataLabel>{" "}
           <StyledRouterLink to={taskLink}>
             <WordBreak all>{runningTaskDisplayName}</WordBreak>
           </StyledRouterLink>
         </MetadataItem>
       )}
-      <MetadataItem>Container Type: {type}</MetadataItem>
-      <MetadataItem>CPU: {cpu}</MetadataItem>
-      <MetadataItem>Memory: {memoryMB} MB</MetadataItem>
-      <MetadataItem>Operating System: {os}</MetadataItem>
-      <MetadataItem>CPU Architecture: {arch}</MetadataItem>
       <MetadataItem>
-        Working Directory: <InlineCode>{workingDir}</InlineCode>
+        <MetadataLabel>Container Type:</MetadataLabel> {type}
+      </MetadataItem>
+      <MetadataItem>
+        <MetadataLabel>CPU:</MetadataLabel> {cpu}
+      </MetadataItem>
+      <MetadataItem>
+        <MetadataLabel>Memory:</MetadataLabel> {memoryMB} MB
+      </MetadataItem>
+      <MetadataItem>
+        <MetadataLabel>Operating System:</MetadataLabel> {os}
+      </MetadataItem>
+      <MetadataItem>
+        <MetadataLabel>CPU Architecture:</MetadataLabel> {arch}
+      </MetadataItem>
+      <MetadataItem>
+        <MetadataLabel>Working Directory:</MetadataLabel>{" "}
+        <InlineCode>{workingDir}</InlineCode>
       </MetadataItem>
     </MetadataCard>
   );

--- a/apps/spruce/src/pages/host/Metadata.tsx
+++ b/apps/spruce/src/pages/host/Metadata.tsx
@@ -5,6 +5,7 @@ import { formatDistanceToNow } from "date-fns";
 import {
   MetadataCard,
   MetadataItem,
+  MetadataLabel,
   MetadataTitle,
 } from "components/MetadataCard";
 import { StyledLink, WordBreak } from "components/styles";
@@ -42,33 +43,51 @@ export const Metadata: React.FC<{
   return (
     <MetadataCard error={error} loading={loading}>
       <MetadataTitle>Host Details</MetadataTitle>
-      <MetadataItem>User: {user}</MetadataItem>
-      {hostUrl && <MetadataItem>Host Name: {hostUrl}</MetadataItem>}
+      <MetadataItem>
+        <MetadataLabel>User:</MetadataLabel> {user}
+      </MetadataItem>
+      {hostUrl && (
+        <MetadataItem>
+          <MetadataLabel>Host Name:</MetadataLabel> {hostUrl}
+        </MetadataItem>
+      )}
       {persistentDnsName && (
-        <MetadataItem>Persistent DNS Name: {persistentDnsName}</MetadataItem>
+        <MetadataItem>
+          <MetadataLabel>Persistent DNS Name:</MetadataLabel>{" "}
+          {persistentDnsName}
+        </MetadataItem>
       )}
       {lastCommunicationTime && (
         <MetadataItem data-cy="host-last-communication">
-          Last Communication:{" "}
+          <MetadataLabel>Last Communication:</MetadataLabel>{" "}
           {formatDistanceToNow(new Date(lastCommunicationTime))} ago
         </MetadataItem>
       )}
       <MetadataItem>
+        <MetadataLabel>Uptime:</MetadataLabel>{" "}
         {/* @ts-expect-error: FIXME. This comment was added by an automated script. */}
-        Uptime: {formatDistanceToNow(new Date(uptime))}
+        {formatDistanceToNow(new Date(uptime))}
       </MetadataItem>
-      <MetadataItem>Started By: {startedBy}</MetadataItem>
-      <MetadataItem>Cloud Provider: {provider}</MetadataItem>
-      {ami && <MetadataItem>AMI: {ami}</MetadataItem>}
       <MetadataItem>
-        Distro:{" "}
+        <MetadataLabel>Started By:</MetadataLabel> {startedBy}
+      </MetadataItem>
+      <MetadataItem>
+        <MetadataLabel>Cloud Provider:</MetadataLabel> {provider}
+      </MetadataItem>
+      {ami && (
+        <MetadataItem>
+          <MetadataLabel>AMI:</MetadataLabel> {ami}
+        </MetadataItem>
+      )}
+      <MetadataItem>
+        <MetadataLabel>Distro:</MetadataLabel>{" "}
         <StyledLink data-cy="distro-link" href={distroLink}>
           {distroId}
         </StyledLink>
       </MetadataItem>
       {startedBy === MCI_USER && (
         <MetadataItem data-cy="current-running-task">
-          Current Task:{" "}
+          <MetadataLabel>Current Task:</MetadataLabel>{" "}
           {runningTaskName ? (
             <StyledLink data-cy="running-task-link" href={taskLink}>
               <WordBreak all>{runningTaskName}</WordBreak>

--- a/apps/spruce/src/pages/jobLogs/Metadata.tsx
+++ b/apps/spruce/src/pages/jobLogs/Metadata.tsx
@@ -2,6 +2,7 @@ import { useJobLogsAnalytics } from "analytics";
 import {
   MetadataCard,
   MetadataItem,
+  MetadataLabel,
   MetadataTitle,
 } from "components/MetadataCard";
 import { StyledLink } from "components/styles";
@@ -17,13 +18,19 @@ export const Metadata: React.FC<{
     <MetadataCard loading={loading}>
       <MetadataTitle>Job log details</MetadataTitle>
       {metadata.groupID && (
-        <MetadataItem>Group: {metadata.groupID}</MetadataItem>
+        <MetadataItem>
+          <MetadataLabel>Group:</MetadataLabel> {metadata.groupID}
+        </MetadataItem>
       )}
       {metadata.builder && (
-        <MetadataItem>Builder: {metadata.builder}</MetadataItem>
+        <MetadataItem>
+          <MetadataLabel>Builder:</MetadataLabel> {metadata.builder}
+        </MetadataItem>
       )}
       {metadata.buildNum && (
-        <MetadataItem>Build number: {metadata.buildNum}</MetadataItem>
+        <MetadataItem>
+          <MetadataLabel>Build number:</MetadataLabel> {metadata.buildNum}
+        </MetadataItem>
       )}
       <MetadataItem>
         <StyledLink

--- a/apps/spruce/src/pages/version/Metadata.tsx
+++ b/apps/spruce/src/pages/version/Metadata.tsx
@@ -5,6 +5,7 @@ import {
   MetadataCard,
   MetadataItem,
   MetadataTitle,
+  MetadataLabel,
 } from "components/MetadataCard";
 import { StyledLink, StyledRouterLink } from "components/styles";
 import {
@@ -13,7 +14,6 @@ import {
 } from "constants/externalResources";
 import { Requester } from "constants/requesters";
 import {
-  getCommitQueueRoute,
   getProjectPatchesRoute,
   getTriggerRoute,
   getUserPatchesRoute,
@@ -22,7 +22,6 @@ import {
 import { VersionQuery } from "gql/generated/types";
 import { useDateFormat } from "hooks";
 import { string } from "utils";
-import { formatZeroIndexForDisplay } from "utils/numbers";
 import ManifestBlob from "./ManifestBlob";
 import { ParametersModal } from "./ParametersModal";
 
@@ -47,9 +46,7 @@ export const Metadata: React.FC<Props> = ({ loading, version }) => {
     isPatch,
     manifest,
     parameters,
-    patch,
     previousVersion,
-    project,
     projectIdentifier,
     projectMetadata,
     requester,
@@ -59,31 +56,20 @@ export const Metadata: React.FC<Props> = ({ loading, version }) => {
     versionTiming,
   } = version || {};
   const { sendEvent } = useVersionAnalytics(id);
-  const { commitQueuePosition } = patch || {};
   const { makespan, timeTaken } = versionTiming || {};
-  const {
-    owner: upstreamOwner,
-    project: upstreamProjectIdentifier,
-    repo: upstreamRepo,
-    revision: upstreamRevision,
-    task: upstreamTask,
-    triggerType,
-    version: upstreamVersion,
-  } = upstreamProject || {};
 
   const { branch, owner, repo } = projectMetadata || {};
 
   const isGithubMergePatch = requester === Requester.GitHubMergeQueue;
 
   return (
-    // @ts-expect-error: FIXME. This comment was added by an automated script.
-    <MetadataCard loading={loading} error={null}>
+    <MetadataCard loading={loading}>
       <MetadataTitle>
         {isPatch ? "Patch Metadata" : "Version Metadata"}
       </MetadataTitle>
 
       <MetadataItem>
-        Project:{" "}
+        <MetadataLabel>Project:</MetadataLabel>{" "}
         {projectIdentifier ? (
           <StyledRouterLink
             to={getProjectPatchesRoute(projectIdentifier)}
@@ -98,13 +84,15 @@ export const Metadata: React.FC<Props> = ({ loading, version }) => {
         )}
       </MetadataItem>
       <MetadataItem>
-        Makespan: {makespan && msToDuration(makespan)}
+        <MetadataLabel>Makespan:</MetadataLabel>{" "}
+        {makespan && msToDuration(makespan)}
       </MetadataItem>
       <MetadataItem>
-        Time taken: {timeTaken && msToDuration(timeTaken)}
+        <MetadataLabel>Time taken:</MetadataLabel>{" "}
+        {timeTaken && msToDuration(timeTaken)}
       </MetadataItem>
       <MetadataItem>
-        Submitted at:{" "}
+        <MetadataLabel>Submitted at:</MetadataLabel>{" "}
         {createTime && (
           <span title={getDateCopy(createTime)}>
             {getDateCopy(createTime, { omitSeconds: true })}
@@ -112,7 +100,7 @@ export const Metadata: React.FC<Props> = ({ loading, version }) => {
         )}
       </MetadataItem>
       <MetadataItem>
-        Started:{" "}
+        <MetadataLabel>Started:</MetadataLabel>{" "}
         {startTime && (
           <span title={getDateCopy(startTime)}>
             {getDateCopy(startTime, { omitSeconds: true })}
@@ -121,14 +109,14 @@ export const Metadata: React.FC<Props> = ({ loading, version }) => {
       </MetadataItem>
       {finishTime && (
         <MetadataItem>
-          Finished:{" "}
+          <MetadataLabel>Finished:</MetadataLabel>{" "}
           <span title={getDateCopy(finishTime)}>
             {getDateCopy(finishTime, { omitSeconds: true })}
           </span>
         </MetadataItem>
       )}
       <MetadataItem>
-        Submitted by:{" "}
+        <MetadataLabel>Submitted by:</MetadataLabel>{" "}
         <StyledRouterLink
           to={getUserPatchesRoute(getAuthorUsername(authorEmail))}
           data-cy="user-patches-link"
@@ -136,10 +124,9 @@ export const Metadata: React.FC<Props> = ({ loading, version }) => {
           {author}
         </StyledRouterLink>
       </MetadataItem>
-      {isPatch ? (
+      {isPatch && baseVersion ? (
         <BaseCommitMetadata
-          // @ts-expect-error: FIXME. This comment was added by an automated script.
-          baseVersionId={baseVersion?.id}
+          baseVersionId={baseVersion.id}
           isGithubMergePatch={isGithubMergePatch}
           onClick={() =>
             sendEvent({ name: "Clicked metadata base commit link" })
@@ -148,39 +135,36 @@ export const Metadata: React.FC<Props> = ({ loading, version }) => {
         />
       ) : (
         <MetadataItem>
-          Previous commit:{" "}
+          <MetadataLabel>Previous commit:</MetadataLabel>{" "}
           <InlineCode
             as={Link}
             data-cy="version-previous-commit"
             onClick={() =>
               sendEvent({ name: "Clicked metadata previous version link" })
             }
-            // @ts-expect-error: FIXME. This comment was added by an automated script.
-            to={getVersionRoute(previousVersion?.id)}
+            to={getVersionRoute(previousVersion.id || "")}
           >
-            {/* @ts-expect-error: FIXME. This comment was added by an automated script. */}
-            {shortenGithash(previousVersion?.revision)}
+            {shortenGithash(previousVersion.revision || "")}
           </InlineCode>
         </MetadataItem>
       )}
-      {isGithubMergePatch && (
+      {isGithubMergePatch && owner && repo && branch && (
         <MetadataItem>
+          <MetadataLabel>GitHub Merge Queue:</MetadataLabel>{" "}
           <StyledLink
             data-cy="github-merge-queue-link"
             hideExternalIcon={false}
-            // @ts-expect-error: FIXME. This comment was added by an automated script.
             href={getGithubMergeQueueUrl(owner, repo, branch)}
           >
             GitHub Merge Queue
           </StyledLink>
         </MetadataItem>
       )}
-      {!isPatch && (
+      {!isPatch && owner && repo && revision && (
         <MetadataItem>
-          GitHub commit:{" "}
+          <MetadataLabel>GitHub commit:</MetadataLabel>{" "}
           <InlineCode
             data-cy="version-github-commit"
-            // @ts-expect-error: FIXME. This comment was added by an automated script.
             href={getGithubCommitUrl(owner, repo, revision)}
             onClick={() =>
               sendEvent({ name: "Clicked metadata github commit link" })
@@ -190,43 +174,28 @@ export const Metadata: React.FC<Props> = ({ loading, version }) => {
           </InlineCode>
         </MetadataItem>
       )}
-      {isPatch && commitQueuePosition !== null && (
-        <MetadataItem>
-          <StyledRouterLink
-            data-cy="commit-queue-position"
-            to={getCommitQueueRoute(project)}
-          >
-            Commit queue position:{" "}
-            {/* @ts-expect-error: FIXME. This comment was added by an automated script. */}
-            {formatZeroIndexForDisplay(commitQueuePosition)}
-          </StyledRouterLink>
-        </MetadataItem>
-      )}
       {manifest && <ManifestBlob manifest={manifest} />}
       {upstreamProject && (
         <MetadataItem>
-          Triggered from:{" "}
+          <MetadataLabel>Triggered from:</MetadataLabel>{" "}
           <StyledRouterLink
             to={getTriggerRoute({
-              // @ts-expect-error: FIXME. This comment was added by an automated script.
-              triggerType,
-              upstreamTask,
-              upstreamVersion,
-              // @ts-expect-error: FIXME. This comment was added by an automated script.
-              upstreamRevision,
-              // @ts-expect-error: FIXME. This comment was added by an automated script.
-              upstreamOwner,
-              // @ts-expect-error: FIXME. This comment was added by an automated script.
-              upstreamRepo,
+              triggerType: upstreamProject.triggerType,
+              upstreamTask: upstreamProject.task,
+              upstreamVersion: upstreamProject.version,
+              upstreamRevision: upstreamProject.revision,
+              upstreamOwner: upstreamProject.owner,
+              upstreamRepo: upstreamProject.repo,
             })}
           >
-            {upstreamProjectIdentifier}
+            {upstreamProject.project}
           </StyledRouterLink>
         </MetadataItem>
       )}
       <ParametersModal parameters={parameters} />
       {externalLinksForMetadata?.map(({ displayName, url }) => (
         <MetadataItem key={displayName}>
+          <MetadataLabel>{displayName}:</MetadataLabel>{" "}
           <StyledLink data-cy="external-link" href={url}>
             {displayName}
           </StyledLink>

--- a/apps/spruce/src/pages/version/Metadata.tsx
+++ b/apps/spruce/src/pages/version/Metadata.tsx
@@ -142,9 +142,9 @@ export const Metadata: React.FC<Props> = ({ loading, version }) => {
             onClick={() =>
               sendEvent({ name: "Clicked metadata previous version link" })
             }
-            to={getVersionRoute(previousVersion.id || "")}
+            to={getVersionRoute(previousVersion?.id || "")}
           >
-            {shortenGithash(previousVersion.revision || "")}
+            {shortenGithash(previousVersion?.revision || "")}
           </InlineCode>
         </MetadataItem>
       )}


### PR DESCRIPTION
DEVPROD-10353

### Description
* Updates the remaining metadata panels on spruce to use the new bold metadata label labels introduced in DEVPROD-4512
* Removes the commit queue link from patch metadata
### Screenshots
<img width="360" alt="image" src="https://github.com/user-attachments/assets/e0bf92e5-b555-4e16-b1d5-58e0cee4b6d7">
<img width="289" alt="image" src="https://github.com/user-attachments/assets/9f3ec7dd-fd1b-42e5-b82a-22e7c704515b">

