### PR TITLE
DEVPROD-7660: Add link to image page in task metadata

### DIFF
--- a/apps/spruce/cypress/integration/image/navigation.ts
+++ b/apps/spruce/cypress/integration/image/navigation.ts
@@ -22,4 +22,15 @@ describe("/image/imageId/random redirect route", () => {
         });
     });
   });
+
+  it("navigates to the image page from the task page", () => {
+    cy.visit(
+      "/task/evergreen_ubuntu1604_test_annotations_b_5e4ff3abe3c3317e352062e4_20_02_21_15_13_48",
+    );
+    cy.dataCy("task-image-link")
+      .should("have.attr", "href")
+      .and("eq", "/image/ubuntu1604/build-information");
+    cy.dataCy("task-image-link").click();
+    cy.location("pathname").should("eq", "/image/ubuntu1604/build-information");
+  });
 });

--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -2230,7 +2230,7 @@ export type Query = {
   userSettings?: Maybe<UserSettings>;
   version: Version;
   viewableProjectRefs: Array<GroupedProjects>;
-  waterfall?: Maybe<Waterfall>;
+  waterfall: Waterfall;
 };
 
 export type QueryBbGetCreatedTicketsArgs = {
@@ -3428,7 +3428,9 @@ export type VolumeHost = {
 export type Waterfall = {
   __typename?: "Waterfall";
   buildVariants: Array<WaterfallBuildVariant>;
-  versions: Array<Version>;
+  nextPageOrder: Scalars["Int"]["output"];
+  prevPageOrder: Scalars["Int"]["output"];
+  versions: Array<WaterfallVersion>;
 };
 
 export type WaterfallBuild = {
@@ -3449,6 +3451,10 @@ export type WaterfallBuildVariant = {
 
 export type WaterfallOptions = {
   limit?: InputMaybe<Scalars["Int"]["input"]>;
+  /** Return versions with an order lower than maxOrder. Used for paginating forward. */
+  maxOrder?: InputMaybe<Scalars["Int"]["input"]>;
+  /** Return versions with an order greater than minOrder. Used for paginating backward. */
+  minOrder?: InputMaybe<Scalars["Int"]["input"]>;
   projectIdentifier: Scalars["String"]["input"];
   requesters?: InputMaybe<Array<Scalars["String"]["input"]>>;
 };
@@ -3458,6 +3464,12 @@ export type WaterfallTask = {
   displayName: Scalars["String"]["output"];
   id: Scalars["String"]["output"];
   status: Scalars["String"]["output"];
+};
+
+export type WaterfallVersion = {
+  __typename?: "WaterfallVersion";
+  inactiveVersions?: Maybe<Array<Version>>;
+  version?: Maybe<Version>;
 };
 
 export type Webhook = {

--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -8857,6 +8857,7 @@ export type TaskQuery = {
     generatedBy?: string | null;
     generatedByName?: string | null;
     hostId?: string | null;
+    imageId: string;
     ingestTime?: Date | null;
     isPerfPluginEnabled: boolean;
     latestExecution: number;

--- a/apps/spruce/src/gql/mocks/taskData.ts
+++ b/apps/spruce/src/gql/mocks/taskData.ts
@@ -58,6 +58,7 @@ export const taskQuery: TaskQueryType = {
     canUnschedule: false,
     dependsOn: [],
     displayName: "e2e_test",
+    imageId: "ubuntu1604",
     distroId: "ubuntu1604-small",
     estimatedStart: 1000,
     pod: null,

--- a/apps/spruce/src/gql/queries/task.graphql
+++ b/apps/spruce/src/gql/queries/task.graphql
@@ -84,6 +84,7 @@ query Task($taskId: String!, $execution: Int) {
     generatedBy
     generatedByName
     hostId
+    imageId
     ingestTime
     isPerfPluginEnabled
     latestExecution

--- a/apps/spruce/src/pages/task/metadata/__snapshots__/Metadata_ContainerizedTask.storyshot
+++ b/apps/spruce/src/pages/task/metadata/__snapshots__/Metadata_ContainerizedTask.storyshot
@@ -139,6 +139,7 @@
           class="css-qqg5h5-Divider eb6szep0"
         />
       </div>
+       
       <p
         class="css-1spnncu-Item-wordBreakCss e1ul56zb1 leafygreen-ui-1tb6tuo"
       >

--- a/apps/spruce/src/pages/task/metadata/__snapshots__/Metadata_Default.storyshot
+++ b/apps/spruce/src/pages/task/metadata/__snapshots__/Metadata_Default.storyshot
@@ -139,17 +139,26 @@
           class="css-qqg5h5-Divider eb6szep0"
         />
       </div>
+       
       <p
         class="css-1spnncu-Item-wordBreakCss e1ul56zb1 leafygreen-ui-1tb6tuo"
-        data-cy="task-metadata-ami"
       >
         <b
           class="css-1xk67r-MetadataLabel e1ul56zb0"
         >
-          AMI:
+          ID:
         </b>
          
-        ami-0c83bb0a9f48c15bf
+        <a
+          class="lg-ui-0001 css-1gw3cuq-StyledLink leafygreen-ui-16e7rxl"
+          data-cy="task-host-link"
+          href="/host/i-0e0e62799806e037d"
+          target="_self"
+        >
+          <span>
+            i-0e0e62799806e037d
+          </span>
+        </a>
       </p>
       <p
         class="css-1spnncu-Item-wordBreakCss e1ul56zb1 leafygreen-ui-1tb6tuo"
@@ -176,19 +185,30 @@
         <b
           class="css-1xk67r-MetadataLabel e1ul56zb0"
         >
-          ID:
+          Image:
         </b>
          
         <a
           class="lg-ui-0001 css-1gw3cuq-StyledLink leafygreen-ui-16e7rxl"
-          data-cy="task-host-link"
-          href="/host/i-0e0e62799806e037d"
-          target="_self"
+          data-cy="task-image-link"
+          href="/image/ubuntu1604/build-information"
         >
           <span>
-            i-0e0e62799806e037d
+            ubuntu1604
           </span>
         </a>
+      </p>
+      <p
+        class="css-1spnncu-Item-wordBreakCss e1ul56zb1 leafygreen-ui-1tb6tuo"
+        data-cy="task-metadata-ami"
+      >
+        <b
+          class="css-1xk67r-MetadataLabel e1ul56zb0"
+        >
+          AMI:
+        </b>
+         
+        ami-0c83bb0a9f48c15bf
       </p>
       <p
         class="css-1spnncu-Item-wordBreakCss e1ul56zb1 leafygreen-ui-1tb6tuo"

--- a/apps/spruce/src/pages/task/metadata/__snapshots__/Metadata_OOMTracker.storyshot
+++ b/apps/spruce/src/pages/task/metadata/__snapshots__/Metadata_OOMTracker.storyshot
@@ -135,17 +135,26 @@
           class="css-qqg5h5-Divider eb6szep0"
         />
       </div>
+       
       <p
         class="css-1spnncu-Item-wordBreakCss e1ul56zb1 leafygreen-ui-1tb6tuo"
-        data-cy="task-metadata-ami"
       >
         <b
           class="css-1xk67r-MetadataLabel e1ul56zb0"
         >
-          AMI:
+          ID:
         </b>
          
-        ami-0c83bb0a9f48c15bf
+        <a
+          class="lg-ui-0001 css-1gw3cuq-StyledLink leafygreen-ui-16e7rxl"
+          data-cy="task-host-link"
+          href="/host/i-0e0e62799806e037d"
+          target="_self"
+        >
+          <span>
+            i-0e0e62799806e037d
+          </span>
+        </a>
       </p>
       <p
         class="css-1spnncu-Item-wordBreakCss e1ul56zb1 leafygreen-ui-1tb6tuo"
@@ -172,19 +181,30 @@
         <b
           class="css-1xk67r-MetadataLabel e1ul56zb0"
         >
-          ID:
+          Image:
         </b>
          
         <a
           class="lg-ui-0001 css-1gw3cuq-StyledLink leafygreen-ui-16e7rxl"
-          data-cy="task-host-link"
-          href="/host/i-0e0e62799806e037d"
-          target="_self"
+          data-cy="task-image-link"
+          href="/image/ubuntu1604/build-information"
         >
           <span>
-            i-0e0e62799806e037d
+            ubuntu1604
           </span>
         </a>
+      </p>
+      <p
+        class="css-1spnncu-Item-wordBreakCss e1ul56zb1 leafygreen-ui-1tb6tuo"
+        data-cy="task-metadata-ami"
+      >
+        <b
+          class="css-1xk67r-MetadataLabel e1ul56zb0"
+        >
+          AMI:
+        </b>
+         
+        ami-0c83bb0a9f48c15bf
       </p>
       <p
         class="css-1spnncu-Item-wordBreakCss e1ul56zb1 leafygreen-ui-1tb6tuo"

--- a/apps/spruce/src/pages/task/metadata/__snapshots__/Metadata_WithAbortMessage.storyshot
+++ b/apps/spruce/src/pages/task/metadata/__snapshots__/Metadata_WithAbortMessage.storyshot
@@ -139,17 +139,26 @@
           class="css-qqg5h5-Divider eb6szep0"
         />
       </div>
+       
       <p
         class="css-1spnncu-Item-wordBreakCss e1ul56zb1 leafygreen-ui-1tb6tuo"
-        data-cy="task-metadata-ami"
       >
         <b
           class="css-1xk67r-MetadataLabel e1ul56zb0"
         >
-          AMI:
+          ID:
         </b>
          
-        ami-0c83bb0a9f48c15bf
+        <a
+          class="lg-ui-0001 css-1gw3cuq-StyledLink leafygreen-ui-16e7rxl"
+          data-cy="task-host-link"
+          href="/host/i-0e0e62799806e037d"
+          target="_self"
+        >
+          <span>
+            i-0e0e62799806e037d
+          </span>
+        </a>
       </p>
       <p
         class="css-1spnncu-Item-wordBreakCss e1ul56zb1 leafygreen-ui-1tb6tuo"
@@ -176,19 +185,30 @@
         <b
           class="css-1xk67r-MetadataLabel e1ul56zb0"
         >
-          ID:
+          Image:
         </b>
          
         <a
           class="lg-ui-0001 css-1gw3cuq-StyledLink leafygreen-ui-16e7rxl"
-          data-cy="task-host-link"
-          href="/host/i-0e0e62799806e037d"
-          target="_self"
+          data-cy="task-image-link"
+          href="/image/ubuntu1604/build-information"
         >
           <span>
-            i-0e0e62799806e037d
+            ubuntu1604
           </span>
         </a>
+      </p>
+      <p
+        class="css-1spnncu-Item-wordBreakCss e1ul56zb1 leafygreen-ui-1tb6tuo"
+        data-cy="task-metadata-ami"
+      >
+        <b
+          class="css-1xk67r-MetadataLabel e1ul56zb0"
+        >
+          AMI:
+        </b>
+         
+        ami-0c83bb0a9f48c15bf
       </p>
       <p
         class="css-1spnncu-Item-wordBreakCss e1ul56zb1 leafygreen-ui-1tb6tuo"

--- a/apps/spruce/src/pages/task/metadata/__snapshots__/Metadata_WithDependencies.storyshot
+++ b/apps/spruce/src/pages/task/metadata/__snapshots__/Metadata_WithDependencies.storyshot
@@ -139,17 +139,26 @@
           class="css-qqg5h5-Divider eb6szep0"
         />
       </div>
+       
       <p
         class="css-1spnncu-Item-wordBreakCss e1ul56zb1 leafygreen-ui-1tb6tuo"
-        data-cy="task-metadata-ami"
       >
         <b
           class="css-1xk67r-MetadataLabel e1ul56zb0"
         >
-          AMI:
+          ID:
         </b>
          
-        ami-0c83bb0a9f48c15bf
+        <a
+          class="lg-ui-0001 css-1gw3cuq-StyledLink leafygreen-ui-16e7rxl"
+          data-cy="task-host-link"
+          href="/host/i-0e0e62799806e037d"
+          target="_self"
+        >
+          <span>
+            i-0e0e62799806e037d
+          </span>
+        </a>
       </p>
       <p
         class="css-1spnncu-Item-wordBreakCss e1ul56zb1 leafygreen-ui-1tb6tuo"
@@ -176,19 +185,30 @@
         <b
           class="css-1xk67r-MetadataLabel e1ul56zb0"
         >
-          ID:
+          Image:
         </b>
          
         <a
           class="lg-ui-0001 css-1gw3cuq-StyledLink leafygreen-ui-16e7rxl"
-          data-cy="task-host-link"
-          href="/host/i-0e0e62799806e037d"
-          target="_self"
+          data-cy="task-image-link"
+          href="/image/ubuntu1604/build-information"
         >
           <span>
-            i-0e0e62799806e037d
+            ubuntu1604
           </span>
         </a>
+      </p>
+      <p
+        class="css-1spnncu-Item-wordBreakCss e1ul56zb1 leafygreen-ui-1tb6tuo"
+        data-cy="task-metadata-ami"
+      >
+        <b
+          class="css-1xk67r-MetadataLabel e1ul56zb0"
+        >
+          AMI:
+        </b>
+         
+        ami-0c83bb0a9f48c15bf
       </p>
       <p
         class="css-1spnncu-Item-wordBreakCss e1ul56zb1 leafygreen-ui-1tb6tuo"

--- a/apps/spruce/src/pages/task/metadata/index.tsx
+++ b/apps/spruce/src/pages/task/metadata/index.tsx
@@ -17,6 +17,7 @@ import {
   getHoneycombTraceUrl,
   getHoneycombSystemMetricsUrl,
 } from "constants/externalResources";
+import { showImageVisibilityPage } from "constants/featureFlags";
 import {
   getDistroSettingsRoute,
   getTaskQueueRoute,
@@ -26,6 +27,7 @@ import {
   getVersionRoute,
   getProjectPatchesRoute,
   getPodRoute,
+  getImageRoute,
 } from "constants/routes";
 import { zIndex } from "constants/tokens";
 import { TaskQuery } from "gql/generated/types";
@@ -70,6 +72,7 @@ export const Metadata: React.FC<Props> = ({ error, loading, task, taskId }) => {
     generatedBy,
     generatedByName,
     hostId,
+    imageId,
     ingestTime,
     minQueuePosition: taskQueuePosition,
     pod,
@@ -353,10 +356,22 @@ export const Metadata: React.FC<Props> = ({ error, loading, task, taskId }) => {
 
       {!isDisplayTask && (
         <MetadataCard>
-          <MetadataTitle>Host Information</MetadataTitle>
-          {ami && (
-            <MetadataItem data-cy="task-metadata-ami">
-              <MetadataLabel>AMI:</MetadataLabel> {ami}
+          <MetadataTitle>Host Information</MetadataTitle>{" "}
+          {!isContainerTask && hostId && (
+            <MetadataItem>
+              <MetadataLabel>ID:</MetadataLabel>{" "}
+              <StyledLink
+                data-cy="task-host-link"
+                href={getHostRoute(hostId)}
+                onClick={() =>
+                  taskAnalytics.sendEvent({
+                    name: "Clicked metadata link",
+                    "link.type": "host link",
+                  })
+                }
+              >
+                {hostId}
+              </StyledLink>
             </MetadataItem>
           )}
           {!isContainerTask && distroId && (
@@ -376,21 +391,26 @@ export const Metadata: React.FC<Props> = ({ error, loading, task, taskId }) => {
               </StyledRouterLink>
             </MetadataItem>
           )}
-          {!isContainerTask && hostId && (
+          {showImageVisibilityPage && !isContainerTask && imageId && (
             <MetadataItem>
-              <MetadataLabel>ID:</MetadataLabel>{" "}
-              <StyledLink
-                data-cy="task-host-link"
-                href={getHostRoute(hostId)}
+              <MetadataLabel>Image:</MetadataLabel>{" "}
+              <StyledRouterLink
+                data-cy="task-image-link"
                 onClick={() =>
                   taskAnalytics.sendEvent({
                     name: "Clicked metadata link",
-                    "link.type": "host link",
+                    "link.type": "image link",
                   })
                 }
+                to={getImageRoute(imageId)}
               >
-                {hostId}
-              </StyledLink>
+                {imageId}
+              </StyledRouterLink>
+            </MetadataItem>
+          )}
+          {ami && (
+            <MetadataItem data-cy="task-metadata-ami">
+              <MetadataLabel>AMI:</MetadataLabel> {ami}
             </MetadataItem>
           )}
           {isContainerTask && (


### PR DESCRIPTION
DEVPROD-7660
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
Reverts my previous revert. The issue has been fixed on the backend and the page should no longer crash for any task.

### Screenshots
<!-- add screenshots of visible changes -->
<img width="304" alt="Screenshot 2024-09-13 at 3 05 05 PM" src="https://github.com/user-attachments/assets/3e55a20f-ae2a-42cc-878c-2458fd3aa19b">


### Testing
- Cypress tests
