### PR TITLE
DEVPROD-10151: Rename owner field in project settings

### DIFF
--- a/apps/spruce/src/pages/projectSettings/CreateProjectModal.tsx
+++ b/apps/spruce/src/pages/projectSettings/CreateProjectModal.tsx
@@ -147,7 +147,7 @@ const modalFormDefinition = (githubOrgs: string[]) => ({
       projectName: projectName.schema,
       owner: {
         type: "string" as "string",
-        title: "Owner",
+        title: "GitHub Organization",
         oneOf: githubOrgs.map((org) => ({
           type: "string" as "string",
           title: org,

--- a/apps/spruce/src/pages/projectSettings/tabs/GeneralTab/getFormSchema.tsx
+++ b/apps/spruce/src/pages/projectSettings/tabs/GeneralTab/getFormSchema.tsx
@@ -48,7 +48,7 @@ export const getFormSchema = (
             properties: {
               owner: {
                 type: "string" as "string",
-                title: "Owner",
+                title: "GitHub Organization",
                 format: "noSpaces",
                 // @ts-expect-error: FIXME. This comment was added by an automated script.
                 minLength: getMinLength(projectType, repoData, "owner"),


### PR DESCRIPTION
DEVPROD-10151
<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️ -->
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
<!-- add description, context, thought process, etc -->
Rename "Owner" ➡️ "GitHub Organization"

### Screenshots
<!-- add screenshots of visible changes -->
<img width="454" alt="image" src="https://github.com/user-attachments/assets/a7c2fefd-ce34-43ed-ad43-53dd8813564f">