### PR TITLE
DEVPROD-11157 Make task selection regex on configure page case insensitive

### DIFF
--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -2764,7 +2764,7 @@ export type SpruceConfig = {
   secretFields: Array<Scalars["String"]["output"]>;
   slack?: Maybe<SlackConfig>;
   spawnHost: SpawnHostConfig;
-  ui?: Maybe<UiConfig>;
+  ui: UiConfig;
 };
 
 export type StatusCount = {
@@ -3231,6 +3231,7 @@ export type TriggerAliasInput = {
 
 export type UiConfig = {
   __typename?: "UIConfig";
+  betaFeatures: BetaFeatures;
   defaultProject: Scalars["String"]["output"];
   userVoice?: Maybe<Scalars["String"]["output"]>;
 };
@@ -8798,7 +8799,7 @@ export type SpruceConfigQuery = {
       unexpirableHostsPerUser: number;
       unexpirableVolumesPerUser: number;
     };
-    ui?: { __typename?: "UIConfig"; defaultProject: string } | null;
+    ui: { __typename?: "UIConfig"; defaultProject: string };
   } | null;
 };
 

--- a/apps/spruce/src/pages/configurePatch/configurePatchCore/ConfigureTasks/index.tsx
+++ b/apps/spruce/src/pages/configurePatch/configurePatchCore/ConfigureTasks/index.tsx
@@ -92,7 +92,7 @@ const ConfigureTasks: React.FC<Props> = ({
       tasks,
       // @ts-expect-error: FIXME. This comment was added by an automated script.
       previouslySelectedVariants,
-      new RegExp(search),
+      new RegExp(search, "i"),
     );
   }, [
     selectedBuildVariantTasks,


### PR DESCRIPTION
DEVPROD-11157
<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
Updates the flag on the task selection modal on the configure page to support case-insensitive regex by default so it reflects the same type of search done on the tasks table.

### Screenshots
<img width="870" alt="image" src="https://github.com/user-attachments/assets/405ce742-3aa5-4024-b1a8-dc27ce3f631b">

