### PR TITLE
DEVPROD-7854: Remove complex version redirect logic

### DIFF
--- a/apps/spruce/cypress/integration/version/routes.ts
+++ b/apps/spruce/cypress/integration/version/routes.ts
@@ -11,25 +11,6 @@ const versions = {
 const versionRoute = (id: string) => `/version/${id}`;
 
 describe("Version route", () => {
-  describe("Redirects", () => {
-    it("Redirects to configure patch page if patch is not activated", () => {
-      cy.visit(versionRoute(versions[3]));
-      cy.location().should((loc) => {
-        expect(loc.pathname).to.equal(`/patch/${versions[3]}/configure/tasks`);
-      });
-    });
-    it("Redirects to the commit queue page if a patch is on the commit queue and has not been activated", () => {
-      cy.visit(versionRoute(versions[4]));
-      cy.location().should((loc) => {
-        expect(loc.pathname).to.equal(`/commit-queue/mongodb-mongo-master`);
-      });
-    });
-    it("Throws a 404 if the version and patch doesn't exist", () => {
-      cy.visit(versionRoute(versions[1]));
-      cy.validateToast("error", "Unable to find patch or version i-dont-exist");
-    });
-  });
-
   describe("Metadata", () => {
     it("Shows patch parameters if they exist", () => {
       cy.visit(versionRoute(versions[0]));
@@ -69,13 +50,11 @@ describe("Version route", () => {
     describe("Grouped Task Status Badge", () => {
       it("Shows tooltip with task's name on hover", () => {
         cy.dataCy("build-variants").within(() => {
-          cy.dataCy("grouped-task-status-badge")
-            .first()
-            .trigger("mouseover")
-            .within(($el) => {
-              // @ts-expect-error
-              expect($el.text()).to.contain("1Succeeded");
-            });
+          cy.dataCy("grouped-task-status-badge").first().as("statusBadge");
+          cy.get("@statusBadge").trigger("mouseover");
+          cy.get("@statusBadge").within(($el) => {
+            expect($el.text()).to.contain("1Succeeded");
+          });
         });
       });
 

--- a/apps/spruce/cypress/integration/version/unscheduled_patch/configure_patch.ts
+++ b/apps/spruce/cypress/integration/version/unscheduled_patch/configure_patch.ts
@@ -6,20 +6,8 @@ describe("Configure Patch Page", () => {
   const patchWithDisplayTasks = "5e6bb9e23066155a993e0f1b";
 
   describe("Initial state reflects patch data", () => {
-    it("Should Redirect to configure page for unconfigured patches", () => {
-      cy.visit(`/version/${unactivatedPatchId}`);
-      cy.location().should((loc) =>
-        expect(loc.pathname).to.eq(
-          `/patch/${unactivatedPatchId}/configure/tasks`,
-        ),
-      );
-    });
-    it("Patch name input field value is patch description", () => {
-      cy.visit(`/version/${unactivatedPatchId}`);
-      cy.dataCy("patch-name-input").should("have.value", "test meee");
-    });
     it("First build variant in list is selected by default", () => {
-      cy.visit(`/version/${unactivatedPatchId}`);
+      cy.visit(`/patch/${unactivatedPatchId}/configure/tasks`);
       cy.dataCy("build-variant-list-item")
         .first()
         .should("have.attr", "data-selected", "true");
@@ -33,6 +21,7 @@ describe("Configure Patch Page", () => {
         expect(loc.pathname).to.eq(`/version/5ecedafb562343215a7ff297/tasks`),
       );
     });
+
     it("should not allow canceling an unconfigured patch", () => {
       cy.visit(`/patch/${unactivatedPatchId}/configure/tasks`);
       cy.dataCy("cancel-button").should("not.exist");
@@ -189,7 +178,7 @@ describe("Configure Patch Page", () => {
 
     describe("Task filter input", () => {
       it("Updating the task filter input filters tasks in view", () => {
-        cy.visit(`/version/${unactivatedPatchId}`);
+        cy.visit(`/patch/${unactivatedPatchId}/configure/tasks`);
         cy.contains("Ubuntu 16.04").click();
         cy.dataCy("task-checkbox").should("have.length", 45);
         cy.dataCy("selected-task-disclaimer").contains(
@@ -203,7 +192,7 @@ describe("Configure Patch Page", () => {
         );
       });
       it("The task filter input works across multiple build variants", () => {
-        cy.visit(`/version/${unactivatedPatchId}`);
+        cy.visit(`/patch/${unactivatedPatchId}/configure/tasks`);
         cy.get("body").type("{meta}", {
           release: false,
         });
@@ -489,7 +478,7 @@ describe("Configure Patch Page", () => {
 
     describe("Selecting a trigger alias", () => {
       beforeEach(() => {
-        cy.visit(`/version/${unactivatedPatchId}`);
+        cy.visit(`/patch/${unactivatedPatchId}/configure/tasks`);
         cy.dataCy("trigger-alias-list-item")
           .contains("logkeeper-alias")
           .click();
@@ -569,7 +558,7 @@ describe("Configure Patch Page", () => {
 
   describe("Scheduling a patch", () => {
     beforeEach(() => {
-      cy.visit(`/patch/${unactivatedPatchId}`);
+      cy.visit(`/patch/${unactivatedPatchId}/configure/tasks`);
     });
     it("Clicking 'Schedule' button schedules patch and redirects to patch page", () => {
       const val = "hello world";

--- a/apps/spruce/src/components/PatchesPage/ListArea/PatchCard/index.tsx
+++ b/apps/spruce/src/components/PatchesPage/ListArea/PatchCard/index.tsx
@@ -10,6 +10,7 @@ import {
   getProjectPatchesRoute,
   getVersionRoute,
   getUserPatchesRoute,
+  getPatchRoute,
 } from "constants/routes";
 import { mapUmbrellaStatusToQueryParam } from "constants/task";
 import { fontSize, size } from "constants/tokens";
@@ -106,7 +107,11 @@ const PatchCard: React.FC<PatchCardProps> = ({
         <DescriptionLink
           data-cy="patch-card-patch-link"
           onClick={() => analytics.sendEvent({ name: "Clicked patch link" })}
-          to={getVersionRoute(id)}
+          to={
+            isUnconfigured
+              ? getPatchRoute(id, { configure: true })
+              : getVersionRoute(id)
+          }
         >
           {description || "no description"}
         </DescriptionLink>

--- a/apps/spruce/src/components/Redirects/PatchRedirect.tsx
+++ b/apps/spruce/src/components/Redirects/PatchRedirect.tsx
@@ -1,7 +1,12 @@
 import { useParams, Navigate } from "react-router-dom";
-import { getVersionRoute, slugs } from "constants/routes";
+import { getPatchRoute, slugs } from "constants/routes";
 
 export const PatchRedirect: React.FC = () => {
   const { [slugs.versionId]: versionId } = useParams();
-  return <Navigate replace to={getVersionRoute(versionId ?? "")} />;
+  return (
+    <Navigate
+      replace
+      to={getPatchRoute(versionId ?? "", { configure: true })}
+    />
+  );
 };

--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -6105,12 +6105,6 @@ export type GithubProjectConflictsQuery = {
   };
 };
 
-export type HasVersionQueryVariables = Exact<{
-  id: Scalars["String"]["input"];
-}>;
-
-export type HasVersionQuery = { __typename?: "Query"; hasVersion: boolean };
-
 export type HostEventsQueryVariables = Exact<{
   id: Scalars["String"]["input"];
   tag: Scalars["String"]["input"];
@@ -6363,21 +6357,6 @@ export type InstanceTypesQueryVariables = Exact<{ [key: string]: never }>;
 export type InstanceTypesQuery = {
   __typename?: "Query";
   instanceTypes: Array<string>;
-};
-
-export type IsPatchConfiguredQueryVariables = Exact<{
-  id: Scalars["String"]["input"];
-}>;
-
-export type IsPatchConfiguredQuery = {
-  __typename?: "Query";
-  patch: {
-    __typename?: "Patch";
-    activated: boolean;
-    alias?: string | null;
-    id: string;
-    projectID: string;
-  };
 };
 
 export type CustomCreatedIssuesQueryVariables = Exact<{

--- a/apps/spruce/src/gql/queries/has-version.graphql
+++ b/apps/spruce/src/gql/queries/has-version.graphql
@@ -1,3 +1,0 @@
-query HasVersion($id: String!) {
-  hasVersion(patchId: $id)
-}

--- a/apps/spruce/src/gql/queries/index.ts
+++ b/apps/spruce/src/gql/queries/index.ts
@@ -19,7 +19,6 @@ import DISTROS from "./distros.graphql";
 import FAILED_TASK_STATUS_ICON_TOOLTIP from "./failed-task-status-icon-tooltip.graphql";
 import GITHUB_ORGS from "./github-orgs.graphql";
 import GITHUB_PROJECT_CONFLICTS from "./github-project-conflicts.graphql";
-import HAS_VERSION from "./has-version.graphql";
 import HOST_EVENTS from "./host-events.graphql";
 import HOST from "./host.graphql";
 import HOSTS from "./hosts.graphql";
@@ -30,7 +29,6 @@ import IMAGE_PACKAGES from "./image-packages.graphql";
 import IMAGE_TOOLCHAINS from "./image-toolchains.graphql";
 import IMAGES from "./images.graphql";
 import INSTANCE_TYPES from "./instance-types.graphql";
-import IS_PATCH_CONFIGURED from "./is-patch-configured.graphql";
 import JIRA_CUSTOM_CREATED_ISSUES from "./jira-custom-created-issues.graphql";
 import JIRA_ISSUES from "./jira-issues.graphql";
 import JIRA_SUSPECTED_ISSUES from "./jira-suspected-issues.graphql";
@@ -109,7 +107,6 @@ export {
   FAILED_TASK_STATUS_ICON_TOOLTIP,
   GITHUB_ORGS,
   GITHUB_PROJECT_CONFLICTS,
-  HAS_VERSION,
   HOST_EVENTS,
   HOST,
   HOSTS,
@@ -120,7 +117,6 @@ export {
   IMAGE_TOOLCHAINS,
   IMAGES,
   INSTANCE_TYPES,
-  IS_PATCH_CONFIGURED,
   JIRA_CUSTOM_CREATED_ISSUES,
   JIRA_ISSUES,
   JIRA_SUSPECTED_ISSUES,

--- a/apps/spruce/src/gql/queries/is-patch-configured.graphql
+++ b/apps/spruce/src/gql/queries/is-patch-configured.graphql
@@ -1,8 +1,0 @@
-query IsPatchConfigured($id: String!) {
-  patch(patchId: $id) {
-    activated
-    alias
-    id
-    projectID
-  }
-}

--- a/apps/spruce/src/pages/Version.tsx
+++ b/apps/spruce/src/pages/Version.tsx
@@ -1,6 +1,5 @@
-import { useState, useEffect } from "react";
-import { useLazyQuery, useQuery } from "@apollo/client";
-import { useParams, Navigate } from "react-router-dom";
+import { useQuery } from "@apollo/client";
+import { useParams } from "react-router-dom";
 import { ProjectBanner } from "components/Banners";
 import { PatchAndTaskFullPageLoad } from "components/Loading/PatchAndTaskFullPageLoad";
 import PageTitle from "components/PageTitle";
@@ -11,21 +10,12 @@ import {
   PageLayout,
   PageSider,
 } from "components/styles";
-import { commitQueueAlias } from "constants/patch";
-import { getCommitQueueRoute, getPatchRoute, slugs } from "constants/routes";
+import { slugs } from "constants/routes";
 import { useToastContext } from "context/toast";
-import {
-  VersionQuery,
-  VersionQueryVariables,
-  IsPatchConfiguredQuery,
-  IsPatchConfiguredQueryVariables,
-  HasVersionQuery,
-  HasVersionQueryVariables,
-} from "gql/generated/types";
-import { VERSION, IS_PATCH_CONFIGURED, HAS_VERSION } from "gql/queries";
+import { VersionQuery, VersionQueryVariables } from "gql/generated/types";
+import { VERSION } from "gql/queries";
 import { useSpruceConfig } from "hooks";
 import { PageDoesNotExist } from "pages/NotFound";
-import { isPatchUnconfigured } from "utils/patch";
 import { shortenGithash, githubPRLinkify } from "utils/string";
 import { jiraLinkify } from "utils/string/jiraLinkify";
 import { WarningBanner, ErrorBanner, IgnoredBanner } from "./version/Banners";
@@ -34,21 +24,17 @@ import BuildVariantCard from "./version/BuildVariantCard";
 import { ActionButtons, Metadata, VersionTabs } from "./version/index";
 import { NameChangeModal } from "./version/NameChangeModal";
 
-// IMPORTANT: If you make any changes to the state logic in this file, please make sure to update the ADR:
-// docs/decisions/2023-12-13_version_page_logic.md
 export const VersionPage: React.FC = () => {
   const spruceConfig = useSpruceConfig();
   const { [slugs.versionId]: versionId } = useParams();
   const dispatchToast = useToastContext();
 
-  const [redirectURL, setRedirectURL] = useState(undefined);
-  const [isLoadingData, setIsLoadingData] = useState(true);
-
   // This query is used to fetch the version data.
-  const [getVersion, { data: versionData, error: versionError }] = useLazyQuery<
-    VersionQuery,
-    VersionQueryVariables
-  >(VERSION, {
+  const {
+    data: versionData,
+    error: versionError,
+    loading: versionLoading,
+  } = useQuery<VersionQuery, VersionQueryVariables>(VERSION, {
     // @ts-expect-error: FIXME. This comment was added by an automated script.
     variables: { id: versionId },
     fetchPolicy: "cache-and-network",
@@ -56,82 +42,14 @@ export const VersionPage: React.FC = () => {
       dispatchToast.error(
         `There was an error loading the version: ${error.message}`,
       );
-      setIsLoadingData(false);
     },
   });
 
-  // If the version is a patch, we need to check if it's been configured.
-  const [getPatch, { data: patchData, error: patchError }] = useLazyQuery<
-    IsPatchConfiguredQuery,
-    IsPatchConfiguredQueryVariables
-  >(IS_PATCH_CONFIGURED, {
-    // @ts-expect-error: FIXME. This comment was added by an automated script.
-    variables: { id: versionId },
-    onError: (error) => {
-      dispatchToast.error(
-        `There was an error loading this patch: ${error.message}`,
-      );
-      setIsLoadingData(false);
-    },
-  });
-
-  // This query checks if the provided id has a configured version.
-  const { error: hasVersionError } = useQuery<
-    HasVersionQuery,
-    HasVersionQueryVariables
-  >(HAS_VERSION, {
-    // @ts-expect-error: FIXME. This comment was added by an automated script.
-    variables: { id: versionId },
-    onCompleted: ({ hasVersion }) => {
-      setIsLoadingData(true);
-      if (hasVersion) {
-        // @ts-expect-error: FIXME. This comment was added by an automated script.
-        getVersion({ variables: { id: versionId } });
-      } else {
-        // @ts-expect-error: FIXME. This comment was added by an automated script.
-        getPatch({ variables: { id: versionId } });
-      }
-    },
-    onError: (error) => {
-      dispatchToast.error(error.message);
-      setIsLoadingData(false);
-    },
-  });
-
-  // Decide where to redirect the user based off of whether or not the patch has been activated.
-  // If the patch is activated and not on the commit queue, we can safely fetch the associated version.
-  useEffect(() => {
-    if (patchData) {
-      const { patch } = patchData;
-      const { activated, alias, projectID } = patch;
-      // @ts-expect-error: FIXME. This comment was added by an automated script.
-      if (isPatchUnconfigured({ alias, activated })) {
-        // @ts-expect-error: FIXME. This comment was added by an automated script.
-        setRedirectURL(getPatchRoute(versionId, { configure: true }));
-        setIsLoadingData(false);
-      } else if (!activated && alias === commitQueueAlias) {
-        // @ts-expect-error: FIXME. This comment was added by an automated script.
-        setRedirectURL(getCommitQueueRoute(projectID));
-        setIsLoadingData(false);
-      } else {
-        // @ts-expect-error: FIXME. This comment was added by an automated script.
-        getVersion({ variables: { id: versionId } });
-      }
-    }
-  }, [patchData, getVersion, versionId]);
-
-  // If we have successfully loaded a version, we can show the page.
-  useEffect(() => {
-    if (versionData) {
-      setIsLoadingData(false);
-    }
-  }, [versionData]);
-
-  if (isLoadingData) {
+  if (versionLoading) {
     return <PatchAndTaskFullPageLoad />;
   }
 
-  if (hasVersionError || patchError || versionError) {
+  if (versionError) {
     return (
       <PageWrapper data-cy="version-page">
         <PageDoesNotExist />
@@ -139,12 +57,6 @@ export const VersionPage: React.FC = () => {
     );
   }
 
-  // If it's a patch, redirect to the proper page.
-  if (redirectURL) {
-    return <Navigate replace to={redirectURL} />;
-  }
-
-  // If it's a version, proceed with loading the version page.
   const { version } = versionData || {};
   const {
     errors,


### PR DESCRIPTION
DEVPROD-7854
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? -->

### Description
Sometimes the redirect logic in the `Version` component doesn't work correctly. When you visit an unconfigured patch, it will occasionally throw this error, even though the logic in the component states that we should fetch the patch and redirect to the `ConfigurePatch` component:

<img width="497" alt="Screenshot 2024-08-30 at 11 09 00 AM" src="https://github.com/user-attachments/assets/ad2cf74d-e213-4663-be04-e287a9b1ee0a">


I think we should just remove the redirect logic because it is really hard to understand, and because we can link to the correct routes from the parent component. This is analogous to how the legacy UI handles it ([code](https://github.com/evergreen-ci/evergreen/blob/ea920d63b25e7c1ba814632fe2f3a69fd3624e5a/service/templates/patches.html#L53-L67)).

### Testing
- Updated Cypress tests
- Tested that patch/version links returned from the CLI still work on Spruce