### PR TITLE
DEVPROD-10353 Make base commit label in patch metadata bold

### DIFF
--- a/apps/spruce/src/pages/version/Metadata.tsx
+++ b/apps/spruce/src/pages/version/Metadata.tsx
@@ -150,13 +150,12 @@ export const Metadata: React.FC<Props> = ({ loading, version }) => {
       )}
       {isGithubMergePatch && owner && repo && branch && (
         <MetadataItem>
-          <MetadataLabel>GitHub Merge Queue:</MetadataLabel>{" "}
           <StyledLink
             data-cy="github-merge-queue-link"
             hideExternalIcon={false}
             href={getGithubMergeQueueUrl(owner, repo, branch)}
           >
-            GitHub Merge Queue
+            <MetadataLabel>GitHub Merge Queue</MetadataLabel>
           </StyledLink>
         </MetadataItem>
       )}

--- a/apps/spruce/src/pages/version/Metadata.tsx
+++ b/apps/spruce/src/pages/version/Metadata.tsx
@@ -231,7 +231,7 @@ const BaseCommitMetadata: React.FC<BaseCommitMetadataProps> = ({
 
   return (
     <MetadataItem>
-      Base commit:{" "}
+      <MetadataLabel>Base commit:</MetadataLabel>{" "}
       {isBaseVersionPending ? (
         <InlineCode data-cy="patch-base-commit">
           {shortenGithash(revision)}


### PR DESCRIPTION
DEVPROD-10353
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? -->

### Description
Looks like i missed a spot in 705940bd2747b2f706440f94384457f9aeff62a6 
### Screenshots
Before:
<img width="313" alt="image" src="https://github.com/user-attachments/assets/6c0663ec-c62a-4e38-bcb0-e05946802634">
After:
<img width="291" alt="image" src="https://github.com/user-attachments/assets/c8e39755-82c1-4bb6-ad65-d36b8ac35b51">
