### PR TITLE
DEVPROD-10544 Set @graphql-eslint/no-deprecated rule to WARN

### DIFF
--- a/apps/spruce/.eslintrc.cjs
+++ b/apps/spruce/.eslintrc.cjs
@@ -13,6 +13,7 @@ module.exports = {
       extends: "plugin:@graphql-eslint/operations-recommended",
       rules: {
         "@graphql-eslint/selection-set-depth": OFF,
+        "@graphql-eslint/no-deprecated": WARN,
       },
     },
   ],

--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -748,6 +748,8 @@ export type Host = {
   distro?: Maybe<DistroInfo>;
   distroId?: Maybe<Scalars["String"]["output"]>;
   elapsed?: Maybe<Scalars["Time"]["output"]>;
+  /** events returns the event log entries for a given host. */
+  events: HostEvents;
   expiration?: Maybe<Scalars["Time"]["output"]>;
   homeVolume?: Maybe<Volume>;
   homeVolumeID?: Maybe<Scalars["String"]["output"]>;
@@ -768,6 +770,13 @@ export type Host = {
   uptime?: Maybe<Scalars["Time"]["output"]>;
   user?: Maybe<Scalars["String"]["output"]>;
   volumes: Array<Volume>;
+};
+
+/** Host models a host, which are used for things like running tasks or as virtual workstations. */
+export type HostEventsArgs = {
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  page?: InputMaybe<Scalars["Int"]["input"]>;
+  sortDir?: InputMaybe<SortDirection>;
 };
 
 export type HostAllocatorSettings = {
@@ -1879,7 +1888,6 @@ export type Project = {
   perfEnabled?: Maybe<Scalars["Boolean"]["output"]>;
   periodicBuilds?: Maybe<Array<PeriodicBuild>>;
   prTestingEnabled?: Maybe<Scalars["Boolean"]["output"]>;
-  private?: Maybe<Scalars["Boolean"]["output"]>;
   projectHealthView: ProjectHealthView;
   remotePath: Scalars["String"]["output"];
   repo: Scalars["String"]["output"];
@@ -2018,7 +2026,6 @@ export type ProjectInput = {
   perfEnabled?: InputMaybe<Scalars["Boolean"]["input"]>;
   periodicBuilds?: InputMaybe<Array<PeriodicBuildInput>>;
   prTestingEnabled?: InputMaybe<Scalars["Boolean"]["input"]>;
-  private?: InputMaybe<Scalars["Boolean"]["input"]>;
   projectHealthView?: InputMaybe<ProjectHealthView>;
   remotePath?: InputMaybe<Scalars["String"]["input"]>;
   repo?: InputMaybe<Scalars["String"]["input"]>;
@@ -2150,6 +2157,7 @@ export type Query = {
   githubProjectConflicts: GithubProjectConflicts;
   hasVersion: Scalars["Boolean"]["output"];
   host?: Maybe<Host>;
+  /** @deprecated Use host.events instead. */
   hostEvents: HostEvents;
   hosts: HostsResponse;
   image?: Maybe<Image>;
@@ -2180,6 +2188,7 @@ export type Query = {
   userSettings?: Maybe<UserSettings>;
   version: Version;
   viewableProjectRefs: Array<GroupedProjects>;
+  waterfall?: Maybe<Waterfall>;
 };
 
 export type QueryBbGetCreatedTicketsArgs = {
@@ -2320,6 +2329,10 @@ export type QueryVersionArgs = {
   versionId: Scalars["String"]["input"];
 };
 
+export type QueryWaterfallArgs = {
+  options: WaterfallOptions;
+};
+
 export type RemoveFavoriteProjectInput = {
   projectIdentifier: Scalars["String"]["input"];
 };
@@ -2366,7 +2379,6 @@ export type RepoRef = {
   perfEnabled: Scalars["Boolean"]["output"];
   periodicBuilds?: Maybe<Array<PeriodicBuild>>;
   prTestingEnabled: Scalars["Boolean"]["output"];
-  private: Scalars["Boolean"]["output"];
   remotePath: Scalars["String"]["output"];
   repo: Scalars["String"]["output"];
   repotrackerDisabled: Scalars["Boolean"]["output"];
@@ -2410,7 +2422,6 @@ export type RepoRefInput = {
   perfEnabled?: InputMaybe<Scalars["Boolean"]["input"]>;
   periodicBuilds?: InputMaybe<Array<PeriodicBuildInput>>;
   prTestingEnabled?: InputMaybe<Scalars["Boolean"]["input"]>;
-  private?: InputMaybe<Scalars["Boolean"]["input"]>;
   remotePath?: InputMaybe<Scalars["String"]["input"]>;
   repo?: InputMaybe<Scalars["String"]["input"]>;
   repotrackerDisabled?: InputMaybe<Scalars["Boolean"]["input"]>;
@@ -2553,7 +2564,6 @@ export type SleepSchedule = {
   __typename?: "SleepSchedule";
   dailyStartTime: Scalars["String"]["output"];
   dailyStopTime: Scalars["String"]["output"];
-  isBetaTester?: Maybe<Scalars["Boolean"]["output"]>;
   nextStartTime?: Maybe<Scalars["Time"]["output"]>;
   nextStopTime?: Maybe<Scalars["Time"]["output"]>;
   permanentlyExempt: Scalars["Boolean"]["output"];
@@ -2566,7 +2576,6 @@ export type SleepSchedule = {
 export type SleepScheduleInput = {
   dailyStartTime: Scalars["String"]["input"];
   dailyStopTime: Scalars["String"]["input"];
-  isBetaTester?: InputMaybe<Scalars["Boolean"]["input"]>;
   permanentlyExempt: Scalars["Boolean"]["input"];
   shouldKeepOff: Scalars["Boolean"]["input"];
   temporarilyExemptUntil?: InputMaybe<Scalars["Time"]["input"]>;
@@ -3372,6 +3381,41 @@ export type Volume = {
 export type VolumeHost = {
   hostId: Scalars["String"]["input"];
   volumeId: Scalars["String"]["input"];
+};
+
+export type Waterfall = {
+  __typename?: "Waterfall";
+  buildVariants: Array<WaterfallBuildVariant>;
+  versions: Array<Version>;
+};
+
+export type WaterfallBuild = {
+  __typename?: "WaterfallBuild";
+  activated?: Maybe<Scalars["Boolean"]["output"]>;
+  displayName: Scalars["String"]["output"];
+  id: Scalars["String"]["output"];
+  tasks: Array<WaterfallTask>;
+  version: Scalars["String"]["output"];
+};
+
+export type WaterfallBuildVariant = {
+  __typename?: "WaterfallBuildVariant";
+  builds: Array<WaterfallBuild>;
+  displayName: Scalars["String"]["output"];
+  id: Scalars["String"]["output"];
+};
+
+export type WaterfallOptions = {
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  projectIdentifier: Scalars["String"]["input"];
+  requesters?: InputMaybe<Array<Scalars["String"]["input"]>>;
+};
+
+export type WaterfallTask = {
+  __typename?: "WaterfallTask";
+  displayName: Scalars["String"]["output"];
+  id: Scalars["String"]["output"];
+  status: Scalars["String"]["output"];
 };
 
 export type Webhook = {


### PR DESCRIPTION
DEVPROD-10544

### Description
Noticed the lint task has started to fail with a no-deprecated error. This PR updates the eslint check to only warn if we use a deprecated field. 

