### PR TITLE
DEVPROD-5753: Update test to accommodate updated test data

### DIFF
--- a/apps/parsley/src/gql/generated/types.ts
+++ b/apps/parsley/src/gql/generated/types.ts
@@ -3250,6 +3250,7 @@ export type User = {
   parsleySettings: ParsleySettings;
   patches: Patches;
   permissions: Permissions;
+  settings: UserSettings;
   subscriptions?: Maybe<Array<GeneralSubscription>>;
   userId: Scalars["String"]["output"];
 };

--- a/apps/spruce/cypress/integration/hosts/update_status_modal.ts
+++ b/apps/spruce/cypress/integration/hosts/update_status_modal.ts
@@ -27,6 +27,6 @@ describe("Update Status Modal", () => {
     });
     cy.dataCy("update-host-status-modal").should("not.exist");
     // Because the static hosts that exists in the dev environment cannot be decommissioned, we should expect an error.
-    cy.validateToast("error");
+    cy.validateToast("success");
   });
 });

--- a/apps/spruce/cypress/integration/hosts/update_status_modal.ts
+++ b/apps/spruce/cypress/integration/hosts/update_status_modal.ts
@@ -17,7 +17,7 @@ describe("Update Status Modal", () => {
 
     cy.dataCy("host-status-select").click();
 
-    cy.dataCy("decommissioned-option").click();
+    cy.dataCy("terminated-option").click();
 
     cy.dataCy("host-status-notes").type("notes");
 

--- a/apps/spruce/cypress/integration/hosts/update_status_modal.ts
+++ b/apps/spruce/cypress/integration/hosts/update_status_modal.ts
@@ -26,7 +26,6 @@ describe("Update Status Modal", () => {
       cy.contains("button", "Update").click({ force: true });
     });
     cy.dataCy("update-host-status-modal").should("not.exist");
-    // Because the static hosts that exists in the dev environment cannot be decommissioned, we should expect an error.
     cy.validateToast("success");
   });
 });

--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -3250,6 +3250,7 @@ export type User = {
   parsleySettings: ParsleySettings;
   patches: Patches;
   permissions: Permissions;
+  settings: UserSettings;
   subscriptions?: Maybe<Array<GeneralSubscription>>;
   userId: Scalars["String"]["output"];
 };


### PR DESCRIPTION
DEVPROD-5753

### Description
Update the "update host status" e2e test to select an option that's not `decommissioned`. The EVG pr updated the test data and the resolver was outputting an error message that was too large for the current electron window size. 

### Evergreen PR
https://github.com/evergreen-ci/evergreen/pull/8337
