### PR TITLE
DEVPROD-11880: Reposition tooltip in last active version column

### DIFF
--- a/apps/spruce/src/pages/waterfall/BuildRow.tsx
+++ b/apps/spruce/src/pages/waterfall/BuildRow.tsx
@@ -26,6 +26,7 @@ const { black, gray, white } = palette;
 type Props = {
   build: BuildVariant;
   handlePinClick: () => void;
+  lastActiveVersionId: string;
   pinned: boolean;
   projectIdentifier: string;
   versions: WaterfallVersion[];
@@ -34,6 +35,7 @@ type Props = {
 export const BuildRow: React.FC<Props> = ({
   build,
   handlePinClick,
+  lastActiveVersionId,
   pinned,
   projectIdentifier,
   versions,
@@ -93,6 +95,7 @@ export const BuildRow: React.FC<Props> = ({
                 key={b.id}
                 build={b}
                 handleTaskClick={handleTaskClick}
+                isRightmostBuild={b.version === lastActiveVersionId}
               />
             );
           }
@@ -106,7 +109,8 @@ export const BuildRow: React.FC<Props> = ({
 const BuildGrid: React.FC<{
   build: Build;
   handleTaskClick: (s: string) => () => void;
-}> = ({ build, handleTaskClick }) => (
+  isRightmostBuild: boolean;
+}> = ({ build, handleTaskClick, isRightmostBuild }) => (
   <BuildContainer
     onClick={(event: React.MouseEvent) => {
       handleTaskClick(
@@ -123,6 +127,7 @@ const BuildGrid: React.FC<{
         <SquareMemo
           key={id}
           data-tooltip={`${displayName} - ${taskStatusToCopy[taskStatus]}`}
+          isRightmostBuild={isRightmostBuild}
           status={taskStatus}
           to={getTaskRoute(id, { execution })}
         />
@@ -148,7 +153,7 @@ const StyledIconButton = styled(IconButton)`
   ${({ active }) => active && "transform: rotate(-30deg);"}
 `;
 
-const Square = styled(Link)<{ status: TaskStatus }>`
+const Square = styled(Link)<{ isRightmostBuild: boolean; status: TaskStatus }>`
   width: ${SQUARE_SIZE}px;
   height: ${SQUARE_SIZE}px;
   border: 1px solid ${white};
@@ -165,7 +170,8 @@ const Square = styled(Link)<{ status: TaskStatus }>`
     position: absolute;
     bottom: calc(100% + 5px);
     left: 50%;
-    transform: translate(-50%);
+    transform: ${({ isRightmostBuild }) =>
+      isRightmostBuild ? "translate(-90%)" : "translate(-50%)"};
     z-index: 1;
     width: max-content;
     max-width: 450px;

--- a/apps/spruce/src/pages/waterfall/WaterfallGrid.tsx
+++ b/apps/spruce/src/pages/waterfall/WaterfallGrid.tsx
@@ -94,11 +94,13 @@ export const WaterfallGrid: React.FC<WaterfallGridProps> = ({
     refEl as React.MutableRefObject<HTMLElement>,
   );
 
-  const { buildVariants, versions } = useFilters({
+  const { activeVersionIds, buildVariants, versions } = useFilters({
     buildVariants: data.waterfall.buildVariants,
     flattenedVersions: data.waterfall.flattenedVersions,
     pins,
   });
+
+  const lastActiveVersionId = activeVersionIds[activeVersionIds.length - 1];
 
   return (
     <Container ref={refEl}>
@@ -124,6 +126,7 @@ export const WaterfallGrid: React.FC<WaterfallGridProps> = ({
           key={b.id}
           build={b}
           handlePinClick={handlePinBV(b.id)}
+          lastActiveVersionId={lastActiveVersionId}
           pinned={pins.includes(b.id)}
           projectIdentifier={projectIdentifier}
           versions={versions}

--- a/apps/spruce/src/pages/waterfall/useFilters.ts
+++ b/apps/spruce/src/pages/waterfall/useFilters.ts
@@ -80,14 +80,12 @@ export const useFilters = ({
 
   const activeVersionIds = useMemo(
     () =>
-      new Set(
-        versionsResult.reduce((ids: string[], { version }) => {
-          if (version) {
-            ids.push(version.id);
-          }
-          return ids;
-        }, []),
-      ),
+      versionsResult.reduce((ids: string[], { version }) => {
+        if (version) {
+          ids.push(version.id);
+        }
+        return ids;
+      }, []),
     [versionsResult],
   );
 
@@ -125,12 +123,12 @@ export const useFilters = ({
         buildVariantFilterRegex.some((r) => bv.displayName.match(r));
       if (passesBVFilter) {
         if (
-          activeVersionIds.size !== bv.builds.length ||
+          activeVersionIds.length !== bv.builds.length ||
           taskFilterRegex.length
         ) {
           const activeBuilds: Build[] = [];
           bv.builds.forEach((b) => {
-            if (activeVersionIds.has(b.version)) {
+            if (activeVersionIds.includes(b.version)) {
               if (taskFilterRegex.length) {
                 const activeTasks = b.tasks.filter((t) =>
                   taskFilterRegex.some((r) => t.displayName.match(r)),
@@ -165,7 +163,11 @@ export const useFilters = ({
     taskFilterRegex,
   ]);
 
-  return { buildVariants: buildVariantsResult, versions: versionsResult };
+  return {
+    activeVersionIds,
+    buildVariants: buildVariantsResult,
+    versions: versionsResult,
+  };
 };
 
 /**


### PR DESCRIPTION
DEVPROD-11880
<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
<!-- add description, context, thought process, etc -->
Position tooltip to the left of the task box in the last active version column so that the tooltip is not cut off at the edge of the window.

### Screenshots
<!-- add screenshots of visible changes -->
<img width="1267" alt="image" src="https://github.com/user-attachments/assets/b0b8adfd-bc95-4a3c-8027-917b2fa3ae0b">