### PR TITLE
DEVPROD-7848: Add loading state to task queue select

### DIFF
--- a/apps/spruce/src/pages/taskQueue/index.tsx
+++ b/apps/spruce/src/pages/taskQueue/index.tsx
@@ -3,6 +3,7 @@ import { useQuery } from "@apollo/client";
 import styled from "@emotion/styled";
 import Badge from "@leafygreen-ui/badge";
 import { H2, H2Props, H3, H3Props } from "@leafygreen-ui/typography";
+import pluralize from "pluralize";
 import { useParams, useNavigate } from "react-router-dom";
 import { useTaskQueueAnalytics } from "analytics";
 import SearchableDropdown from "components/SearchableDropdown";
@@ -90,12 +91,18 @@ const TaskQueue = () => {
           // @ts-expect-error: FIXME. This comment was added by an automated script.
           buttonRenderer={(option: TaskQueueDistro) => (
             <DistroLabel>
-              <StyledBadge>{`${option?.taskCount || 0} ${
-                option?.taskCount === 1 ? "TASK" : "TASKS"
-              }`}</StyledBadge>
-              <StyledBadge>{`${option?.hostCount || 0} ${
-                option?.hostCount === 1 ? "HOST" : "HOSTS"
-              }`}</StyledBadge>
+              {loadingDistrosData || !selectedDistro ? (
+                <StyledBadge>Loading...</StyledBadge>
+              ) : (
+                <>
+                  <StyledBadge>
+                    {pluralize("task", option?.taskCount ?? 0, true)}
+                  </StyledBadge>
+                  <StyledBadge>
+                    {pluralize("host", option?.hostCount ?? 0, true)}
+                  </StyledBadge>
+                </>
+              )}
               <DistroName> {option?.id} </DistroName>
             </DistroLabel>
           )}

--- a/apps/spruce/src/pages/taskQueue/index.tsx
+++ b/apps/spruce/src/pages/taskQueue/index.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { useQuery } from "@apollo/client";
 import styled from "@emotion/styled";
 import Badge from "@leafygreen-ui/badge";
-import { H2, H2Props, H3, H3Props } from "@leafygreen-ui/typography";
+import { H2, H3 } from "@leafygreen-ui/typography";
 import pluralize from "pluralize";
 import { useParams, useNavigate } from "react-router-dom";
 import { useTaskQueueAnalytics } from "analytics";
@@ -84,23 +84,23 @@ const TaskQueue = () => {
     options.filter((d) => d.id.toLowerCase().includes(match.toLowerCase()));
 
   return (
-    <StyledPageWrapper>
-      <StyledH2>Task Queue</StyledH2>
+    <PageWrapper>
+      <H2>Task Queue</H2>
       <SearchableDropdownWrapper>
         <SearchableDropdown
           // @ts-expect-error: FIXME. This comment was added by an automated script.
           buttonRenderer={(option: TaskQueueDistro) => (
             <DistroLabel>
               {loadingDistrosData || !selectedDistro ? (
-                <StyledBadge>Loading...</StyledBadge>
+                <Badge>Loading...</Badge>
               ) : (
                 <>
-                  <StyledBadge>
+                  <Badge>
                     {pluralize("task", option?.taskCount ?? 0, true)}
-                  </StyledBadge>
-                  <StyledBadge>
+                  </Badge>
+                  <Badge>
                     {pluralize("host", option?.hostCount ?? 0, true)}
-                  </StyledBadge>
+                  </Badge>
                 </>
               )}
               <DistroName> {option?.id} </DistroName>
@@ -129,7 +129,7 @@ const TaskQueue = () => {
         /* Only show name & link if distro exists. */
         !loadingDistrosData && (
           <TableHeader>
-            <StyledH3>{distroId}</StyledH3>
+            <H3>{distroId}</H3>
             <StyledRouterLink
               to={getAllHostsRoute({ distroId, startedBy: MCI_USER })}
             >
@@ -145,20 +145,19 @@ const TaskQueue = () => {
           taskQueue={taskQueueItemsData?.distroTaskQueue}
         />
       )}
-    </StyledPageWrapper>
+    </PageWrapper>
   );
 };
 
 const SearchableDropdownWrapper = styled.div`
+  margin-top: ${size.xs};
   width: 400px;
 `;
 const DistroLabel = styled.div`
   display: flex;
+  gap: ${size.xs};
   align-items: center;
   white-space: nowrap;
-`;
-const StyledBadge = styled(Badge)`
-  margin-right: ${size.xs};
 `;
 const DistroName = styled.div`
   overflow: hidden;
@@ -168,15 +167,6 @@ const TableHeader = styled.div`
   display: flex;
   align-items: center;
   margin: ${size.m} 0 ${size.s} 0;
-`;
-const StyledH2 = styled(H2)<H2Props>`
-  margin-bottom: ${size.xs};
-`;
-const StyledH3 = styled(H3)<H3Props>`
-  margin-right: ${size.s};
-`;
-const StyledPageWrapper = styled(PageWrapper)`
-  display: flex;
-  flex-direction: column;
+  gap: ${size.s};
 `;
 export default TaskQueue;


### PR DESCRIPTION
DEVPROD-7848
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
<!-- add description, context, thought process, etc -->
While loading, show "Loading" badge in distro select dropdown instead of 0 tasks/0 hosts badges

### Screenshots
<!-- add screenshots of visible changes -->
<img width="481" alt="image" src="https://github.com/user-attachments/assets/c45412c6-f59a-49e5-afe7-86ad448816b2">