### PR TITLE
DEVPROD-828: Add multisort to TaskDurationTable

### DIFF
--- a/apps/spruce/cypress/integration/page_tabs.ts
+++ b/apps/spruce/cypress/integration/page_tabs.ts
@@ -18,7 +18,7 @@ describe("Tabs", () => {
         .should("have.attr", "aria-selected")
         .and("eq", "true");
       locationPathEquals(patches.duration.route);
-      cy.location("search").should("contain", "sorts=STATUS%3ADESC");
+      cy.location("search").should("contain", "sorts=DURATION%3ADESC");
     });
 
     it("Applies default sorts on task tab when switching from another tab without any filters", () => {

--- a/apps/spruce/cypress/integration/page_tabs.ts
+++ b/apps/spruce/cypress/integration/page_tabs.ts
@@ -18,7 +18,7 @@ describe("Tabs", () => {
         .should("have.attr", "aria-selected")
         .and("eq", "true");
       locationPathEquals(patches.duration.route);
-      cy.location("search").should("contain", "duration=DESC");
+      cy.location("search").should("contain", "sortBy=DURATION&sortDir=DESC");
     });
 
     it("Applies default sorts on task tab when switching from another tab without any filters", () => {

--- a/apps/spruce/cypress/integration/page_tabs.ts
+++ b/apps/spruce/cypress/integration/page_tabs.ts
@@ -18,7 +18,7 @@ describe("Tabs", () => {
         .should("have.attr", "aria-selected")
         .and("eq", "true");
       locationPathEquals(patches.duration.route);
-      cy.location("search").should("contain", "sortBy=DURATION&sortDir=DESC");
+      cy.location("search").should("contain", "sorts=STATUS%3ADESC");
     });
 
     it("Applies default sorts on task tab when switching from another tab without any filters", () => {

--- a/apps/spruce/cypress/integration/version/task_duration.ts
+++ b/apps/spruce/cypress/integration/version/task_duration.ts
@@ -28,7 +28,7 @@ describe("Task Duration Tab", () => {
       cy.dataCy("tree-select-options").within(() =>
         cy.contains("Running").click({ force: true }),
       );
-      cy.dataCy("task-duration-table-row").should("have.length", 2);
+      cy.dataCy("task-duration-table-row").should("have.length", 3);
       cy.location("search").should(
         "include",
         "page=0&sortBy=DURATION&sortDir=DESC&statuses=failed-umbrella%2Cfailed%2Cknown-issue",

--- a/apps/spruce/cypress/integration/version/task_duration.ts
+++ b/apps/spruce/cypress/integration/version/task_duration.ts
@@ -13,7 +13,7 @@ describe("Task Duration Tab", () => {
       cy.dataCy("task-duration-table-row").should("have.length", 1);
       cy.location("search").should(
         "include",
-        `duration=DESC&page=0&taskName=${filterText}`,
+        `page=0&sortBy=DURATION&sortDir=DESC&taskName=${filterText}`,
       );
       // Clear text filter.
       cy.dataCy("task-name-filter-popover").click();
@@ -28,17 +28,20 @@ describe("Task Duration Tab", () => {
       cy.dataCy("tree-select-options").within(() =>
         cy.contains("Running").click({ force: true }),
       );
-      cy.dataCy("task-duration-table-row").should("have.length", 3);
+      cy.dataCy("task-duration-table-row").should("have.length", 2);
       cy.location("search").should(
         "include",
-        "duration=DESC&page=0&statuses=running-umbrella%2Cstarted%2Cdispatched",
+        "page=0&sortBy=DURATION&sortDir=DESC&statuses=failed-umbrella%2Cfailed%2Cknown-issue",
       );
       // Clear status filter.
       cy.dataCy("status-filter-popover").click();
       cy.dataCy("tree-select-options").within(() =>
         cy.contains("Succeeded").click({ force: true }),
       );
-      cy.location("search").should("include", `duration=DESC&page=0`);
+      cy.location("search").should(
+        "include",
+        "page=0&sortBy=DURATION&sortDir=DESC",
+      );
     });
 
     it("updates URL appropriately when build variant filter is applied", () => {
@@ -51,7 +54,7 @@ describe("Task Duration Tab", () => {
       cy.dataCy("task-duration-table-row").should("have.length", 2);
       cy.location("search").should(
         "include",
-        `duration=DESC&page=0&variant=${filterText}`,
+        `page=0&sortBy=DURATION&sortDir=DESC&variant=${filterText}`,
       );
       // Clear text filter.
       cy.dataCy("build-variant-filter-popover").click();
@@ -62,8 +65,10 @@ describe("Task Duration Tab", () => {
 
     it("updates URL appropriately when sort is changing", () => {
       const durationSortControl = "button[aria-label='Sort by Task Duration']";
+      const statusSortControl = "button[aria-label='Sort by Status']";
+      const variantSortControl = "button[aria-label='Sort by Build Variant']";
       // The default sort (DURATION DESC) should be applied
-      cy.location("search").should("include", "duration=DESC");
+      cy.location("search").should("include", "sortBy=DURATION&sortDir=DESC");
       const longestTask = "test-thirdparty";
       cy.contains(longestTask).should("be.visible");
       cy.dataCy("task-duration-table-row")
@@ -72,12 +77,27 @@ describe("Task Duration Tab", () => {
       cy.get(durationSortControl).click();
       cy.location("search").should("not.include", "duration");
       cy.get(durationSortControl).click();
-      cy.location("search").should("include", "duration=ASC");
+      cy.location("search").should("include", "sortBy=DURATION&sortDir=ASC");
       const shortestTask = "test-auth";
       cy.contains(shortestTask).should("be.visible");
       cy.dataCy("task-duration-table-row")
         .first()
         .should("contain", shortestTask);
+      cy.get(statusSortControl).click();
+      cy.location("search").should(
+        "include",
+        "page=0&sorts=DURATION%3AASC%3BSTATUS%3AASC",
+      );
+      cy.get(statusSortControl).click();
+      cy.location("search").should(
+        "include",
+        "page=0&sorts=DURATION%3AASC%3BSTATUS%3ADESC",
+      );
+      cy.get(variantSortControl).click();
+      cy.location("search").should(
+        "include",
+        "page=0&sorts=DURATION%3AASC%3BSTATUS%3ADESC",
+      );
     });
 
     it("clearing all filters resets to the default sort", () => {
@@ -85,9 +105,9 @@ describe("Task Duration Tab", () => {
       cy.get(durationSortControl).click();
       cy.location("search").should("not.include", "duration");
       cy.get(durationSortControl).click();
-      cy.location("search").should("include", "duration=ASC");
+      cy.location("search").should("include", "sortBy=DURATION&sortDir=ASC");
       cy.contains("Clear all filters").click();
-      cy.location("search").should("include", "duration=DESC");
+      cy.location("search").should("include", "sortBy=DURATION&sortDir=DESC");
     });
 
     it("shows message when no test results are found", () => {

--- a/apps/spruce/cypress/integration/version/task_duration.ts
+++ b/apps/spruce/cypress/integration/version/task_duration.ts
@@ -98,6 +98,11 @@ describe("Task Duration Tab", () => {
         "include",
         "page=0&sorts=DURATION%3AASC%3BSTATUS%3ADESC",
       );
+      cy.reload();
+      cy.location("search").should(
+        "include",
+        "page=0&sorts=DURATION%3AASC%3BSTATUS%3ADESC",
+      );
     });
 
     it("clearing all filters resets to the default sort", () => {

--- a/apps/spruce/cypress/integration/version/task_duration.ts
+++ b/apps/spruce/cypress/integration/version/task_duration.ts
@@ -13,7 +13,7 @@ describe("Task Duration Tab", () => {
       cy.dataCy("task-duration-table-row").should("have.length", 1);
       cy.location("search").should(
         "include",
-        `page=0&sortBy=DURATION&sortDir=DESC&taskName=${filterText}`,
+        `page=0&sorts=DURATION%3ADESC&taskName=${filterText}`,
       );
       // Clear text filter.
       cy.dataCy("task-name-filter-popover").click();
@@ -31,17 +31,14 @@ describe("Task Duration Tab", () => {
       cy.dataCy("task-duration-table-row").should("have.length", 3);
       cy.location("search").should(
         "include",
-        "page=0&sortBy=DURATION&sortDir=DESC&statuses=running-umbrella%2Cstarted%2Cdispatched",
+        "page=0&sorts=DURATION%3ADESC&statuses=running-umbrella%2Cstarted%2Cdispatched",
       );
       // Clear status filter.
       cy.dataCy("status-filter-popover").click();
       cy.dataCy("tree-select-options").within(() =>
         cy.contains("Succeeded").click({ force: true }),
       );
-      cy.location("search").should(
-        "include",
-        "page=0&sortBy=DURATION&sortDir=DESC",
-      );
+      cy.location("search").should("include", "page=0&sorts=DURATION%3ADESC");
     });
 
     it("updates URL appropriately when build variant filter is applied", () => {
@@ -54,7 +51,7 @@ describe("Task Duration Tab", () => {
       cy.dataCy("task-duration-table-row").should("have.length", 2);
       cy.location("search").should(
         "include",
-        `page=0&sortBy=DURATION&sortDir=DESC&variant=${filterText}`,
+        `page=0&sorts=DURATION%3ADESC&variant=${filterText}`,
       );
       // Clear text filter.
       cy.dataCy("build-variant-filter-popover").click();
@@ -68,7 +65,7 @@ describe("Task Duration Tab", () => {
       const statusSortControl = "button[aria-label='Sort by Status']";
       const variantSortControl = "button[aria-label='Sort by Build Variant']";
       // The default sort (DURATION DESC) should be applied
-      cy.location("search").should("include", "sortBy=DURATION&sortDir=DESC");
+      cy.location("search").should("include", "sorts=DURATION%3ADESC");
       const longestTask = "test-thirdparty";
       cy.contains(longestTask).should("be.visible");
       cy.dataCy("task-duration-table-row")
@@ -77,7 +74,7 @@ describe("Task Duration Tab", () => {
       cy.get(durationSortControl).click();
       cy.location("search").should("not.include", "duration");
       cy.get(durationSortControl).click();
-      cy.location("search").should("include", "sortBy=DURATION&sortDir=ASC");
+      cy.location("search").should("include", "sorts=DURATION%3AASC");
       const shortestTask = "test-auth";
       cy.contains(shortestTask).should("be.visible");
       cy.dataCy("task-duration-table-row")
@@ -98,11 +95,6 @@ describe("Task Duration Tab", () => {
         "include",
         "page=0&sorts=DURATION%3AASC%3BSTATUS%3ADESC",
       );
-      cy.reload();
-      cy.location("search").should(
-        "include",
-        "page=0&sorts=DURATION%3AASC%3BSTATUS%3ADESC",
-      );
     });
 
     it("clearing all filters resets to the default sort", () => {
@@ -110,9 +102,9 @@ describe("Task Duration Tab", () => {
       cy.get(durationSortControl).click();
       cy.location("search").should("not.include", "duration");
       cy.get(durationSortControl).click();
-      cy.location("search").should("include", "sortBy=DURATION&sortDir=ASC");
+      cy.location("search").should("include", "sorts=DURATION%3AASC");
       cy.contains("Clear all filters").click();
-      cy.location("search").should("include", "sortBy=DURATION&sortDir=DESC");
+      cy.location("search").should("include", "sorts=DURATION%3ADESC");
     });
 
     it("shows message when no test results are found", () => {

--- a/apps/spruce/cypress/integration/version/task_duration.ts
+++ b/apps/spruce/cypress/integration/version/task_duration.ts
@@ -31,7 +31,7 @@ describe("Task Duration Tab", () => {
       cy.dataCy("task-duration-table-row").should("have.length", 3);
       cy.location("search").should(
         "include",
-        "page=0&sortBy=DURATION&sortDir=DESC&statuses=failed-umbrella%2Cfailed%2Cknown-issue",
+        "page=0&sortBy=DURATION&sortDir=DESC&statuses=running-umbrella%2Cstarted%2Cdispatched",
       );
       // Clear status filter.
       cy.dataCy("status-filter-popover").click();

--- a/apps/spruce/src/analytics/version/useVersionAnalytics.ts
+++ b/apps/spruce/src/analytics/version/useVersionAnalytics.ts
@@ -30,6 +30,7 @@ type Action =
   | { name: "Filtered downstream tasks table"; "filter.by": string | string[] }
   | { name: "Filtered tasks table"; "filter.by": string | string[] }
   | { name: "Filtered task duration table"; "filter.by": string | string[] }
+  | { name: "Sorted task duration table"; "sort.by": string | string[] }
   | { name: "Viewed notification modal" }
   | { name: "Viewed schedule tasks modal" }
   | { name: "Clicked restart tasks button"; abort: boolean }

--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -756,6 +756,7 @@ export type Host = {
   distro?: Maybe<DistroInfo>;
   distroId?: Maybe<Scalars["String"]["output"]>;
   elapsed?: Maybe<Scalars["Time"]["output"]>;
+  eventTypes: Array<HostEventType>;
   /** events returns the event log entries for a given host. */
   events: HostEvents;
   expiration?: Maybe<Scalars["Time"]["output"]>;
@@ -782,9 +783,7 @@ export type Host = {
 
 /** Host models a host, which are used for things like running tasks or as virtual workstations. */
 export type HostEventsArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  page?: InputMaybe<Scalars["Int"]["input"]>;
-  sortDir?: InputMaybe<SortDirection>;
+  opts: HostEventsInput;
 };
 
 export type HostAllocatorSettings = {
@@ -887,6 +886,14 @@ export type HostEvents = {
   __typename?: "HostEvents";
   count: Scalars["Int"]["output"];
   eventLogEntries: Array<HostEventLogEntry>;
+};
+
+export type HostEventsInput = {
+  eventTypes?: InputMaybe<Array<HostEventType>>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  page?: InputMaybe<Scalars["Int"]["input"]>;
+  /** sort by timestamp */
+  sortDir?: InputMaybe<SortDirection>;
 };
 
 export enum HostSortBy {

--- a/apps/spruce/src/hooks/useTableSort/index.ts
+++ b/apps/spruce/src/hooks/useTableSort/index.ts
@@ -8,6 +8,7 @@ const { getSortString } = queryString;
 
 interface Props {
   sendAnalyticsEvents?: (sorter: SortingState) => void;
+  // TODO: DEVPROD-11539 - Remove this prop and make the default behavior to use a single query param.
   singleQueryParam?: boolean;
 }
 

--- a/apps/spruce/src/hooks/useTableSort/index.ts
+++ b/apps/spruce/src/hooks/useTableSort/index.ts
@@ -7,7 +7,7 @@ import { queryString } from "utils";
 const { getSortString } = queryString;
 
 interface Props {
-  sendAnalyticsEvents?: (sorter?: SortingState) => void;
+  sendAnalyticsEvents?: (sorter: SortingState) => void;
 }
 
 type CallbackType = (sorter: SortingState) => void;
@@ -31,7 +31,6 @@ export const useTableSort = (props?: Props): CallbackType => {
       [TableQueryParams.SortDir]: undefined,
       [TableQueryParams.SortBy]: undefined,
     };
-
     if (sorter.length === 1) {
       const { desc, id } = sorter[0];
       // @ts-expect-error: FIXME. This comment was added by an automated script.

--- a/apps/spruce/src/hooks/useTableSort/index.ts
+++ b/apps/spruce/src/hooks/useTableSort/index.ts
@@ -31,6 +31,7 @@ export const useTableSort = (props?: Props): CallbackType => {
       [TableQueryParams.SortDir]: undefined,
       [TableQueryParams.SortBy]: undefined,
     };
+
     if (sorter.length === 1) {
       const { desc, id } = sorter[0];
       // @ts-expect-error: FIXME. This comment was added by an automated script.

--- a/apps/spruce/src/hooks/useTableSort/index.ts
+++ b/apps/spruce/src/hooks/useTableSort/index.ts
@@ -8,6 +8,7 @@ const { getSortString } = queryString;
 
 interface Props {
   sendAnalyticsEvents?: (sorter: SortingState) => void;
+  singleQueryParam?: boolean;
 }
 
 type CallbackType = (sorter: SortingState) => void;
@@ -32,7 +33,7 @@ export const useTableSort = (props?: Props): CallbackType => {
       [TableQueryParams.SortBy]: undefined,
     };
 
-    if (sorter.length === 1) {
+    if (sorter.length === 1 && !props?.singleQueryParam) {
       const { desc, id } = sorter[0];
       // @ts-expect-error: FIXME. This comment was added by an automated script.
       nextQueryParams[TableQueryParams.SortDir] = desc

--- a/apps/spruce/src/pages/task/taskTabs/ExecutionTasksTable.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/ExecutionTasksTable.tsx
@@ -77,7 +77,6 @@ export const ExecutionTasksTable: React.FC<Props> = ({
   );
 
   const tableSortHandler = useTableSort({
-    // @ts-expect-error: FIXME. This comment was added by an automated script.
     sendAnalyticsEvents: (sorter: SortingState) =>
       sendEvent({
         name: "Sorted execution tasks table",

--- a/apps/spruce/src/pages/task/taskTabs/TestsTable.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/TestsTable.tsx
@@ -114,7 +114,6 @@ export const TestsTable: React.FC<TestsTableProps> = ({ task }) => {
   };
 
   const tableSortHandler = useTableSort({
-    // @ts-expect-error: FIXME. This comment was added by an automated script.
     sendAnalyticsEvents: (sorter: SortingState) =>
       sendEvent({
         name: "Sorted tests table",

--- a/apps/spruce/src/pages/version/TaskDuration.tsx
+++ b/apps/spruce/src/pages/version/TaskDuration.tsx
@@ -28,7 +28,6 @@ const { parseQueryString } = queryString;
 interface Props {
   taskCount: number;
 }
-
 const TaskDuration: React.FC<Props> = ({ taskCount }) => {
   const dispatchToast = useToastContext();
   const { [slugs.versionId]: versionId } = useParams();
@@ -40,16 +39,13 @@ const TaskDuration: React.FC<Props> = ({ taskCount }) => {
   // @ts-expect-error: FIXME. This comment was added by an automated script.
   const queryVariables = useQueryVariables(search, versionId);
   const hasQueryVariables = Object.keys(parseQueryString(search)).length > 0;
-  const { limit, page, sorts } = queryVariables.taskFilterOptions;
+  const { limit, page } = queryVariables.taskFilterOptions;
   const [hasInitialized, setHasInitialized] = useState(false);
 
   useEffect(() => {
-    if (!sorts?.length) {
-      updateQueryParams({
-        [TableQueryParams.SortBy]: TaskSortCategory.Duration,
-        [TableQueryParams.SortDir]: SortDirection.Desc,
-      });
-    }
+    updateQueryParams({
+      [TableQueryParams.Sorts]: defaultSort,
+    });
     setHasInitialized(true);
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
@@ -65,10 +61,7 @@ const TaskDuration: React.FC<Props> = ({ taskCount }) => {
       [PatchTasksQueryParams.BaseStatuses]: undefined,
       // @ts-expect-error: FIXME. This comment was added by an automated script.
       [PaginationQueryParams.Page]: undefined,
-      [TableQueryParams.SortBy]: TaskSortCategory.Duration,
-      [TableQueryParams.SortDir]: SortDirection.Desc,
-      // @ts-expect-error: FIXME. This comment was added by an automated script.
-      [PatchTasksQueryParams.Sorts]: undefined,
+      [TableQueryParams.Sorts]: defaultSort,
     });
   };
 
@@ -148,3 +141,5 @@ const TableControlWrapper = styled.div`
 `;
 
 export default TaskDuration;
+
+const defaultSort = `${TaskSortCategory.Duration}:${SortDirection.Desc}`;

--- a/apps/spruce/src/pages/version/TaskDuration.tsx
+++ b/apps/spruce/src/pages/version/TaskDuration.tsx
@@ -108,8 +108,8 @@ const TaskDuration: React.FC<Props> = ({ taskCount }) => {
         totalCount={taskCount}
       />
       {
-        // Ensures that the TaskDurationTable initial sorting state intializes with
-        // the correct default values when applicable.
+        // Ensures that the TaskDurationTable initial sort
+        // button states intialize with the correct default values.
         hasInitialized && (
           <TaskDurationTable
             loading={loading}

--- a/apps/spruce/src/pages/version/taskDuration/TaskDurationTable.test.tsx
+++ b/apps/spruce/src/pages/version/taskDuration/TaskDurationTable.test.tsx
@@ -5,10 +5,15 @@ import {
   userEvent,
   within,
 } from "@evg-ui/lib/test_utils";
-import { VersionTaskDurationsQuery } from "gql/generated/types";
-import { TaskDurationTable } from "./TaskDurationTable";
+import {
+  SortDirection,
+  TaskSortCategory,
+  VersionTaskDurationsQuery,
+} from "gql/generated/types";
+import { PatchTasksQueryParams } from "types/task";
+import { getInitialParams, TaskDurationTable } from "./TaskDurationTable";
 
-describe("taskDurationTable", () => {
+describe("TaskDurationTable", () => {
   it("renders all rows", () => {
     render(
       <MockedProvider>
@@ -37,6 +42,43 @@ describe("taskDurationTable", () => {
   });
 });
 
+describe("getInitialParams", () => {
+  it("should get the correct initialSort when passed in sortBy and sortDir keys", () => {
+    const { initialSort } = getInitialParams({
+      sortBy: TaskSortCategory.Duration,
+      sortDir: "ASC",
+    });
+    expect(initialSort).toEqual([
+      {
+        id: PatchTasksQueryParams.Duration,
+        desc: false,
+      },
+    ]);
+  });
+  it("should get the correct initialSort when passed in sorts key", () => {
+    const { initialSort } = getInitialParams({
+      sorts: `${TaskSortCategory.Duration}:${SortDirection.Desc};${TaskSortCategory.Variant}:${SortDirection.Asc};${TaskSortCategory.Status}:${SortDirection.Asc};${TaskSortCategory.Name}:${SortDirection.Desc}`,
+    });
+    expect(initialSort).toEqual([
+      {
+        desc: true,
+        id: PatchTasksQueryParams.Duration,
+      },
+      {
+        desc: false,
+        id: PatchTasksQueryParams.Variant,
+      },
+      {
+        desc: false,
+        id: PatchTasksQueryParams.Statuses,
+      },
+      {
+        desc: true,
+        id: PatchTasksQueryParams.TaskName,
+      },
+    ]);
+  });
+});
 const tasks: VersionTaskDurationsQuery["version"]["tasks"]["data"] = [
   {
     id: "spruce_ubuntu1604_check_codegen_patch_345da020487255d1b9fb87bed4ceb98397a0c5a5_624af28fa4cf4714c7a6c19a_22_04_04_13_28_48",

--- a/apps/spruce/src/pages/version/taskDuration/TaskDurationTable.test.tsx
+++ b/apps/spruce/src/pages/version/taskDuration/TaskDurationTable.test.tsx
@@ -43,18 +43,6 @@ describe("TaskDurationTable", () => {
 });
 
 describe("getInitialParams", () => {
-  it("should get the correct initialSort when passed in sortBy and sortDir keys", () => {
-    const { initialSort } = getInitialParams({
-      sortBy: TaskSortCategory.Duration,
-      sortDir: "ASC",
-    });
-    expect(initialSort).toEqual([
-      {
-        id: PatchTasksQueryParams.Duration,
-        desc: false,
-      },
-    ]);
-  });
   it("should get the correct initialSort when passed in sorts key", () => {
     const { initialSort } = getInitialParams({
       sorts: `${TaskSortCategory.Duration}:${SortDirection.Desc};${TaskSortCategory.Variant}:${SortDirection.Asc};${TaskSortCategory.Status}:${SortDirection.Asc};${TaskSortCategory.Name}:${SortDirection.Desc}`,

--- a/apps/spruce/src/pages/version/taskDuration/TaskDurationTable.tsx
+++ b/apps/spruce/src/pages/version/taskDuration/TaskDurationTable.tsx
@@ -283,7 +283,6 @@ export const getInitialParams = (queryParams: {
       },
     ];
   } else if (sorts) {
-    console.log(sorts);
     initialSort = parseSortString(sorts, {
       sortByKey: "sortCategory",
       sortDirKey: "direction",

--- a/apps/spruce/src/pages/version/taskDuration/TaskDurationTable.tsx
+++ b/apps/spruce/src/pages/version/taskDuration/TaskDurationTable.tsx
@@ -8,6 +8,7 @@ import {
   useLeafyGreenTable,
   LGColumnDef,
   LeafyGreenTable,
+  OnChangeFn,
 } from "@leafygreen-ui/table";
 import { useParams } from "react-router-dom";
 import { Unpacked } from "@evg-ui/lib/types/utils";
@@ -17,11 +18,17 @@ import { TablePlaceholder } from "components/Table/TablePlaceholder";
 import { onChangeHandler } from "components/Table/utils";
 import { TaskLink } from "components/TasksTable/TaskLink";
 import TaskStatusBadge from "components/TaskStatusBadge";
+import { TableQueryParams } from "constants/queryParams";
 import { slugs } from "constants/routes";
-import { VersionTaskDurationsQuery, SortDirection } from "gql/generated/types";
-import { useTaskStatuses } from "hooks";
+import {
+  VersionTaskDurationsQuery,
+  SortDirection,
+  TaskSortCategory,
+} from "gql/generated/types";
+import { useTableSort, useTaskStatuses } from "hooks";
 import { useQueryParams } from "hooks/useQueryParam";
 import { PatchTasksQueryParams } from "types/task";
+import { parseSortString } from "utils/queryString";
 import { TaskDurationCell } from "./TaskDurationCell";
 
 const { getDefaultOptions: getDefaultFiltering } = ColumnFiltering;
@@ -53,7 +60,6 @@ export const TaskDurationTable: React.FC<Props> = ({
     () => getInitialParams(queryParams),
     [], // eslint-disable-line react-hooks/exhaustive-deps
   );
-
   const setFilters = (f: ColumnFiltersState) =>
     // @ts-expect-error: FIXME. This comment was added by an automated script.
     getDefaultFiltering(table).onColumnFiltersChange(f);
@@ -79,24 +85,15 @@ export const TaskDurationTable: React.FC<Props> = ({
     });
   };
 
-  const setSorting = (s: SortingState) =>
-    // @ts-expect-error: FIXME. This comment was added by an automated script.
-    getDefaultSorting(table).onSortingChange(s);
-
-  const updateSort = (sortState: SortingState) => {
-    const updatedParams = {
-      ...queryParams,
-      page: "0",
-      [PatchTasksQueryParams.Duration]: undefined,
-    };
-
-    sortState.forEach(({ desc, id }) => {
-      // @ts-expect-error: FIXME. This comment was added by an automated script.
-      updatedParams[id] = desc ? SortDirection.Desc : SortDirection.Asc;
-    });
-
-    setQueryParams(updatedParams);
-  };
+  const setSorting: OnChangeFn<SortingState> = (s) =>
+    getDefaultSorting?.(table).onSortingChange?.(s);
+  const tableSortHandler = useTableSort({
+    sendAnalyticsEvents: (sorter) =>
+      sendEvent({
+        name: "Sorted task duration table",
+        "sort.by": sorter.map(({ id }) => id),
+      }),
+  });
 
   const columns: LGColumnDef<TaskDurationData>[] = useMemo(
     () => [
@@ -106,6 +103,7 @@ export const TaskDurationTable: React.FC<Props> = ({
         header: "Task Name",
         size: 250,
         enableColumnFilter: true,
+        enableSorting: true,
         cell: ({
           getValue,
           row: {
@@ -130,6 +128,7 @@ export const TaskDurationTable: React.FC<Props> = ({
         header: "Status",
         size: 120,
         enableColumnFilter: true,
+        enableSorting: true,
         // @ts-expect-error: FIXME. This comment was added by an automated script.
         cell: ({ getValue }) => <TaskStatusBadge status={getValue()} />,
         meta: {
@@ -145,6 +144,7 @@ export const TaskDurationTable: React.FC<Props> = ({
         header: "Build Variant",
         size: 150,
         enableColumnFilter: true,
+        enableSorting: true,
         meta: {
           search: {
             "data-cy": "build-variant-filter-popover",
@@ -184,10 +184,12 @@ export const TaskDurationTable: React.FC<Props> = ({
       // @ts-expect-error: FIXME. This comment was added by an automated script.
       data: tasks ?? [],
       defaultColumn: {
+        enableMultiSort: true,
         // Handle bug in sorting order
         // https://github.com/TanStack/table/issues/4289
         sortDescFirst: false,
       },
+      isMultiSortEvent: () => true, // Override default requirement for shift-click to multisort.
       getFacetedMinMaxValues: getFacetedMinMaxValues(),
       initialState: {
         columnFilters: initialFilters,
@@ -204,14 +206,14 @@ export const TaskDurationTable: React.FC<Props> = ({
           table.resetRowSelection();
         },
       ),
-      onSortingChange: onChangeHandler<SortingState>(
-        // @ts-expect-error: FIXME. This comment was added by an automated script.
-        setSorting,
-        (updatedState) => {
-          updateSort(updatedState);
-          table.resetRowSelection();
-        },
-      ),
+      onSortingChange: onChangeHandler<SortingState>(setSorting, (sorts) => {
+        tableSortHandler(
+          sorts.map(({ desc, id }) => ({
+            id: columnIdToSortCategory[id],
+            desc,
+          })),
+        );
+      }),
     });
 
   return (
@@ -226,8 +228,21 @@ export const TaskDurationTable: React.FC<Props> = ({
     />
   );
 };
+const columnIdToSortCategory: { [key: string]: TaskSortCategory } = {
+  [PatchTasksQueryParams.Duration]: TaskSortCategory.Duration,
+  [PatchTasksQueryParams.TaskName]: TaskSortCategory.Name,
+  [PatchTasksQueryParams.Statuses]: TaskSortCategory.Status,
+  [PatchTasksQueryParams.Variant]: TaskSortCategory.Variant,
+};
 
-const getInitialParams = (queryParams: {
+const sortCategoryToColumnId: { [key: string]: PatchTasksQueryParams } = {
+  [TaskSortCategory.Duration]: PatchTasksQueryParams.Duration,
+  [TaskSortCategory.Name]: PatchTasksQueryParams.TaskName,
+  [TaskSortCategory.Status]: PatchTasksQueryParams.Statuses,
+  [TaskSortCategory.Variant]: PatchTasksQueryParams.Variant,
+};
+
+export const getInitialParams = (queryParams: {
   [key: string]: any;
 }): {
   initialFilters: ColumnFiltersState;
@@ -237,7 +252,9 @@ const getInitialParams = (queryParams: {
     [PatchTasksQueryParams.TaskName]: taskName,
     [PatchTasksQueryParams.Statuses]: statuses,
     [PatchTasksQueryParams.Variant]: variant,
-    [PatchTasksQueryParams.Duration]: duration,
+    [TableQueryParams.SortBy]: sortBy,
+    [TableQueryParams.SortDir]: sortDir,
+    [TableQueryParams.Sorts]: sorts,
   } = queryParams;
 
   const initialFilters = [];
@@ -257,20 +274,27 @@ const getInitialParams = (queryParams: {
     initialFilters.push({ id: PatchTasksQueryParams.Variant, value: variant });
   }
 
+  let initialSort: SortingState = [];
+  if (sortBy && sortDir) {
+    initialSort = [
+      {
+        id: sortCategoryToColumnId[sortBy],
+        desc: sortDir === SortDirection.Desc,
+      },
+    ];
+  } else if (sorts) {
+    console.log(sorts);
+    initialSort = parseSortString(sorts, {
+      sortByKey: "sortCategory",
+      sortDirKey: "direction",
+      sortCategoryEnum: TaskSortCategory,
+    }).map(({ direction, sortCategory }) => ({
+      id: sortCategoryToColumnId[sortCategory],
+      desc: direction === SortDirection.Desc,
+    }));
+  }
   return {
     initialFilters,
-    initialSort: duration
-      ? [
-          {
-            id: PatchTasksQueryParams.Duration,
-            desc: duration === SortDirection.Desc,
-          },
-        ]
-      : [
-          {
-            id: PatchTasksQueryParams.Duration,
-            desc: true,
-          },
-        ],
+    initialSort,
   };
 };

--- a/apps/spruce/src/pages/version/taskDuration/TaskDurationTable.tsx
+++ b/apps/spruce/src/pages/version/taskDuration/TaskDurationTable.tsx
@@ -273,14 +273,16 @@ export const getInitialParams = (queryParams: {
     initialFilters.push({ id: PatchTasksQueryParams.Variant, value: variant });
   }
 
-  const initialSort: SortingState = parseSortString(sorts, {
-    sortByKey: "sortCategory",
-    sortDirKey: "direction",
-    sortCategoryEnum: TaskSortCategory,
-  }).map(({ direction, sortCategory }) => ({
-    id: sortCategoryToColumnId[sortCategory],
-    desc: direction === SortDirection.Desc,
-  }));
+  const initialSort: SortingState = sorts
+    ? parseSortString(sorts, {
+        sortByKey: "sortCategory",
+        sortDirKey: "direction",
+        sortCategoryEnum: TaskSortCategory,
+      }).map(({ direction, sortCategory }) => ({
+        id: sortCategoryToColumnId[sortCategory],
+        desc: direction === SortDirection.Desc,
+      }))
+    : [];
 
   return {
     initialFilters,

--- a/apps/spruce/src/pages/version/taskDuration/TaskDurationTable.tsx
+++ b/apps/spruce/src/pages/version/taskDuration/TaskDurationTable.tsx
@@ -88,6 +88,7 @@ export const TaskDurationTable: React.FC<Props> = ({
   const setSorting: OnChangeFn<SortingState> = (s) =>
     getDefaultSorting?.(table).onSortingChange?.(s);
   const tableSortHandler = useTableSort({
+    singleQueryParam: true,
     sendAnalyticsEvents: (sorter) =>
       sendEvent({
         name: "Sorted task duration table",
@@ -252,8 +253,6 @@ export const getInitialParams = (queryParams: {
     [PatchTasksQueryParams.TaskName]: taskName,
     [PatchTasksQueryParams.Statuses]: statuses,
     [PatchTasksQueryParams.Variant]: variant,
-    [TableQueryParams.SortBy]: sortBy,
-    [TableQueryParams.SortDir]: sortDir,
     [TableQueryParams.Sorts]: sorts,
   } = queryParams;
 
@@ -274,24 +273,15 @@ export const getInitialParams = (queryParams: {
     initialFilters.push({ id: PatchTasksQueryParams.Variant, value: variant });
   }
 
-  let initialSort: SortingState = [];
-  if (sortBy && sortDir) {
-    initialSort = [
-      {
-        id: sortCategoryToColumnId[sortBy],
-        desc: sortDir === SortDirection.Desc,
-      },
-    ];
-  } else if (sorts) {
-    initialSort = parseSortString(sorts, {
-      sortByKey: "sortCategory",
-      sortDirKey: "direction",
-      sortCategoryEnum: TaskSortCategory,
-    }).map(({ direction, sortCategory }) => ({
-      id: sortCategoryToColumnId[sortCategory],
-      desc: direction === SortDirection.Desc,
-    }));
-  }
+  const initialSort: SortingState = parseSortString(sorts, {
+    sortByKey: "sortCategory",
+    sortDirKey: "direction",
+    sortCategoryEnum: TaskSortCategory,
+  }).map(({ direction, sortCategory }) => ({
+    id: sortCategoryToColumnId[sortCategory],
+    desc: direction === SortDirection.Desc,
+  }));
+
   return {
     initialFilters,
     initialSort,

--- a/apps/spruce/src/pages/version/taskDuration/__snapshots__/TaskDurationTable_Default.storyshot
+++ b/apps/spruce/src/pages/version/taskDuration/__snapshots__/TaskDurationTable_Default.storyshot
@@ -54,6 +54,33 @@
                   </div>
                 </button>
               </div>
+              <button
+                aria-disabled="false"
+                aria-label="Sort by Task Name"
+                class="leafygreen-ui-tcjr3n"
+                data-testid="lg-table-sort-icon-button"
+                tabindex="0"
+              >
+                <div
+                  class="leafygreen-ui-xhlipt"
+                >
+                  <svg
+                    aria-label="Unsorted Icon"
+                    class="leafygreen-ui-jc2z8v"
+                    fill="none"
+                    height="16"
+                    role="img"
+                    viewBox="0 0 16 16"
+                    width="16"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M3.685 1.143c.22-.19.545-.19.765 0l2.482 2.149a.584.584 0 0 1-.383 1.026H5.236v7.364H6.55c.541 0 .792.672.383 1.026l-2.482 2.15a.584.584 0 0 1-.765 0l-2.482-2.15a.584.584 0 0 1 .383-1.026h1.312V4.318H1.586a.584.584 0 0 1-.383-1.026l2.482-2.15ZM8 8a1 1 0 0 1 1-1h5a1 1 0 1 1 0 2H9a1 1 0 0 1-1-1ZM9 4a1 1 0 0 0 0 2h5a1 1 0 1 0 0-2H9ZM8 11a1 1 0 0 1 1-1h5a1 1 0 1 1 0 2H9a1 1 0 0 1-1-1Z"
+                      fill="currentColor"
+                    />
+                  </svg>
+                </div>
+              </button>
             </div>
           </th>
           <th
@@ -99,6 +126,33 @@
                   </div>
                 </button>
               </div>
+              <button
+                aria-disabled="false"
+                aria-label="Sort by Status"
+                class="leafygreen-ui-tcjr3n"
+                data-testid="lg-table-sort-icon-button"
+                tabindex="0"
+              >
+                <div
+                  class="leafygreen-ui-xhlipt"
+                >
+                  <svg
+                    aria-label="Unsorted Icon"
+                    class="leafygreen-ui-jc2z8v"
+                    fill="none"
+                    height="16"
+                    role="img"
+                    viewBox="0 0 16 16"
+                    width="16"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M3.685 1.143c.22-.19.545-.19.765 0l2.482 2.149a.584.584 0 0 1-.383 1.026H5.236v7.364H6.55c.541 0 .792.672.383 1.026l-2.482 2.15a.584.584 0 0 1-.765 0l-2.482-2.15a.584.584 0 0 1 .383-1.026h1.312V4.318H1.586a.584.584 0 0 1-.383-1.026l2.482-2.15ZM8 8a1 1 0 0 1 1-1h5a1 1 0 1 1 0 2H9a1 1 0 0 1-1-1ZM9 4a1 1 0 0 0 0 2h5a1 1 0 1 0 0-2H9ZM8 11a1 1 0 0 1 1-1h5a1 1 0 1 1 0 2H9a1 1 0 0 1-1-1Z"
+                      fill="currentColor"
+                    />
+                  </svg>
+                </div>
+              </button>
             </div>
           </th>
           <th
@@ -144,6 +198,33 @@
                   </div>
                 </button>
               </div>
+              <button
+                aria-disabled="false"
+                aria-label="Sort by Build Variant"
+                class="leafygreen-ui-tcjr3n"
+                data-testid="lg-table-sort-icon-button"
+                tabindex="0"
+              >
+                <div
+                  class="leafygreen-ui-xhlipt"
+                >
+                  <svg
+                    aria-label="Unsorted Icon"
+                    class="leafygreen-ui-jc2z8v"
+                    fill="none"
+                    height="16"
+                    role="img"
+                    viewBox="0 0 16 16"
+                    width="16"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M3.685 1.143c.22-.19.545-.19.765 0l2.482 2.149a.584.584 0 0 1-.383 1.026H5.236v7.364H6.55c.541 0 .792.672.383 1.026l-2.482 2.15a.584.584 0 0 1-.765 0l-2.482-2.15a.584.584 0 0 1 .383-1.026h1.312V4.318H1.586a.584.584 0 0 1-.383-1.026l2.482-2.15ZM8 8a1 1 0 0 1 1-1h5a1 1 0 1 1 0 2H9a1 1 0 0 1-1-1ZM9 4a1 1 0 0 0 0 2h5a1 1 0 1 0 0-2H9ZM8 11a1 1 0 0 1 1-1h5a1 1 0 1 1 0 2H9a1 1 0 0 1-1-1Z"
+                      fill="currentColor"
+                    />
+                  </svg>
+                </div>
+              </button>
             </div>
           </th>
           <th
@@ -165,8 +246,8 @@
                   class="leafygreen-ui-xhlipt"
                 >
                   <svg
-                    aria-label="Sort Descending Icon"
-                    class="leafygreen-ui-1t2jgtk"
+                    aria-label="Unsorted Icon"
+                    class="leafygreen-ui-jc2z8v"
                     fill="none"
                     height="16"
                     role="img"
@@ -175,7 +256,7 @@
                     xmlns="http://www.w3.org/2000/svg"
                   >
                     <path
-                      d="M4.45 14.696a.584.584 0 0 1-.765 0l-2.482-2.15a.584.584 0 0 1 .383-1.025h1.312V2.168a1.169 1.169 0 1 1 2.338 0v9.351H6.55c.541 0 .792.673.383 1.027L4.45 14.696ZM8 3a1 1 0 0 0 0 2h6a1 1 0 1 0 0-2H8ZM7 7a1 1 0 0 1 1-1h4a1 1 0 1 1 0 2H8a1 1 0 0 1-1-1ZM8 9a1 1 0 1 0 0 2h2a1 1 0 1 0 0-2H8Z"
+                      d="M3.685 1.143c.22-.19.545-.19.765 0l2.482 2.149a.584.584 0 0 1-.383 1.026H5.236v7.364H6.55c.541 0 .792.672.383 1.026l-2.482 2.15a.584.584 0 0 1-.765 0l-2.482-2.15a.584.584 0 0 1 .383-1.026h1.312V4.318H1.586a.584.584 0 0 1-.383-1.026l2.482-2.15ZM8 8a1 1 0 0 1 1-1h5a1 1 0 1 1 0 2H9a1 1 0 0 1-1-1ZM9 4a1 1 0 0 0 0 2h5a1 1 0 1 0 0-2H9ZM8 11a1 1 0 0 1 1-1h5a1 1 0 1 1 0 2H9a1 1 0 0 1-1-1Z"
                       fill="currentColor"
                     />
                   </svg>

--- a/apps/spruce/src/pages/version/taskDuration/__snapshots__/TaskDurationTable_LongContent.storyshot
+++ b/apps/spruce/src/pages/version/taskDuration/__snapshots__/TaskDurationTable_LongContent.storyshot
@@ -54,6 +54,33 @@
                   </div>
                 </button>
               </div>
+              <button
+                aria-disabled="false"
+                aria-label="Sort by Task Name"
+                class="leafygreen-ui-tcjr3n"
+                data-testid="lg-table-sort-icon-button"
+                tabindex="0"
+              >
+                <div
+                  class="leafygreen-ui-xhlipt"
+                >
+                  <svg
+                    aria-label="Unsorted Icon"
+                    class="leafygreen-ui-jc2z8v"
+                    fill="none"
+                    height="16"
+                    role="img"
+                    viewBox="0 0 16 16"
+                    width="16"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M3.685 1.143c.22-.19.545-.19.765 0l2.482 2.149a.584.584 0 0 1-.383 1.026H5.236v7.364H6.55c.541 0 .792.672.383 1.026l-2.482 2.15a.584.584 0 0 1-.765 0l-2.482-2.15a.584.584 0 0 1 .383-1.026h1.312V4.318H1.586a.584.584 0 0 1-.383-1.026l2.482-2.15ZM8 8a1 1 0 0 1 1-1h5a1 1 0 1 1 0 2H9a1 1 0 0 1-1-1ZM9 4a1 1 0 0 0 0 2h5a1 1 0 1 0 0-2H9ZM8 11a1 1 0 0 1 1-1h5a1 1 0 1 1 0 2H9a1 1 0 0 1-1-1Z"
+                      fill="currentColor"
+                    />
+                  </svg>
+                </div>
+              </button>
             </div>
           </th>
           <th
@@ -99,6 +126,33 @@
                   </div>
                 </button>
               </div>
+              <button
+                aria-disabled="false"
+                aria-label="Sort by Status"
+                class="leafygreen-ui-tcjr3n"
+                data-testid="lg-table-sort-icon-button"
+                tabindex="0"
+              >
+                <div
+                  class="leafygreen-ui-xhlipt"
+                >
+                  <svg
+                    aria-label="Unsorted Icon"
+                    class="leafygreen-ui-jc2z8v"
+                    fill="none"
+                    height="16"
+                    role="img"
+                    viewBox="0 0 16 16"
+                    width="16"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M3.685 1.143c.22-.19.545-.19.765 0l2.482 2.149a.584.584 0 0 1-.383 1.026H5.236v7.364H6.55c.541 0 .792.672.383 1.026l-2.482 2.15a.584.584 0 0 1-.765 0l-2.482-2.15a.584.584 0 0 1 .383-1.026h1.312V4.318H1.586a.584.584 0 0 1-.383-1.026l2.482-2.15ZM8 8a1 1 0 0 1 1-1h5a1 1 0 1 1 0 2H9a1 1 0 0 1-1-1ZM9 4a1 1 0 0 0 0 2h5a1 1 0 1 0 0-2H9ZM8 11a1 1 0 0 1 1-1h5a1 1 0 1 1 0 2H9a1 1 0 0 1-1-1Z"
+                      fill="currentColor"
+                    />
+                  </svg>
+                </div>
+              </button>
             </div>
           </th>
           <th
@@ -144,6 +198,33 @@
                   </div>
                 </button>
               </div>
+              <button
+                aria-disabled="false"
+                aria-label="Sort by Build Variant"
+                class="leafygreen-ui-tcjr3n"
+                data-testid="lg-table-sort-icon-button"
+                tabindex="0"
+              >
+                <div
+                  class="leafygreen-ui-xhlipt"
+                >
+                  <svg
+                    aria-label="Unsorted Icon"
+                    class="leafygreen-ui-jc2z8v"
+                    fill="none"
+                    height="16"
+                    role="img"
+                    viewBox="0 0 16 16"
+                    width="16"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M3.685 1.143c.22-.19.545-.19.765 0l2.482 2.149a.584.584 0 0 1-.383 1.026H5.236v7.364H6.55c.541 0 .792.672.383 1.026l-2.482 2.15a.584.584 0 0 1-.765 0l-2.482-2.15a.584.584 0 0 1 .383-1.026h1.312V4.318H1.586a.584.584 0 0 1-.383-1.026l2.482-2.15ZM8 8a1 1 0 0 1 1-1h5a1 1 0 1 1 0 2H9a1 1 0 0 1-1-1ZM9 4a1 1 0 0 0 0 2h5a1 1 0 1 0 0-2H9ZM8 11a1 1 0 0 1 1-1h5a1 1 0 1 1 0 2H9a1 1 0 0 1-1-1Z"
+                      fill="currentColor"
+                    />
+                  </svg>
+                </div>
+              </button>
             </div>
           </th>
           <th
@@ -165,8 +246,8 @@
                   class="leafygreen-ui-xhlipt"
                 >
                   <svg
-                    aria-label="Sort Descending Icon"
-                    class="leafygreen-ui-1t2jgtk"
+                    aria-label="Unsorted Icon"
+                    class="leafygreen-ui-jc2z8v"
                     fill="none"
                     height="16"
                     role="img"
@@ -175,7 +256,7 @@
                     xmlns="http://www.w3.org/2000/svg"
                   >
                     <path
-                      d="M4.45 14.696a.584.584 0 0 1-.765 0l-2.482-2.15a.584.584 0 0 1 .383-1.025h1.312V2.168a1.169 1.169 0 1 1 2.338 0v9.351H6.55c.541 0 .792.673.383 1.027L4.45 14.696ZM8 3a1 1 0 0 0 0 2h6a1 1 0 1 0 0-2H8ZM7 7a1 1 0 0 1 1-1h4a1 1 0 1 1 0 2H8a1 1 0 0 1-1-1ZM8 9a1 1 0 1 0 0 2h2a1 1 0 1 0 0-2H8Z"
+                      d="M3.685 1.143c.22-.19.545-.19.765 0l2.482 2.149a.584.584 0 0 1-.383 1.026H5.236v7.364H6.55c.541 0 .792.672.383 1.026l-2.482 2.15a.584.584 0 0 1-.765 0l-2.482-2.15a.584.584 0 0 1 .383-1.026h1.312V4.318H1.586a.584.584 0 0 1-.383-1.026l2.482-2.15ZM8 8a1 1 0 0 1 1-1h5a1 1 0 1 1 0 2H9a1 1 0 0 1-1-1ZM9 4a1 1 0 0 0 0 2h5a1 1 0 1 0 0-2H9ZM8 11a1 1 0 0 1 1-1h5a1 1 0 1 1 0 2H9a1 1 0 0 1-1-1Z"
                       fill="currentColor"
                     />
                   </svg>

--- a/apps/spruce/src/pages/version/useQueryVariables/index.ts
+++ b/apps/spruce/src/pages/version/useQueryVariables/index.ts
@@ -3,7 +3,6 @@ import {
   VersionTasksQueryVariables,
   SortOrder,
   TaskSortCategory,
-  SortDirection,
 } from "gql/generated/types";
 import usePagination from "hooks/usePagination";
 import { PatchTasksQueryParams } from "types/task";
@@ -26,33 +25,13 @@ export const useQueryVariables = (
     [PatchTasksQueryParams.BaseStatuses]: baseStatuses,
   } = queryParams;
 
-  let sortsToApply: SortOrder[] = [];
-  const taskSortCategories: string[] = Object.values(TaskSortCategory);
-  const parsedSortBy = getString(queryParams[TableQueryParams.SortBy]);
-  const sortBy = taskSortCategories.includes(parsedSortBy)
-    ? (parsedSortBy as TaskSortCategory)
-    : undefined;
-  const parsedSortDir = getString(queryParams[TableQueryParams.SortDir]);
-  const sortDir =
-    parsedSortDir === SortDirection.Desc
-      ? SortDirection.Desc
-      : SortDirection.Asc;
-  // 'sortBy', 'sortDir' and 'sorts' are set by useTableSort in <TaskDurationTable />
-  // 'sorts' is set by <PatchTasksTable />
-  if (sortBy && sortDir) {
-    sortsToApply = [{ Key: sortBy, Direction: sortDir }];
-  } else if (sorts) {
-    sortsToApply = parseSortString<
-      "Key",
-      "Direction",
-      TaskSortCategory,
-      SortOrder
-    >(sorts, {
-      sortByKey: "Key",
-      sortDirKey: "Direction",
-      sortCategoryEnum: TaskSortCategory,
-    });
-  }
+  const sortsToApply: SortOrder[] = sorts
+    ? parseSortString<"Key", "Direction", TaskSortCategory, SortOrder>(sorts, {
+        sortByKey: "Key",
+        sortDirKey: "Direction",
+        sortCategoryEnum: TaskSortCategory,
+      })
+    : [];
 
   return {
     versionId,

--- a/apps/spruce/src/pages/version/useQueryVariables/index.ts
+++ b/apps/spruce/src/pages/version/useQueryVariables/index.ts
@@ -26,8 +26,6 @@ export const useQueryVariables = (
     [PatchTasksQueryParams.BaseStatuses]: baseStatuses,
   } = queryParams;
 
-  // This should be reworked once the antd tables are removed.
-  // At the current state, sorts & duration will never both be defined.
   let sortsToApply: SortOrder[] = [];
   const taskSortCategories: string[] = Object.values(TaskSortCategory);
   const parsedSortBy = getString(queryParams[TableQueryParams.SortBy]);
@@ -39,7 +37,8 @@ export const useQueryVariables = (
     parsedSortDir === SortDirection.Desc
       ? SortDirection.Desc
       : SortDirection.Asc;
-
+  // 'sortBy', 'sortDir' and 'sorts' are set by useTableSort in <TaskDurationTable />
+  // 'sorts' is set by <PatchTasksTable />
   if (sortBy && sortDir) {
     sortsToApply = [{ Key: sortBy, Direction: sortDir }];
   } else if (sorts) {

--- a/apps/spruce/src/pages/version/useQueryVariables/useQueryVariables.test.tsx
+++ b/apps/spruce/src/pages/version/useQueryVariables/useQueryVariables.test.tsx
@@ -4,18 +4,19 @@ import { TaskSortCategory, SortDirection } from "gql/generated/types";
 import { useQueryVariables } from ".";
 
 describe("useQueryVariables", () => {
-  const search =
-    "page=0&limit=20&sorts=NAME%3AASC%3BSTATUS%3AASC%3BBASE_STATUS%3ADESC%3BVARIANT%3AASC&statuses=success&taskName=generate";
-  // @ts-expect-error: FIXME. This comment was added by an automated script.
-  const wrapper = ({ children }) => (
-    <MemoryRouter initialEntries={[`?${search}`]}>{children}</MemoryRouter>
-  );
+  const getWrapper = (search: string) =>
+    function ({ children }: { children: React.ReactNode }) {
+      return (
+        <MemoryRouter initialEntries={[`?${search}`]}>{children}</MemoryRouter>
+      );
+    };
 
   it("returns appropriate variables based on search string", () => {
     const versionId = "version";
-
+    const search =
+      "page=0&limit=20&sorts=NAME%3AASC%3BSTATUS%3AASC%3BBASE_STATUS%3ADESC%3BVARIANT%3AASC&statuses=success&taskName=generate";
     const { result } = renderHook(() => useQueryVariables(search, versionId), {
-      wrapper,
+      wrapper: getWrapper(search),
     });
     expect(result.current).toStrictEqual({
       versionId,
@@ -33,6 +34,78 @@ describe("useQueryVariables", () => {
         page: 0,
         limit: 20,
       },
+    });
+  });
+  it("extracts sort value from 'sortBy' and 'sortDir' query params", () => {
+    const versionId = "version";
+    const search =
+      "page=0&limit=20&sortBy=DURATION&sortDir=ASC&statuses=success&taskName=generate";
+    const { result } = renderHook(() => useQueryVariables(search, versionId), {
+      wrapper: getWrapper(search),
+    });
+    expect(result.current).toStrictEqual({
+      versionId,
+      taskFilterOptions: {
+        taskName: "generate",
+        variant: "",
+        statuses: ["success"],
+        baseStatuses: [],
+        sorts: [
+          { Key: TaskSortCategory.Duration, Direction: SortDirection.Asc },
+        ],
+        page: 0,
+        limit: 20,
+      },
+    });
+  });
+  describe("filters invalid sorts from the search string", () => {
+    it("when passed in with the 'sorts' query param", () => {
+      const versionId = "version";
+      const search =
+        "page=0&limit=20&sorts=FAKE_NAME%3AASC%3BFAKE_STATUS%3AASC%3BFAKE_BASE_STATUS%3ADESC%3BVARIANT%3AASC&statuses=success&taskName=generate";
+      const { result } = renderHook(
+        () => useQueryVariables(search, versionId),
+        {
+          wrapper: getWrapper(search),
+        },
+      );
+      expect(result.current).toStrictEqual({
+        versionId,
+        taskFilterOptions: {
+          taskName: "generate",
+          variant: "",
+          statuses: ["success"],
+          baseStatuses: [],
+          sorts: [
+            { Key: TaskSortCategory.Variant, Direction: SortDirection.Asc },
+          ],
+          page: 0,
+          limit: 20,
+        },
+      });
+    });
+    it("when passed in with the 'sortBy' and 'sortDir' query params", () => {
+      const versionId = "version";
+      const search =
+        "page=0&limit=20&sortBy=fake&sortDir=fake&statuses=success&taskName=generate";
+      const { result } = renderHook(
+        () => useQueryVariables(search, versionId),
+        {
+          wrapper: getWrapper(search),
+        },
+      );
+      expect(result.current).toStrictEqual({
+        versionId,
+        taskFilterOptions: {
+          taskName: "generate",
+          variant: "",
+          statuses: ["success"],
+          baseStatuses: [],
+          sorts: [],
+          page: 0,
+          limit: 20,
+        },
+      });
     });
   });
 });

--- a/apps/spruce/src/pages/version/useQueryVariables/useQueryVariables.test.tsx
+++ b/apps/spruce/src/pages/version/useQueryVariables/useQueryVariables.test.tsx
@@ -36,10 +36,10 @@ describe("useQueryVariables", () => {
       },
     });
   });
-  it("extracts sort value from 'sortBy' and 'sortDir' query params", () => {
+  it("filters invalid sorts from the search string", () => {
     const versionId = "version";
     const search =
-      "page=0&limit=20&sortBy=DURATION&sortDir=ASC&statuses=success&taskName=generate";
+      "page=0&limit=20&sorts=FAKE_NAME%3AASC%3BFAKE_STATUS%3AASC%3BFAKE_BASE_STATUS%3ADESC%3BVARIANT%3AASC&statuses=success&taskName=generate";
     const { result } = renderHook(() => useQueryVariables(search, versionId), {
       wrapper: getWrapper(search),
     });
@@ -51,61 +51,11 @@ describe("useQueryVariables", () => {
         statuses: ["success"],
         baseStatuses: [],
         sorts: [
-          { Key: TaskSortCategory.Duration, Direction: SortDirection.Asc },
+          { Key: TaskSortCategory.Variant, Direction: SortDirection.Asc },
         ],
         page: 0,
         limit: 20,
       },
-    });
-  });
-  describe("filters invalid sorts from the search string", () => {
-    it("when passed in with the 'sorts' query param", () => {
-      const versionId = "version";
-      const search =
-        "page=0&limit=20&sorts=FAKE_NAME%3AASC%3BFAKE_STATUS%3AASC%3BFAKE_BASE_STATUS%3ADESC%3BVARIANT%3AASC&statuses=success&taskName=generate";
-      const { result } = renderHook(
-        () => useQueryVariables(search, versionId),
-        {
-          wrapper: getWrapper(search),
-        },
-      );
-      expect(result.current).toStrictEqual({
-        versionId,
-        taskFilterOptions: {
-          taskName: "generate",
-          variant: "",
-          statuses: ["success"],
-          baseStatuses: [],
-          sorts: [
-            { Key: TaskSortCategory.Variant, Direction: SortDirection.Asc },
-          ],
-          page: 0,
-          limit: 20,
-        },
-      });
-    });
-    it("when passed in with the 'sortBy' and 'sortDir' query params", () => {
-      const versionId = "version";
-      const search =
-        "page=0&limit=20&sortBy=fake&sortDir=fake&statuses=success&taskName=generate";
-      const { result } = renderHook(
-        () => useQueryVariables(search, versionId),
-        {
-          wrapper: getWrapper(search),
-        },
-      );
-      expect(result.current).toStrictEqual({
-        versionId,
-        taskFilterOptions: {
-          taskName: "generate",
-          variant: "",
-          statuses: ["success"],
-          baseStatuses: [],
-          sorts: [],
-          page: 0,
-          limit: 20,
-        },
-      });
     });
   });
 });


### PR DESCRIPTION
DEVPROD-828

### Description
These code changes add multisort to the Task Duration Table by utilizing the `useTableSort` hook. 
Tickets produced during this work: 
https://jira.mongodb.org/browse/DEVPROD-11421
https://jira.mongodb.org/browse/DEVPROD-11539
https://jira.mongodb.org/browse/DEVPROD-11537
https://jira.mongodb.org/browse/DEVPROD-11422