### PR TITLE
DEVPROD-12386 Track `is_patch` and `requester` for tasks and versions

### DIFF
--- a/apps/parsley/src/gql/generated/types.ts
+++ b/apps/parsley/src/gql/generated/types.ts
@@ -3484,6 +3484,7 @@ export type WaterfallBuildVariant = {
 };
 
 export type WaterfallOptions = {
+  date?: InputMaybe<Scalars["Time"]["input"]>;
   limit?: InputMaybe<Scalars["Int"]["input"]>;
   /** Return versions with an order lower than maxOrder. Used for paginating forward. */
   maxOrder?: InputMaybe<Scalars["Int"]["input"]>;
@@ -3497,6 +3498,7 @@ export type WaterfallOptions = {
 export type WaterfallTask = {
   __typename?: "WaterfallTask";
   displayName: Scalars["String"]["output"];
+  execution: Scalars["Int"]["output"];
   id: Scalars["String"]["output"];
   status: Scalars["String"]["output"];
 };

--- a/apps/spruce/src/analytics/task/useTaskAnalytics.ts
+++ b/apps/spruce/src/analytics/task/useTaskAnalytics.ts
@@ -88,7 +88,9 @@ export const useTaskAnalytics = () => {
     latestExecution,
     // @ts-expect-error: FIXME. This comment was added by an automated script.
     project: { identifier } = { identifier: null },
+    requester = "",
     status: taskStatus,
+    versionMetadata: { isPatch } = { isPatch: false },
   } = eventData?.task || {};
   const isLatestExecution = latestExecution === execution;
 
@@ -99,5 +101,7 @@ export const useTaskAnalytics = () => {
     "task.id": taskId || "",
     "task.failed_test_count": failedTestCount || "",
     "task.project.identifier": identifier,
+    "version.is_patch": isPatch,
+    "version.requester": requester,
   });
 };

--- a/apps/spruce/src/analytics/version/useVersionAnalytics.ts
+++ b/apps/spruce/src/analytics/version/useVersionAnalytics.ts
@@ -62,10 +62,12 @@ export const useVersionAnalytics = (id: string) => {
       fetchPolicy: "cache-first",
     },
   );
-  const { status } = eventData?.version || {};
+  const { isPatch, requester, status } = eventData?.version || {};
 
   return useAnalyticsRoot<Action, AnalyticsIdentifier>("Version", {
     "version.status": status || "",
     "version.id": id,
+    "version.is_patch": isPatch || false,
+    "version.requester": requester || "",
   });
 };


### PR DESCRIPTION
DEVPROD-12386
<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️ -->
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
This change adds automatic tracking of requesters for version and task interactions in honeycomb. This will be useful to determine what types of actions people take on different types of version and task pages.
