### PR TITLE
DEVPROD-11701 Configure timeout for setup-node script

### DIFF
--- a/.evergreen/shared.yml
+++ b/.evergreen/shared.yml
@@ -108,6 +108,7 @@ functions:
         file: expansion.yml
     - command: shell.exec
       params:
+        exec_timeout_secs: 60
         shell: bash
         script: |
           ${PREPARE_SHELL}

--- a/apps/parsley/src/gql/generated/types.ts
+++ b/apps/parsley/src/gql/generated/types.ts
@@ -96,6 +96,15 @@ export enum BannerTheme {
   Warning = "WARNING",
 }
 
+export type BetaFeatures = {
+  __typename?: "BetaFeatures";
+  spruceWaterfallEnabled: Scalars["Boolean"]["output"];
+};
+
+export type BetaFeaturesInput = {
+  spruceWaterfallEnabled: Scalars["Boolean"]["input"];
+};
+
 export enum BootstrapMethod {
   LegacySsh = "LEGACY_SSH",
   Ssh = "SSH",
@@ -1269,6 +1278,7 @@ export type Mutation = {
   spawnVolume: Scalars["Boolean"]["output"];
   unscheduleTask: Task;
   unscheduleVersionTasks?: Maybe<Scalars["String"]["output"]>;
+  updateBetaFeatures?: Maybe<UpdateBetaFeaturesPayload>;
   updateHostStatus: Scalars["Int"]["output"];
   updateParsleySettings?: Maybe<UpdateParsleySettingsPayload>;
   updatePublicKey: Array<PublicKey>;
@@ -1518,6 +1528,10 @@ export type MutationUnscheduleTaskArgs = {
 export type MutationUnscheduleVersionTasksArgs = {
   abort: Scalars["Boolean"]["input"];
   versionId: Scalars["String"]["input"];
+};
+
+export type MutationUpdateBetaFeaturesArgs = {
+  opts: UpdateBetaFeaturesInput;
 };
 
 export type MutationUpdateHostStatusArgs = {
@@ -3186,6 +3200,15 @@ export type UiConfig = {
   userVoice?: Maybe<Scalars["String"]["output"]>;
 };
 
+export type UpdateBetaFeaturesInput = {
+  betaFeatures: BetaFeaturesInput;
+};
+
+export type UpdateBetaFeaturesPayload = {
+  __typename?: "UpdateBetaFeaturesPayload";
+  betaFeatures?: Maybe<BetaFeatures>;
+};
+
 export type UpdateParsleySettingsInput = {
   parsleySettings: ParsleySettingsInput;
 };
@@ -3244,6 +3267,7 @@ export type UseSpruceOptionsInput = {
  */
 export type User = {
   __typename?: "User";
+  betaFeatures: BetaFeatures;
   displayName: Scalars["String"]["output"];
   emailAddress: Scalars["String"]["output"];
   parsleyFilters: Array<ParsleyFilter>;


### PR DESCRIPTION
DEVPROD-11701


### Description
Adds a timeout for setup-node. I took a look at a few tasks and this step is usually pretty quick usually only a few seconds. So I figured a 1 minute timeout should be sufficient to catch if we are downloading node or if we are doing something else.
