### PR TITLE
DEVPROD-12078: Allow dot character in ctx regex

### DIFF
--- a/apps/parsley/src/utils/resmoke/helpers.test.ts
+++ b/apps/parsley/src/utils/resmoke/helpers.test.ts
@@ -53,6 +53,8 @@ describe("resmoke/helpers", () => {
       expect(getContext(line)).toBe("conn1");
       line = `{"t":{"$date":"2022-09-08T14:51:21.568+00:00"},"s":"I",  "c":"COMMAND",  "ctx":"ReplCoord-1" }`;
       expect(getContext(line)).toBe("ReplCoord-1");
+      line = `{"t":{"$date":"2022-09-08T14:51:21.568+00:00"},"s":"I",  "c":"COMMAND",  "ctx":"ReplCoord.local.log" }`;
+      expect(getContext(line)).toBe("ReplCoord.local.log");
       line = `{"t":{"$date":"2022-09-08T14:51:21.568+00:00"},"s":"I",  "c":"-",  "ctx":"-" }`;
       expect(getContext(line)).toBe("-");
     });

--- a/apps/parsley/src/utils/resmoke/helpers.ts
+++ b/apps/parsley/src/utils/resmoke/helpers.ts
@@ -176,10 +176,10 @@ const getSvc = (line: string) => line.match(svcRegex)?.[1];
  * The context
  * @example "ctx":"conn1"
  * @example "ctx":"conn2"
- * @example "ctx":"conn3"
  * @example "ctx":"ConfigServerCatalogCacheLoader::getDatabase"
+ * @example "ctx":"ConfigServerCatalogCacheLoader.local.log"
  */
-const ctxRegex = /"ctx":"([a-zA-Z0-9-:]+)"/;
+const ctxRegex = /"ctx":"([a-zA-Z0-9-:.]+)"/;
 
 /**
  * `getContext` returns the ctx associated with a resmoke line this is found in the resmoke json


### PR DESCRIPTION
DEVPROD-12078
<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️ -->
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
Some lines from the log linked in the ticket are not getting parsed properly because our regex for ctx is a little too strict. We need to allow `.` character.

### Testing
- Added unit test
- Confirmed manually the lines are getting parsed properly using the link from the ticket

