### PR TITLE
DEVPROD-5753: Remove host counts in `validateToast`

### DIFF
--- a/apps/spruce/cypress/integration/hosts/select_hosts.ts
+++ b/apps/spruce/cypress/integration/hosts/select_hosts.ts
@@ -62,7 +62,7 @@ describe("Select hosts in hosts page table", () => {
     cy.dataCy("restart-jasper-button").should("be.visible").click();
     cy.dataCy("restart-jasper-button-popover").should("be.visible");
     cy.contains("button", "Yes").click();
-    cy.validateToast("success", "Marked Jasper as restarting for 3 hosts");
+    cy.validateToast("success", "Marked Jasper as restarting");
   });
 
   it("Can reprovision for selected hosts", () => {
@@ -75,6 +75,6 @@ describe("Select hosts in hosts page table", () => {
     cy.dataCy("reprovision-button").should("be.visible").click();
     cy.dataCy("reprovision-button-popover").should("be.visible");
     cy.contains("button", "Yes").click();
-    cy.validateToast("success", "Marked hosts to reprovision for 3 hosts");
+    cy.validateToast("success", "Marked hosts to reprovision");
   });
 });

--- a/apps/spruce/cypress/integration/hosts/update_status_modal.ts
+++ b/apps/spruce/cypress/integration/hosts/update_status_modal.ts
@@ -26,9 +26,6 @@ describe("Update Status Modal", () => {
       cy.contains("button", "Update").click({ force: true });
     });
     cy.dataCy("update-host-status-modal").should("not.exist");
-    cy.validateToast(
-      "success",
-      "Status was changed to terminated for 13 hosts",
-    );
+    cy.validateToast("success", "Status was changed to terminated");
   });
 });


### PR DESCRIPTION
DEVPROD-5753
<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
This is to be able to merge Arjun's PR. 

Although the copy itself is generated on the frontend, the number comes from the backend, so we should remove it since it's subject to change.

### Evergreen PR
* evergreen-ci/evergreen/pull/8460
