### PR TITLE
DEVPROD-12354: Instrument waterfall render

### DIFF
--- a/packages/lib/src/analytics/utils.ts
+++ b/packages/lib/src/analytics/utils.ts
@@ -1,6 +1,8 @@
 import { trace } from "@opentelemetry/api";
 import { ActionType, AnalyticsProperties } from "./types";
 
+export const TRACER_NAME = "analytics";
+
 /**
  * `sendEventTrace` is a function that sends an event to our analytics provider in the form of a OTEL trace
  * @param action - The action to send to our analytics provider
@@ -17,7 +19,7 @@ export const sendEventTrace = <A extends ActionType>(
     return;
   }
   const globalAttributes = AttributeStore.getGlobalAttributes() ?? {};
-  const tracer = trace.getTracer("analytics");
+  const tracer = trace.getTracer(TRACER_NAME);
 
   tracer.startActiveSpan(name, (span) => {
     span.setAttributes({


### PR DESCRIPTION
DEVPROD-12354
<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️ -->
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
<!-- add description, context, thought process, etc -->
Add instrumentation that creates a span measuring the duration of the waterfall render. Timing does not include the length of request.

I had hoped to add this span to the trace that includes the HTTP.POST event, but I was unable to do so. I'd prefer to start tracking this measurement and potentially figure that out later.

### Testing
<!-- add a description of how you tested it -->
[Example span](https://ui.honeycomb.io/mongodb-4b/environments/staging/datasets/spruce/result/rfdvjSkAbeW/trace/C113KhhWPh5?fields[]=s_name&source=query&span=e45e5b4be0f3e987) - this render very performant since staging doesn't have any sizable projects.