### PR TITLE
DEVPROD-12638: Fix job log URL template

### DIFF
--- a/apps/parsley/src/constants/logURLTemplates.ts
+++ b/apps/parsley/src/constants/logURLTemplates.ts
@@ -139,7 +139,7 @@ const getEvergreenCompleteLogsURL = (
   execution: string | number,
   groupID: string,
 ) =>
-  `${evergreenURL}/rest/v2/tasks/${taskID}/build/TestLogs/${groupID}?execution=${execution}`;
+  `${evergreenURL}/rest/v2/tasks/${taskID}/build/TestLogs/${groupID}%2F?execution=${execution}`;
 
 export {
   constructEvergreenTaskLogURL,

--- a/apps/parsley/src/gql/generated/types.ts
+++ b/apps/parsley/src/gql/generated/types.ts
@@ -3507,6 +3507,7 @@ export type WaterfallPagination = {
 export type WaterfallTask = {
   __typename?: "WaterfallTask";
   displayName: Scalars["String"]["output"];
+  displayStatus: Scalars["String"]["output"];
   execution: Scalars["Int"]["output"];
   id: Scalars["String"]["output"];
   status: Scalars["String"]["output"];

--- a/apps/parsley/src/pages/LogView/LoadingPage/useResolveLogURLAndRenderingType.test.tsx
+++ b/apps/parsley/src/pages/LogView/LoadingPage/useResolveLogURLAndRenderingType.test.tsx
@@ -403,12 +403,12 @@ describe("useResolveLogURLAndRenderingType", () => {
     await waitFor(() => {
       expect(result.current).toMatchObject({
         downloadURL:
-          "http://test-evergreen.com/rest/v2/tasks/a-task-id/build/TestLogs/job0?execution=0",
+          "http://test-evergreen.com/rest/v2/tasks/a-task-id/build/TestLogs/job0%2F?execution=0",
         htmlLogURL: "",
         jobLogsURL: "http://test-spruce.com/job-logs/a-task-id/0/job0",
         loading: false,
         rawLogURL:
-          "http://test-evergreen.com/rest/v2/tasks/a-task-id/build/TestLogs/job0?execution=0",
+          "http://test-evergreen.com/rest/v2/tasks/a-task-id/build/TestLogs/job0%2F?execution=0",
       });
     });
   });


### PR DESCRIPTION
DEVPROD-12638
<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️ -->
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
<!-- add description, context, thought process, etc -->
Fix log template by escaping slash.

### Testing
<!-- add a description of how you tested it -->
Visit http://localhost:5173/resmoke/mongosync_1.9.x_v70_to_v70_rhel80_ctc_custom_replica_sets_fsm_patch_111e453563b31a35f322e74ffd909fdbb99cbc0e_672bb2ee8de6fe0006f70397_24_11_06_18_18_23/0/job1/all?bookmarks=0,5545359: no instances of `job10`, which indicated incorrect escaping, are present.