### PR TITLE
DEVPROD-1065: Remove antd layout

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,5 @@
 DEVPROD-NNNNN
-<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? -->
+<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->
 
 ### Description
 <!-- add description, context, thought process, etc -->

--- a/README.md
+++ b/README.md
@@ -14,13 +14,21 @@ Check out the
 [Yarn Workspaces documentation](https://classic.yarnpkg.com/lang/en/docs/workspaces/)
 for more.
 
-### Upgrades
+### Dependencies
 
 To upgrade a dependency across workspaces:
 
 ```bash
 yarn upgrade-interactive [--latest] [package-name]
 ```
+
+To remove all installed dependencies:
+
+```bash
+yarn clean
+```
+
+You can then rerun `yarn install`.
 
 ### Scripts
 

--- a/apps/spruce/src/components/Loading/PatchAndTaskFullPageLoad.tsx
+++ b/apps/spruce/src/components/Loading/PatchAndTaskFullPageLoad.tsx
@@ -19,11 +19,9 @@ export const PatchAndTaskFullPageLoad: React.FC = () => (
           <Skeleton active paragraph={{ rows: 4 }} title={false} />
         </SiderCard>
       </PageSider>
-      <PageLayout>
-        <PageContent>
-          <Skeleton active paragraph={{ rows: 8 }} title />
-        </PageContent>
-      </PageLayout>
+      <PageContent>
+        <Skeleton active paragraph={{ rows: 8 }} title />
+      </PageContent>
     </PageLayout>
   </PageWrapper>
 );

--- a/apps/spruce/src/components/styles/Layout.tsx
+++ b/apps/spruce/src/components/styles/Layout.tsx
@@ -1,17 +1,9 @@
-import { css } from "@emotion/react";
 import styled from "@emotion/styled";
 import { palette } from "@leafygreen-ui/palette";
 import { H2, H2Props, Body, BodyProps } from "@leafygreen-ui/typography";
-import { Layout } from "antd";
 import { size, fontSize } from "constants/tokens";
 
-const { gray, red, white } = palette;
-const { Content, Sider } = Layout;
-
-const whiteBackground = css`
-  background: ${white};
-  background-color: ${white};
-`;
+const { gray, red } = palette;
 
 export const PageWrapper = styled.div`
   grid-area: contents;
@@ -30,14 +22,21 @@ export const PageGrid = styled.div`
   height: 100vh;
 `;
 
-/* Flexbox-based antd components to be used together */
-export const PageLayout = styled(Layout)`
-  ${whiteBackground}
+export const PageLayout = styled.section<{ hasSider?: boolean }>`
+  display: flex;
+  flex: auto;
+  flex-direction: ${({ hasSider }) => (hasSider ? "row" : "column")};
+  min-height: 0;
 `;
-export const PageSider = styled(Sider)`
-  ${whiteBackground}
+export const PageSider = styled.aside<{ width?: number }>`
+  ${({ width = 275 }) => `
+   max-width: ${width}px;
+   min-width: ${width}px;
+   width: ${width}px;
+   `}
 `;
-export const PageContent = styled(Content)`
+export const PageContent = styled.main`
+  flex: auto;
   margin-left: ${size.s};
   overflow: hidden;
 `;
@@ -78,7 +77,7 @@ export const ErrorMessage = styled(Body)<BodyProps>`
   color: ${red.base};
 `;
 
-export const HR = styled("hr")`
+export const HR = styled.hr`
   background-color: ${gray.light2};
   border: 0;
   height: 1px;

--- a/apps/spruce/src/pages/Task.tsx
+++ b/apps/spruce/src/pages/Task.tsx
@@ -139,19 +139,13 @@ export const Task = () => {
             taskId={taskId}
           />
         </PageSider>
-        <LogWrapper>
-          <PageContent>
-            {task && <TaskTabs isDisplayTask={isDisplayTask} task={task} />}
-          </PageContent>
-        </LogWrapper>
+        <PageContent>
+          {task && <TaskTabs isDisplayTask={isDisplayTask} task={task} />}
+        </PageContent>
       </PageLayout>
     </PageWrapper>
   );
 };
