### PR TITLE
DEVPROD-11852 Tag release environment in all OTEL spans and support beta tracking in honeycomb

### DIFF
--- a/.evergreen/deploy.yml
+++ b/.evergreen/deploy.yml
@@ -6,7 +6,8 @@ functions:
           if [ "${target}" = "staging" ]; then
             echo "REACT_APP_HONEYCOMB_ENDPOINT: ${HONEYCOMB_ENDPOINT_STAGING}" >> honeycomb.yml
             echo "REACT_APP_HONEYCOMB_INGEST_KEY: ${HONEYCOMB_INGEST_KEY_STAGING}" >> honeycomb.yml
-          elif [ "${target}" = "production" ]; then
+            # If target is production or beta, set the honeycomb endpoint and ingest key to production
+          elif [ "${target}" = "production" ] || [ "${target}" = "beta" ]; then
             echo "REACT_APP_HONEYCOMB_ENDPOINT: ${HONEYCOMB_ENDPOINT_PROD}" >> honeycomb.yml
             echo "REACT_APP_HONEYCOMB_INGEST_KEY: ${HONEYCOMB_INGEST_KEY_PROD}" >> honeycomb.yml
           fi

--- a/apps/parsley/src/main.tsx
+++ b/apps/parsley/src/main.tsx
@@ -6,7 +6,11 @@ import {
 } from "@evg-ui/lib/utils/observability";
 import { toEscapedRegex } from "@evg-ui/lib/utils/string";
 import { initializeErrorHandling } from "components/ErrorHandling";
-import { evergreenURL, isDevelopmentBuild } from "utils/environmentVariables";
+import {
+  evergreenURL,
+  getReleaseStage,
+  isDevelopmentBuild,
+} from "utils/environmentVariables";
 import App from "./App";
 
 initializeErrorHandling();
@@ -14,6 +18,7 @@ initializeHoneycomb({
   backendURL: toEscapedRegex(evergreenURL || ""),
   debug: isDevelopmentBuild(),
   endpoint: process.env.REACT_APP_HONEYCOMB_ENDPOINT || "",
+  environment: getReleaseStage(),
   ingestKey: process.env.REACT_APP_HONEYCOMB_INGEST_KEY || "",
   serviceName: "parsley",
 });

--- a/apps/spruce/src/index.tsx
+++ b/apps/spruce/src/index.tsx
@@ -6,7 +6,11 @@ import {
 } from "@evg-ui/lib/utils/observability";
 import { toEscapedRegex } from "@evg-ui/lib/utils/string";
 import { initializeErrorHandling } from "components/ErrorHandling";
-import { getUiUrl, isDevelopmentBuild } from "utils/environmentVariables";
+import {
+  getReleaseStage,
+  getUiUrl,
+  isDevelopmentBuild,
+} from "utils/environmentVariables";
 import App from "./App";
 
 initializeErrorHandling();
@@ -16,6 +20,7 @@ initializeHoneycomb({
   ingestKey: process.env.REACT_APP_HONEYCOMB_INGEST_KEY || "",
   backendURL: toEscapedRegex(getUiUrl() || ""),
   serviceName: "spruce",
+  environment: getReleaseStage(),
 });
 injectOpenTelemetryAttributeStoreIntoWindow();
 

--- a/packages/lib/src/utils/observability/honeycomb.ts
+++ b/packages/lib/src/utils/observability/honeycomb.ts
@@ -19,6 +19,8 @@ interface HoneycombConfig {
   debug: boolean;
   /** The INGEST key for the Honeycomb SDK */
   ingestKey: string;
+  /** The environment we are running in */
+  environment: string;
 }
 
 /**
@@ -29,11 +31,13 @@ interface HoneycombConfig {
  * @param config.debug - Whether to start the SDK in debug mode.
  * @param config.serviceName - The name of the service.
  * @param config.endpoint - The endpoint for the Honeycomb SDK to send traces to if we are not using the default.
+ * @param config.environment - The environment we are running in.
  */
 const initializeHoneycomb = ({
   backendURL,
   debug,
   endpoint,
+  environment,
   ingestKey,
   serviceName,
 }: HoneycombConfig) => {
@@ -87,6 +91,7 @@ const initializeHoneycomb = ({
         // Add user.id as an attribute to all traces.
         resourceAttributes: {
           "user.id": userId,
+          environment,
         },
         localVisualizations: debug,
         serviceName,


### PR DESCRIPTION
DEVPROD-11852


### Description
This PR adds an environment field for all spans the apps send. This will allow for filtering of honeycomb spans when performing queries. `environment = beta` will show only spruce beta or parsley beta spans.
Example query:
https://ui.honeycomb.io/mongodb-4b/environments/production/datasets/spruce/result/dot6UtisTcA?tab=traces