### PR TITLE
DEVPROD-11410 Don't init @opentelemetry/instrumentation-fetch if running on parsley

### DIFF
--- a/packages/lib/src/utils/observability/honeycomb.ts
+++ b/packages/lib/src/utils/observability/honeycomb.ts
@@ -1,5 +1,8 @@
 import { HoneycombWebSDK } from "@honeycombio/opentelemetry-web";
-import { getWebAutoInstrumentations } from "@opentelemetry/auto-instrumentations-web";
+import {
+  getWebAutoInstrumentations,
+  InstrumentationConfigMap,
+} from "@opentelemetry/auto-instrumentations-web";
 import { detectGraphqlQuery } from "./utils";
 
 /**
@@ -47,36 +50,39 @@ const initializeHoneycomb = ({
   } else {
     try {
       const userId = localStorage.getItem("userId") ?? undefined;
+      const webAutoInstrumentationConfig: InstrumentationConfigMap = {
+        "@opentelemetry/instrumentation-document-load": {
+          ignoreNetworkEvents: true,
+        },
+      };
+      if (serviceName !== "parsley") {
+        webAutoInstrumentationConfig["@opentelemetry/instrumentation-fetch"] = {
+          // Add GraphQL operation name as an attribute to HTTP traces.
+          applyCustomAttributesOnSpan: (span, request) => {
+            if (span && request) {
+              const { body } = request;
+              if (!body || typeof body !== "string") {
+                return;
+              }
+              const graphqlQuery = detectGraphqlQuery(body);
+              if (graphqlQuery) {
+                span.setAttribute(
+                  "graphql.operation_name",
+                  graphqlQuery.operationName,
+                );
+                span.setAttribute("graphql.query_type", graphqlQuery.queryType);
+              }
+            }
+          },
+          // Allow connecting frontend & backend traces.
+          propagateTraceHeaderCorsUrls: [new RegExp(backendURL || "")],
+        };
+      }
       const honeycombSdk = new HoneycombWebSDK({
         debug,
         endpoint,
         instrumentations: [
-          getWebAutoInstrumentations({
-            "@opentelemetry/instrumentation-fetch": {
-              // Add GraphQL operation name as an attribute to HTTP traces.
-              applyCustomAttributesOnSpan: (span, request) => {
-                if (span && request) {
-                  const body = request.body as string;
-                  const graphqlQuery = detectGraphqlQuery(body);
-                  if (graphqlQuery) {
-                    span.setAttribute(
-                      "graphql.operation_name",
-                      graphqlQuery.operationName,
-                    );
-                    span.setAttribute(
-                      "graphql.query_type",
-                      graphqlQuery.queryType,
-                    );
-                  }
-                }
-              },
-              // Allow connecting frontend & backend traces.
-              propagateTraceHeaderCorsUrls: [new RegExp(backendURL || "")],
-            },
-            "@opentelemetry/instrumentation-document-load": {
-              ignoreNetworkEvents: true,
-            },
-          }),
+          getWebAutoInstrumentations(webAutoInstrumentationConfig),
         ],
         // Add user.id as an attribute to all traces.
         resourceAttributes: {


### PR DESCRIPTION
DEVPROD-11410

### Description
After a ton of debugging, I finally identified why Parsley was throwing CORS errors whenever we tried to instrument requests.

Initially, I suspected that the Honeycomb collector returning a CORS error might have caused the same error to propagate to requests made to Evergreen. However, after fixing the CORS settings in the Honeycomb collector, the error persisted.

My next hypothesis was that the instrumentation itself was causing issues since disabling Honeycomb resolved the bug. It turns out that `@opentelemetry/instrumentation-fetch` was the culprit. This package instruments all fetch requests the app makes. For some reason, on certain Parsley requests—specifically when we utilize a [`streamedFetch` ](https://github.com/evergreen-ci/ui/blob/5595ff5155b7bf60bb778329061a1075384decb3/apps/parsley/src/utils/fetchLogFile/index.ts#L30) method to download log files—the requests would fail with a CORS error.

My hypothesis is that whatever the library does to instrument fetch causes the request to not correctly propagate the necessary CORS headers to the browser when the request uses streaming.

As a temporary workaround, I am disabling this instrumentation for Parsley requests while we wait to hear back from Honeycomb.

### Testing
Deploy this on beta and test:
https://parsley-beta.corp.mongodb.com/evergreen/evergreen_ui_deploy_deploy_parsley_beta_patch_17c35ade4fdb85bb5013e3d0d44cde6010173027_66e9fb23e8fc4600079dbe7f_24_09_17_21_57_02/0/task?bookmarks=0,294

