### PR TITLE
DEVPROD-9738: Match on user defined failing commands

### DIFF
--- a/apps/parsley/src/gql/generated/types.ts
+++ b/apps/parsley/src/gql/generated/types.ts
@@ -2230,7 +2230,7 @@ export type Query = {
   userSettings?: Maybe<UserSettings>;
   version: Version;
   viewableProjectRefs: Array<GroupedProjects>;
-  waterfall?: Maybe<Waterfall>;
+  waterfall: Waterfall;
 };
 
 export type QueryBbGetCreatedTicketsArgs = {
@@ -3428,7 +3428,9 @@ export type VolumeHost = {
 export type Waterfall = {
   __typename?: "Waterfall";
   buildVariants: Array<WaterfallBuildVariant>;
-  versions: Array<Version>;
+  nextPageOrder: Scalars["Int"]["output"];
+  prevPageOrder: Scalars["Int"]["output"];
+  versions: Array<WaterfallVersion>;
 };
 
 export type WaterfallBuild = {
@@ -3449,6 +3451,10 @@ export type WaterfallBuildVariant = {
 
 export type WaterfallOptions = {
   limit?: InputMaybe<Scalars["Int"]["input"]>;
+  /** Return versions with an order lower than maxOrder. Used for paginating forward. */
+  maxOrder?: InputMaybe<Scalars["Int"]["input"]>;
+  /** Return versions with an order greater than minOrder. Used for paginating backward. */
+  minOrder?: InputMaybe<Scalars["Int"]["input"]>;
   projectIdentifier: Scalars["String"]["input"];
   requesters?: InputMaybe<Array<Scalars["String"]["input"]>>;
 };
@@ -3458,6 +3464,12 @@ export type WaterfallTask = {
   displayName: Scalars["String"]["output"];
   id: Scalars["String"]["output"];
   status: Scalars["String"]["output"];
+};
+
+export type WaterfallVersion = {
+  __typename?: "WaterfallVersion";
+  inactiveVersions?: Maybe<Array<Version>>;
+  version?: Maybe<Version>;
 };
 
 export type Webhook = {

--- a/apps/parsley/src/utils/string/index.ts
+++ b/apps/parsley/src/utils/string/index.ts
@@ -135,7 +135,14 @@ export const trimSeverity = (line: string) => {
  * @returns true if line is the failing log line, false otherwise
  */
 export const isFailingLine = (line: string, failingCommand: string) => {
+  console.log(failingCommand);
   const failedExpression = `${failingCommand} failed`;
   const timeoutExpression = `${failingCommand} stopped early`;
-  return line.includes(failedExpression) || line.includes(timeoutExpression);
+  // The "Finished" command is matched when the task status is set to fail by the user.
+  const finished = `Finished command ${failingCommand}`;
+  return (
+    line.includes(failedExpression) ||
+    line.includes(timeoutExpression) ||
+    line.includes(finished)
+  );
 };

--- a/apps/parsley/src/utils/string/index.ts
+++ b/apps/parsley/src/utils/string/index.ts
@@ -135,14 +135,13 @@ export const trimSeverity = (line: string) => {
  * @returns true if line is the failing log line, false otherwise
  */
 export const isFailingLine = (line: string, failingCommand: string) => {
-  console.log(failingCommand);
   const failedExpression = `${failingCommand} failed`;
   const timeoutExpression = `${failingCommand} stopped early`;
   // The "Finished" command is matched when the task status is set to fail by the user.
-  const finished = `Finished command ${failingCommand}`;
+  const finishedExpression = `Finished command ${failingCommand}`;
   return (
     line.includes(failedExpression) ||
     line.includes(timeoutExpression) ||
-    line.includes(finished)
+    line.includes(finishedExpression)
   );
 };

--- a/apps/parsley/src/utils/string/string.test.ts
+++ b/apps/parsley/src/utils/string/string.test.ts
@@ -182,6 +182,12 @@ describe("isFailingLine", () => {
         "'shell.exec' in function 'attach-cypress-results' (step 3.3 of 8) in block 'post'",
       ),
     ).toBe(true);
+    expect(
+      isFailingLine(
+        "[2023/01/02 10:42:29.414] Finished command 'shell.exec' in function 'attach-cypress-results' (step 3.3 of 8) in 20.085137ms.",
+        "'shell.exec' in function 'attach-cypress-results' (step 3.3 of 8) in block 'post'",
+      ),
+    ).toBe(true);
   });
   it("should return false if not a failing line", () => {
     expect(

--- a/apps/parsley/src/utils/string/string.test.ts
+++ b/apps/parsley/src/utils/string/string.test.ts
@@ -184,8 +184,8 @@ describe("isFailingLine", () => {
     ).toBe(true);
     expect(
       isFailingLine(
-        "[2023/01/02 10:42:29.414] Finished command 'shell.exec' in function 'attach-cypress-results' (step 3.3 of 8) in 20.085137ms.",
-        "'shell.exec' in function 'attach-cypress-results' (step 3.3 of 8) in block 'post'",
+        "[2023/01/02 10:42:29.414] Finished command 'shell.exec' in function 'check-codegen' (step 2 of 2).",
+        "'shell.exec' in function 'check-codegen' (step 2 of 2)",
       ),
     ).toBe(true);
   });
@@ -198,7 +198,7 @@ describe("isFailingLine", () => {
     ).toBe(false);
     expect(
       isFailingLine(
-        "[2023/01/02 10:42:29.414] Finished command 'shell.exec' in function 'check-codegen' (step 2 of 2).",
+        "[2023/01/02 10:42:29.414] Running command 'shell.exec' in function 'check-codegen' (step 2 of 2).",
         "'shell.exec' in function 'check-codegen' (step 2 of 2)",
       ),
     ).toBe(false);


### PR DESCRIPTION
DEVPROD-9738

### Description
It's possible for the user to force a failed status on a task by calling the task_status API within a command. In this case, there may not be an explicit failure logged but the command section should still be matched on with the jump to failing line feature. 