### PR TITLE
DEVPROD-12004: Send entire public key document when editing spawn host

### DIFF
--- a/apps/spruce/src/components/Spawn/editHostModal/utils.ts
+++ b/apps/spruce/src/components/Spawn/editHostModal/utils.ts
@@ -26,6 +26,10 @@ export const computeDiff = (
     );
   }
 
+  if (mutationParams.publicKey) {
+    mutationParams.publicKey = currEditState.publicKey;
+  }
+
   // Always overwrite the whole sleep schedule, no need to update on a per-field basis.
   if (mutationParams.sleepSchedule) {
     mutationParams.sleepSchedule = currEditState.sleepSchedule;

--- a/apps/spruce/src/components/Spawn/utils/hostUptime.ts
+++ b/apps/spruce/src/components/Spawn/utils/hostUptime.ts
@@ -90,7 +90,7 @@ export const getHostUptimeWarnings = ({
  * @returns - object with enabledHoursCount indicating total hours per week and enabledWeekdaysCount indicating number of days per week
  */
 export const getEnabledHoursCount = (
-  hostUptime: HostUptime,
+  hostUptime?: HostUptime,
 ): { enabledHoursCount: number; enabledWeekdaysCount: number } => {
   if (!hostUptime) {
     return {

--- a/apps/spruce/src/pages/spawn/spawnHost/EditSpawnHostModal.tsx
+++ b/apps/spruce/src/pages/spawn/spawnHost/EditSpawnHostModal.tsx
@@ -46,16 +46,16 @@ export const EditSpawnHostModal: React.FC<EditSpawnHostModalProps> = ({
   const {
     disableExpirationCheckbox,
     instanceTypesData,
-    noExpirationCheckboxTooltip,
+    noExpirationCheckboxTooltip = "",
     publicKeysData,
     volumesData,
   } = useLoadFormData(host);
 
   let instanceTypes = instanceTypesData?.instanceTypes ?? [];
-  // The list of instance types provided by Evergreen can be out-of-date, so make sure the instance type in use is considered valid by RJSF
-  // @ts-expect-error: FIXME. This comment was added by an automated script.
-  if (!instanceTypes.includes(host.instanceType)) {
-    // @ts-expect-error: FIXME. This comment was added by an automated script.
+
+  // The list of instance types provided by Evergreen can be out-of-date,
+  // so make sure the instance type in use is considered valid by RJSF.
+  if (host.instanceType && !instanceTypes.includes(host.instanceType)) {
     instanceTypes = [...instanceTypes, host.instanceType];
   }
 
@@ -76,7 +76,7 @@ export const EditSpawnHostModal: React.FC<EditSpawnHostModalProps> = ({
     rdpPassword: "",
     userTags,
     expirationDetails: {
-      expiration: host.expiration ? host.expiration.toString() : null,
+      expiration: host.expiration ? host.expiration.toString() : undefined,
       noExpiration: host.noExpiration,
       hostUptime:
         host?.sleepSchedule && !isNullSleepSchedule(host?.sleepSchedule)
@@ -86,38 +86,32 @@ export const EditSpawnHostModal: React.FC<EditSpawnHostModalProps> = ({
     publicKeySection: { useExisting: true, publicKeyNameDropdown: "" },
   };
 
-  // @ts-expect-error: FIXME. This comment was added by an automated script.
   const [formState, setFormState] = useState<FormState>(initialFormState);
   const [hasError, setHasError] = useState(false);
 
   const hostUptimeWarnings = useMemo(() => {
     const { enabledHoursCount, enabledWeekdaysCount } = getEnabledHoursCount(
-      // @ts-expect-error: FIXME. This comment was added by an automated script.
       formState?.expirationDetails?.hostUptime,
     );
     const warnings = getHostUptimeWarnings({
       enabledHoursCount,
       enabledWeekdaysCount,
-      // @ts-expect-error: FIXME. This comment was added by an automated script.
       runContinuously:
         formState?.expirationDetails?.hostUptime?.sleepSchedule?.timeSelection
-          ?.runContinuously,
+          ?.runContinuously ?? false,
     });
     return { enabledHoursCount, warnings };
   }, [formState?.expirationDetails?.hostUptime]);
 
   const { schema, uiSchema } = getFormSchema({
     canEditInstanceType: host.status === HostStatus.Stopped,
-    // @ts-expect-error: FIXME. This comment was added by an automated script.
     canEditRdpPassword:
-      // @ts-expect-error: FIXME. This comment was added by an automated script.
-      host.distro.isWindows && host.status === HostStatus.Running,
+      (host?.distro?.isWindows && host.status === HostStatus.Running) ?? false,
     canEditSshKeys: host.status === HostStatus.Running,
     disableExpirationCheckbox,
     hostUptimeWarnings,
     instanceTypes: instanceTypes ?? [],
     myPublicKeys: publicKeys ?? [],
-    // @ts-expect-error: FIXME. This comment was added by an automated script.
     noExpirationCheckboxTooltip,
     permanentlyExempt: !!host.sleepSchedule?.permanentlyExempt,
     timeZone:
@@ -125,17 +119,16 @@ export const EditSpawnHostModal: React.FC<EditSpawnHostModalProps> = ({
     volumes,
   });
 
-  // EDIT HOST MUTATION
   const [editSpawnHostMutation, { loading: loadingSpawnHost }] = useMutation<
     EditSpawnHostMutation,
     EditSpawnHostMutationVariables
   >(EDIT_SPAWN_HOST, {
-    onCompleted(mutationResult) {
+    onCompleted: (mutationResult) => {
       const { id } = mutationResult?.editSpawnHost ?? {};
       dispatchToast.success(`Successfully modified spawned host: ${id}`);
       onCancel();
     },
-    onError(err) {
+    onError: (err) => {
       dispatchToast.error(
         `There was an error while modifying your host: ${err.message}`,
       );
@@ -145,12 +138,10 @@ export const EditSpawnHostModal: React.FC<EditSpawnHostModalProps> = ({
   });
 
   const initialEditState = formToGql({
-    // @ts-expect-error: FIXME. This comment was added by an automated script.
     formData: initialFormState,
     hostId: host.id,
     myPublicKeys: publicKeys,
     oldUserTags: userTags,
-    timeZone,
   });
 
   const currEditState = formToGql({
@@ -171,25 +162,27 @@ export const EditSpawnHostModal: React.FC<EditSpawnHostModalProps> = ({
     });
     editSpawnHostMutation({
       variables: {
-        // @ts-expect-error: FIXME. This comment was added by an automated script.
-        hostId: host.id,
         ...mutationParams,
+        hostId: host.id,
       },
     });
   };
 
   return (
     <ConfirmationModal
-      buttonText={loadingSpawnHost ? "Saving" : "Save"}
-      data-cy="edit-spawn-host-modal"
-      onCancel={() => {
-        onCancel();
-        // @ts-expect-error: FIXME. This comment was added by an automated script.
-        setFormState(initialFormState);
+      cancelButtonProps={{
+        onClick: () => {
+          onCancel();
+          setFormState(initialFormState);
+        },
       }}
-      onConfirm={onSubmit}
+      confirmButtonProps={{
+        onClick: onSubmit,
+        children: loadingSpawnHost ? "Saving" : "Save",
+        disabled: !hasChanges || hasError || loadingSpawnHost,
+      }}
+      data-cy="edit-spawn-host-modal"
       open={visible}
-      submitDisabled={!hasChanges || hasError || loadingSpawnHost}
       title="Edit Host Details"
     >
       <SpruceForm

--- a/apps/spruce/src/pages/spawn/spawnHost/spawnHostButton/SpawnHostModal.tsx
+++ b/apps/spruce/src/pages/spawn/spawnHost/spawnHostButton/SpawnHostModal.tsx
@@ -61,12 +61,12 @@ export const SpawnHostModal: React.FC<SpawnHostModalProps> = ({
     SpawnHostMutation,
     SpawnHostMutationVariables
   >(SPAWN_HOST, {
-    onCompleted(hostMutation) {
+    onCompleted: (hostMutation) => {
       const { id } = hostMutation?.spawnHost ?? {};
       dispatchToast.success(`Successfully spawned host: ${id}`);
       setOpen(false);
     },
-    onError(err) {
+    onError: (err) => {
       dispatchToast.error(
         `There was an error while spawning your host: ${err.message}`,
       );
@@ -86,8 +86,7 @@ export const SpawnHostModal: React.FC<SpawnHostModalProps> = ({
   );
 
   useVirtualWorkstationDefaultExpiration({
-    // @ts-expect-error: FIXME. This comment was added by an automated script.
-    isVirtualWorkstation: selectedDistro?.isVirtualWorkStation,
+    isVirtualWorkstation: selectedDistro?.isVirtualWorkStation ?? false,
     setFormState,
     formState,
     disableExpirationCheckbox: formSchemaInput.disableExpirationCheckbox,
@@ -95,16 +94,14 @@ export const SpawnHostModal: React.FC<SpawnHostModalProps> = ({
 
   const hostUptimeWarnings = useMemo(() => {
     const { enabledHoursCount, enabledWeekdaysCount } = getEnabledHoursCount(
-      // @ts-expect-error: FIXME. This comment was added by an automated script.
       formState?.expirationDetails?.hostUptime,
     );
     const warnings = getHostUptimeWarnings({
       enabledHoursCount,
       enabledWeekdaysCount,
-      // @ts-expect-error: FIXME. This comment was added by an automated script.
       runContinuously:
         formState?.expirationDetails?.hostUptime?.sleepSchedule?.timeSelection
-          ?.runContinuously,
+          ?.runContinuously ?? false,
     });
     return { enabledHoursCount, warnings };
   }, [formState?.expirationDetails?.hostUptime]);
@@ -129,13 +126,10 @@ export const SpawnHostModal: React.FC<SpawnHostModalProps> = ({
 
   const spawnHost = () => {
     const mutationInput = formToGql({
-      // @ts-expect-error: FIXME. This comment was added by an automated script.
-      isVirtualWorkStation: selectedDistro?.isVirtualWorkStation,
+      isVirtualWorkStation: selectedDistro?.isVirtualWorkStation ?? false,
       formData: formState,
-      // @ts-expect-error: FIXME. This comment was added by an automated script.
-      myPublicKeys: formSchemaInput.myPublicKeys,
+      myPublicKeys: formSchemaInput.myPublicKeys ?? [],
       spawnTaskData: spawnTaskData?.task,
-      timeZone,
     });
     spawnAnalytics.sendEvent({
       name: "Created a spawn host",
@@ -151,14 +145,16 @@ export const SpawnHostModal: React.FC<SpawnHostModalProps> = ({
 
   return (
     <ConfirmationModal
-      buttonText={loadingSpawnHost ? "Spawning" : "Spawn a host"}
-      data-cy="spawn-host-modal"
-      onCancel={() => {
-        setOpen(false);
+      cancelButtonProps={{
+        onClick: () => setOpen(false),
       }}
-      onConfirm={spawnHost}
+      confirmButtonProps={{
+        children: loadingSpawnHost ? "Spawning" : "Spawn a host",
+        onClick: spawnHost,
+        disabled: hasError || loadingSpawnHost,
+      }}
+      data-cy="spawn-host-modal"
       open={open}
-      submitDisabled={hasError || loadingSpawnHost}
       title="Spawn New Host"
     >
       <SpruceForm


### PR DESCRIPTION
DEVPROD-12004
<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️ -->
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
This bug is caused by the fact that the user has a public key with an empty string name (`""`). I have no idea how they were able to do this, because we have checks to make sure this doesn't happen. I have told the user in the ticket to delete their empty key.

Regardless, the error behavior can be fixed by making sure that we send the entire public key document when editing the host.

Separately, fixed nearby TypeScript errors and updated deprecated `ConfirmationModal` props.

### Steps to reproduce original bug
1. Have a public key with an empty string name (`""`). I had to add via the database since you cannot do this from the UI.
2. Have a public key with a non-empty name. Use the **same key** as the public key above.
3. Try to edit host with your public key. It will fail. This is because it diffs the keys (which are the same) and results in an empty string. So we end up trying to add an empty key.
