### PR TITLE
DEVPROD-11667: Support git tag requester for project notifications

### DIFF
--- a/apps/spruce/src/constants/triggers.ts
+++ b/apps/spruce/src/constants/triggers.ts
@@ -11,6 +11,7 @@ import {
   VersionTriggers,
   ProjectTriggers,
 } from "types/triggers";
+import { Requester } from "./requesters";
 
 export const renotifyDefaultTime = "48";
 export const regexDisplayName = "display-name";
@@ -54,10 +55,11 @@ export const failureTypeSubscriberConfig: ExtraField = {
 };
 
 export const requesterSubscriberOptions = {
-  gitter_request: "Commit",
-  patch_request: "Patch",
-  github_pull_request: "Pull Request",
-  ad_hoc: "Periodic Build",
+  [Requester.Gitter]: "Commit",
+  [Requester.Patch]: "Patch",
+  [Requester.GitHubPR]: "Pull Request",
+  [Requester.AdHoc]: "Periodic Build",
+  [Requester.GitTag]: "Git Tag",
 };
 
 export const requesterSubscriberConfig: ExtraField = {

--- a/apps/spruce/src/constants/triggers.ts
+++ b/apps/spruce/src/constants/triggers.ts
@@ -66,7 +66,7 @@ export const requesterSubscriberConfig: ExtraField = {
   text: "Build Initiator",
   key: ExtraFieldKey.BUILD_INITIATOR,
   fieldType: "select",
-  default: "gitter_request",
+  default: Requester.Gitter,
   options: requesterSubscriberOptions,
 };
 


### PR DESCRIPTION
DEVPROD-11667
<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️ -->
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
Add Git Tag as an option for project notifications. Once deployed, I can edit our subscription.

### Screenshots
<!-- add screenshots of visible changes -->
<img width="320" alt="Screenshot 2024-11-05 at 3 15 48 PM" src="https://github.com/user-attachments/assets/1bcad558-7b32-438c-bf4d-e0272e357311">


### Testing
- Updated `commit-queue-sandbox` project subscriptions to listen for any task failure on git tag version. Then created a [git tag version](https://spruce-staging.corp.mongodb.com/version/sandbox_testtag10_672a78e7f3b818000df15234/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC). Afterwards, received this notification:
<img width="548" alt="Screenshot 2024-11-05 at 3 14 41 PM" src="https://github.com/user-attachments/assets/02cf81c4-f1b9-4aa1-b10a-4491e766e098">

