### PR TITLE
DEVPROD-10482 Update valid projects label to use ID instead of name

### DIFF
--- a/apps/spruce/cypress/integration/distroSettings/project_section.ts
+++ b/apps/spruce/cypress/integration/distroSettings/project_section.ts
@@ -17,7 +17,7 @@ describe("project section", () => {
     cy.getInputByLabel("Key").type("key-name");
     cy.getInputByLabel("Value").type("my-value");
     cy.contains("button", "Add project").click();
-    cy.getInputByLabel("Project Name").type("spruce");
+    cy.getInputByLabel("Project ID").type("spruce");
 
     save();
     cy.validateToast("success");
@@ -26,7 +26,7 @@ describe("project section", () => {
     cy.reload();
     cy.getInputByLabel("Key").should("have.value", "key-name");
     cy.getInputByLabel("Value").should("have.value", "my-value");
-    cy.getInputByLabel("Project Name").should("have.value", "spruce");
+    cy.getInputByLabel("Project ID").should("have.value", "spruce");
 
     // Undo changes.
     cy.dataCy("delete-item-button").first().click();

--- a/apps/spruce/src/pages/distroSettings/tabs/ProjectTab/getFormSchema.ts
+++ b/apps/spruce/src/pages/distroSettings/tabs/ProjectTab/getFormSchema.ts
@@ -35,7 +35,7 @@ export const getFormSchema = (): ReturnType<GetFormSchema> => ({
         title: "Valid Projects",
         items: {
           type: "string" as "string",
-          title: "Project Name",
+          title: "Project ID",
           default: "",
           minLength: 1,
         },


### PR DESCRIPTION
DEVPROD-10482

### Description
Updates the label used on the distro settings valid projects section to make it more clear that it is expecting a project id instead of an identifier


