### PR TITLE
DEVPROD-7857: Send Sentry alerts for 422 errors in Spruce

### DIFF
--- a/apps/parsley/src/gql/generated/types.ts
+++ b/apps/parsley/src/gql/generated/types.ts
@@ -3462,8 +3462,8 @@ export type VolumeHost = {
 export type Waterfall = {
   __typename?: "Waterfall";
   buildVariants: Array<WaterfallBuildVariant>;
-  nextPageOrder: Scalars["Int"]["output"];
-  prevPageOrder: Scalars["Int"]["output"];
+  flattenedVersions: Array<Version>;
+  pagination: WaterfallPagination;
   versions: Array<WaterfallVersion>;
 };
 
@@ -3481,6 +3481,7 @@ export type WaterfallBuildVariant = {
   builds: Array<WaterfallBuild>;
   displayName: Scalars["String"]["output"];
   id: Scalars["String"]["output"];
+  version: Scalars["String"]["output"];
 };
 
 export type WaterfallOptions = {
@@ -3493,6 +3494,14 @@ export type WaterfallOptions = {
   projectIdentifier: Scalars["String"]["input"];
   requesters?: InputMaybe<Array<Scalars["String"]["input"]>>;
   revision?: InputMaybe<Scalars["String"]["input"]>;
+};
+
+export type WaterfallPagination = {
+  __typename?: "WaterfallPagination";
+  hasNextPage: Scalars["Boolean"]["output"];
+  hasPrevPage: Scalars["Boolean"]["output"];
+  nextPageOrder: Scalars["Int"]["output"];
+  prevPageOrder: Scalars["Int"]["output"];
 };
 
 export type WaterfallTask = {

--- a/apps/parsley/src/gql/generated/types.ts
+++ b/apps/parsley/src/gql/generated/types.ts
@@ -3484,6 +3484,7 @@ export type WaterfallBuildVariant = {
 };
 
 export type WaterfallOptions = {
+  date?: InputMaybe<Scalars["Time"]["input"]>;
   limit?: InputMaybe<Scalars["Int"]["input"]>;
   /** Return versions with an order lower than maxOrder. Used for paginating forward. */
   maxOrder?: InputMaybe<Scalars["Int"]["input"]>;
@@ -3497,6 +3498,7 @@ export type WaterfallOptions = {
 export type WaterfallTask = {
   __typename?: "WaterfallTask";
   displayName: Scalars["String"]["output"];
+  execution: Scalars["Int"]["output"];
   id: Scalars["String"]["output"];
   status: Scalars["String"]["output"];
 };

--- a/apps/spruce/package.json
+++ b/apps/spruce/package.json
@@ -50,6 +50,7 @@
   },
   "dependencies": {
     "@apollo/client": "3.10.4",
+    "@apollo/server": "^4.11.0",
     "@emotion/css": "11.13.4",
     "@emotion/react": "11.13.3",
     "@emotion/styled": "11.13.0",

--- a/apps/spruce/src/gql/GQLWrapper.tsx
+++ b/apps/spruce/src/gql/GQLWrapper.tsx
@@ -1,9 +1,9 @@
 import { ApolloProvider } from "@apollo/client";
 import { FullPageLoad } from "components/Loading/FullPageLoad";
-import { useCreateGQLCLient } from "hooks/useCreateGQLClient";
+import { useCreateGQLClient } from "hooks/useCreateGQLClient";
 
 const GQLWrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-  const client = useCreateGQLCLient();
+  const client = useCreateGQLClient();
   if (!client) {
     return <FullPageLoad />;
   }

--- a/apps/spruce/src/gql/client/link/index.ts
+++ b/apps/spruce/src/gql/client/link/index.ts
@@ -1,8 +1,8 @@
 import { ApolloLink, ServerParseError } from "@apollo/client";
 import { onError } from "@apollo/client/link/error";
 import { RetryLink } from "@apollo/client/link/retry";
+import { shouldLogoutAndRedirect } from "@evg-ui/lib/utils/request";
 import { leaveBreadcrumb, SentryBreadcrumb } from "utils/errorReporting";
-import { shouldLogoutAndRedirect } from "utils/request";
 
 export { logGQLToSentryLink } from "./logGQLToSentryLink";
 export { logGQLErrorsLink } from "./logGQLErrorsLink";

--- a/apps/spruce/src/gql/client/link/logGQLErrorsLink.test.ts
+++ b/apps/spruce/src/gql/client/link/logGQLErrorsLink.test.ts
@@ -1,3 +1,4 @@
+import { gql, Operation } from "@apollo/client";
 import { GraphQLError } from "graphql";
 import * as ErrorReporting from "utils/errorReporting";
 import { reportingFn } from "./logGQLErrorsLink";
@@ -12,12 +13,12 @@ describe("reportingFn", () => {
 
   it("reportError should be called with secret fields redacted", () => {
     const secretFields = ["password", "creditCard"];
-    const operation = {
+    const operation: Operation = {
       operationName: "exampleOperation",
       variables: {
         input: { password: "password123", creditCard: "1234567890123456" },
       },
-      query: null,
+      query: gql``,
       setContext: vi.fn(),
       getContext: vi.fn(),
       extensions: {},
@@ -26,7 +27,6 @@ describe("reportingFn", () => {
       path: ["a", "path", "1"],
     });
 
-    // @ts-expect-error: FIXME. This comment was added by an automated script.
     reportingFn(secretFields, operation)(gqlErr);
 
     expect(ErrorReporting.reportError).toHaveBeenCalledTimes(1);

--- a/apps/spruce/src/gql/client/link/logGQLErrorsLink.test.ts
+++ b/apps/spruce/src/gql/client/link/logGQLErrorsLink.test.ts
@@ -18,7 +18,7 @@ describe("reportingFn", () => {
       variables: {
         input: { password: "password123", creditCard: "1234567890123456" },
       },
-      // @ts-expect-error: It's not necessary to run an actual query.
+      // @ts-ignore-error: It's not necessary to run an actual query.
       query: null,
       setContext: vi.fn(),
       getContext: vi.fn(),

--- a/apps/spruce/src/gql/client/link/logGQLErrorsLink.test.ts
+++ b/apps/spruce/src/gql/client/link/logGQLErrorsLink.test.ts
@@ -1,4 +1,4 @@
-import { gql, Operation } from "@apollo/client";
+import { Operation } from "@apollo/client";
 import { GraphQLError } from "graphql";
 import * as ErrorReporting from "utils/errorReporting";
 import { reportingFn } from "./logGQLErrorsLink";
@@ -18,7 +18,8 @@ describe("reportingFn", () => {
       variables: {
         input: { password: "password123", creditCard: "1234567890123456" },
       },
-      query: gql``,
+      // @ts-expect-error: It's not necessary to run an actual query.
+      query: null,
       setContext: vi.fn(),
       getContext: vi.fn(),
       extensions: {},

--- a/apps/spruce/src/gql/client/link/logGQLErrorsLink.ts
+++ b/apps/spruce/src/gql/client/link/logGQLErrorsLink.ts
@@ -1,5 +1,6 @@
 import { Operation } from "@apollo/client";
 import { onError } from "@apollo/client/link/error";
+import { ApolloServerErrorCode } from "@apollo/server/errors";
 import { GraphQLError } from "graphql";
 import { reportError } from "utils/errorReporting";
 import { deleteNestedKey } from "utils/object";
@@ -11,7 +12,20 @@ export const reportingFn =
     if (path) {
       fingerprint.push(...path);
     }
-    reportError(new Error(gqlErr.message), {
+
+    const isValidationError =
+      gqlErr.extensions?.code ===
+      ApolloServerErrorCode.GRAPHQL_VALIDATION_FAILED;
+
+    const err = isValidationError
+      ? new GraphQLError(
+          `GraphQL validation error in '${operation.operationName}': ${gqlErr.message}`,
+        )
+      : new Error(
+          `Error occurred in '${operation.operationName}': ${gqlErr.message}`,
+        );
+
+    const sendError = reportError(err, {
       fingerprint,
       tags: { operationName: operation.operationName },
       context: {
@@ -22,7 +36,13 @@ export const reportingFn =
           "REDACTED",
         ),
       },
-    }).warning();
+    });
+
+    if (isValidationError) {
+      sendError.severe();
+    } else {
+      sendError.warning();
+    }
   };
 
 export const logGQLErrorsLink = (secretFields: string[]) =>

--- a/apps/spruce/src/gql/client/link/logGQLErrorsLink.ts
+++ b/apps/spruce/src/gql/client/link/logGQLErrorsLink.ts
@@ -2,8 +2,8 @@ import { Operation } from "@apollo/client";
 import { onError } from "@apollo/client/link/error";
 import { ApolloServerErrorCode } from "@apollo/server/errors";
 import { GraphQLError } from "graphql";
+import { deleteNestedKey } from "@evg-ui/lib/utils/object";
 import { reportError } from "utils/errorReporting";
-import { deleteNestedKey } from "utils/object";
 
 export const reportingFn =
   (secretFields: string[], operation: Operation) => (gqlErr: GraphQLError) => {

--- a/apps/spruce/src/gql/client/link/logGQLToSentryLink.ts
+++ b/apps/spruce/src/gql/client/link/logGQLToSentryLink.ts
@@ -1,6 +1,6 @@
 import { Operation, FetchResult, ApolloLink } from "@apollo/client";
+import { deleteNestedKey } from "@evg-ui/lib/utils/object";
 import { leaveBreadcrumb, SentryBreadcrumb } from "utils/errorReporting";
-import { deleteNestedKey } from "utils/object";
 
 export const leaveBreadcrumbMapFn =
   (operation: Operation, secretFields: string[]) => (response: FetchResult) => {

--- a/apps/spruce/src/gql/fetch/index.ts
+++ b/apps/spruce/src/gql/fetch/index.ts
@@ -7,9 +7,8 @@ export const secretFieldsReq: RequestInit = {
     "content-type": "application/json",
   },
   body: JSON.stringify({
-    // @ts-expect-error: FIXME. This comment was added by an automated script.
     operationName: (SECRET_FIELDS.definitions[0] as OperationDefinitionNode)
-      .name.value,
+      ?.name?.value,
     query: SECRET_FIELDS.loc?.source.body,
     variables: {},
   }),

--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -3462,8 +3462,8 @@ export type VolumeHost = {
 export type Waterfall = {
   __typename?: "Waterfall";
   buildVariants: Array<WaterfallBuildVariant>;
-  nextPageOrder: Scalars["Int"]["output"];
-  prevPageOrder: Scalars["Int"]["output"];
+  flattenedVersions: Array<Version>;
+  pagination: WaterfallPagination;
   versions: Array<WaterfallVersion>;
 };
 
@@ -3481,6 +3481,7 @@ export type WaterfallBuildVariant = {
   builds: Array<WaterfallBuild>;
   displayName: Scalars["String"]["output"];
   id: Scalars["String"]["output"];
+  version: Scalars["String"]["output"];
 };
 
 export type WaterfallOptions = {
@@ -3493,6 +3494,14 @@ export type WaterfallOptions = {
   projectIdentifier: Scalars["String"]["input"];
   requesters?: InputMaybe<Array<Scalars["String"]["input"]>>;
   revision?: InputMaybe<Scalars["String"]["input"]>;
+};
+
+export type WaterfallPagination = {
+  __typename?: "WaterfallPagination";
+  hasNextPage: Scalars["Boolean"]["output"];
+  hasPrevPage: Scalars["Boolean"]["output"];
+  nextPageOrder: Scalars["Int"]["output"];
+  prevPageOrder: Scalars["Int"]["output"];
 };
 
 export type WaterfallTask = {

--- a/apps/spruce/src/hooks/useCreateGQLClient/index.ts
+++ b/apps/spruce/src/hooks/useCreateGQLClient/index.ts
@@ -1,5 +1,9 @@
 import { useEffect, useState } from "react";
 import { HttpLink, ApolloClient, NormalizedCacheObject } from "@apollo/client";
+import {
+  fetchWithRetry,
+  shouldLogoutAndRedirect,
+} from "@evg-ui/lib/utils/request";
 import { useAuthDispatchContext } from "context/Auth";
 import { cache } from "gql/client/cache";
 import {
@@ -13,11 +17,10 @@ import { secretFieldsReq } from "gql/fetch";
 import { SecretFieldsQuery } from "gql/generated/types";
 import { environmentVariables } from "utils";
 import { leaveBreadcrumb, SentryBreadcrumb } from "utils/errorReporting";
-import { fetchWithRetry, shouldLogoutAndRedirect } from "utils/request";
 
 const { getGQLUrl } = environmentVariables;
 
-export const useCreateGQLCLient = (): ApolloClient<NormalizedCacheObject> => {
+export const useCreateGQLClient = (): ApolloClient<NormalizedCacheObject> => {
   const { dispatchAuthenticated, logoutAndRedirect } = useAuthDispatchContext();
   const [secretFields, setSecretFields] = useState<string[]>();
   const [gqlClient, setGQLClient] = useState<any>();
@@ -40,7 +43,7 @@ export const useCreateGQLCLient = (): ApolloClient<NormalizedCacheObject> => {
           logoutAndRedirect();
         }
       });
-  }, []);
+  }, [dispatchAuthenticated, logoutAndRedirect]);
 
   useEffect(() => {
     if (secretFields && !gqlClient) {

--- a/apps/spruce/src/pages/Login.tsx
+++ b/apps/spruce/src/pages/Login.tsx
@@ -1,10 +1,10 @@
 import { useEffect, useState } from "react";
 import styled from "@emotion/styled";
 import { Navigate, useLocation } from "react-router-dom";
+import { fetchWithRetry } from "@evg-ui/lib/utils/request";
 import { useAuthDispatchContext, useAuthStateContext } from "context/Auth";
 import { secretFieldsReq } from "gql/fetch";
 import { getGQLUrl } from "utils/environmentVariables";
-import { fetchWithRetry } from "utils/request";
 
 type LocationState = {
   referrer?: string;

--- a/apps/spruce/src/utils/object/index.ts
+++ b/apps/spruce/src/utils/object/index.ts
@@ -1,4 +1,3 @@
-import { deleteNestedKey } from "./deleteNestedKey";
 import { omit } from "./omit";
 
-export { omit, deleteNestedKey };
+export { omit };

--- a/apps/spruce/src/utils/request.test.ts
+++ b/apps/spruce/src/utils/request.test.ts
@@ -1,4 +1,4 @@
-import { post, fetchWithRetry } from "./request";
+import { post } from "./request";
 
 describe("request utils", () => {
   describe("post", () => {
@@ -45,83 +45,6 @@ describe("request utils", () => {
         credentials: "include",
       });
       expect(errorReportingMock).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  describe("fetchWithRetry", () => {
-    beforeEach(() => {
-      vi.spyOn(global, "fetch");
-    });
-
-    afterEach(() => {
-      vi.restoreAllMocks();
-    });
-
-    it("successfully fetches data on the first try", async () => {
-      const mockData = { success: true };
-      vi.mocked(global.fetch).mockResolvedValueOnce({
-        json: () => Promise.resolve(mockData),
-        ok: true,
-      } as Response);
-
-      const result = await fetchWithRetry<{ success: boolean }>(
-        "https://example.com",
-        {},
-      );
-      expect(result).toStrictEqual(mockData);
-      expect(global.fetch).toHaveBeenCalledTimes(1);
-    });
-
-    it("retries the specified number of times on failure, then succeeds", async () => {
-      const mockData = { success: true };
-      vi.mocked(global.fetch)
-        .mockRejectedValueOnce(new Error("Network failure"))
-        .mockRejectedValueOnce(new Error("Network failure"))
-        .mockResolvedValueOnce({
-          ok: true,
-          json: () => Promise.resolve(mockData),
-        } as Response);
-
-      const result = await fetchWithRetry<{ success: boolean }>(
-        "https://example.com",
-        {},
-        2,
-      );
-      expect(result).toStrictEqual(mockData);
-      expect(global.fetch).toHaveBeenCalledTimes(3);
-    });
-
-    it("fails after the specified number of retries", async () => {
-      vi.mocked(global.fetch).mockRejectedValue(new Error("Network failure"));
-
-      await expect(
-        fetchWithRetry("https://example.com", {}, 2),
-      ).rejects.toThrow("Network failure");
-      expect(global.fetch).toHaveBeenCalledTimes(3);
-    });
-
-    it("rejects if the response is not ok and does not retry fetch", async () => {
-      vi.mocked(global.fetch).mockResolvedValueOnce({
-        ok: false,
-        status: 500,
-        statusText: "Internal Server Error",
-      } as Response);
-      let error = null;
-      try {
-        await fetchWithRetry("https://example.com", {});
-      } catch (err) {
-        error = err;
-      }
-      expect(error).toBeInstanceOf(Error);
-      // @ts-expect-error: FIXME. This comment was added by an automated script.
-      expect(error.message).toBe("GET Error: 500 - Internal Server Error");
-      expect(error).toHaveProperty("cause");
-      // @ts-expect-error: FIXME. This comment was added by an automated script.
-      expect(error.cause).toStrictEqual({
-        statusCode: 500,
-        message: "Internal Server Error",
-      });
-      expect(global.fetch).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/apps/spruce/src/utils/request.ts
+++ b/apps/spruce/src/utils/request.ts
@@ -1,9 +1,6 @@
 import { getUiUrl } from "./environmentVariables";
 import { reportError } from "./errorReporting";
 
-export const shouldLogoutAndRedirect = (statusCode: number) =>
-  statusCode === 401;
-
 export const post = async (url: string, body: unknown) => {
   try {
     const response = await fetch(`${getUiUrl()}${url}`, {
@@ -28,34 +25,3 @@ const getErrorMessage = (response: Response, method: string) => {
 const handleError = (error: string) => {
   reportError(new Error(error)).warning();
 };
-
-export const fetchWithRetry = <T = any>(
-  url: string,
-  options: RequestInit,
-  retries: number = 3,
-  backoff: number = 150,
-): Promise<{ data: T }> =>
-  new Promise((resolve, reject) => {
-    const attemptFetch = (attempt: number): void => {
-      fetch(url, options)
-        .then((res) => {
-          if (res.ok) {
-            return res.json();
-          }
-          reject(
-            new Error(getErrorMessage(res, "GET"), {
-              cause: { statusCode: res.status, message: res.statusText },
-            }),
-          );
-        })
-        .then((data) => resolve(data))
-        .catch((err) => {
-          if (attempt <= retries) {
-            setTimeout(() => attemptFetch(attempt + 1), backoff * attempt);
-          } else {
-            reject(err);
-          }
-        });
-    };
-    attemptFetch(1);
-  });

--- a/packages/lib/src/utils/object/index.ts
+++ b/packages/lib/src/utils/object/index.ts
@@ -1,6 +1,5 @@
 /**
- *
- * Deletes a key from an object, including any nested objects.
+ * `deleteNestedKey` deletes a key from an object, including any nested objects.
  *
  * It modifies the original object by removing or updating any property that matches the
  * key name. If the key is found in nested objects, those are removed as well. The function

--- a/packages/lib/src/utils/object/object.test.ts
+++ b/packages/lib/src/utils/object/object.test.ts
@@ -1,4 +1,4 @@
-import { deleteNestedKey } from "./deleteNestedKey";
+import { deleteNestedKey } from ".";
 
 describe("deleteNestedKey", () => {
   it("replaces key with redacted string when it's defined", () => {

--- a/packages/lib/src/utils/request/index.ts
+++ b/packages/lib/src/utils/request/index.ts
@@ -1,0 +1,38 @@
+export const shouldLogoutAndRedirect = (statusCode: number) =>
+  statusCode === 401;
+
+const getErrorMessage = (response: Response, method: string) => {
+  const { status, statusText } = response;
+  return `${method} Error: ${status} - ${statusText}`;
+};
+
+export const fetchWithRetry = <T = any>(
+  url: string,
+  options: RequestInit,
+  retries: number = 3,
+  backoff: number = 150,
+): Promise<{ data: T }> =>
+  new Promise((resolve, reject) => {
+    const attemptFetch = (attempt: number): void => {
+      fetch(url, options)
+        .then((res) => {
+          if (res.ok) {
+            return res.json();
+          }
+          reject(
+            new Error(getErrorMessage(res, "GET"), {
+              cause: { message: res.statusText, statusCode: res.status },
+            }),
+          );
+        })
+        .then((data) => resolve(data))
+        .catch((err) => {
+          if (attempt <= retries) {
+            setTimeout(() => attemptFetch(attempt + 1), backoff * attempt);
+          } else {
+            reject(err);
+          }
+        });
+    };
+    attemptFetch(1);
+  });

--- a/packages/lib/src/utils/request/request.test.ts
+++ b/packages/lib/src/utils/request/request.test.ts
@@ -1,0 +1,81 @@
+import { fetchWithRetry } from ".";
+
+describe("request utils", () => {
+  describe("fetchWithRetry", () => {
+    beforeEach(() => {
+      vi.spyOn(global, "fetch");
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it("successfully fetches data on the first try", async () => {
+      const mockData = { success: true };
+      vi.mocked(global.fetch).mockResolvedValueOnce({
+        json: () => Promise.resolve(mockData),
+        ok: true,
+      } as Response);
+
+      const result = await fetchWithRetry<{ success: boolean }>(
+        "https://example.com",
+        {},
+      );
+      expect(result).toStrictEqual(mockData);
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it("retries the specified number of times on failure, then succeeds", async () => {
+      const mockData = { success: true };
+      vi.mocked(global.fetch)
+        .mockRejectedValueOnce(new Error("Network failure"))
+        .mockRejectedValueOnce(new Error("Network failure"))
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve(mockData),
+        } as Response);
+
+      const result = await fetchWithRetry<{ success: boolean }>(
+        "https://example.com",
+        {},
+        2,
+      );
+      expect(result).toStrictEqual(mockData);
+      expect(global.fetch).toHaveBeenCalledTimes(3);
+    });
+
+    it("fails after the specified number of retries", async () => {
+      vi.mocked(global.fetch).mockRejectedValue(new Error("Network failure"));
+
+      await expect(
+        fetchWithRetry("https://example.com", {}, 2),
+      ).rejects.toThrow("Network failure");
+      expect(global.fetch).toHaveBeenCalledTimes(3);
+    });
+
+    it("rejects if the response is not ok and does not retry fetch", async () => {
+      vi.mocked(global.fetch).mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        statusText: "Internal Server Error",
+      } as Response);
+      let error = null;
+      try {
+        await fetchWithRetry("https://example.com", {});
+      } catch (err) {
+        error = err;
+      }
+      expect(error).toBeInstanceOf(Error);
+      expect(error).toHaveProperty("message");
+      expect((error as Error).message).toBe(
+        "GET Error: 500 - Internal Server Error",
+      );
+      expect(error).toHaveProperty("cause");
+      expect((error as Error).cause).toStrictEqual({
+        statusCode: 500,
+        message: "Internal Server Error",
+      });
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -50,6 +50,11 @@
     lodash "^4.17.21"
     resize-observer-polyfill "^1.5.0"
 
+"@apollo/cache-control-types@^1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@apollo/cache-control-types/-/cache-control-types-1.0.3.tgz#5da62cf64c3b4419dabfef4536b57a40c8ff0b47"
+  integrity sha512-F17/vCp7QVwom9eG7ToauIKdAxpSoadsJnqIfyryLFSkLSOEqu+eC5Z3N8OXcUVStuOMcNHlyraRsA6rRICu4g==
+
 "@apollo/client@3.10.4":
   version "3.10.4"
   resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.10.4.tgz#1abc488c79cf37dc63edf041aee6f9dc5aabc692"
@@ -88,6 +93,146 @@
     ts-invariant "^0.10.3"
     tslib "^2.3.0"
     zen-observable-ts "^1.2.5"
+
+"@apollo/protobufjs@1.2.7":
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/@apollo/protobufjs/-/protobufjs-1.2.7.tgz#3a8675512817e4a046a897e5f4f16415f16a7d8a"
+  integrity sha512-Lahx5zntHPZia35myYDBRuF58tlwPskwHc5CWBZC/4bMKB6siTBWwtMrkqXcsNwQiFSzSx5hKdRPUmemrEp3Gg==
+  dependencies:
+    "@protobufjs/aspromise" "^1.1.2"
+    "@protobufjs/base64" "^1.1.2"
+    "@protobufjs/codegen" "^2.0.4"
+    "@protobufjs/eventemitter" "^1.1.0"
+    "@protobufjs/fetch" "^1.1.0"
+    "@protobufjs/float" "^1.0.2"
+    "@protobufjs/inquire" "^1.1.0"
+    "@protobufjs/path" "^1.1.2"
+    "@protobufjs/pool" "^1.1.0"
+    "@protobufjs/utf8" "^1.1.0"
+    "@types/long" "^4.0.0"
+    long "^4.0.0"
+
+"@apollo/server-gateway-interface@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@apollo/server-gateway-interface/-/server-gateway-interface-1.1.1.tgz#a79632aa921edefcd532589943f6b97c96fa4d3c"
+  integrity sha512-pGwCl/po6+rxRmDMFgozKQo2pbsSwE91TpsDBAOgf74CRDPXHHtM88wbwjab0wMMZh95QfR45GGyDIdhY24bkQ==
+  dependencies:
+    "@apollo/usage-reporting-protobuf" "^4.1.1"
+    "@apollo/utils.fetcher" "^2.0.0"
+    "@apollo/utils.keyvaluecache" "^2.1.0"
+    "@apollo/utils.logger" "^2.0.0"
+
+"@apollo/server@^4.11.0":
+  version "4.11.0"
+  resolved "https://registry.yarnpkg.com/@apollo/server/-/server-4.11.0.tgz#21c0f10ad805192a5485e58ed5c5b3dbe2243174"
+  integrity sha512-SWDvbbs0wl2zYhKG6aGLxwTJ72xpqp0awb2lotNpfezd9VcAvzaUizzKQqocephin2uMoaA8MguoyBmgtPzNWw==
+  dependencies:
+    "@apollo/cache-control-types" "^1.0.3"
+    "@apollo/server-gateway-interface" "^1.1.1"
+    "@apollo/usage-reporting-protobuf" "^4.1.1"
+    "@apollo/utils.createhash" "^2.0.0"
+    "@apollo/utils.fetcher" "^2.0.0"
+    "@apollo/utils.isnodelike" "^2.0.0"
+    "@apollo/utils.keyvaluecache" "^2.1.0"
+    "@apollo/utils.logger" "^2.0.0"
+    "@apollo/utils.usagereporting" "^2.1.0"
+    "@apollo/utils.withrequired" "^2.0.0"
+    "@graphql-tools/schema" "^9.0.0"
+    "@types/express" "^4.17.13"
+    "@types/express-serve-static-core" "^4.17.30"
+    "@types/node-fetch" "^2.6.1"
+    async-retry "^1.2.1"
+    cors "^2.8.5"
+    express "^4.17.1"
+    loglevel "^1.6.8"
+    lru-cache "^7.10.1"
+    negotiator "^0.6.3"
+    node-abort-controller "^3.1.1"
+    node-fetch "^2.6.7"
+    uuid "^9.0.0"
+    whatwg-mimetype "^3.0.0"
+
+"@apollo/usage-reporting-protobuf@^4.1.0", "@apollo/usage-reporting-protobuf@^4.1.1":
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/@apollo/usage-reporting-protobuf/-/usage-reporting-protobuf-4.1.1.tgz#407c3d18c7fbed7a264f3b9a3812620b93499de1"
+  integrity sha512-u40dIUePHaSKVshcedO7Wp+mPiZsaU6xjv9J+VyxpoU/zL6Jle+9zWeG98tr/+SZ0nZ4OXhrbb8SNr0rAPpIDA==
+  dependencies:
+    "@apollo/protobufjs" "1.2.7"
+
+"@apollo/utils.createhash@^2.0.0":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@apollo/utils.createhash/-/utils.createhash-2.0.1.tgz#9d982a166833ce08265ff70f8ef781d65109bdaa"
+  integrity sha512-fQO4/ZOP8LcXWvMNhKiee+2KuKyqIcfHrICA+M4lj/h/Lh1H10ICcUtk6N/chnEo5HXu0yejg64wshdaiFitJg==
+  dependencies:
+    "@apollo/utils.isnodelike" "^2.0.1"
+    sha.js "^2.4.11"
+
+"@apollo/utils.dropunuseddefinitions@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@apollo/utils.dropunuseddefinitions/-/utils.dropunuseddefinitions-2.0.1.tgz#916cd912cbd88769d3b0eab2d24f4674eeda8124"
+  integrity sha512-EsPIBqsSt2BwDsv8Wu76LK5R1KtsVkNoO4b0M5aK0hx+dGg9xJXuqlr7Fo34Dl+y83jmzn+UvEW+t1/GP2melA==
+
+"@apollo/utils.fetcher@^2.0.0":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@apollo/utils.fetcher/-/utils.fetcher-2.0.1.tgz#2f6e3edc8ce79fbe916110d9baaddad7e13d955f"
+  integrity sha512-jvvon885hEyWXd4H6zpWeN3tl88QcWnHp5gWF5OPF34uhvoR+DFqcNxs9vrRaBBSY3qda3Qe0bdud7tz2zGx1A==
+
+"@apollo/utils.isnodelike@^2.0.0", "@apollo/utils.isnodelike@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@apollo/utils.isnodelike/-/utils.isnodelike-2.0.1.tgz#08a7e50f08d2031122efa25af089d1c6ee609f31"
+  integrity sha512-w41XyepR+jBEuVpoRM715N2ZD0xMD413UiJx8w5xnAZD2ZkSJnMJBoIzauK83kJpSgNuR6ywbV29jG9NmxjK0Q==
+
+"@apollo/utils.keyvaluecache@^2.1.0":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@apollo/utils.keyvaluecache/-/utils.keyvaluecache-2.1.1.tgz#f3f79a2f00520c6ab7a77a680a4e1fec4d19e1a6"
+  integrity sha512-qVo5PvUUMD8oB9oYvq4ViCjYAMWnZ5zZwEjNF37L2m1u528x5mueMlU+Cr1UinupCgdB78g+egA1G98rbJ03Vw==
+  dependencies:
+    "@apollo/utils.logger" "^2.0.1"
+    lru-cache "^7.14.1"
+
+"@apollo/utils.logger@^2.0.0", "@apollo/utils.logger@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@apollo/utils.logger/-/utils.logger-2.0.1.tgz#74faeb97d7ad9f22282dfb465bcb2e6873b8a625"
+  integrity sha512-YuplwLHaHf1oviidB7MxnCXAdHp3IqYV8n0momZ3JfLniae92eYqMIx+j5qJFX6WKJPs6q7bczmV4lXIsTu5Pg==
+
+"@apollo/utils.printwithreducedwhitespace@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@apollo/utils.printwithreducedwhitespace/-/utils.printwithreducedwhitespace-2.0.1.tgz#f4fadea0ae849af2c19c339cc5420d1ddfaa905e"
+  integrity sha512-9M4LUXV/fQBh8vZWlLvb/HyyhjJ77/I5ZKu+NBWV/BmYGyRmoEP9EVAy7LCVoY3t8BDcyCAGfxJaLFCSuQkPUg==
+
+"@apollo/utils.removealiases@2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@apollo/utils.removealiases/-/utils.removealiases-2.0.1.tgz#2873c93d72d086c60fc0d77e23d0f75e66a2598f"
+  integrity sha512-0joRc2HBO4u594Op1nev+mUF6yRnxoUH64xw8x3bX7n8QBDYdeYgY4tF0vJReTy+zdn2xv6fMsquATSgC722FA==
+
+"@apollo/utils.sortast@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@apollo/utils.sortast/-/utils.sortast-2.0.1.tgz#58c90bb8bd24726346b61fa51ba7fcf06e922ef7"
+  integrity sha512-eciIavsWpJ09za1pn37wpsCGrQNXUhM0TktnZmHwO+Zy9O4fu/WdB4+5BvVhFiZYOXvfjzJUcc+hsIV8RUOtMw==
+  dependencies:
+    lodash.sortby "^4.7.0"
+
+"@apollo/utils.stripsensitiveliterals@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@apollo/utils.stripsensitiveliterals/-/utils.stripsensitiveliterals-2.0.1.tgz#2f3350483be376a98229f90185eaf19888323132"
+  integrity sha512-QJs7HtzXS/JIPMKWimFnUMK7VjkGQTzqD9bKD1h3iuPAqLsxd0mUNVbkYOPTsDhUKgcvUOfOqOJWYohAKMvcSA==
+
+"@apollo/utils.usagereporting@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@apollo/utils.usagereporting/-/utils.usagereporting-2.1.0.tgz#11bca6a61fcbc6e6d812004503b38916e74313f4"
+  integrity sha512-LPSlBrn+S17oBy5eWkrRSGb98sWmnEzo3DPTZgp8IQc8sJe0prDgDuppGq4NeQlpoqEHz0hQeYHAOA0Z3aQsxQ==
+  dependencies:
+    "@apollo/usage-reporting-protobuf" "^4.1.0"
+    "@apollo/utils.dropunuseddefinitions" "^2.0.1"
+    "@apollo/utils.printwithreducedwhitespace" "^2.0.1"
+    "@apollo/utils.removealiases" "2.0.1"
+    "@apollo/utils.sortast" "^2.0.1"
+    "@apollo/utils.stripsensitiveliterals" "^2.0.1"
+
+"@apollo/utils.withrequired@^2.0.0":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@apollo/utils.withrequired/-/utils.withrequired-2.0.1.tgz#e72bc512582a6f26af150439f7eb7473b46ba874"
+  integrity sha512-YBDiuAX9i1lLc6GeTy1m7DGLFn/gMnvXqlalOIMjM7DeOgIacEjjfwPqb0M1CQ2v11HhR15d1NmxJoRCfrNqcA==
 
 "@ardatan/relay-compiler@12.0.0":
   version "12.0.0"
@@ -1723,7 +1868,7 @@
     tslib "^2.4.0"
     value-or-promise "^1.0.12"
 
-"@graphql-tools/schema@^9.0.18", "@graphql-tools/schema@^9.0.19":
+"@graphql-tools/schema@^9.0.0", "@graphql-tools/schema@^9.0.18", "@graphql-tools/schema@^9.0.19":
   version "9.0.19"
   resolved "https://registry.yarnpkg.com/@graphql-tools/schema/-/schema-9.0.19.tgz#c4ad373b5e1b8a0cf365163435b7d236ebdd06e7"
   integrity sha512-oBRPoNBtCkk0zbUsyP4GaIzCt8C0aCI4ycIRUL67KK5pOHljKLBBtGT+Jr6hkzA74C8Gco8bpZPe7aWFjiaK2w==
@@ -3951,6 +4096,16 @@
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.51.tgz#cfd70924a25a3fd32b218e5e420e6897e1ac4f40"
   integrity sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==
 
+"@types/express-serve-static-core@^4.17.30":
+  version "4.19.6"
+  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.19.6.tgz#e01324c2a024ff367d92c66f48553ced0ab50267"
+  integrity sha512-N4LZ2xG7DatVqhCZzOGb1Yi5lMbXSZcmdLDe9EzSndPV2HpWYWzRbaerl2n27irrm94EPpprqa8KpskPT085+A==
+  dependencies:
+    "@types/node" "*"
+    "@types/qs" "*"
+    "@types/range-parser" "*"
+    "@types/send" "*"
+
 "@types/express-serve-static-core@^4.17.33":
   version "4.19.1"
   resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.19.1.tgz#57d34698bb580720fd6e3c360d4b2fdef579b979"
@@ -3961,7 +4116,7 @@
     "@types/range-parser" "*"
     "@types/send" "*"
 
-"@types/express@^4.17.21":
+"@types/express@^4.17.13", "@types/express@^4.17.21":
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.21.tgz#c26d4a151e60efe0084b23dc3369ebc631ed192d"
   integrity sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==
@@ -4047,6 +4202,11 @@
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.17.4.tgz#0303b64958ee070059e3a7184048a55159fe20b7"
   integrity sha512-wYCP26ZLxaT3R39kiN2+HcJ4kTd3U1waI/cY7ivWYqFP6pW3ZNpvi6Wd6PHZx7T/t8z0vlkXMg3QYLa7DZ/IJQ==
 
+"@types/long@^4.0.0":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@types/long/-/long-4.0.2.tgz#b74129719fc8d11c01868010082d483b7545591a"
+  integrity sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==
+
 "@types/mdx@^2.0.0":
   version "2.0.13"
   resolved "https://registry.yarnpkg.com/@types/mdx/-/mdx-2.0.13.tgz#68f6877043d377092890ff5b298152b0a21671bd"
@@ -4061,6 +4221,14 @@
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-5.1.2.tgz#07508b45797cb81ec3f273011b054cd0755eddca"
   integrity sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==
+
+"@types/node-fetch@^2.6.1":
+  version "2.6.11"
+  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.6.11.tgz#9b39b78665dae0e82a08f02f4967d62c66f95d24"
+  integrity sha512-24xFj9R5+rfQJLRyM56qh+wnVSYhyXC2tkoBndtY0U+vubqNsYXGjufB2nn8Q6gt0LrARwL6UBtMCSVCwl4B1g==
+  dependencies:
+    "@types/node" "*"
+    form-data "^4.0.0"
 
 "@types/node@*", "@types/node@>=13.7.0", "@types/node@^22.0.0":
   version "22.5.5"
@@ -4913,6 +5081,13 @@ astral-regex@^2.0.0:
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-2.0.0.tgz#483143c567aeed4785759c0865786dc77d7d2e31"
   integrity sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==
 
+async-retry@^1.2.1:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/async-retry/-/async-retry-1.3.3.tgz#0e7f36c04d8478e7a58bdbed80cedf977785f280"
+  integrity sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==
+  dependencies:
+    retry "0.13.1"
+
 async-validator@^4.1.0:
   version "4.2.5"
   resolved "https://registry.yarnpkg.com/async-validator/-/async-validator-4.2.5.tgz#c96ea3332a521699d0afaaceed510a54656c6339"
@@ -5086,6 +5261,24 @@ body-parser@1.20.2:
     iconv-lite "0.4.24"
     on-finished "2.4.1"
     qs "6.11.0"
+    raw-body "2.5.2"
+    type-is "~1.6.18"
+    unpipe "1.0.0"
+
+body-parser@1.20.3:
+  version "1.20.3"
+  resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.20.3.tgz#1953431221c6fb5cd63c4b36d53fab0928e548c6"
+  integrity sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==
+  dependencies:
+    bytes "3.1.2"
+    content-type "~1.0.5"
+    debug "2.6.9"
+    depd "2.0.0"
+    destroy "1.2.0"
+    http-errors "2.0.0"
+    iconv-lite "0.4.24"
+    on-finished "2.4.1"
+    qs "6.13.0"
     raw-body "2.5.2"
     type-is "~1.6.18"
     unpipe "1.0.0"
@@ -5694,6 +5887,11 @@ cookie@0.6.0:
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.6.0.tgz#2798b04b071b0ecbff0dbb62a505a8efa4e19051"
   integrity sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==
 
+cookie@0.7.1:
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.7.1.tgz#2f73c42142d5d5cf71310a74fc4ae61670e5dbc9"
+  integrity sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==
+
 copy-anything@^2.0.1:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/copy-anything/-/copy-anything-2.0.6.tgz#092454ea9584a7b7ad5573062b2a87f5900fc480"
@@ -5722,6 +5920,14 @@ core-util-is@~1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.3.tgz#a6042d3634c2b27e9328f837b965fac83808db85"
   integrity sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==
+
+cors@^2.8.5:
+  version "2.8.5"
+  resolved "https://registry.yarnpkg.com/cors/-/cors-2.8.5.tgz#eac11da51592dd86b9f06f6e7ac293b3df875d29"
+  integrity sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==
+  dependencies:
+    object-assign "^4"
+    vary "^1"
 
 cosmiconfig@8.0.0:
   version "8.0.0"
@@ -6310,6 +6516,11 @@ encodeurl@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
   integrity sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==
+
+encodeurl@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-2.0.0.tgz#7b8ea898077d7e409d3ac45474ea38eaf0857a58"
+  integrity sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==
 
 end-of-stream@^1.1.0:
   version "1.4.4"
@@ -7085,6 +7296,43 @@ executable@^4.1.1:
   dependencies:
     pify "^2.2.0"
 
+express@^4.17.1:
+  version "4.21.1"
+  resolved "https://registry.yarnpkg.com/express/-/express-4.21.1.tgz#9dae5dda832f16b4eec941a4e44aa89ec481b281"
+  integrity sha512-YSFlK1Ee0/GC8QaO91tHcDxJiE/X4FbpAyQWkxAvG6AXCuR65YzK8ua6D9hvi/TzUfZMpc+BwuM1IPw8fmQBiQ==
+  dependencies:
+    accepts "~1.3.8"
+    array-flatten "1.1.1"
+    body-parser "1.20.3"
+    content-disposition "0.5.4"
+    content-type "~1.0.4"
+    cookie "0.7.1"
+    cookie-signature "1.0.6"
+    debug "2.6.9"
+    depd "2.0.0"
+    encodeurl "~2.0.0"
+    escape-html "~1.0.3"
+    etag "~1.8.1"
+    finalhandler "1.3.1"
+    fresh "0.5.2"
+    http-errors "2.0.0"
+    merge-descriptors "1.0.3"
+    methods "~1.1.2"
+    on-finished "2.4.1"
+    parseurl "~1.3.3"
+    path-to-regexp "0.1.10"
+    proxy-addr "~2.0.7"
+    qs "6.13.0"
+    range-parser "~1.2.1"
+    safe-buffer "5.2.1"
+    send "0.19.0"
+    serve-static "1.16.2"
+    setprototypeof "1.2.0"
+    statuses "2.0.1"
+    type-is "~1.6.18"
+    utils-merge "1.0.1"
+    vary "~1.1.2"
+
 express@^4.19.2:
   version "4.19.2"
   resolved "https://registry.yarnpkg.com/express/-/express-4.19.2.tgz#e25437827a3aa7f2a827bc8171bbbb664a356465"
@@ -7296,6 +7544,19 @@ finalhandler@1.2.0:
   dependencies:
     debug "2.6.9"
     encodeurl "~1.0.2"
+    escape-html "~1.0.3"
+    on-finished "2.4.1"
+    parseurl "~1.3.3"
+    statuses "2.0.1"
+    unpipe "~1.0.0"
+
+finalhandler@1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/finalhandler/-/finalhandler-1.3.1.tgz#0c575f1d1d324ddd1da35ad7ece3df7d19088019"
+  integrity sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==
+  dependencies:
+    debug "2.6.9"
+    encodeurl "~2.0.0"
     escape-html "~1.0.3"
     on-finished "2.4.1"
     parseurl "~1.3.3"
@@ -8051,7 +8312,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@2.0.4, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.1, inherits@~2.0.3:
+inherits@2, inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.1, inherits@~2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -8942,6 +9203,16 @@ log-update@^6.0.0:
     strip-ansi "^7.1.0"
     wrap-ansi "^9.0.0"
 
+loglevel@^1.6.8:
+  version "1.9.2"
+  resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.9.2.tgz#c2e028d6c757720107df4e64508530db6621ba08"
+  integrity sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==
+
+long@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/long/-/long-4.0.0.tgz#9a7b71cfb7d361a194ea555241c92f7468d5bf28"
+  integrity sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==
+
 long@^5.0.0:
   version "5.2.3"
   resolved "https://registry.yarnpkg.com/long/-/long-5.2.3.tgz#a3ba97f3877cf1d778eccbcb048525ebb77499e1"
@@ -8996,6 +9267,11 @@ lru-cache@^5.1.1:
   integrity sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==
   dependencies:
     yallist "^3.0.2"
+
+lru-cache@^7.10.1, lru-cache@^7.14.1:
+  version "7.18.3"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-7.18.3.tgz#f793896e0fd0e954a59dfdd82f0773808df6aa89"
+  integrity sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==
 
 lz-string@^1.5.0:
   version "1.5.0"
@@ -9074,6 +9350,11 @@ merge-descriptors@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61"
   integrity sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w==
+
+merge-descriptors@1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.3.tgz#d80319a65f3c7935351e5cfdac8f9318504dbed5"
+  integrity sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==
 
 merge-stream@^2.0.0:
   version "2.0.0"
@@ -9283,6 +9564,11 @@ negotiator@0.6.3:
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.3.tgz#58e323a72fedc0d6f9cd4d31fe49f51479590ccd"
   integrity sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==
 
+negotiator@^0.6.3:
+  version "0.6.4"
+  resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.4.tgz#777948e2452651c570b712dd01c23e262713fff7"
+  integrity sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==
+
 no-case@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/no-case/-/no-case-3.0.4.tgz#d361fd5c9800f558551a8369fc0dcd4662b6124d"
@@ -9290,6 +9576,11 @@ no-case@^3.0.4:
   dependencies:
     lower-case "^2.0.2"
     tslib "^2.0.3"
+
+node-abort-controller@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/node-abort-controller/-/node-abort-controller-3.1.1.tgz#a94377e964a9a37ac3976d848cb5c765833b8548"
+  integrity sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==
 
 node-fetch@^2.6.1, node-fetch@^2.6.12, node-fetch@^2.6.7:
   version "2.7.0"
@@ -9349,7 +9640,7 @@ nwsapi@^2.2.7:
   resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.2.10.tgz#0b77a68e21a0b483db70b11fad055906e867cda8"
   integrity sha512-QK0sRs7MKv0tKe1+5uZIQk/C8XGza4DAnztJG8iD+TpJIORARrCxczA738awHrZoHeTjSSoHqao2teO0dC/gFQ==
 
-object-assign@^4.1.0, object-assign@^4.1.1:
+object-assign@^4, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==
@@ -9670,6 +9961,11 @@ path-scurry@^1.6.1:
     lru-cache "^10.2.0"
     minipass "^5.0.0 || ^6.0.2 || ^7.0.0"
 
+path-to-regexp@0.1.10:
+  version "0.1.10"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.10.tgz#67e9108c5c0551b9e5326064387de4763c4d5f8b"
+  integrity sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==
+
 path-to-regexp@0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
@@ -9923,6 +10219,13 @@ qs@6.11.0:
   integrity sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==
   dependencies:
     side-channel "^1.0.4"
+
+qs@6.13.0:
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.13.0.tgz#6ca3bd58439f7e245655798997787b0d88a51906"
+  integrity sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==
+  dependencies:
+    side-channel "^1.0.6"
 
 qs@~6.10.3:
   version "6.10.5"
@@ -10779,6 +11082,11 @@ restore-cursor@^4.0.0:
     onetime "^5.1.0"
     signal-exit "^3.0.2"
 
+retry@0.13.1:
+  version "0.13.1"
+  resolved "https://registry.yarnpkg.com/retry/-/retry-0.13.1.tgz#185b1587acf67919d63b357349e03537b2484658"
+  integrity sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==
+
 reusify@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
@@ -10959,6 +11267,25 @@ send@0.18.0:
     range-parser "~1.2.1"
     statuses "2.0.1"
 
+send@0.19.0:
+  version "0.19.0"
+  resolved "https://registry.yarnpkg.com/send/-/send-0.19.0.tgz#bbc5a388c8ea6c048967049dbeac0e4a3f09d7f8"
+  integrity sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==
+  dependencies:
+    debug "2.6.9"
+    depd "2.0.0"
+    destroy "1.2.0"
+    encodeurl "~1.0.2"
+    escape-html "~1.0.3"
+    etag "~1.8.1"
+    fresh "0.5.2"
+    http-errors "2.0.0"
+    mime "1.6.0"
+    ms "2.1.3"
+    on-finished "2.4.1"
+    range-parser "~1.2.1"
+    statuses "2.0.1"
+
 sentence-case@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/sentence-case/-/sentence-case-3.0.4.tgz#3645a7b8c117c787fde8702056225bb62a45131f"
@@ -10991,6 +11318,16 @@ serve-static@1.15.0:
     escape-html "~1.0.3"
     parseurl "~1.3.3"
     send "0.18.0"
+
+serve-static@1.16.2:
+  version "1.16.2"
+  resolved "https://registry.yarnpkg.com/serve-static/-/serve-static-1.16.2.tgz#b6a5343da47f6bdd2673848bf45754941e803296"
+  integrity sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==
+  dependencies:
+    encodeurl "~2.0.0"
+    escape-html "~1.0.3"
+    parseurl "~1.3.3"
+    send "0.19.0"
 
 serve@14.2.1:
   version "14.2.1"
@@ -11045,6 +11382,14 @@ setprototypeof@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.2.0.tgz#66c9a24a73f9fc28cbe66b09fed3d33dcaf1b424"
   integrity sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==
+
+sha.js@^2.4.11:
+  version "2.4.11"
+  resolved "https://registry.yarnpkg.com/sha.js/-/sha.js-2.4.11.tgz#37a5cf0b81ecbc6943de109ba2960d1b26584ae7"
+  integrity sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==
+  dependencies:
+    inherits "^2.0.1"
+    safe-buffer "^5.0.1"
 
 shallowequal@^1.1.0:
   version "1.1.0"
@@ -12078,7 +12423,7 @@ value-or-promise@^1.0.11, value-or-promise@^1.0.12:
   resolved "https://registry.yarnpkg.com/value-or-promise/-/value-or-promise-1.0.12.tgz#0e5abfeec70148c78460a849f6b003ea7986f15c"
   integrity sha512-Z6Uz+TYwEqE7ZN50gwn+1LCVo9ZVrpxRPOhOLnncYkY1ZzOYtrX8Fwf/rFktZ8R5mJms6EZf5TqNOMeZmnPq9Q==
 
-vary@~1.1.2:
+vary@^1, vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==
@@ -12332,6 +12677,11 @@ whatwg-encoding@^3.1.1:
   integrity sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==
   dependencies:
     iconv-lite "0.6.3"
+
+whatwg-mimetype@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz#5fa1a7623867ff1af6ca3dc72ad6b8a4208beba7"
+  integrity sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==
 
 whatwg-mimetype@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
DEVPROD-7857
<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️ -->
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
Send immediate Sentry alerts for 422 errors.

This PR also moves certain utils up to the `lib` folder so that they can be used in the upcoming PR for Parsley, which requires a lot more changes.


### Testing
- [Sample issue](https://mongodb-org.sentry.io/issues/6025875166/?referrer=slack&notification_uuid=a77e421c-39d8-4d51-91ce-08ee813d1b3c&environment=staging&alert_rule_id=14677842&alert_type=issue)
