### PR TITLE
DEVPROD-10319: Fix time conversion logic in msToDuration

### DIFF
--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -756,6 +756,7 @@ export type Host = {
   distro?: Maybe<DistroInfo>;
   distroId?: Maybe<Scalars["String"]["output"]>;
   elapsed?: Maybe<Scalars["Time"]["output"]>;
+  eventTypes: Array<HostEventType>;
   /** events returns the event log entries for a given host. */
   events: HostEvents;
   expiration?: Maybe<Scalars["Time"]["output"]>;
@@ -782,9 +783,7 @@ export type Host = {
 
 /** Host models a host, which are used for things like running tasks or as virtual workstations. */
 export type HostEventsArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  page?: InputMaybe<Scalars["Int"]["input"]>;
-  sortDir?: InputMaybe<SortDirection>;
+  opts: HostEventsInput;
 };
 
 export type HostAllocatorSettings = {
@@ -887,6 +886,14 @@ export type HostEvents = {
   __typename?: "HostEvents";
   count: Scalars["Int"]["output"];
   eventLogEntries: Array<HostEventLogEntry>;
+};
+
+export type HostEventsInput = {
+  eventTypes?: InputMaybe<Array<HostEventType>>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  page?: InputMaybe<Scalars["Int"]["input"]>;
+  /** sort by timestamp */
+  sortDir?: InputMaybe<SortDirection>;
 };
 
 export enum HostSortBy {

--- a/apps/spruce/src/utils/string/index.ts
+++ b/apps/spruce/src/utils/string/index.ts
@@ -27,7 +27,7 @@ export const msToDuration = (ms: number): string => {
 
   const seconds = Math.floor(minutesMilli / 1000);
 
-  if (days >= 1) {
+  if (days > 0) {
     return `${Math.trunc(days)}d ${hours}h ${minutes}m ${seconds}s`;
   }
   if (hours > 0) {

--- a/apps/spruce/src/utils/string/index.ts
+++ b/apps/spruce/src/utils/string/index.ts
@@ -13,14 +13,21 @@ export const msToDuration = (ms: number): string => {
   if (ms === 0) {
     return "0s";
   }
-  const days = Math.floor(ms / (24 * 60 * 60 * 1000));
-  const daysMilli = ms % (24 * 60 * 60 * 1000);
-  const hours = Math.floor(daysMilli / (60 * 60 * 1000));
-  const hoursMilli = ms % (60 * 60 * 1000);
-  const minutes = Math.floor(hoursMilli / (60 * 1000));
-  const minutesMilli = ms % (60 * 1000);
+  const msPerDay = 24 * 60 * 60 * 1000;
+  const days = Math.floor(ms / msPerDay);
+  const daysMilli = ms % msPerDay;
+
+  const msPerHour = 60 * 60 * 1000;
+  const hours = Math.floor(daysMilli / msPerHour);
+  const hoursMilli = ms % msPerHour;
+
+  const msPerMinute = 60 * 1000;
+  const minutes = Math.floor(hoursMilli / msPerMinute);
+  const minutesMilli = ms % msPerMinute;
+
   const seconds = Math.floor(minutesMilli / 1000);
-  if (days > 1) {
+
+  if (days >= 1) {
     return `${Math.trunc(days)}d ${hours}h ${minutes}m ${seconds}s`;
   }
   if (hours > 0) {

--- a/apps/spruce/src/utils/string/string.test.ts
+++ b/apps/spruce/src/utils/string/string.test.ts
@@ -25,6 +25,15 @@ describe("msToDuration", () => {
     expect(msToDuration(ms)).toBe("3d 5h 20m 5s");
   });
 
+  it("converts milli to 1d 19h 44m 29s", () => {
+    const ms =
+      1 * 24 * 60 * 60 * 1000 +
+      19 * 60 * 60 * 1000 +
+      44 * 60 * 1000 +
+      29 * 1000;
+    expect(msToDuration(ms)).toBe("1d 19h 44m 29s");
+  });
+
   it("converts milli to 5h 0m", () => {
     const ms = 5 * 60 * 60 * 1000;
     expect(msToDuration(ms)).toBe("5h 0m");


### PR DESCRIPTION
DEVPROD-10319
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
A user reported that the task durations were out of order. It seems like the values in the task duration table are sorted correctly, but the value that we report is not correct.

### Screenshots
<!-- add screenshots of visible changes -->
(Properly renders `1d` now)

<img width="230" alt="Screenshot 2024-09-18 at 12 40 12 PM" src="https://github.com/user-attachments/assets/424feadf-5a4f-4ed3-9ae4-e25526709769">

### Testing
- Added unit test