### PR TITLE
DEVPROD-11900: Add alpha info banner to beta deploys

### DIFF
--- a/apps/spruce/src/pages/waterfall/index.tsx
+++ b/apps/spruce/src/pages/waterfall/index.tsx
@@ -1,38 +1,35 @@
 import { Suspense } from "react";
 import { Global, css } from "@emotion/react";
 import styled from "@emotion/styled";
+import Banner from "@leafygreen-ui/banner";
 import { TableSkeleton } from "@leafygreen-ui/skeleton-loader";
 import { useParams } from "react-router-dom";
 import { navBarHeight } from "components/Header/Navbar";
 import { slugs } from "constants/routes";
 import { size } from "constants/tokens";
+import { useSpruceConfig } from "hooks";
+import { isBeta } from "utils/environmentVariables";
+import { jiraLinkify } from "utils/string";
 import { VERSION_LIMIT } from "./styles";
 import { WaterfallFilters } from "./WaterfallFilters";
 import { WaterfallGrid } from "./WaterfallGrid";
 
 const Waterfall: React.FC = () => {
   const { [slugs.projectIdentifier]: projectIdentifier } = useParams();
+  const spruceConfig = useSpruceConfig();
+  const jiraHost = spruceConfig?.jira?.host;
 
   return (
     <>
-      {/* Safari performance of the waterfall chokes if using overflow-y: scroll, so we need the page to scroll instead.
-    Update navbar layout to accommodate this. */}
-      <Global
-        styles={css`
-          header {
-            position: unset !important;
-          }
-          #banner-container {
-            margin-top: calc(${navBarHeight} + ${size.s});
-          }
-          nav {
-            position: fixed !important;
-            width: 100%;
-            z-index: 1;
-          }
-        `}
-      />
+      <Global styles={navbarStyles} />
       <PageContainer data-cy="waterfall-page">
+        {isBeta() && (
+          <Banner>
+            <strong>Thanks for using the Waterfall Alpha!</strong> Feedback?
+            Open a ticket within the project epic{" "}
+            {jiraLinkify("DEVPROD-3976", jiraHost ?? "")}.
+          </Banner>
+        )}
         <WaterfallFilters projectIdentifier={projectIdentifier ?? ""} />
         {/* TODO DEVPROD-11708: Use dynamic column limit in skeleton */}
         <Suspense
@@ -50,6 +47,22 @@ const PageContainer = styled.div`
   flex-direction: column;
   gap: ${size.s};
   padding: ${size.m} ${size.l};
+`;
+
+/* Safari performance of the waterfall chokes if using overflow-y: scroll, so we need the page to scroll instead.
+    Update navbar layout to accommodate this. */
+const navbarStyles = css`
+  header {
+    position: unset !important;
+  }
+  #banner-container {
+    margin-top: ${navBarHeight};
+  }
+  nav {
+    position: fixed !important;
+    width: 100%;
+    z-index: 1;
+  }
 `;
 
 export default Waterfall;


### PR DESCRIPTION
DEVPROD-11900
<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️ -->
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
<!-- add description, context, thought process, etc -->
Add banner directing users to give feedback on the waterfall

I made the banner non-dismissible because I think having it visible will help reinforce that this page is a work in progress

### Screenshots
<!-- add screenshots of visible changes -->
<img width="1167" alt="image" src="https://github.com/user-attachments/assets/933a71f9-2777-4dc9-b9d5-8cc050d71d30">