### PR TITLE
DEVPROD-12509: Use display status in waterfall

### DIFF
--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -3507,6 +3507,7 @@ export type WaterfallPagination = {
 export type WaterfallTask = {
   __typename?: "WaterfallTask";
   displayName: Scalars["String"]["output"];
+  displayStatus: Scalars["String"]["output"];
   execution: Scalars["Int"]["output"];
   id: Scalars["String"]["output"];
   status: Scalars["String"]["output"];
@@ -9624,6 +9625,7 @@ export type WaterfallQuery = {
         tasks: Array<{
           __typename?: "WaterfallTask";
           displayName: string;
+          displayStatus: string;
           execution: number;
           id: string;
           status: string;

--- a/apps/spruce/src/gql/queries/waterfall.graphql
+++ b/apps/spruce/src/gql/queries/waterfall.graphql
@@ -9,6 +9,7 @@ query Waterfall($options: WaterfallOptions!) {
         id
         tasks {
           displayName
+          displayStatus
           execution
           id
           status

--- a/apps/spruce/src/pages/waterfall/BuildRow.tsx
+++ b/apps/spruce/src/pages/waterfall/BuildRow.tsx
@@ -114,10 +114,10 @@ const BuildGrid: React.FC<{
       );
     }}
   >
-    {build.tasks.map(({ displayName, execution, id, status }) => {
+    {build.tasks.map(({ displayName, displayStatus, execution, id }) => {
       // If the entire build is inactive, use inactive status for all tasks
       const taskStatus = build.activated
-        ? (status as TaskStatus)
+        ? (displayStatus as TaskStatus)
         : TaskStatus.Inactive;
       return (
         <SquareMemo

--- a/apps/spruce/src/pages/waterfall/index.tsx
+++ b/apps/spruce/src/pages/waterfall/index.tsx
@@ -87,6 +87,7 @@ const Waterfall: React.FC = () => {
 const PageContainer = styled.div`
   display: flex;
   flex-direction: column;
+  gap: ${size.s};
   padding: ${size.m};
 `;
 
@@ -106,8 +107,6 @@ const navbarStyles = css`
   }
 `;
 
-const BadgesContainer = styled.div`
-  margin-top: ${size.s};
-`;
+const BadgesContainer = styled.div``;
 
 export default Waterfall;


### PR DESCRIPTION
DEVPROD-12509
<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️ -->
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
<!-- add description, context, thought process, etc -->
- Use display status in waterfall
- Also fix spacing so that beta site banner has some padding

### Screenshots
<!-- add screenshots of visible changes -->
<img width="191" alt="image" src="https://github.com/user-attachments/assets/ece2fb65-3f9c-4da8-a29c-fe60845f456c">

<!-- Have you have updated the analytics documentation if necessary?  
https://docs.google.com/spreadsheets/d/1s4_nq8ZiphXp5Uq_-9HT6GPqz-KOyaq6HuvmXYaSNzg/edit?usp=sharing -->

### Evergreen PR
<!-- link to a corresponding Evergreen PR if applicable -->
https://github.com/evergreen-ci/evergreen/pull/8454