### PR TITLE
DEVPROD-12802 Ensure userId AttributeStore reads and writes are not stale

### DIFF
--- a/apps/parsley/src/analytics/useAnalyticAttributes.ts
+++ b/apps/parsley/src/analytics/useAnalyticAttributes.ts
@@ -1,12 +1,10 @@
 import { useEffect } from "react";
 import { useLogContext } from "context/LogContext";
 
-export const useAnalyticAttributes = () => {
+export const useAnalyticAttributes = (userId: string) => {
   const { logMetadata } = useLogContext();
   const { logType, renderingType } = logMetadata || {};
   const { AttributeStore } = window;
-
-  const userId = localStorage.getItem("userId");
 
   useEffect(() => {
     if (!AttributeStore) {

--- a/apps/parsley/src/pages/index.tsx
+++ b/apps/parsley/src/pages/index.tsx
@@ -26,7 +26,7 @@ const Content: React.FC = () => {
   const { user } = useUser();
   localStorage.setItem("userId", user?.userId ?? "");
 
-  useAnalyticAttributes();
+  useAnalyticAttributes(user?.userId ?? "");
   const { isAuthenticated } = useAuthContext();
   return isAuthenticated ? (
     <Routes>

--- a/apps/spruce/src/analytics/useAnalyticsAttributes.ts
+++ b/apps/spruce/src/analytics/useAnalyticsAttributes.ts
@@ -1,7 +1,6 @@
 import { useEffect } from "react";
 
-export const useAnalyticsAttributes = () => {
-  const userId = localStorage.getItem("userId");
+export const useAnalyticsAttributes = (userId: string) => {
   const { AttributeStore } = window;
 
   useEffect(() => {

--- a/apps/spruce/src/components/Content/Layout.tsx
+++ b/apps/spruce/src/components/Content/Layout.tsx
@@ -27,13 +27,13 @@ const shouldDisableForTest =
 
 export const Layout: React.FC = () => {
   const { isAuthenticated } = useAuthStateContext();
-  useAnalyticsAttributes();
   useAnnouncementToast();
 
   // this top-level query is required for authentication to work
   // afterware is used at apollo link level to authenticate or deauthenticate user based on response to query
   // therefore this could be any query as long as it is top-level
   const { data } = useQuery<UserQuery, UserQueryVariables>(USER);
+  useAnalyticsAttributes(data?.user?.userId ?? "");
   localStorage.setItem("userId", data?.user?.userId ?? "");
   const { userSettings } = useUserSettings();
   const { useSpruceOptions } = userSettings ?? {};


### PR DESCRIPTION
DEVPROD-12802
<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
It looks like `user.id` is not always reliably displayed in honeycomb events. I think this was caused by relying on localstorage to populate the user.id since sometimes it may not be populated at the point we request it or it may have been populated after the hook to write has already run. 

