### PR TITLE
DEVPROD-1770: Use modern query param hooks with tables

### DIFF
--- a/apps/spruce/cypress/integration/task/execution_task_table.ts
+++ b/apps/spruce/cypress/integration/task/execution_task_table.ts
@@ -7,8 +7,7 @@ describe("Execution task table", () => {
   });
 
   it("Should have a default sort order applied", () => {
-    cy.location("search").should("contain", "sortBy=STATUS");
-    cy.location("search").should("contain", "sortDir=ASC");
+    cy.location("search").should("contain", "sorts=STATUS%3AASC");
   });
 
   it("Updates the url when column headers are clicked", () => {

--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -3489,6 +3489,7 @@ export type WaterfallOptions = {
   minOrder?: InputMaybe<Scalars["Int"]["input"]>;
   projectIdentifier: Scalars["String"]["input"];
   requesters?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  revision?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type WaterfallTask = {

--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -96,6 +96,15 @@ export enum BannerTheme {
   Warning = "WARNING",
 }
 
+export type BetaFeatures = {
+  __typename?: "BetaFeatures";
+  spruceWaterfallEnabled: Scalars["Boolean"]["output"];
+};
+
+export type BetaFeaturesInput = {
+  spruceWaterfallEnabled: Scalars["Boolean"]["input"];
+};
+
 export enum BootstrapMethod {
   LegacySsh = "LEGACY_SSH",
   Ssh = "SSH",
@@ -1269,6 +1278,7 @@ export type Mutation = {
   spawnVolume: Scalars["Boolean"]["output"];
   unscheduleTask: Task;
   unscheduleVersionTasks?: Maybe<Scalars["String"]["output"]>;
+  updateBetaFeatures?: Maybe<UpdateBetaFeaturesPayload>;
   updateHostStatus: Scalars["Int"]["output"];
   updateParsleySettings?: Maybe<UpdateParsleySettingsPayload>;
   updatePublicKey: Array<PublicKey>;
@@ -1518,6 +1528,10 @@ export type MutationUnscheduleTaskArgs = {
 export type MutationUnscheduleVersionTasksArgs = {
   abort: Scalars["Boolean"]["input"];
   versionId: Scalars["String"]["input"];
+};
+
+export type MutationUpdateBetaFeaturesArgs = {
+  opts: UpdateBetaFeaturesInput;
 };
 
 export type MutationUpdateHostStatusArgs = {
@@ -3186,6 +3200,15 @@ export type UiConfig = {
   userVoice?: Maybe<Scalars["String"]["output"]>;
 };
 
+export type UpdateBetaFeaturesInput = {
+  betaFeatures: BetaFeaturesInput;
+};
+
+export type UpdateBetaFeaturesPayload = {
+  __typename?: "UpdateBetaFeaturesPayload";
+  betaFeatures?: Maybe<BetaFeatures>;
+};
+
 export type UpdateParsleySettingsInput = {
   parsleySettings: ParsleySettingsInput;
 };
@@ -3244,6 +3267,7 @@ export type UseSpruceOptionsInput = {
  */
 export type User = {
   __typename?: "User";
+  betaFeatures: BetaFeatures;
   displayName: Scalars["String"]["output"];
   emailAddress: Scalars["String"]["output"];
   parsleyFilters: Array<ParsleyFilter>;

--- a/apps/spruce/src/hooks/useTableSort/index.ts
+++ b/apps/spruce/src/hooks/useTableSort/index.ts
@@ -18,6 +18,7 @@ type CallbackType = (sorter: SortingState) => void;
  * `useTableSort` manages sorting via query params with react-table.
  * @param props - Object containing the following:
  * @param props.sendAnalyticsEvents - Optional callback that makes a call to sendEvent.
+ * @param props.singleQueryParam - Optional boolean that determines whether to use a single query param for sorting.
  * @returns tableChangeHandler - Function that accepts react-table's sort state and updates query params with these values.
  */
 export const useTableSort = (props?: Props): CallbackType => {

--- a/apps/spruce/src/pages/hosts/utils.ts
+++ b/apps/spruce/src/pages/hosts/utils.ts
@@ -25,8 +25,12 @@ const useQueryVariables = (): HostsQueryVariables => {
     currentTaskId,
     statuses,
     startedBy,
-    sortBy,
-    sortDir,
+    sortBy: Object.values(HostSortBy).includes(sortBy)
+      ? sortBy
+      : HostSortBy.Status,
+    sortDir: Object.values(SortDirection).includes(sortDir)
+      ? sortDir
+      : SortDirection.Asc,
     page,
     limit,
   };

--- a/apps/spruce/src/pages/hosts/utils.ts
+++ b/apps/spruce/src/pages/hosts/utils.ts
@@ -1,54 +1,32 @@
 import { ColumnFiltersState, SortingState } from "@tanstack/react-table";
-import { useLocation } from "react-router-dom";
 import {
   HostSortBy,
   HostsQueryVariables,
   SortDirection,
 } from "gql/generated/types";
 import usePagination from "hooks/usePagination";
+import { useQueryParam } from "hooks/useQueryParam";
 import { mapQueryParamToId } from "types/host";
-import { toArray } from "utils/array";
-import { getString, parseQueryString } from "utils/queryString";
-
-type QueryParam = keyof HostsQueryVariables;
-
-const getSortBy = (sortByParam: string | string[] = ""): HostSortBy => {
-  const sortBy = getString(sortByParam) as HostSortBy;
-
-  return Object.values(HostSortBy).includes(sortBy)
-    ? sortBy
-    : HostSortBy.Status; // default sortBy value
-};
-
-const getSortDir = (sortDirParam: string | string[]): SortDirection => {
-  const sortDir = getString(sortDirParam) as SortDirection;
-
-  return Object.values(SortDirection).includes(sortDir)
-    ? sortDir
-    : SortDirection.Asc; // default sortDir value
-};
+import { HostsQueryParams } from "./constants";
 
 const useQueryVariables = (): HostsQueryVariables => {
   const { limit, page } = usePagination();
-  const { search } = useLocation();
-  const {
-    currentTaskId,
-    distroId,
-    hostId,
-    sortBy,
-    sortDir,
-    startedBy,
-    statuses,
-  } = parseQueryString(search) as { [key in QueryParam]: string | string[] };
+  const [currentTaskId] = useQueryParam(HostsQueryParams.CurrentTaskId, "");
+  const [distroId] = useQueryParam(HostsQueryParams.DistroId, "");
+  const [hostId] = useQueryParam(HostsQueryParams.HostId, "");
+  const [sortBy] = useQueryParam(HostsQueryParams.SortBy, HostSortBy.Status);
+  const [sortDir] = useQueryParam(HostsQueryParams.SortDir, SortDirection.Asc);
+  const [startedBy] = useQueryParam(HostsQueryParams.StartedBy, "");
+  const [statuses] = useQueryParam(HostsQueryParams.Statuses, []);
 
   return {
-    hostId: getString(hostId),
-    distroId: getString(distroId),
-    currentTaskId: getString(currentTaskId),
-    statuses: toArray(statuses),
-    startedBy: getString(startedBy),
-    sortBy: getSortBy(sortBy),
-    sortDir: getSortDir(sortDir),
+    hostId,
+    distroId,
+    currentTaskId,
+    statuses,
+    startedBy,
+    sortBy,
+    sortDir,
     page,
     limit,
   };

--- a/apps/spruce/src/pages/task/taskTabs/ExecutionTasksTable.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/ExecutionTasksTable.tsx
@@ -18,8 +18,7 @@ import {
   SortDirection,
 } from "gql/generated/types";
 import { useTableSort } from "hooks";
-import { useQueryParams } from "hooks/useQueryParam";
-import { useUpdateURLQueryParams } from "hooks/useUpdateURLQueryParams";
+import { useQueryParam } from "hooks/useQueryParam";
 import { parseSortString } from "utils/queryString";
 
 const { getDefaultOptions: getDefaultSorting } = RowSorting;
@@ -37,20 +36,11 @@ export const ExecutionTasksTable: React.FC<Props> = ({
   isPatch,
 }) => {
   const { sendEvent } = useTaskAnalytics();
-  const updateQueryParams = useUpdateURLQueryParams();
-
-  const [queryParams] = useQueryParams();
-  const sortBy = queryParams[TableQueryParams.SortBy] as string;
-  const sortDir = queryParams[TableQueryParams.SortDir] as string;
-  const sorts = queryParams[TableQueryParams.Sorts] as string;
-
+  const [sorts, setSorts] = useQueryParam(TableQueryParams.Sorts, "");
   // Apply default sort if no sorting method is defined.
   useEffect(() => {
-    if (!sorts && !sortBy && !sortDir) {
-      updateQueryParams({
-        sortBy: TaskSortCategory.Status,
-        sortDir: SortDirection.Asc,
-      });
+    if (!sorts) {
+      setSorts(defaultSortQueryParam);
     }
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
@@ -61,7 +51,7 @@ export const ExecutionTasksTable: React.FC<Props> = ({
   ]);
 
   const initialSorting = useMemo(
-    () => getInitialSorting(queryParams),
+    () => getInitialSorting(sorts),
     [], // eslint-disable-line react-hooks/exhaustive-deps
   );
 
@@ -77,6 +67,7 @@ export const ExecutionTasksTable: React.FC<Props> = ({
   );
 
   const tableSortHandler = useTableSort({
+    singleQueryParam: true,
     sendAnalyticsEvents: (sorter: SortingState) =>
       sendEvent({
         name: "Sorted execution tasks table",
@@ -117,42 +108,27 @@ export const ExecutionTasksTable: React.FC<Props> = ({
   );
 };
 
-const getInitialSorting = (queryParams: {
-  [key: string]: any;
-}): SortingState => {
-  const {
-    [TableQueryParams.SortBy]: sortBy,
-    [TableQueryParams.SortDir]: sortDir,
-    [TableQueryParams.Sorts]: sorts,
-  } = queryParams;
-
-  let initialSorting = [{ id: TaskSortCategory.Status, desc: false }];
-  if (sortBy && sortDir) {
-    initialSorting = [
-      {
-        id: sortBy as TaskSortCategory,
-        desc: sortDir === SortDirection.Desc,
-      },
-    ];
-  } else if (sorts) {
-    const parsedSorts = parseSortString<
-      "id",
-      "direction",
-      TaskSortCategory,
-      {
-        id: TaskSortCategory;
-        direction: SortDirection;
-      }
-    >(sorts, {
-      sortCategoryEnum: TaskSortCategory,
-      sortByKey: "id",
-      sortDirKey: "direction",
-    });
-    initialSorting = parsedSorts.map(({ direction, id }) => ({
-      id,
-      desc: direction === SortDirection.Desc,
-    }));
-  }
+const getInitialSorting = (sorts: string): SortingState => {
+  const initialSorting = sorts
+    ? parseSortString<
+        "id",
+        "direction",
+        TaskSortCategory,
+        {
+          id: TaskSortCategory;
+          direction: SortDirection;
+        }
+      >(sorts, {
+        sortCategoryEnum: TaskSortCategory,
+        sortByKey: "id",
+        sortDirKey: "direction",
+      }).map(({ direction, id }) => ({
+        id,
+        desc: direction === SortDirection.Desc,
+      }))
+    : [{ id: TaskSortCategory.Status, desc: false }];
 
   return initialSorting;
 };
+
+const defaultSortQueryParam = `${TaskSortCategory.Status}:${SortDirection.Asc}`;

--- a/apps/spruce/src/pages/task/taskTabs/ExecutionTasksTable.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/ExecutionTasksTable.tsx
@@ -19,7 +19,7 @@ import {
 } from "gql/generated/types";
 import { useTableSort } from "hooks";
 import { useQueryParam } from "hooks/useQueryParam";
-import { parseSortString } from "utils/queryString";
+import { parseSortString, toSortString } from "utils/queryString";
 
 const { getDefaultOptions: getDefaultSorting } = RowSorting;
 
@@ -131,4 +131,8 @@ const getInitialSorting = (sorts: string): SortingState => {
   return initialSorting;
 };
 
-const defaultSortQueryParam = `${TaskSortCategory.Status}:${SortDirection.Asc}`;
+const defaultSortQueryParam =
+  toSortString({
+    columnKey: TaskSortCategory.Status,
+    order: "ascend",
+  }) ?? "";

--- a/apps/spruce/src/pages/task/taskTabs/TestsTable.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/TestsTable.tsx
@@ -66,6 +66,7 @@ export const TestsTable: React.FC<TestsTableProps> = ({ task }) => {
       // @ts-expect-error: FIXME. This comment was added by an automated script.
       appliedDefaultSort.current = pathname;
       setQueryParams({
+        ...queryParams,
         [TableQueryParams.SortBy]: TestSortCategory.Status,
         [TableQueryParams.SortDir]: SortDirection.Asc,
       });

--- a/apps/spruce/src/pages/task/taskTabs/TestsTable.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/TestsTable.tsx
@@ -27,7 +27,7 @@ import {
   TestSortOptions,
 } from "gql/generated/types";
 import { TASK_TESTS } from "gql/queries";
-import { useTableSort, useUpdateURLQueryParams, usePolling } from "hooks";
+import { useTableSort, usePolling } from "hooks";
 import { useQueryParams } from "hooks/useQueryParam";
 import {
   RequiredQueryParams,
@@ -48,7 +48,6 @@ interface TestsTableProps {
 
 export const TestsTable: React.FC<TestsTableProps> = ({ task }) => {
   const { pathname } = useLocation();
-  const updateQueryParams = useUpdateURLQueryParams();
   const { sendEvent } = useTaskAnalytics();
 
   const [queryParams, setQueryParams] = useQueryParams();
@@ -64,19 +63,15 @@ export const TestsTable: React.FC<TestsTableProps> = ({ task }) => {
       return;
     }
 
-    if (
-      sortBy === undefined &&
-      updateQueryParams &&
-      appliedDefaultSort.current !== pathname
-    ) {
+    if (sortBy === undefined && appliedDefaultSort.current !== pathname) {
       // @ts-expect-error: FIXME. This comment was added by an automated script.
       appliedDefaultSort.current = pathname;
-      updateQueryParams({
+      setQueryParams({
         [TableQueryParams.SortBy]: TestSortCategory.Status,
         [TableQueryParams.SortDir]: SortDirection.Asc,
       });
     }
-  }, [pathname, updateQueryParams]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [pathname, setQueryParams]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const { data, loading, refetch, startPolling, stopPolling } = useQuery<
     TaskTestsQuery,

--- a/apps/spruce/src/pages/task/taskTabs/TestsTable.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/TestsTable.tsx
@@ -62,7 +62,6 @@ export const TestsTable: React.FC<TestsTableProps> = ({ task }) => {
     if (execution == null) {
       return;
     }
-
     if (sortBy === undefined && appliedDefaultSort.current !== pathname) {
       // @ts-expect-error: FIXME. This comment was added by an automated script.
       appliedDefaultSort.current = pathname;
@@ -71,7 +70,7 @@ export const TestsTable: React.FC<TestsTableProps> = ({ task }) => {
         [TableQueryParams.SortDir]: SortDirection.Asc,
       });
     }
-  }, [pathname, setQueryParams]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [pathname]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const { data, loading, refetch, startPolling, stopPolling } = useQuery<
     TaskTestsQuery,

--- a/apps/spruce/src/pages/version/TaskDuration.tsx
+++ b/apps/spruce/src/pages/version/TaskDuration.tsx
@@ -17,7 +17,7 @@ import {
 } from "gql/generated/types";
 import { VERSION_TASK_DURATIONS } from "gql/queries";
 import { usePolling } from "hooks";
-import { useUpdateURLQueryParams } from "hooks/useUpdateURLQueryParams";
+import { useQueryParams } from "hooks/useQueryParam";
 import { PatchTasksQueryParams } from "types/task";
 import { queryString } from "utils";
 import { TaskDurationTable } from "./taskDuration/TaskDurationTable";
@@ -33,7 +33,7 @@ const TaskDuration: React.FC<Props> = ({ taskCount }) => {
   const { [slugs.versionId]: versionId } = useParams();
   const { search } = useLocation();
 
-  const updateQueryParams = useUpdateURLQueryParams();
+  const [, setQueryParams] = useQueryParams();
   // @ts-expect-error: FIXME. This comment was added by an automated script.
   const versionAnalytics = useVersionAnalytics(versionId);
   // @ts-expect-error: FIXME. This comment was added by an automated script.
@@ -43,23 +43,18 @@ const TaskDuration: React.FC<Props> = ({ taskCount }) => {
   const [hasInitialized, setHasInitialized] = useState(false);
 
   useEffect(() => {
-    updateQueryParams({
+    setQueryParams({
       [TableQueryParams.Sorts]: defaultSort,
     });
     setHasInitialized(true);
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   const clearQueryParams = () => {
-    updateQueryParams({
-      // @ts-expect-error: FIXME. This comment was added by an automated script.
+    setQueryParams({
       [PatchTasksQueryParams.TaskName]: undefined,
-      // @ts-expect-error: FIXME. This comment was added by an automated script.
       [PatchTasksQueryParams.Variant]: undefined,
-      // @ts-expect-error: FIXME. This comment was added by an automated script.
       [PatchTasksQueryParams.Statuses]: undefined,
-      // @ts-expect-error: FIXME. This comment was added by an automated script.
       [PatchTasksQueryParams.BaseStatuses]: undefined,
-      // @ts-expect-error: FIXME. This comment was added by an automated script.
       [PaginationQueryParams.Page]: undefined,
       [TableQueryParams.Sorts]: defaultSort,
     });

--- a/apps/spruce/src/pages/version/TaskDuration.tsx
+++ b/apps/spruce/src/pages/version/TaskDuration.tsx
@@ -33,7 +33,7 @@ const TaskDuration: React.FC<Props> = ({ taskCount }) => {
   const { [slugs.versionId]: versionId } = useParams();
   const { search } = useLocation();
 
-  const [, setQueryParams] = useQueryParams();
+  const [queryParams, setQueryParams] = useQueryParams();
   // @ts-expect-error: FIXME. This comment was added by an automated script.
   const versionAnalytics = useVersionAnalytics(versionId);
   // @ts-expect-error: FIXME. This comment was added by an automated script.
@@ -44,6 +44,7 @@ const TaskDuration: React.FC<Props> = ({ taskCount }) => {
 
   useEffect(() => {
     setQueryParams({
+      ...queryParams,
       [TableQueryParams.Sorts]: defaultSort,
     });
     setHasInitialized(true);
@@ -51,6 +52,7 @@ const TaskDuration: React.FC<Props> = ({ taskCount }) => {
 
   const clearQueryParams = () => {
     setQueryParams({
+      ...queryParams,
       [PatchTasksQueryParams.TaskName]: undefined,
       [PatchTasksQueryParams.Variant]: undefined,
       [PatchTasksQueryParams.Statuses]: undefined,

--- a/apps/spruce/src/pages/version/tasks/PatchTasksTable.tsx
+++ b/apps/spruce/src/pages/version/tasks/PatchTasksTable.tsx
@@ -30,7 +30,7 @@ export const PatchTasksTable: React.FC<Props> = ({
   tasks,
 }) => {
   const { [slugs.versionId]: versionId } = useParams();
-  const [, setQueryParams] = useQueryParams();
+  const [queryParams, setQueryParams] = useQueryParams();
   // @ts-expect-error: FIXME. This comment was added by an automated script.
   const { sendEvent } = useVersionAnalytics(versionId);
   const filterHookProps = {
@@ -69,6 +69,7 @@ export const PatchTasksTable: React.FC<Props> = ({
 
   const tableChangeHandler: TableOnChange<Task> = (...[, , sorter]) => {
     setQueryParams({
+      ...queryParams,
       sorts: toSortString(sorter),
       [PaginationQueryParams.Page]: "0",
     });

--- a/apps/spruce/src/pages/version/tasks/PatchTasksTable.tsx
+++ b/apps/spruce/src/pages/version/tasks/PatchTasksTable.tsx
@@ -7,10 +7,10 @@ import { slugs } from "constants/routes";
 import { Task, VersionTasksQuery, SortOrder } from "gql/generated/types";
 import {
   useTaskStatuses,
-  useUpdateURLQueryParams,
   useStatusesFilter,
   useFilterInputChangeHandler,
 } from "hooks";
+import { useQueryParams } from "hooks/useQueryParam";
 import { PatchTasksQueryParams, TableOnChange } from "types/task";
 import { queryString } from "utils";
 
@@ -30,7 +30,7 @@ export const PatchTasksTable: React.FC<Props> = ({
   tasks,
 }) => {
   const { [slugs.versionId]: versionId } = useParams();
-  const updateQueryParams = useUpdateURLQueryParams();
+  const [, setQueryParams] = useQueryParams();
   // @ts-expect-error: FIXME. This comment was added by an automated script.
   const { sendEvent } = useVersionAnalytics(versionId);
   const filterHookProps = {
@@ -68,8 +68,7 @@ export const PatchTasksTable: React.FC<Props> = ({
   });
 
   const tableChangeHandler: TableOnChange<Task> = (...[, , sorter]) => {
-    updateQueryParams({
-      // @ts-expect-error: FIXME. This comment was added by an automated script.
+    setQueryParams({
       sorts: toSortString(sorter),
       [PaginationQueryParams.Page]: "0",
     });


### PR DESCRIPTION
DEVPROD-1770

### Description
Replace `useUpdateURLQueryParams` with `useQueryParams` or `useQueryParam` in table components. I also updated ExectionTaskTable so rely on sorts instead of sortBy and sortDir because it made these code changes simpler.
