### PR TITLE
DEVPROD-11706: Add filtered commits to inactive modal

### DIFF
--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -3462,8 +3462,8 @@ export type VolumeHost = {
 export type Waterfall = {
   __typename?: "Waterfall";
   buildVariants: Array<WaterfallBuildVariant>;
-  nextPageOrder: Scalars["Int"]["output"];
-  prevPageOrder: Scalars["Int"]["output"];
+  flattenedVersions: Array<Version>;
+  pagination: WaterfallPagination;
   versions: Array<WaterfallVersion>;
 };
 
@@ -3481,6 +3481,7 @@ export type WaterfallBuildVariant = {
   builds: Array<WaterfallBuild>;
   displayName: Scalars["String"]["output"];
   id: Scalars["String"]["output"];
+  version: Scalars["String"]["output"];
 };
 
 export type WaterfallOptions = {
@@ -3493,6 +3494,14 @@ export type WaterfallOptions = {
   projectIdentifier: Scalars["String"]["input"];
   requesters?: InputMaybe<Array<Scalars["String"]["input"]>>;
   revision?: InputMaybe<Scalars["String"]["input"]>;
+};
+
+export type WaterfallPagination = {
+  __typename?: "WaterfallPagination";
+  hasNextPage: Scalars["Boolean"]["output"];
+  hasPrevPage: Scalars["Boolean"]["output"];
+  nextPageOrder: Scalars["Int"]["output"];
+  prevPageOrder: Scalars["Int"]["output"];
 };
 
 export type WaterfallTask = {
@@ -9604,6 +9613,7 @@ export type WaterfallQuery = {
       __typename?: "WaterfallBuildVariant";
       displayName: string;
       id: string;
+      version: string;
       builds: Array<{
         __typename?: "WaterfallBuild";
         activated?: boolean | null;

--- a/apps/spruce/src/gql/queries/waterfall.graphql
+++ b/apps/spruce/src/gql/queries/waterfall.graphql
@@ -17,6 +17,7 @@ query Waterfall($options: WaterfallOptions!) {
       }
       displayName
       id
+      version
     }
     versions {
       inactiveVersions {

--- a/apps/spruce/src/pages/waterfall/InactiveVersions/InactiveVersionsModal.stories.tsx
+++ b/apps/spruce/src/pages/waterfall/InactiveVersions/InactiveVersionsModal.stories.tsx
@@ -1,0 +1,69 @@
+import styled from "@emotion/styled";
+import { StoryObj } from "@storybook/react";
+import { InactiveVersionsButton } from ".";
+import { InactiveVersion } from "../styles";
+import {
+  inactiveVersion,
+  inactiveBrokenVersion,
+  version,
+  versionWithGitTag,
+  versionWithUpstreamProject,
+  versionBroken,
+} from "../testData";
+
+export default {
+  title: "Pages/Waterfall/InactiveVersions",
+  component: InactiveVersionsButton,
+};
+
+const render: StoryObj<typeof InactiveVersionsButton>["render"] = (args) => (
+  <Container>
+    <InactiveVersion>
+      <InactiveVersionsButton {...args} />
+    </InactiveVersion>
+  </Container>
+);
+
+export const Default: StoryObj<typeof InactiveVersionsButton> = {
+  render,
+  args: {
+    versions: [inactiveVersion],
+  },
+};
+
+export const Broken: StoryObj<typeof InactiveVersionsButton> = {
+  render,
+  args: {
+    versions: [inactiveVersion, inactiveBrokenVersion],
+  },
+};
+
+export const FilteredAndInactive: StoryObj<typeof InactiveVersionsButton> = {
+  render,
+  args: {
+    versions: [
+      version,
+      versionWithGitTag,
+      inactiveVersion,
+      versionWithUpstreamProject,
+      versionBroken,
+      inactiveBrokenVersion,
+    ],
+  },
+};
+
+export const Filtered: StoryObj<typeof InactiveVersionsButton> = {
+  render,
+  args: {
+    versions: [
+      version,
+      versionWithGitTag,
+      versionWithUpstreamProject,
+      versionBroken,
+    ],
+  },
+};
+
+const Container = styled.div`
+  display: flex;
+`;

--- a/apps/spruce/src/pages/waterfall/InactiveVersions/InactiveVersionsModal.tsx
+++ b/apps/spruce/src/pages/waterfall/InactiveVersions/InactiveVersionsModal.tsx
@@ -16,7 +16,7 @@ export const InactiveVersionsModal: React.FC<Props> = ({
   setOpen,
   versions,
 }) => {
-  const hasFilteredVersions =
+  const hasUnmatchingVersions =
     versions?.some(({ activated }) => activated) ?? false;
 
   return (
@@ -24,12 +24,12 @@ export const InactiveVersionsModal: React.FC<Props> = ({
       data-cy="inactive-versions-modal"
       open={open}
       setOpen={setOpen}
-      title={`${versions?.length} ${hasFilteredVersions ? "Unmatching" : "Inactive"} ${pluralize("Version", versions?.length)}`}
+      title={`${versions?.length} ${hasUnmatchingVersions ? "Unmatching" : "Inactive"} ${pluralize("Version", versions?.length)}`}
     >
       {versions?.map((version) => (
         <StyledVersionLabel
           key={version.id}
-          shouldDisableText={hasFilteredVersions}
+          shouldDisableText={hasUnmatchingVersions}
           view={VersionLabelView.Modal}
           {...version}
         />

--- a/apps/spruce/src/pages/waterfall/InactiveVersions/InactiveVersionsModal.tsx
+++ b/apps/spruce/src/pages/waterfall/InactiveVersions/InactiveVersionsModal.tsx
@@ -1,0 +1,43 @@
+import styled from "@emotion/styled";
+import pluralize from "pluralize";
+import { DisplayModal } from "components/DisplayModal";
+import { size } from "constants/tokens";
+import { WaterfallVersionFragment } from "gql/generated/types";
+import { VersionLabel, VersionLabelView } from "../VersionLabel";
+
+type Props = {
+  open: boolean;
+  setOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  versions: WaterfallVersionFragment[];
+};
+
+export const InactiveVersionsModal: React.FC<Props> = ({
+  open,
+  setOpen,
+  versions,
+}) => {
+  const hasFilteredVersions =
+    versions?.some(({ activated }) => activated) ?? false;
+
+  return (
+    <DisplayModal
+      data-cy="inactive-versions-modal"
+      open={open}
+      setOpen={setOpen}
+      title={`${versions?.length} ${hasFilteredVersions ? "Unmatching" : "Inactive"} ${pluralize("Version", versions?.length)}`}
+    >
+      {versions?.map((version) => (
+        <StyledVersionLabel
+          key={version.id}
+          shouldDisableText={hasFilteredVersions}
+          view={VersionLabelView.Modal}
+          {...version}
+        />
+      ))}
+    </DisplayModal>
+  );
+};
+
+const StyledVersionLabel = styled(VersionLabel)`
+  padding-top: ${size.xs};
+`;

--- a/apps/spruce/src/pages/waterfall/InactiveVersions/__snapshots__/InactiveVersionsModal_Broken.storyshot
+++ b/apps/spruce/src/pages/waterfall/InactiveVersions/__snapshots__/InactiveVersionsModal_Broken.storyshot
@@ -1,0 +1,52 @@
+<div>
+  <div
+    class="css-ov1ktg"
+  >
+    <div
+      class="css-1wl27xf-InactiveVersion e1i0zkr30"
+    >
+      <div
+        class="css-104hg2i-StyledBadge e19pzgwa0 leafygreen-ui-dhdzha"
+        data-cy="broken-versions-badge"
+      >
+        1
+         broken
+      </div>
+      <button
+        aria-disabled="false"
+        aria-label="Open inactive versions modal"
+        class="lg-ui-button-0000 leafygreen-ui-168frnw"
+        data-cy="inactive-versions-button"
+        data-lgid="lg-button"
+        type="button"
+      >
+        <div
+          class="leafygreen-ui-v038xi"
+        />
+        <div
+          class="leafygreen-ui-b15bbd"
+        >
+          <svg
+            aria-label="List Icon"
+            class="leafygreen-ui-a4wnk0"
+            fill="none"
+            height="16"
+            role="img"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M3.125 2.75a1.25 1.25 0 1 0 0 2.5 1.25 1.25 0 0 0 0-2.5ZM3.125 6.75a1.25 1.25 0 1 0 0 2.5 1.25 1.25 0 0 0 0-2.5ZM1.875 12a1.25 1.25 0 1 1 2.5 0 1.25 1.25 0 0 1-2.5 0ZM6.625 3a1 1 0 0 0 0 2h6.5a1 1 0 1 0 0-2h-6.5ZM5.625 8a1 1 0 0 1 1-1h6.5a1 1 0 1 1 0 2h-6.5a1 1 0 0 1-1-1ZM6.625 11a1 1 0 1 0 0 2h6.5a1 1 0 1 0 0-2h-6.5Z"
+              fill="currentColor"
+            />
+          </svg>
+          2
+          <div
+            class="css-1twzd73-InactiveVersionLine e19pzgwa1"
+          />
+        </div>
+      </button>
+    </div>
+  </div>
+</div>

--- a/apps/spruce/src/pages/waterfall/InactiveVersions/__snapshots__/InactiveVersionsModal_Default.storyshot
+++ b/apps/spruce/src/pages/waterfall/InactiveVersions/__snapshots__/InactiveVersionsModal_Default.storyshot
@@ -1,0 +1,45 @@
+<div>
+  <div
+    class="css-ov1ktg"
+  >
+    <div
+      class="css-1wl27xf-InactiveVersion e1i0zkr30"
+    >
+      <button
+        aria-disabled="false"
+        aria-label="Open inactive versions modal"
+        class="lg-ui-button-0000 leafygreen-ui-168frnw"
+        data-cy="inactive-versions-button"
+        data-lgid="lg-button"
+        type="button"
+      >
+        <div
+          class="leafygreen-ui-v038xi"
+        />
+        <div
+          class="leafygreen-ui-b15bbd"
+        >
+          <svg
+            aria-label="List Icon"
+            class="leafygreen-ui-a4wnk0"
+            fill="none"
+            height="16"
+            role="img"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M3.125 2.75a1.25 1.25 0 1 0 0 2.5 1.25 1.25 0 0 0 0-2.5ZM3.125 6.75a1.25 1.25 0 1 0 0 2.5 1.25 1.25 0 0 0 0-2.5ZM1.875 12a1.25 1.25 0 1 1 2.5 0 1.25 1.25 0 0 1-2.5 0ZM6.625 3a1 1 0 0 0 0 2h6.5a1 1 0 1 0 0-2h-6.5ZM5.625 8a1 1 0 0 1 1-1h6.5a1 1 0 1 1 0 2h-6.5a1 1 0 0 1-1-1ZM6.625 11a1 1 0 1 0 0 2h6.5a1 1 0 1 0 0-2h-6.5Z"
+              fill="currentColor"
+            />
+          </svg>
+          1
+          <div
+            class="css-1twzd73-InactiveVersionLine e19pzgwa1"
+          />
+        </div>
+      </button>
+    </div>
+  </div>
+</div>

--- a/apps/spruce/src/pages/waterfall/InactiveVersions/__snapshots__/InactiveVersionsModal_Filtered.storyshot
+++ b/apps/spruce/src/pages/waterfall/InactiveVersions/__snapshots__/InactiveVersionsModal_Filtered.storyshot
@@ -1,0 +1,52 @@
+<div>
+  <div
+    class="css-ov1ktg"
+  >
+    <div
+      class="css-1wl27xf-InactiveVersion e1i0zkr30"
+    >
+      <div
+        class="css-104hg2i-StyledBadge e19pzgwa0 leafygreen-ui-dhdzha"
+        data-cy="broken-versions-badge"
+      >
+        1
+         broken
+      </div>
+      <button
+        aria-disabled="false"
+        aria-label="Open inactive versions modal"
+        class="lg-ui-button-0000 leafygreen-ui-168frnw"
+        data-cy="inactive-versions-button"
+        data-lgid="lg-button"
+        type="button"
+      >
+        <div
+          class="leafygreen-ui-v038xi"
+        />
+        <div
+          class="leafygreen-ui-b15bbd"
+        >
+          <svg
+            aria-label="List Icon"
+            class="leafygreen-ui-a4wnk0"
+            fill="none"
+            height="16"
+            role="img"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M3.125 2.75a1.25 1.25 0 1 0 0 2.5 1.25 1.25 0 0 0 0-2.5ZM3.125 6.75a1.25 1.25 0 1 0 0 2.5 1.25 1.25 0 0 0 0-2.5ZM1.875 12a1.25 1.25 0 1 1 2.5 0 1.25 1.25 0 0 1-2.5 0ZM6.625 3a1 1 0 0 0 0 2h6.5a1 1 0 1 0 0-2h-6.5ZM5.625 8a1 1 0 0 1 1-1h6.5a1 1 0 1 1 0 2h-6.5a1 1 0 0 1-1-1ZM6.625 11a1 1 0 1 0 0 2h6.5a1 1 0 1 0 0-2h-6.5Z"
+              fill="currentColor"
+            />
+          </svg>
+          4
+          <div
+            class="css-1twzd73-InactiveVersionLine e19pzgwa1"
+          />
+        </div>
+      </button>
+    </div>
+  </div>
+</div>

--- a/apps/spruce/src/pages/waterfall/InactiveVersions/__snapshots__/InactiveVersionsModal_FilteredAndInactive.storyshot
+++ b/apps/spruce/src/pages/waterfall/InactiveVersions/__snapshots__/InactiveVersionsModal_FilteredAndInactive.storyshot
@@ -1,0 +1,52 @@
+<div>
+  <div
+    class="css-ov1ktg"
+  >
+    <div
+      class="css-1wl27xf-InactiveVersion e1i0zkr30"
+    >
+      <div
+        class="css-104hg2i-StyledBadge e19pzgwa0 leafygreen-ui-dhdzha"
+        data-cy="broken-versions-badge"
+      >
+        2
+         broken
+      </div>
+      <button
+        aria-disabled="false"
+        aria-label="Open inactive versions modal"
+        class="lg-ui-button-0000 leafygreen-ui-168frnw"
+        data-cy="inactive-versions-button"
+        data-lgid="lg-button"
+        type="button"
+      >
+        <div
+          class="leafygreen-ui-v038xi"
+        />
+        <div
+          class="leafygreen-ui-b15bbd"
+        >
+          <svg
+            aria-label="List Icon"
+            class="leafygreen-ui-a4wnk0"
+            fill="none"
+            height="16"
+            role="img"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M3.125 2.75a1.25 1.25 0 1 0 0 2.5 1.25 1.25 0 0 0 0-2.5ZM3.125 6.75a1.25 1.25 0 1 0 0 2.5 1.25 1.25 0 0 0 0-2.5ZM1.875 12a1.25 1.25 0 1 1 2.5 0 1.25 1.25 0 0 1-2.5 0ZM6.625 3a1 1 0 0 0 0 2h6.5a1 1 0 1 0 0-2h-6.5ZM5.625 8a1 1 0 0 1 1-1h6.5a1 1 0 1 1 0 2h-6.5a1 1 0 0 1-1-1ZM6.625 11a1 1 0 1 0 0 2h6.5a1 1 0 1 0 0-2h-6.5Z"
+              fill="currentColor"
+            />
+          </svg>
+          6
+          <div
+            class="css-1twzd73-InactiveVersionLine e19pzgwa1"
+          />
+        </div>
+      </button>
+    </div>
+  </div>
+</div>

--- a/apps/spruce/src/pages/waterfall/InactiveVersions/index.tsx
+++ b/apps/spruce/src/pages/waterfall/InactiveVersions/index.tsx
@@ -3,18 +3,18 @@ import styled from "@emotion/styled";
 import Badge, { Variant } from "@leafygreen-ui/badge";
 import Button from "@leafygreen-ui/button";
 import { palette } from "@leafygreen-ui/palette";
-import pluralize from "pluralize";
-import { DisplayModal } from "components/DisplayModal";
 import Icon from "components/Icon";
 import { size } from "constants/tokens";
-import { WaterfallQuery } from "gql/generated/types";
-import { VersionLabel } from "../VersionLabel";
+import { WaterfallVersionFragment } from "gql/generated/types";
+import { InactiveVersionsModal } from "./InactiveVersionsModal";
 
 const { gray } = palette;
+
 interface Props {
-  versions: WaterfallQuery["waterfall"]["versions"][0]["inactiveVersions"];
+  versions: WaterfallVersionFragment[];
   containerHeight: number | undefined;
 }
+
 export const InactiveVersionsButton: React.FC<Props> = ({
   containerHeight,
   versions,
@@ -27,20 +27,11 @@ export const InactiveVersionsButton: React.FC<Props> = ({
   const [modalOpen, setModalOpen] = useState(false);
   return (
     <>
-      <DisplayModal
-        data-cy="inactive-versions-modal"
+      <InactiveVersionsModal
         open={modalOpen}
         setOpen={setModalOpen}
-        title={`${versions?.length} Inactive ${pluralize("Version", versions?.length)}`}
-      >
-        {versions?.map((version) => (
-          <StyledVersionLabel
-            key={version.id}
-            trimMessage={false}
-            {...version}
-          />
-        ))}
-      </DisplayModal>
+        versions={versions}
+      />
       {brokenVersionsCount > 0 && (
         <StyledBadge data-cy="broken-versions-badge" variant={Variant.Red}>
           {brokenVersionsCount} broken
@@ -55,7 +46,7 @@ export const InactiveVersionsButton: React.FC<Props> = ({
         size="xsmall"
       >
         <Icon fill={gray.base} glyph="List" />
-        <span>{versions?.length}</span>
+        {versions?.length}
         <InactiveVersionLine containerHeight={containerHeight ?? 0} />
       </Button>
     </>
@@ -69,10 +60,6 @@ const InactiveVersionLine = styled.div<{ containerHeight: number }>`
   margin-left: 50%;
   top: 30px;
   z-index: 1;
-`;
-
-const StyledVersionLabel = styled(VersionLabel)`
-  padding-top: ${size.xs};
 `;
 
 const StyledBadge = styled(Badge)`

--- a/apps/spruce/src/pages/waterfall/VersionLabel/VersionLabel.stories.tsx
+++ b/apps/spruce/src/pages/waterfall/VersionLabel/VersionLabel.stories.tsx
@@ -4,7 +4,7 @@ import {
   getSpruceConfigMock,
   getUserSettingsMock,
 } from "gql/mocks/getSpruceConfig";
-import { VersionLabel } from ".";
+import { VersionLabel, VersionLabelView } from ".";
 
 export default {
   title: "Pages/Waterfall/VersionLabel",
@@ -123,12 +123,12 @@ export const InactiveUntrimmedMessage: StoryObj<typeof VersionLabel> = {
 
 export const SmallSize: StoryObj<typeof VersionLabel> = {
   ...Default,
-  args: { ...version, size: "small" },
+  args: { ...version, view: VersionLabelView.Waterfall },
 };
 
 export const Broken: StoryObj<typeof VersionLabel> = {
   ...Default,
-  args: versionBroken,
+  args: { ...versionBroken, view: VersionLabelView.Waterfall },
 };
 
 const Container = styled.div`

--- a/apps/spruce/src/pages/waterfall/VersionLabel/VersionLabel.stories.tsx
+++ b/apps/spruce/src/pages/waterfall/VersionLabel/VersionLabel.stories.tsx
@@ -5,93 +5,27 @@ import {
   getUserSettingsMock,
 } from "gql/mocks/getSpruceConfig";
 import { VersionLabel, VersionLabelView } from ".";
+import {
+  version,
+  versionWithGitTag,
+  versionWithUpstreamProject,
+  versionBroken,
+} from "../testData";
 
 export default {
   title: "Pages/Waterfall/VersionLabel",
   component: VersionLabel,
-};
-
-const version = {
-  activated: true,
-  author: "Sophie Stadler",
-  createTime: new Date("2024-09-19T14:56:08Z"),
-  gitTags: null,
-  id: "evergreen_ui_aec8832bace91f0f3b6d8ad3bb3b27fb4263be83",
-  message:
-    "DEVPROD-11387: Remove CSS grid layout, plus some additional description to demonstrate the overflow capabilities of the component (#397)",
-  revision: "aec8832bace91f0f3b6d8ad3bb3b27fb4263be83",
-  upstreamProject: null,
-};
-
-const versionWithGitTag = {
-  activated: true,
-  author: "Sophie Stadler",
-  createTime: new Date("2024-09-19T16:14:10Z"),
-  gitTags: [
-    {
-      tag: "parsley/v2.1.64",
-    },
-  ],
-  id: "evergreen_ui_deb77a36604446272d610d267f1cd9f95e4fe8ff",
-  message: "parsley/v2.1.64",
-  revision: "deb77a36604446272d610d267f1cd9f95e4fe8ff",
-  upstreamProject: null,
-};
-
-const versionWithUpstreamProject = {
-  activated: true,
-  author: "Sophie Stadler",
-  createTime: new Date("2024-09-19T16:06:54Z"),
-  gitTags: [
-    {
-      tag: "spruce/v4.1.87",
-    },
-  ],
-  id: "evergreen_ui_130948895a46d4fd04292e7783069918e4e7cd5a",
-  message: "spruce/v4.1.87",
-  revision: "130948895a46d4fd04292e7783069918e4e7cd5a",
-  upstreamProject: {
-    owner: "evergreen-ci",
-    project: "evergreen",
-    repo: "evergreen",
-    revision: "abcdefg",
-    task: {
-      execution: 0,
-      id: "678",
-    },
-    triggerID: "12345",
-    triggerType: "task",
-    version: {
-      id: "9876",
+  args: {
+    view: VersionLabelView.Modal,
+  },
+  argTypes: {
+    view: {
+      options: Object.values(VersionLabelView),
+      control: { type: "select" },
     },
   },
 };
 
-const versionInactiveUntrimmedMessage = {
-  activated: false,
-  author: "Sophie Stadler",
-  createTime: new Date("2024-09-19T14:56:08Z"),
-  gitTags: null,
-  id: "evergreen_ui_aec8832bace91f0f3b6d8ad3bb3b27fb4263be83",
-  message:
-    "DEVPROD-11387: Remove CSS grid layout, plus some additional description to demonstrate the overflow capabilities of the component (#397)",
-  revision: "aec8832bace91f0f3b6d8ad3bb3b27fb4263be83",
-  upstreamProject: null,
-  trimMessage: false,
-};
-
-const versionBroken = {
-  activated: true,
-  author: "Sophie Stadler",
-  createTime: new Date("2024-09-19T14:56:08Z"),
-  gitTags: null,
-  id: "evergreen_ui_aec8832bace91f0f3b6d8ad3bb3b27fb4263be83",
-  message:
-    "DEVPROD-11387: Remove CSS grid layout, plus some additional description to demonstrate the overflow capabilities of the component (#397)",
-  revision: "aec8832bace91f0f3b6d8ad3bb3b27fb4263be83",
-  upstreamProject: null,
-  errors: ["errors happened"],
-};
 export const Default: StoryObj<typeof VersionLabel> = {
   render: (args) => (
     <Container>
@@ -116,11 +50,6 @@ export const UpstreamProject: StoryObj<typeof VersionLabel> = {
   args: versionWithUpstreamProject,
 };
 
-export const InactiveUntrimmedMessage: StoryObj<typeof VersionLabel> = {
-  ...Default,
-  args: versionInactiveUntrimmedMessage,
-};
-
 export const SmallSize: StoryObj<typeof VersionLabel> = {
   ...Default,
   args: { ...version, view: VersionLabelView.Waterfall },
@@ -128,7 +57,7 @@ export const SmallSize: StoryObj<typeof VersionLabel> = {
 
 export const Broken: StoryObj<typeof VersionLabel> = {
   ...Default,
-  args: { ...versionBroken, view: VersionLabelView.Waterfall },
+  args: versionBroken,
 };
 
 const Container = styled.div`

--- a/apps/spruce/src/pages/waterfall/VersionLabel/__snapshots__/VersionLabel_Broken.storyshot
+++ b/apps/spruce/src/pages/waterfall/VersionLabel/__snapshots__/VersionLabel_Broken.storyshot
@@ -28,8 +28,8 @@
         </div>
       </p>
       <p
-        class="css-69ll71-CommitMessage e3zirl01 leafygreen-ui-1tb6tuo"
-        title="DEVPROD-11387: Remove CSS grid layout, plus some additional description to demonstrate the overflow capabilities of the component (#397)"
+        class="css-9ip3is-CommitMessage e3zirl01 leafygreen-ui-1tb6tuo"
+        view="modal"
       >
         <strong>
           Sophie Stadler

--- a/apps/spruce/src/pages/waterfall/VersionLabel/__snapshots__/VersionLabel_Default.storyshot
+++ b/apps/spruce/src/pages/waterfall/VersionLabel/__snapshots__/VersionLabel_Default.storyshot
@@ -1,5 +1,49 @@
 <div>
-  <div>
-    Failed to render component.
+  <div
+    class="css-1pp2qz6"
+  >
+    <div
+      class="css-bnbttx-VersionContainer-columnBasis-wordBreakCss e3zirl02"
+      data-cy="version-label-active"
+    >
+      <p
+        class="leafygreen-ui-1tb6tuo"
+      >
+        <a
+          class="lg-ui-0000 leafygreen-ui-hvznge"
+          href="/version/evergreen_ui_aec8832bace91f0f3b6d8ad3bb3b27fb4263be83/tasks"
+        >
+          <code
+            class="leafygreen-ui-i6ovbf"
+          >
+            aec8832
+          </code>
+        </a>
+         
+        09/19/2024, 10:56
+      </p>
+      <p
+        class="css-9ip3is-CommitMessage e3zirl01 leafygreen-ui-1tb6tuo"
+        view="modal"
+      >
+        <strong>
+          Sophie Stadler
+        </strong>
+         •
+         
+        <a
+          class="lg-ui-0001 css-1gw3cuq-StyledLink leafygreen-ui-16e7rxl"
+          data-cy="jira-link"
+          href="https://jira.mongodb.org/browse/DEVPROD-11387"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          <span>
+            DEVPROD-11387
+          </span>
+        </a>
+        : Remove CSS grid layout, plus some additional description to demonstrate the overflow capabilities of the component (#397)
+      </p>
+    </div>
   </div>
 </div>

--- a/apps/spruce/src/pages/waterfall/VersionLabel/__snapshots__/VersionLabel_GitTag.storyshot
+++ b/apps/spruce/src/pages/waterfall/VersionLabel/__snapshots__/VersionLabel_GitTag.storyshot
@@ -1,5 +1,44 @@
 <div>
-  <div>
-    Failed to render component.
+  <div
+    class="css-1pp2qz6"
+  >
+    <div
+      class="css-bnbttx-VersionContainer-columnBasis-wordBreakCss e3zirl02"
+      data-cy="version-label-active"
+    >
+      <p
+        class="leafygreen-ui-1tb6tuo"
+      >
+        <a
+          class="lg-ui-0000 leafygreen-ui-hvznge"
+          href="/version/evergreen_ui_deb77a36604446272d610d267f1cd9f95e4fe8ff/tasks"
+        >
+          <code
+            class="leafygreen-ui-i6ovbf"
+          >
+            deb77a3
+          </code>
+        </a>
+         
+        09/19/2024, 12:14
+      </p>
+      <p
+        class="css-9ip3is-CommitMessage e3zirl01 leafygreen-ui-1tb6tuo"
+        view="modal"
+      >
+        <strong>
+          Sophie Stadler
+        </strong>
+         •
+         
+        parsley/v2.1.64
+      </p>
+      <p
+        class="leafygreen-ui-1tb6tuo"
+      >
+        Git Tags: 
+        parsley/v2.1.64
+      </p>
+    </div>
   </div>
 </div>

--- a/apps/spruce/src/pages/waterfall/VersionLabel/__snapshots__/VersionLabel_SmallSize.storyshot
+++ b/apps/spruce/src/pages/waterfall/VersionLabel/__snapshots__/VersionLabel_SmallSize.storyshot
@@ -1,5 +1,50 @@
 <div>
-  <div>
-    Failed to render component.
+  <div
+    class="css-1pp2qz6"
+  >
+    <div
+      class="css-1etpc4y-VersionContainer-columnBasis-wordBreakCss e3zirl02"
+      data-cy="version-label-active"
+    >
+      <p
+        class="leafygreen-ui-1tb6tuo"
+      >
+        <a
+          class="lg-ui-0000 leafygreen-ui-hvznge"
+          href="/version/evergreen_ui_aec8832bace91f0f3b6d8ad3bb3b27fb4263be83/tasks"
+        >
+          <code
+            class="leafygreen-ui-i6ovbf"
+          >
+            aec8832
+          </code>
+        </a>
+         
+        09/19/2024, 10:56
+      </p>
+      <p
+        class="css-69ll71-CommitMessage e3zirl01 leafygreen-ui-1tb6tuo"
+        title="DEVPROD-11387: Remove CSS grid layout, plus some additional description to demonstrate the overflow capabilities of the component (#397)"
+        view="waterfall"
+      >
+        <strong>
+          Sophie Stadler
+        </strong>
+         •
+         
+        <a
+          class="lg-ui-0001 css-1gw3cuq-StyledLink leafygreen-ui-16e7rxl"
+          data-cy="jira-link"
+          href="https://jira.mongodb.org/browse/DEVPROD-11387"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          <span>
+            DEVPROD-11387
+          </span>
+        </a>
+        : Remove CSS grid layout, plus some additional description to demonstrate the overflow capabilities of the component (#397)
+      </p>
+    </div>
   </div>
 </div>

--- a/apps/spruce/src/pages/waterfall/VersionLabel/__snapshots__/VersionLabel_UpstreamProject.storyshot
+++ b/apps/spruce/src/pages/waterfall/VersionLabel/__snapshots__/VersionLabel_UpstreamProject.storyshot
@@ -1,5 +1,58 @@
 <div>
-  <div>
-    Failed to render component.
+  <div
+    class="css-1pp2qz6"
+  >
+    <div
+      class="css-bnbttx-VersionContainer-columnBasis-wordBreakCss e3zirl02"
+      data-cy="version-label-active"
+    >
+      <p
+        class="leafygreen-ui-1tb6tuo"
+      >
+        <a
+          class="lg-ui-0000 leafygreen-ui-hvznge"
+          href="/version/evergreen_ui_130948895a46d4fd04292e7783069918e4e7cd5a/tasks"
+        >
+          <code
+            class="leafygreen-ui-i6ovbf"
+          >
+            1309488
+          </code>
+        </a>
+         
+        09/19/2024, 12:06
+      </p>
+      <p
+        class="leafygreen-ui-1tb6tuo"
+      >
+        Triggered by:
+         
+        <a
+          class="lg-ui-0001 css-1gw3cuq-StyledLink leafygreen-ui-16e7rxl"
+          href="/task/678"
+        >
+          <span>
+            evergreen
+          </span>
+        </a>
+      </p>
+      <p
+        class="css-9ip3is-CommitMessage e3zirl01 leafygreen-ui-1tb6tuo"
+        view="modal"
+      >
+        <strong>
+          Sophie Stadler
+        </strong>
+         •
+         
+        spruce/v4.1.87
+      </p>
+      <p
+        class="leafygreen-ui-1tb6tuo"
+      >
+        Git Tags: 
+        spruce/v4.1.87
+      </p>
+    </div>
   </div>
 </div>

--- a/apps/spruce/src/pages/waterfall/WaterfallGrid.tsx
+++ b/apps/spruce/src/pages/waterfall/WaterfallGrid.tsx
@@ -6,7 +6,7 @@ import { WaterfallQuery, WaterfallQueryVariables } from "gql/generated/types";
 import { WATERFALL } from "gql/queries";
 import { useDimensions } from "hooks/useDimensions";
 import { BuildRow } from "./BuildRow";
-import { InactiveVersionsButton } from "./InactiveVersionsButton";
+import { InactiveVersionsButton } from "./InactiveVersions";
 import {
   BuildVariantTitle,
   gridGroupCss,
@@ -15,7 +15,7 @@ import {
   VERSION_LIMIT,
 } from "./styles";
 import { useFilters } from "./useFilters";
-import { VersionLabel } from "./VersionLabel";
+import { VersionLabel, VersionLabelView } from "./VersionLabel";
 
 type WaterfallGridProps = {
   projectIdentifier: string;
@@ -51,7 +51,11 @@ export const WaterfallGrid: React.FC<WaterfallGridProps> = ({
         <Versions data-cy="version-labels">
           {versions.map(({ inactiveVersions, version }) =>
             version ? (
-              <VersionLabel key={version.id} size="small" {...version} />
+              <VersionLabel
+                key={version.id}
+                view={VersionLabelView.Waterfall}
+                {...version}
+              />
             ) : (
               <InactiveVersion>
                 <InactiveVersionsButton

--- a/apps/spruce/src/pages/waterfall/index.tsx
+++ b/apps/spruce/src/pages/waterfall/index.tsx
@@ -60,7 +60,7 @@ const navbarStyles = css`
     position: unset !important;
   }
   #banner-container {
-    margin-top: ${navBarHeight};
+    padding-top: ${navBarHeight};
   }
   nav {
     position: fixed !important;

--- a/apps/spruce/src/pages/waterfall/testData.ts
+++ b/apps/spruce/src/pages/waterfall/testData.ts
@@ -1,0 +1,103 @@
+import { Requester } from "constants/requesters";
+
+export const version = {
+  activated: true,
+  author: "Sophie Stadler",
+  createTime: new Date("2024-09-19T14:56:08Z"),
+  errors: [],
+  gitTags: null,
+  id: "evergreen_ui_aec8832bace91f0f3b6d8ad3bb3b27fb4263be83",
+  message:
+    "DEVPROD-11387: Remove CSS grid layout, plus some additional description to demonstrate the overflow capabilities of the component (#397)",
+  requester: Requester.Gitter,
+  revision: "aec8832bace91f0f3b6d8ad3bb3b27fb4263be83",
+  upstreamProject: null,
+};
+
+export const versionWithGitTag = {
+  activated: true,
+  author: "Sophie Stadler",
+  createTime: new Date("2024-09-19T16:14:10Z"),
+  errors: [],
+  gitTags: [
+    {
+      tag: "parsley/v2.1.64",
+    },
+  ],
+  id: "evergreen_ui_deb77a36604446272d610d267f1cd9f95e4fe8ff",
+  message: "parsley/v2.1.64",
+  requester: Requester.GitTag,
+  revision: "deb77a36604446272d610d267f1cd9f95e4fe8ff",
+  upstreamProject: null,
+};
+
+export const versionWithUpstreamProject = {
+  activated: true,
+  author: "Sophie Stadler",
+  createTime: new Date("2024-09-19T16:06:54Z"),
+  errors: [],
+  gitTags: [
+    {
+      tag: "spruce/v4.1.87",
+    },
+  ],
+  id: "evergreen_ui_130948895a46d4fd04292e7783069918e4e7cd5a",
+  message: "spruce/v4.1.87",
+  requester: Requester.GitTag,
+  revision: "130948895a46d4fd04292e7783069918e4e7cd5a",
+  upstreamProject: {
+    owner: "evergreen-ci",
+    project: "evergreen",
+    repo: "evergreen",
+    revision: "abcdefg",
+    task: {
+      execution: 0,
+      id: "678",
+    },
+    triggerID: "12345",
+    triggerType: "task",
+    version: {
+      id: "9876",
+    },
+  },
+};
+
+export const versionBroken = {
+  activated: true,
+  author: "Sophie Stadler",
+  createTime: new Date("2024-09-19T14:56:08Z"),
+  errors: ["errors happened"],
+  gitTags: null,
+  id: "evergreen_ui_aec8832bace91f0f3b6d8ad3bb3b27fb4263be83",
+  message:
+    "DEVPROD-11387: Remove CSS grid layout, plus some additional description to demonstrate the overflow capabilities of the component (#397)",
+  requester: Requester.Gitter,
+  revision: "aec8832bace91f0f3b6d8ad3bb3b27fb4263be83",
+  upstreamProject: null,
+};
+
+export const inactiveVersion = {
+  activated: false,
+  author: "Sophie Stadler",
+  createTime: new Date("2024-10-24T14:56:08Z"),
+  errors: [],
+  gitTags: null,
+  id: "81667704832f1021cc9573bd5edafc32",
+  message: "Inactive Version by Sophie Stadler",
+  requester: Requester.Gitter,
+  revision: "a659b9908f6be84afd8142e9c2e403783e1385afefaa728792b3c23b9d6acf7a",
+  upstreamProject: null,
+};
+
+export const inactiveBrokenVersion = {
+  activated: false,
+  author: "Sophie Stadler",
+  createTime: new Date("2024-10-25T14:56:08Z"),
+  errors: ["Error string"],
+  gitTags: null,
+  id: "08576a4e52f9c350430182597a4b22c0",
+  message: "Inactive Version by Sophie Stadler",
+  requester: Requester.Gitter,
+  revision: "a659b9908f6be84afd8142e9c2e403783e1385afefaa728792b3c23b9d6acf7a",
+  upstreamProject: null,
+};

--- a/apps/spruce/src/pages/waterfall/useFilters.test.tsx
+++ b/apps/spruce/src/pages/waterfall/useFilters.test.tsx
@@ -54,6 +54,7 @@ const waterfall = {
     {
       id: "1",
       displayName: "BV 1",
+      version: "a",
       builds: [
         {
           activated: true,


### PR DESCRIPTION
DEVPROD-11706
<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️ -->
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
<!-- add description, context, thought process, etc -->
Add filtered commits—now considered "inactive" on the waterfall—to the inactive version modal.

If filtered but activated commits are present, unactivated commits will use disabled text.

### Screenshots
<!-- add screenshots of visible changes -->
<img width="1427" alt="image" src="https://github.com/user-attachments/assets/f8faf14a-e67c-4b05-8544-3e530c34bb1c">

### Testing
<!-- add a description of how you tested it -->
Add stories for VersionLabel and InactiveVersionsModal

<!-- Have you have updated the analytics documentation if necessary?  
https://docs.google.com/spreadsheets/d/1s4_nq8ZiphXp5Uq_-9HT6GPqz-KOyaq6HuvmXYaSNzg/edit?usp=sharing -->