### PR TITLE
DEVPROD-10175: Create waterfall page route

### DIFF
--- a/apps/spruce/cypress/integration/waterfall/navigation.ts
+++ b/apps/spruce/cypress/integration/waterfall/navigation.ts
@@ -1,0 +1,6 @@
+describe("navigation", () => {
+  it("can view the waterfall page", () => {
+    cy.visit("/project/evergreen/waterfall");
+    cy.dataCy("waterfall-page").should("be.visible");
+  });
+});

--- a/apps/spruce/src/components/Content/index.tsx
+++ b/apps/spruce/src/components/Content/index.tsx
@@ -6,7 +6,10 @@ import {
   UserPatchesRedirect,
   WaterfallCommitsRedirect,
 } from "components/Redirects";
-import { showImageVisibilityPage } from "constants/featureFlags";
+import {
+  showImageVisibilityPage,
+  showWaterfallPage,
+} from "constants/featureFlags";
 import { redirectRoutes, routes, slugs } from "constants/routes";
 import { CommitQueue } from "pages/CommitQueue";
 import { Commits } from "pages/Commits";
@@ -29,6 +32,7 @@ import { TaskQueue } from "pages/TaskQueue";
 import { UserPatches } from "pages/UserPatches";
 import { VariantHistory } from "pages/VariantHistory";
 import { VersionPage } from "pages/Version";
+import { Waterfall } from "pages/Waterfall";
 import { Layout } from "./Layout";
 
 export const Content: React.FC = () => (
@@ -104,6 +108,9 @@ export const Content: React.FC = () => (
       <Route element={<VersionPage />} path={routes.version}>
         <Route element={null} path={`:${slugs.tab}`} />
       </Route>
+      {showWaterfallPage && (
+        <Route element={<Waterfall />} path={routes.waterfall} />
+      )}
       <Route element={<PageDoesNotExist />} path="*" />
     </Route>
   </Routes>

--- a/apps/spruce/src/constants/featureFlags.ts
+++ b/apps/spruce/src/constants/featureFlags.ts
@@ -1,3 +1,4 @@
 import { isProduction } from "utils/environmentVariables";
 
 export const showImageVisibilityPage = !isProduction();
+export const showWaterfallPage = !isProduction();

--- a/apps/spruce/src/constants/routes.ts
+++ b/apps/spruce/src/constants/routes.ts
@@ -144,6 +144,7 @@ export const routes = {
   userPatches: `${paths.user}/:${slugs.userId}/${PageNames.Patches}`,
   variantHistory: `${paths.variantHistory}/:${slugs.projectIdentifier}/:${slugs.variantName}`,
   version: `${paths.version}/:${slugs.versionId}`,
+  waterfall: `${paths.project}/:${slugs.projectIdentifier}/waterfall`,
 };
 
 export const DEFAULT_PATCH_TAB = PatchTab.Tasks;

--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -881,14 +881,11 @@ export type Image = {
   distros: Array<Distro>;
   events: ImageEventsPayload;
   id: Scalars["String"]["output"];
-  kernel: Scalars["String"]["output"];
   lastDeployed: Scalars["Time"]["output"];
   latestTask?: Maybe<Task>;
-  name: Scalars["String"]["output"];
   operatingSystem: ImageOperatingSystemPayload;
   packages: ImagePackagesPayload;
   toolchains: ImageToolchainsPayload;
-  versionId: Scalars["String"]["output"];
 };
 
 /**

--- a/apps/spruce/src/pages/Waterfall.tsx
+++ b/apps/spruce/src/pages/Waterfall.tsx
@@ -1,0 +1,3 @@
+import { loadable } from "components/SpruceLoader";
+
+export const Waterfall = loadable(() => import("./waterfall/index"));

--- a/apps/spruce/src/pages/waterfall/index.tsx
+++ b/apps/spruce/src/pages/waterfall/index.tsx
@@ -1,0 +1,17 @@
+import { useParams } from "react-router-dom";
+import { PageWrapper } from "components/styles";
+import { slugs } from "constants/routes";
+
+const Waterfall: React.FC = () => {
+  const { [slugs.projectIdentifier]: projectIdentifier } = useParams<{
+    [slugs.projectIdentifier]: string;
+  }>();
+
+  return (
+    <PageWrapper data-cy="waterfall-page">
+      Waterfall Page for {projectIdentifier}
+    </PageWrapper>
+  );
+};
+
+export default Waterfall;


### PR DESCRIPTION
DEVPROD-10175
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? -->

### Description
Adds new route for the new waterfall page. This page is not visible on production.

### Screenshots
(The text on the page is just a placeholder to show that the route & slug is working)
<!-- add screenshots of visible changes -->
<img width="601" alt="Screenshot 2024-09-04 at 10 50 22 AM" src="https://github.com/user-attachments/assets/610eb1b3-6d8b-4aee-8597-30898a35fc8d">


### Testing
<!-- add a description of how you tested it -->
- Added Cypress test

