### PR TITLE
DEVPROD-7662: Add image visibility guide cue

### DIFF
--- a/apps/spruce/cypress/integration/image/navigation.ts
+++ b/apps/spruce/cypress/integration/image/navigation.ts
@@ -1,3 +1,5 @@
+import { SEEN_IMAGE_VISIBILITY_GUIDE_CUE } from "constants/cookies";
+
 describe("/image/imageId/random redirect route", () => {
   it("should redirect to the build information page", () => {
     cy.visit("/image/imageId/random");
@@ -21,6 +23,16 @@ describe("/image/imageId/random redirect route", () => {
           });
         });
     });
+  });
+
+  it("shows the image visibility guide cue on task metadata", () => {
+    cy.setCookie(SEEN_IMAGE_VISIBILITY_GUIDE_CUE, "false");
+    cy.visit(
+      "/task/evergreen_ubuntu1604_test_annotations_b_5e4ff3abe3c3317e352062e4_20_02_21_15_13_48",
+    );
+    cy.dataCy("image-visibility-guide-cue").should("be.visible");
+    cy.contains("button", "Got it").click();
+    cy.dataCy("image-visibility-guide-cue").should("not.exist");
   });
 
   it("navigates to the image page from the task page", () => {

--- a/apps/spruce/cypress/support/e2e.ts
+++ b/apps/spruce/cypress/support/e2e.ts
@@ -19,6 +19,7 @@ import {
   CY_DISABLE_COMMITS_WELCOME_MODAL,
   CY_DISABLE_NEW_USER_WELCOME_MODAL,
   SLACK_NOTIFICATION_BANNER,
+  SEEN_IMAGE_VISIBILITY_GUIDE_CUE,
 } from "constants/cookies";
 import { isMutation } from "../utils/graphql-test-utils";
 // Alternatively you can use CommonJS syntax:
@@ -159,6 +160,7 @@ before(() => {
     cy.setCookie(CY_DISABLE_COMMITS_WELCOME_MODAL, "true");
     cy.setCookie(CY_DISABLE_NEW_USER_WELCOME_MODAL, "true");
     cy.setCookie(SLACK_NOTIFICATION_BANNER, "true");
+    cy.setCookie(SEEN_IMAGE_VISIBILITY_GUIDE_CUE, "true");
     mutationDispatched = false;
     cy.intercept("POST", "/graphql/query", (req) => {
       if (isMutation(req)) {

--- a/apps/spruce/src/components/MetadataCard.tsx
+++ b/apps/spruce/src/components/MetadataCard.tsx
@@ -73,6 +73,7 @@ const Item = styled(Body)<BodyProps>`
   :not(:last-child) {
     margin-bottom: 12px;
   }
+  width: fit-content;
 `;
 
 export const MetadataLabel = styled.b<{ color?: string }>`

--- a/apps/spruce/src/constants/cookies.ts
+++ b/apps/spruce/src/constants/cookies.ts
@@ -13,6 +13,7 @@ export const HIDE_FEEDBACK = "HIDE_FEEDBACK";
 export const INCLUDE_COMMIT_QUEUE_PROJECT_PATCHES =
   "include-commit-queue-project-patches";
 export const INCLUDE_HIDDEN_PATCHES = "include-hidden-patches";
-export const SEEN_MIGRATE_GUIDE_CUE = "seen-migrate-guide-cue";
 export const SLACK_NOTIFICATION_BANNER = "has-closed-slack-banner";
 export const SUBSCRIPTION_METHOD = "subscription-method";
+export const SEEN_IMAGE_VISIBILITY_GUIDE_CUE =
+  "seen-image-visibility-guide-cue";

--- a/apps/spruce/src/pages/task/metadata/ImageVisibilityGuideCue.tsx
+++ b/apps/spruce/src/pages/task/metadata/ImageVisibilityGuideCue.tsx
@@ -1,0 +1,41 @@
+import { useState } from "react";
+import {
+  GuideCue,
+  GuideCueProps,
+  TooltipAlign,
+} from "@leafygreen-ui/guide-cue";
+import Cookies from "js-cookie";
+import { SEEN_IMAGE_VISIBILITY_GUIDE_CUE } from "constants/cookies";
+import { showImageVisibilityPage } from "constants/featureFlags";
+
+export const ImageVisibilityGuideCue: React.FC<{
+  refEl: GuideCueProps["refEl"];
+}> = ({ refEl }) => {
+  const [open, setOpen] = useState(
+    Cookies.get(SEEN_IMAGE_VISIBILITY_GUIDE_CUE) !== "true",
+  );
+
+  const closeGuideCue = () => {
+    Cookies.set(SEEN_IMAGE_VISIBILITY_GUIDE_CUE, "true", { expires: 365 });
+    setOpen(false);
+  };
+
+  return (
+    <GuideCue
+      currentStep={1}
+      data-cy="image-visibility-guide-cue"
+      // Remove once the page is ready for release.
+      enabled={showImageVisibilityPage}
+      numberOfSteps={1}
+      onPrimaryButtonClick={closeGuideCue}
+      open={open}
+      refEl={refEl}
+      setOpen={setOpen}
+      title="Newly Introduced Image Page!"
+      tooltipAlign={TooltipAlign.Right}
+    >
+      Visit the new Image page to view general configuration and package
+      installation information for Evergreen distros.
+    </GuideCue>
+  );
+};

--- a/apps/spruce/src/pages/task/metadata/index.tsx
+++ b/apps/spruce/src/pages/task/metadata/index.tsx
@@ -1,3 +1,4 @@
+import { useRef } from "react";
 import { ApolloError } from "@apollo/client";
 import styled from "@emotion/styled";
 import { palette } from "@leafygreen-ui/palette";
@@ -37,6 +38,7 @@ import { isFailedTaskStatus } from "utils/statuses";
 import { AbortMessage } from "./AbortMessage";
 import { DependsOn } from "./DependsOn";
 import ETATimer from "./ETATimer";
+import { ImageVisibilityGuideCue } from "./ImageVisibilityGuideCue";
 import RuntimeTimer from "./RuntimeTimer";
 import { Stepback, isInStepback } from "./Stepback";
 
@@ -105,6 +107,8 @@ export const Metadata: React.FC<Props> = ({ error, loading, task, taskId }) => {
   const { metadataLinks } = annotation ?? {};
 
   const stepback = isInStepback(task);
+
+  const imageVisibilityGuideCueTriggerRef = useRef<HTMLDivElement>(null);
 
   return (
     <>
@@ -393,8 +397,12 @@ export const Metadata: React.FC<Props> = ({ error, loading, task, taskId }) => {
           )}
           {showImageVisibilityPage && !isContainerTask && imageId && (
             <MetadataItem>
+              <ImageVisibilityGuideCue
+                refEl={imageVisibilityGuideCueTriggerRef}
+              />
               <MetadataLabel>Image:</MetadataLabel>{" "}
               <StyledRouterLink
+                ref={imageVisibilityGuideCueTriggerRef}
                 data-cy="task-image-link"
                 onClick={() =>
                   taskAnalytics.sendEvent({


### PR DESCRIPTION
DEVPROD-7662
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? -->

### Description
Adds guide cue to show on the new image link when the project is released. The ticket to remove the guide cue is [DEVPROD-11247](https://jira.mongodb.org/browse/DEVPROD-11247).

### Screenshots
<img width="429" alt="Screenshot 2024-09-11 at 3 46 44 PM" src="https://github.com/user-attachments/assets/08ecac7c-66d6-4e46-812b-b4a2412c7b49">

### Testing
- Added Cypress test