-
-const LogWrapper = styled(PageLayout)`
-  width: 100%;
-`;
 
 const StyledBadgeWrapper = styled.div`
   > :nth-of-type(2) {

--- a/apps/spruce/src/pages/Version.tsx
+++ b/apps/spruce/src/pages/Version.tsx
@@ -127,14 +127,12 @@ export const VersionPage: React.FC = () => {
           {/* @ts-expect-error: FIXME. This comment was added by an automated script. */}
           <BuildVariantCard versionId={versionId} />
         </PageSider>
-        <PageLayout>
-          <PageContent>
-            <VersionTabs
-              // @ts-expect-error: FIXME. This comment was added by an automated script.
-              version={version}
-            />
-          </PageContent>
-        </PageLayout>
+        <PageContent>
+          <VersionTabs
+            // @ts-expect-error: FIXME. This comment was added by an automated script.
+            version={version}
+          />
+        </PageContent>
       </PageLayout>
     </PageWrapper>
   );

--- a/apps/spruce/src/pages/configurePatch/configurePatchCore/__snapshots__/ConfigurePatchCore_ConfigureTasksDefault.storyshot
+++ b/apps/spruce/src/pages/configurePatch/configurePatchCore/__snapshots__/ConfigurePatchCore_ConfigureTasksDefault.storyshot
@@ -71,533 +71,525 @@
     </div>
   </div>
   <section
-    class="ant-layout ant-layout-has-sider css-1aoao0r-PageLayout-whiteBackground e1xf068s9"
+    class="css-1fnoxta-PageLayout e1xf068s9"
   >
     <aside
-      class="ant-layout-sider ant-layout-sider-dark css-1vgfpw2-PageSider-whiteBackground e1xf068s8"
-      style="flex: 0 0 275px; max-width: 275px; min-width: 275px; width: 275px;"
+      class="css-pfmll8-PageSider e1xf068s8"
+      width="275"
     >
       <div
-        class="ant-layout-sider-children"
+        class="css-1l8tpk-SiderCard e1am38ss0 leafygreen-ui-1ecxdul"
       >
-        <div
-          class="css-1l8tpk-SiderCard e1am38ss0 leafygreen-ui-1ecxdul"
-        >
-          <div>
-            <p
-              class="css-1k03zl5-Title e1ul56zb2 leafygreen-ui-1miy0xp"
-            >
-              Patch Metadata
-            </p>
-            <hr
-              class="css-qqg5h5-Divider eb6szep0"
-            />
-          </div>
+        <div>
           <p
-            class="css-1spnncu-Item-wordBreakCss e1ul56zb1 leafygreen-ui-1tb6tuo"
+            class="css-1k03zl5-Title e1ul56zb2 leafygreen-ui-1miy0xp"
           >
-            <b
-              class="css-1xk67r-MetadataLabel e1ul56zb0"
-            >
-              Submitted by:
-            </b>
-             
-            mohamed.khelif
+            Patch Metadata
           </p>
-          <p
-            class="css-1spnncu-Item-wordBreakCss e1ul56zb1 leafygreen-ui-1tb6tuo"
-          >
-            <b
-              class="css-1xk67r-MetadataLabel e1ul56zb0"
-            >
-              Submitted at:
-            </b>
-             
-            2020-08-28T15:00:17Z
-          </p>
-          <p
-            class="css-1spnncu-Item-wordBreakCss e1ul56zb1 leafygreen-ui-1tb6tuo"
-          >
-            <b
-              class="css-1xk67r-MetadataLabel e1ul56zb0"
-            >
-              Project:
-            </b>
-             
-            <a
-              class="lg-ui-0001 css-1gw3cuq-StyledLink leafygreen-ui-16e7rxl"
-              href="/project/spruce/patches"
-            >
-              <span>
-                spruce
-              </span>
-            </a>
-          </p>
+          <hr
+            class="css-qqg5h5-Divider eb6szep0"
+          />
         </div>
-        <div
-          class="css-1rkkuaq-DisableWrapper e1xdo4m90"
-          data-cy="build-variant-select-wrapper"
+        <p
+          class="css-1spnncu-Item-wordBreakCss e1ul56zb1 leafygreen-ui-1tb6tuo"
         >
-          <span
-            class="css-1etd4q7-UserSelectWrapper e1xdo4m91"
+          <b
+            class="css-1xk67r-MetadataLabel e1ul56zb0"
           >
-            <div
-              class="css-1ff72qn-SiderCard-StyledSiderCard e14bc6yx4 leafygreen-ui-1ecxdul"
-            >
-              <div
-                class="css-993586-Container-cardSidePadding e14bc6yx5"
-              >
-                <p
-                  class="leafygreen-ui-1miy0xp"
-                >
-                  Select Build Variants and Tasks
-                </p>
-                <p
-                  class="leafygreen-ui-ogtczq"
-                  data-lgid="lg-description"
-                >
-                  Use Shift + Click to edit multiple variants simultaneously.
-                </p>
-                <hr
-                  class="css-qqg5h5-Divider eb6szep0"
-                />
-              </div>
-              <div
-                class="css-1xp9bbh-ScrollableBuildVariantContainer e14bc6yx0"
-              >
-                <div
-                  class="css-9u3o4h-BuildVariant-cardSidePadding e14bc6yx3"
-                  data-cy="build-variant-list-item"
-                  data-selected="true"
-                >
-                  <div
-                    class="css-xk6ynb-VariantName e14bc6yx2"
-                  >
-                    <p
-                      class="leafygreen-ui-1miy0xp"
-                    >
-                      Ubuntu 20.04
-                    </p>
-                  </div>
-                </div>
-                <div
-                  class="css-yy9i1r-BuildVariant-cardSidePadding e14bc6yx3"
-                  data-cy="build-variant-list-item"
-                  data-selected="false"
-                >
-                  <div
-                    class="css-xk6ynb-VariantName e14bc6yx2"
-                  >
-                    <p
-                      class="leafygreen-ui-1tb6tuo"
-                    >
-                      Ubuntu 22.04
-                    </p>
-                  </div>
-                </div>
-              </div>
-            </div>
-            <div
-              class="css-1ff72qn-SiderCard-StyledSiderCard e14bc6yx4 leafygreen-ui-1ecxdul"
-            >
-              <div
-                class="css-993586-Container-cardSidePadding e14bc6yx5"
-              >
-                <p
-                  class="leafygreen-ui-1miy0xp"
-                >
-                  Select Downstream Tasks
-                </p>
-                <p
-                  class="leafygreen-ui-ogtczq"
-                  data-lgid="lg-description"
-                >
-                  Use Shift + Click to edit multiple variants simultaneously.
-                </p>
-                <hr
-                  class="css-qqg5h5-Divider eb6szep0"
-                />
-              </div>
-              <div
-                class="css-1xp9bbh-ScrollableBuildVariantContainer e14bc6yx0"
-              >
-                <div
-                  class="css-yy9i1r-BuildVariant-cardSidePadding e14bc6yx3"
-                  data-cy="trigger-alias-list-item"
-                  data-selected="false"
-                >
-                  <div
-                    class="css-xk6ynb-VariantName e14bc6yx2"
-                  >
-                    <p
-                      class="leafygreen-ui-1tb6tuo"
-                    >
-                      evergreen (evergreen)
-                    </p>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </span>
-        </div>
+            Submitted by:
+          </b>
+           
+          mohamed.khelif
+        </p>
+        <p
+          class="css-1spnncu-Item-wordBreakCss e1ul56zb1 leafygreen-ui-1tb6tuo"
+        >
+          <b
+            class="css-1xk67r-MetadataLabel e1ul56zb0"
+          >
+            Submitted at:
+          </b>
+           
+          2020-08-28T15:00:17Z
+        </p>
+        <p
+          class="css-1spnncu-Item-wordBreakCss e1ul56zb1 leafygreen-ui-1tb6tuo"
+        >
+          <b
+            class="css-1xk67r-MetadataLabel e1ul56zb0"
+          >
+            Project:
+          </b>
+           
+          <a
+            class="lg-ui-0001 css-1gw3cuq-StyledLink leafygreen-ui-16e7rxl"
+            href="/project/spruce/patches"
+          >
+            <span>
+              spruce
+            </span>
+          </a>
+        </p>
       </div>
-    </aside>
-    <section
-      class="ant-layout css-1aoao0r-PageLayout-whiteBackground e1xf068s9"
-    >
-      <main
-        class="ant-layout-content css-8bxtim-PageContent e1xf068s7"
+      <div
+        class="css-1rkkuaq-DisableWrapper e1xdo4m90"
+        data-cy="build-variant-select-wrapper"
       >
-        <div
-          class="css-1svlhkk-StyledTabs e1g8s93l0"
-          data-lgid="lg-tabs"
+        <span
+          class="css-1etd4q7-UserSelectWrapper e1xdo4m91"
         >
           <div
-            class="leafygreen-ui-jp7pox"
+            class="css-1ff72qn-SiderCard-StyledSiderCard e14bc6yx4 leafygreen-ui-1ecxdul"
           >
             <div
-              aria-label="Configure Patch Tabs"
-              aria-orientation="horizontal"
-              class="leafygreen-ui-dy551c"
-              data-lgid="lg-tabs-tab_list"
-              role="tablist"
+              class="css-993586-Container-cardSidePadding e14bc6yx5"
             >
-              <button
-                aria-controls="tab-panel-325"
-                aria-selected="true"
-                class="leafygreen-ui-oq6if2"
-                data-cy="tasks-tab"
-                data-text="Configure"
-                id="tab-326"
-                name="Configure"
-                role="tab"
-                tabindex="0"
+              <p
+                class="leafygreen-ui-1miy0xp"
               >
-                <div
-                  class="leafygreen-ui-1nxuzmg"
-                >
-                  Configure
-                </div>
-              </button>
-              <button
-                aria-controls="tab-panel-327"
-                aria-selected="false"
-                class="leafygreen-ui-1vvp6ij"
-                data-cy="changes-tab"
-                data-text="Changes"
-                id="tab-328"
-                name="Changes"
-                role="tab"
-                tabindex="-1"
+                Select Build Variants and Tasks
+              </p>
+              <p
+                class="leafygreen-ui-ogtczq"
+                data-lgid="lg-description"
               >
-                <div
-                  class="leafygreen-ui-1nxuzmg"
-                >
-                  Changes
-                </div>
-              </button>
-              <button
-                aria-controls="tab-panel-329"
-                aria-selected="false"
-                class="leafygreen-ui-1vvp6ij"
-                data-cy="parameters-tab"
-                data-text="Parameters"
-                id="tab-330"
-                name="Parameters"
-                role="tab"
-                tabindex="-1"
-              >
-                <div
-                  class="leafygreen-ui-1nxuzmg"
-                >
-                  Parameters
-                </div>
-              </button>
-            </div>
-            <div
-              class="leafygreen-ui-ov1ktg"
-            >
-              <div
-                class="leafygreen-ui-1sg2lsz"
+                Use Shift + Click to edit multiple variants simultaneously.
+              </p>
+              <hr
+                class="css-qqg5h5-Divider eb6szep0"
               />
             </div>
-          </div>
-          <div
-            data-lgid="lg-tabs-tab_panels"
-          >
             <div
-              aria-labelledby="tab-326"
-              data-cy="tasks-tab"
-              id="tab-panel-325"
-              role="tabpanel"
+              class="css-1xp9bbh-ScrollableBuildVariantContainer e14bc6yx0"
             >
               <div
-                class="css-17881ib-TabContentWrapper-cardSidePadding eoqkpw12"
+                class="css-9u3o4h-BuildVariant-cardSidePadding e14bc6yx3"
+                data-cy="build-variant-list-item"
+                data-selected="true"
               >
                 <div
-                  class="css-1ln61zq-Actions eoqkpw16"
+                  class="css-xk6ynb-VariantName e14bc6yx2"
                 >
-                  <div
-                    class="eoqkpw13 css-1pn85ix-TextInputWrapper-StyledTextInput e17optw11"
+                  <p
+                    class="leafygreen-ui-1miy0xp"
                   >
-                    <div
-                      aria-labelledby="search-tasks"
-                      class="leafygreen-ui-1br9h7w"
-                      data-lgid="lg-text_input"
-                    >
-                      <div
-                        class="leafygreen-ui-1iyoj2o"
-                      />
-                      <div
-                        class="leafygreen-ui-109lyo9"
-                      >
-                        <div
-                          class="leafygreen-ui-1ago99h"
-                        >
-                          <input
-                            aria-describedby=""
-                            aria-disabled="false"
-                            aria-invalid="false"
-                            aria-labelledby="search-tasks"
-                            autocomplete="on"
-                            class="lg-ui-form-field-input-0000 leafygreen-ui-1ago99h"
-                            data-cy="task-filter-input"
-                            id="lg-form_field-input-339"
-                            placeholder="Search tasks regex"
-                            required=""
-                            type="text"
-                            value=""
-                          />
-                        </div>
-                      </div>
-                      <div
-                        aria-live="polite"
-                        aria-relevant="all"
-                        class="leafygreen-ui-11ydt2g"
-                        data-lgid="lg-form_field-feedback"
-                        data-testid="lg-form_field-feedback"
-                        id="lg-form_field-feedback-338"
-                      />
-                    </div>
-                    <div
-                      class="css-4bamt4-IconWrapper e17optw10"
-                    >
-                      <button
-                        aria-disabled="false"
-                        aria-label="Select plus button"
-                        class="leafygreen-ui-tcjr3n"
-                        tabindex="0"
-                      >
-                        <div
-                          class="leafygreen-ui-xhlipt"
-                        >
-                          <svg
-                            aria-label="Plus Icon"
-                            class=""
-                            fill="none"
-                            height="16"
-                            role="img"
-                            viewBox="0 0 16 16"
-                            width="16"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              clip-rule="evenodd"
-                              d="M7.5 2a1 1 0 0 0-1 1v3.5H3a1 1 0 0 0-1 1v1a1 1 0 0 0 1 1h3.5V13a1 1 0 0 0 1 1h1a1 1 0 0 0 1-1V9.5H13a1 1 0 0 0 1-1v-1a1 1 0 0 0-1-1H9.5V3a1 1 0 0 0-1-1h-1Z"
-                              fill="currentColor"
-                              fill-rule="evenodd"
-                            />
-                          </svg>
-                        </div>
-                      </button>
-                    </div>
-                  </div>
-                  <div
-                    class="leafygreen-ui-55kazc css-1oxhyic-InlineCheckbox eoqkpw10"
-                    data-lgid="lg-checkbox"
-                  >
-                    <label
-                      class="leafygreen-ui-1srek1y"
-                      data-lgid="lg-label"
-                      for="checkbox-340"
-                      id="checkbox-340-label"
-                    >
-                      <input
-                        aria-checked="false"
-                        aria-disabled="false"
-                        aria-label="checkbox"
-                        aria-labelledby="checkbox-340-label"
-                        class="lg-ui-input-0000 leafygreen-ui-1a1e5kp"
-                        data-cy="select-all-checkbox"
-                        id="checkbox-340"
-                        type="checkbox"
-                      />
-                      <div
-                        class="lg-ui-check-wrapper-0000 leafygreen-ui-nlfut8"
-                      >
-                        <svg
-                          class="leafygreen-ui-6caof5"
-                          fill="none"
-                          height="10"
-                          stroke="#FFFFFF"
-                          viewBox="0 0 10 10"
-                          width="10"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M2 5.5L4.12132 7.62132L8.36396 3.37868"
-                            stroke="#FFFFFF"
-                            stroke-linecap="round"
-                            stroke-linejoin="round"
-                            stroke-width="2"
-                          />
-                        </svg>
-                      </div>
-                      <div
-                        class="lg-ui-ripple-0000 leafygreen-ui-6vh13p"
-                      />
-                      <span
-                        class="leafygreen-ui-187di61"
-                      >
-                        <div
-                          class="css-118tpd3-LabelContainer eoqkpw15"
-                        >
-                          Select all tasks in this variant
-                        </div>
-                      </span>
-                    </label>
-                  </div>
+                    Ubuntu 20.04
+                  </p>
                 </div>
-                <small
-                  class="css-xwgr3h-StyledDisclaimer eoqkpw14 leafygreen-ui-6flbwy"
-                  data-cy="selected-task-disclaimer"
-                >
-                  0 tasks across 0 build variants, 0 trigger aliases
-                </small>
+              </div>
+              <div
+                class="css-yy9i1r-BuildVariant-cardSidePadding e14bc6yx3"
+                data-cy="build-variant-list-item"
+                data-selected="false"
+              >
                 <div
-                  class="css-1t9ftr3-TaskLayoutGrid ew7x3ml0"
-                  data-cy="configurePatch-tasks"
+                  class="css-xk6ynb-VariantName e14bc6yx2"
                 >
-                  <div
-                    class="leafygreen-ui-55kazc"
-                    data-lgid="lg-checkbox"
+                  <p
+                    class="leafygreen-ui-1tb6tuo"
                   >
-                    <label
-                      class="leafygreen-ui-1srek1y"
-                      data-lgid="lg-label"
-                      for="checkbox-341"
-                      id="checkbox-341-label"
-                    >
-                      <input
-                        aria-checked="false"
-                        aria-disabled="false"
-                        aria-label="checkbox"
-                        aria-labelledby="checkbox-341-label"
-                        class="lg-ui-input-0000 leafygreen-ui-1a1e5kp"
-                        data-cy="task-checkbox"
-                        id="checkbox-341"
-                        type="checkbox"
-                      />
-                      <div
-                        class="lg-ui-check-wrapper-0000 leafygreen-ui-nlfut8"
-                      >
-                        <svg
-                          class="leafygreen-ui-6caof5"
-                          fill="none"
-                          height="10"
-                          stroke="#FFFFFF"
-                          viewBox="0 0 10 10"
-                          width="10"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M2 5.5L4.12132 7.62132L8.36396 3.37868"
-                            stroke="#FFFFFF"
-                            stroke-linecap="round"
-                            stroke-linejoin="round"
-                            stroke-width="2"
-                          />
-                        </svg>
-                      </div>
-                      <div
-                        class="lg-ui-ripple-0000 leafygreen-ui-6vh13p"
-                      />
-                      <span
-                        class="leafygreen-ui-187di61"
-                      >
-                        e2e_test
-                      </span>
-                    </label>
-                  </div>
-                  <div
-                    class="leafygreen-ui-55kazc"
-                    data-lgid="lg-checkbox"
-                  >
-                    <label
-                      class="leafygreen-ui-1srek1y"
-                      data-lgid="lg-label"
-                      for="checkbox-342"
-                      id="checkbox-342-label"
-                    >
-                      <input
-                        aria-checked="false"
-                        aria-disabled="false"
-                        aria-label="checkbox"
-                        aria-labelledby="checkbox-342-label"
-                        class="lg-ui-input-0000 leafygreen-ui-1a1e5kp"
-                        data-cy="task-checkbox"
-                        id="checkbox-342"
-                        type="checkbox"
-                      />
-                      <div
-                        class="lg-ui-check-wrapper-0000 leafygreen-ui-nlfut8"
-                      >
-                        <svg
-                          class="leafygreen-ui-6caof5"
-                          fill="none"
-                          height="10"
-                          stroke="#FFFFFF"
-                          viewBox="0 0 10 10"
-                          width="10"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M2 5.5L4.12132 7.62132L8.36396 3.37868"
-                            stroke="#FFFFFF"
-                            stroke-linecap="round"
-                            stroke-linejoin="round"
-                            stroke-width="2"
-                          />
-                        </svg>
-                      </div>
-                      <div
-                        class="lg-ui-ripple-0000 leafygreen-ui-6vh13p"
-                      />
-                      <span
-                        class="leafygreen-ui-187di61"
-                      >
-                        test
-                      </span>
-                    </label>
-                  </div>
+                    Ubuntu 22.04
+                  </p>
                 </div>
               </div>
             </div>
+          </div>
+          <div
+            class="css-1ff72qn-SiderCard-StyledSiderCard e14bc6yx4 leafygreen-ui-1ecxdul"
+          >
             <div
-              aria-labelledby="tab-328"
+              class="css-993586-Container-cardSidePadding e14bc6yx5"
+            >
+              <p
+                class="leafygreen-ui-1miy0xp"
+              >
+                Select Downstream Tasks
+              </p>
+              <p
+                class="leafygreen-ui-ogtczq"
+                data-lgid="lg-description"
+              >
+                Use Shift + Click to edit multiple variants simultaneously.
+              </p>
+              <hr
+                class="css-qqg5h5-Divider eb6szep0"
+              />
+            </div>
+            <div
+              class="css-1xp9bbh-ScrollableBuildVariantContainer e14bc6yx0"
+            >
+              <div
+                class="css-yy9i1r-BuildVariant-cardSidePadding e14bc6yx3"
+                data-cy="trigger-alias-list-item"
+                data-selected="false"
+              >
+                <div
+                  class="css-xk6ynb-VariantName e14bc6yx2"
+                >
+                  <p
+                    class="leafygreen-ui-1tb6tuo"
+                  >
+                    evergreen (evergreen)
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </span>
+      </div>
+    </aside>
+    <main
+      class="css-7qhrew-PageContent e1xf068s7"
+    >
+      <div
+        class="css-1svlhkk-StyledTabs e1g8s93l0"
+        data-lgid="lg-tabs"
+      >
+        <div
+          class="leafygreen-ui-jp7pox"
+        >
+          <div
+            aria-label="Configure Patch Tabs"
+            aria-orientation="horizontal"
+            class="leafygreen-ui-dy551c"
+            data-lgid="lg-tabs-tab_list"
+            role="tablist"
+          >
+            <button
+              aria-controls="tab-panel-325"
+              aria-selected="true"
+              class="leafygreen-ui-oq6if2"
+              data-cy="tasks-tab"
+              data-text="Configure"
+              id="tab-326"
+              name="Configure"
+              role="tab"
+              tabindex="0"
+            >
+              <div
+                class="leafygreen-ui-1nxuzmg"
+              >
+                Configure
+              </div>
+            </button>
+            <button
+              aria-controls="tab-panel-327"
+              aria-selected="false"
+              class="leafygreen-ui-1vvp6ij"
               data-cy="changes-tab"
-              id="tab-panel-327"
-              role="tabpanel"
-            />
-            <div
-              aria-labelledby="tab-330"
+              data-text="Changes"
+              id="tab-328"
+              name="Changes"
+              role="tab"
+              tabindex="-1"
+            >
+              <div
+                class="leafygreen-ui-1nxuzmg"
+              >
+                Changes
+              </div>
+            </button>
+            <button
+              aria-controls="tab-panel-329"
+              aria-selected="false"
+              class="leafygreen-ui-1vvp6ij"
               data-cy="parameters-tab"
-              id="tab-panel-329"
-              role="tabpanel"
+              data-text="Parameters"
+              id="tab-330"
+              name="Parameters"
+              role="tab"
+              tabindex="-1"
+            >
+              <div
+                class="leafygreen-ui-1nxuzmg"
+              >
+                Parameters
+              </div>
+            </button>
+          </div>
+          <div
+            class="leafygreen-ui-ov1ktg"
+          >
+            <div
+              class="leafygreen-ui-1sg2lsz"
             />
           </div>
         </div>
-      </main>
-    </section>
+        <div
+          data-lgid="lg-tabs-tab_panels"
+        >
+          <div
+            aria-labelledby="tab-326"
+            data-cy="tasks-tab"
+            id="tab-panel-325"
+            role="tabpanel"
+          >
+            <div
+              class="css-17881ib-TabContentWrapper-cardSidePadding eoqkpw12"
+            >
+              <div
+                class="css-1ln61zq-Actions eoqkpw16"
+              >
+                <div
+                  class="eoqkpw13 css-1pn85ix-TextInputWrapper-StyledTextInput e17optw11"
+                >
+                  <div
+                    aria-labelledby="search-tasks"
+                    class="leafygreen-ui-1br9h7w"
+                    data-lgid="lg-text_input"
+                  >
+                    <div
+                      class="leafygreen-ui-1iyoj2o"
+                    />
+                    <div
+                      class="leafygreen-ui-109lyo9"
+                    >
+                      <div
+                        class="leafygreen-ui-1ago99h"
+                      >
+                        <input
+                          aria-describedby=""
+                          aria-disabled="false"
+                          aria-invalid="false"
+                          aria-labelledby="search-tasks"
+                          autocomplete="on"
+                          class="lg-ui-form-field-input-0000 leafygreen-ui-1ago99h"
+                          data-cy="task-filter-input"
+                          id="lg-form_field-input-339"
+                          placeholder="Search tasks regex"
+                          required=""
+                          type="text"
+                          value=""
+                        />
+                      </div>
+                    </div>
+                    <div
+                      aria-live="polite"
+                      aria-relevant="all"
+                      class="leafygreen-ui-11ydt2g"
+                      data-lgid="lg-form_field-feedback"
+                      data-testid="lg-form_field-feedback"
+                      id="lg-form_field-feedback-338"
+                    />
+                  </div>
+                  <div
+                    class="css-4bamt4-IconWrapper e17optw10"
+                  >
+                    <button
+                      aria-disabled="false"
+                      aria-label="Select plus button"
+                      class="leafygreen-ui-tcjr3n"
+                      tabindex="0"
+                    >
+                      <div
+                        class="leafygreen-ui-xhlipt"
+                      >
+                        <svg
+                          aria-label="Plus Icon"
+                          class=""
+                          fill="none"
+                          height="16"
+                          role="img"
+                          viewBox="0 0 16 16"
+                          width="16"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            clip-rule="evenodd"
+                            d="M7.5 2a1 1 0 0 0-1 1v3.5H3a1 1 0 0 0-1 1v1a1 1 0 0 0 1 1h3.5V13a1 1 0 0 0 1 1h1a1 1 0 0 0 1-1V9.5H13a1 1 0 0 0 1-1v-1a1 1 0 0 0-1-1H9.5V3a1 1 0 0 0-1-1h-1Z"
+                            fill="currentColor"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </div>
+                    </button>
+                  </div>
+                </div>
+                <div
+                  class="leafygreen-ui-55kazc css-1oxhyic-InlineCheckbox eoqkpw10"
+                  data-lgid="lg-checkbox"
+                >
+                  <label
+                    class="leafygreen-ui-1srek1y"
+                    data-lgid="lg-label"
+                    for="checkbox-340"
+                    id="checkbox-340-label"
+                  >
+                    <input
+                      aria-checked="false"
+                      aria-disabled="false"
+                      aria-label="checkbox"
+                      aria-labelledby="checkbox-340-label"
+                      class="lg-ui-input-0000 leafygreen-ui-1a1e5kp"
+                      data-cy="select-all-checkbox"
+                      id="checkbox-340"
+                      type="checkbox"
+                    />
+                    <div
+                      class="lg-ui-check-wrapper-0000 leafygreen-ui-nlfut8"
+                    >
+                      <svg
+                        class="leafygreen-ui-6caof5"
+                        fill="none"
+                        height="10"
+                        stroke="#FFFFFF"
+                        viewBox="0 0 10 10"
+                        width="10"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M2 5.5L4.12132 7.62132L8.36396 3.37868"
+                          stroke="#FFFFFF"
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                          stroke-width="2"
+                        />
+                      </svg>
+                    </div>
+                    <div
+                      class="lg-ui-ripple-0000 leafygreen-ui-6vh13p"
+                    />
+                    <span
+                      class="leafygreen-ui-187di61"
+                    >
+                      <div
+                        class="css-118tpd3-LabelContainer eoqkpw15"
+                      >
+                        Select all tasks in this variant
+                      </div>
+                    </span>
+                  </label>
+                </div>
+              </div>
+              <small
+                class="css-xwgr3h-StyledDisclaimer eoqkpw14 leafygreen-ui-6flbwy"
+                data-cy="selected-task-disclaimer"
+              >
+                0 tasks across 0 build variants, 0 trigger aliases
+              </small>
+              <div
+                class="css-1t9ftr3-TaskLayoutGrid ew7x3ml0"
+                data-cy="configurePatch-tasks"
+              >
+                <div
+                  class="leafygreen-ui-55kazc"
+                  data-lgid="lg-checkbox"
+                >
+                  <label
+                    class="leafygreen-ui-1srek1y"
+                    data-lgid="lg-label"
+                    for="checkbox-341"
+                    id="checkbox-341-label"
+                  >
+                    <input
+                      aria-checked="false"
+                      aria-disabled="false"
+                      aria-label="checkbox"
+                      aria-labelledby="checkbox-341-label"
+                      class="lg-ui-input-0000 leafygreen-ui-1a1e5kp"
+                      data-cy="task-checkbox"
+                      id="checkbox-341"
+                      type="checkbox"
+                    />
+                    <div
+                      class="lg-ui-check-wrapper-0000 leafygreen-ui-nlfut8"
+                    >
+                      <svg
+                        class="leafygreen-ui-6caof5"
+                        fill="none"
+                        height="10"
+                        stroke="#FFFFFF"
+                        viewBox="0 0 10 10"
+                        width="10"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M2 5.5L4.12132 7.62132L8.36396 3.37868"
+                          stroke="#FFFFFF"
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                          stroke-width="2"
+                        />
+                      </svg>
+                    </div>
+                    <div
+                      class="lg-ui-ripple-0000 leafygreen-ui-6vh13p"
+                    />
+                    <span
+                      class="leafygreen-ui-187di61"
+                    >
+                      e2e_test
+                    </span>
+                  </label>
+                </div>
+                <div
+                  class="leafygreen-ui-55kazc"
+                  data-lgid="lg-checkbox"
+                >
+                  <label
+                    class="leafygreen-ui-1srek1y"
+                    data-lgid="lg-label"
+                    for="checkbox-342"
+                    id="checkbox-342-label"
+                  >
+                    <input
+                      aria-checked="false"
+                      aria-disabled="false"
+                      aria-label="checkbox"
+                      aria-labelledby="checkbox-342-label"
+                      class="lg-ui-input-0000 leafygreen-ui-1a1e5kp"
+                      data-cy="task-checkbox"
+                      id="checkbox-342"
+                      type="checkbox"
+                    />
+                    <div
+                      class="lg-ui-check-wrapper-0000 leafygreen-ui-nlfut8"
+                    >
+                      <svg
+                        class="leafygreen-ui-6caof5"
+                        fill="none"
+                        height="10"
+                        stroke="#FFFFFF"
+                        viewBox="0 0 10 10"
+                        width="10"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M2 5.5L4.12132 7.62132L8.36396 3.37868"
+                          stroke="#FFFFFF"
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                          stroke-width="2"
+                        />
+                      </svg>
+                    </div>
+                    <div
+                      class="lg-ui-ripple-0000 leafygreen-ui-6vh13p"
+                    />
+                    <span
+                      class="leafygreen-ui-187di61"
+                    >
+                      test
+                    </span>
+                  </label>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            aria-labelledby="tab-328"
+            data-cy="changes-tab"
+            id="tab-panel-327"
+            role="tabpanel"
+          />
+          <div
+            aria-labelledby="tab-330"
+            data-cy="parameters-tab"
+            id="tab-panel-329"
+            role="tabpanel"
+          />
+        </div>
+      </div>
+    </main>
   </section>
 </div>

--- a/apps/spruce/src/pages/configurePatch/configurePatchCore/index.tsx
+++ b/apps/spruce/src/pages/configurePatch/configurePatchCore/index.tsx
@@ -218,41 +218,39 @@ const ConfigurePatchCore: React.FC<ConfigurePatchCoreProps> = ({ patch }) => {
             variants={getVariantEntries(variants, selectedBuildVariantTasks)}
           />
         </PageSider>
-        <PageLayout>
-          <PageContent>
-            <StyledTabs
-              aria-label="Configure Patch Tabs"
-              selected={selectedTab}
-              setSelected={setSelectedTab}
-            >
-              <Tab data-cy="tasks-tab" name="Configure">
-                <ConfigureTasks
-                  activated={activated}
-                  activatedVariants={variantsTasks}
-                  aliasCount={aliasCount}
-                  childPatches={childPatchesWithAliases}
-                  selectableAliases={selectableAliases}
-                  selectedAliases={selectedAliases}
-                  selectedBuildVariants={selectedBuildVariants}
-                  selectedBuildVariantTasks={selectedBuildVariantTasks}
-                  setSelectedAliases={setSelectedAliases}
-                  setSelectedBuildVariantTasks={setSelectedBuildVariantTasks}
-                  totalSelectedTaskCount={totalSelectedTaskCount}
-                />
-              </Tab>
-              <Tab data-cy="changes-tab" name="Changes">
-                <CodeChanges patchId={id} />
-              </Tab>
-              <Tab data-cy="parameters-tab" name="Parameters">
-                <ParametersContent
-                  patchActivated={activated}
-                  patchParameters={patchParams}
-                  setPatchParams={setPatchParams}
-                />
-              </Tab>
-            </StyledTabs>
-          </PageContent>
-        </PageLayout>
+        <PageContent>
+          <StyledTabs
+            aria-label="Configure Patch Tabs"
+            selected={selectedTab}
+            setSelected={setSelectedTab}
+          >
+            <Tab data-cy="tasks-tab" name="Configure">
+              <ConfigureTasks
+                activated={activated}
+                activatedVariants={variantsTasks}
+                aliasCount={aliasCount}
+                childPatches={childPatchesWithAliases}
+                selectableAliases={selectableAliases}
+                selectedAliases={selectedAliases}
+                selectedBuildVariants={selectedBuildVariants}
+                selectedBuildVariantTasks={selectedBuildVariantTasks}
+                setSelectedAliases={setSelectedAliases}
+                setSelectedBuildVariantTasks={setSelectedBuildVariantTasks}
+                totalSelectedTaskCount={totalSelectedTaskCount}
+              />
+            </Tab>
+            <Tab data-cy="changes-tab" name="Changes">
+              <CodeChanges patchId={id} />
+            </Tab>
+            <Tab data-cy="parameters-tab" name="Parameters">
+              <ParametersContent
+                patchActivated={activated}
+                patchParameters={patchParams}
+                setPatchParams={setPatchParams}
+              />
+            </Tab>
+          </StyledTabs>
+        </PageContent>
       </PageLayout>
     </>
   );

--- a/apps/spruce/src/pages/container/index.tsx
+++ b/apps/spruce/src/pages/container/index.tsx
@@ -44,11 +44,9 @@ const Container = () => {
           {/* @ts-expect-error: FIXME. This comment was added by an automated script. */}
           <Metadata error={error} loading={loading} pod={pod} />
         </PageSider>
-        <PageLayout>
-          <PageContent>
-            <EventsTable />
-          </PageContent>
-        </PageLayout>
+        <PageContent>
+          <EventsTable />
+        </PageContent>
       </PageLayout>
     </PageWrapper>
   );

--- a/apps/spruce/src/pages/host/index.tsx
+++ b/apps/spruce/src/pages/host/index.tsx
@@ -136,21 +136,19 @@ const Host: React.FC = () => {
                 </Code>
               )}
             </PageSider>
-            <PageLayout>
-              <PageContent>
-                <HostTable
-                  // @ts-expect-error: FIXME. This comment was added by an automated script.
-                  error={error}
-                  // @ts-expect-error: FIXME. This comment was added by an automated script.
-                  eventData={hostEventData}
-                  // @ts-expect-error: FIXME. This comment was added by an automated script.
-                  eventsCount={eventsCount}
-                  limit={limit}
-                  loading={hostEventLoading}
-                  page={page}
-                />
-              </PageContent>
-            </PageLayout>
+            <PageContent>
+              <HostTable
+                // @ts-expect-error: FIXME. This comment was added by an automated script.
+                error={error}
+                // @ts-expect-error: FIXME. This comment was added by an automated script.
+                eventData={hostEventData}
+                // @ts-expect-error: FIXME. This comment was added by an automated script.
+                eventsCount={eventsCount}
+                limit={limit}
+                loading={hostEventLoading}
+                page={page}
+              />
+            </PageContent>
           </PageLayout>
         </>
       )}

--- a/apps/spruce/src/pages/jobLogs/index.tsx
+++ b/apps/spruce/src/pages/jobLogs/index.tsx
@@ -73,16 +73,14 @@ const JobLogs: React.FC<JobLogsProps> = ({ isLogkeeper }) => {
         <PageSider>
           <Metadata loading={loading} metadata={metadata} />
         </PageSider>
-        <PageLayout>
-          <PageContent>
-            <JobLogsTable
-              buildId={buildIdFromParams}
-              isLogkeeper={isLogkeeper}
-              loading={loading}
-              tests={resultsToRender}
-            />
-          </PageContent>
-        </PageLayout>
+        <PageContent>
+          <JobLogsTable
+            buildId={buildIdFromParams}
+            isLogkeeper={isLogkeeper}
+            loading={loading}
+            tests={resultsToRender}
+          />
+        </PageContent>
       </StyledPageLayout>
     </PageWrapper>
   );


### PR DESCRIPTION
DEVPROD-1065 - Take 2, fixes #312 
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? -->

### Description
<!-- add description, context, thought process, etc -->
- Remove antd layout, as well as some superfluous `PageLayout` components used throughout the app
- Fix problem that caused revert of #312, which was a rogue `width: 100%;` on the task page
- Bonus PR template/README updates

### Screenshots
<!-- add screenshots of visible changes -->
Fixed task page:
<img width="1488" alt="image" src="https://github.com/user-attachments/assets/22a90c83-64a2-4967-a1f9-c993948bb10a">

### Testing
<!-- add a description of how you tested it -->
- Updated snapshots

<!-- Have you have updated the analytics documentation if necessary?  
https://docs.google.com/spreadsheets/d/1s4_nq8ZiphXp5Uq_-9HT6GPqz-KOyaq6HuvmXYaSNzg/edit?usp=sharing -->

### Evergreen PR
<!-- link to a corresponding Evergreen PR if applicable -->
