### PR TITLE
DEVPROD-12038 Remove sentry sampling

### DIFF
--- a/apps/parsley/src/components/ErrorHandling/Sentry.tsx
+++ b/apps/parsley/src/components/ErrorHandling/Sentry.tsx
@@ -38,7 +38,6 @@ const initializeSentry = () => {
       environment: getReleaseStage() || "development",
       maxValueLength: 500,
       normalizeDepth: 5,
-      sampleRate: 0.5,
     });
   } catch (e) {
     console.error("Failed to initialize Sentry", e);

--- a/apps/parsley/src/components/ErrorHandling/initialize.test.ts
+++ b/apps/parsley/src/components/ErrorHandling/initialize.test.ts
@@ -39,7 +39,6 @@ describe("should initialize error handlers according to release stage", () => {
       environment: "production",
       maxValueLength: 500,
       normalizeDepth: 5,
-      sampleRate: 0.5,
     });
   });
 
@@ -57,7 +56,6 @@ describe("should initialize error handlers according to release stage", () => {
       environment: "beta",
       maxValueLength: 500,
       normalizeDepth: 5,
-      sampleRate: 0.5,
     });
   });
 
@@ -75,7 +73,6 @@ describe("should initialize error handlers according to release stage", () => {
       environment: "staging",
       maxValueLength: 500,
       normalizeDepth: 5,
-      sampleRate: 0.5,
     });
   });
 });

--- a/apps/spruce/src/components/ErrorHandling/Sentry.tsx
+++ b/apps/spruce/src/components/ErrorHandling/Sentry.tsx
@@ -38,7 +38,6 @@ const initializeSentry = () => {
       environment: getReleaseStage() || "development",
       maxValueLength: 500,
       normalizeDepth: 5,
-      sampleRate: 0.5,
     });
   } catch (e) {
     console.error("Failed to initialize Sentry", e);

--- a/apps/spruce/src/components/ErrorHandling/initialize.test.ts
+++ b/apps/spruce/src/components/ErrorHandling/initialize.test.ts
@@ -43,7 +43,6 @@ describe("should initialize error handlers according to release stage", () => {
       environment: "production",
       maxValueLength: 500,
       normalizeDepth: 5,
-      sampleRate: 0.5,
     });
   });
 
@@ -62,7 +61,6 @@ describe("should initialize error handlers according to release stage", () => {
       environment: "beta",
       maxValueLength: 500,
       normalizeDepth: 5,
-      sampleRate: 0.5,
     });
   });
 
@@ -81,7 +79,6 @@ describe("should initialize error handlers according to release stage", () => {
       environment: "staging",
       maxValueLength: 500,
       normalizeDepth: 5,
-      sampleRate: 0.5,
     });
   });
 });


### PR DESCRIPTION
DEVPROD-12038


### Description
Sentry currently samples at a 50% rate but this sometimes results in scenarios where we don't log crucial errors. We have reduced the overall logging volume of sentry so it should be safe to increase this value

