### PR TITLE
DEVPROD-11705: Collapse filtered versions

### DIFF
--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -230,29 +230,6 @@ export type CloudProviderConfig = {
   aws?: Maybe<AwsConfig>;
 };
 
-/**
- * CommitQueue is returned by the commitQueue query.
- * It contains information about the patches on the commit queue (e.g. author, code changes) for a given project.
- */
-export type CommitQueue = {
-  __typename?: "CommitQueue";
-  message?: Maybe<Scalars["String"]["output"]>;
-  owner?: Maybe<Scalars["String"]["output"]>;
-  projectId?: Maybe<Scalars["String"]["output"]>;
-  queue?: Maybe<Array<CommitQueueItem>>;
-  repo?: Maybe<Scalars["String"]["output"]>;
-};
-
-export type CommitQueueItem = {
-  __typename?: "CommitQueueItem";
-  enqueueTime?: Maybe<Scalars["Time"]["output"]>;
-  issue?: Maybe<Scalars["String"]["output"]>;
-  modules?: Maybe<Array<Module>>;
-  patch?: Maybe<Patch>;
-  source?: Maybe<Scalars["String"]["output"]>;
-  version?: Maybe<Scalars["String"]["output"]>;
-};
-
 export type CommitQueueParams = {
   __typename?: "CommitQueueParams";
   enabled?: Maybe<Scalars["Boolean"]["output"]>;
@@ -1202,12 +1179,6 @@ export type MetadataLinkInput = {
   url: Scalars["String"]["input"];
 };
 
-export type Module = {
-  __typename?: "Module";
-  issue?: Maybe<Scalars["String"]["output"]>;
-  module?: Maybe<Scalars["String"]["output"]>;
-};
-
 export type ModuleCodeChange = {
   __typename?: "ModuleCodeChange";
   branchName: Scalars["String"]["output"];
@@ -1251,7 +1222,6 @@ export type Mutation = {
   detachVolumeFromHost: Scalars["Boolean"]["output"];
   editAnnotationNote: Scalars["Boolean"]["output"];
   editSpawnHost: Host;
-  enqueuePatch: Patch;
   forceRepotrackerRun: Scalars["Boolean"]["output"];
   migrateVolume: Scalars["Boolean"]["output"];
   moveAnnotationIssue: Scalars["Boolean"]["output"];
@@ -1259,7 +1229,6 @@ export type Mutation = {
   promoteVarsToRepo: Scalars["Boolean"]["output"];
   removeAnnotationIssue: Scalars["Boolean"]["output"];
   removeFavoriteProject: Project;
-  removeItemFromCommitQueue?: Maybe<Scalars["String"]["output"]>;
   removePublicKey: Array<PublicKey>;
   removeVolume: Scalars["Boolean"]["output"];
   reprovisionToNew: Scalars["Int"]["output"];
@@ -1389,11 +1358,6 @@ export type MutationEditSpawnHostArgs = {
   spawnHost?: InputMaybe<EditSpawnHostInput>;
 };
 
-export type MutationEnqueuePatchArgs = {
-  commitMessage?: InputMaybe<Scalars["String"]["input"]>;
-  patchId: Scalars["String"]["input"];
-};
-
 export type MutationForceRepotrackerRunArgs = {
   projectId: Scalars["String"]["input"];
 };
@@ -1427,11 +1391,6 @@ export type MutationRemoveAnnotationIssueArgs = {
 
 export type MutationRemoveFavoriteProjectArgs = {
   opts: RemoveFavoriteProjectInput;
-};
-
-export type MutationRemoveItemFromCommitQueueArgs = {
-  commitQueueId: Scalars["String"]["input"];
-  issue: Scalars["String"]["input"];
 };
 
 export type MutationRemovePublicKeyArgs = {
@@ -1686,10 +1645,8 @@ export type Patch = {
   authorDisplayName: Scalars["String"]["output"];
   baseTaskStatuses: Array<Scalars["String"]["output"]>;
   builds: Array<Build>;
-  canEnqueueToCommitQueue: Scalars["Boolean"]["output"];
   childPatchAliases?: Maybe<Array<ChildPatchAlias>>;
   childPatches?: Maybe<Array<Patch>>;
-  commitQueuePosition?: Maybe<Scalars["Int"]["output"]>;
   createTime?: Maybe<Scalars["Time"]["output"]>;
   description: Scalars["String"]["output"];
   duration?: Maybe<PatchDuration>;
@@ -2224,7 +2181,6 @@ export type Query = {
   buildBaron: BuildBaron;
   buildVariantsForTaskName?: Maybe<Array<BuildVariantTuple>>;
   clientConfig?: Maybe<ClientConfig>;
-  commitQueue: CommitQueue;
   distro?: Maybe<Distro>;
   distroEvents: DistroEventsPayload;
   distroTaskQueue: Array<TaskQueueItem>;
@@ -2279,10 +2235,6 @@ export type QueryBuildBaronArgs = {
 export type QueryBuildVariantsForTaskNameArgs = {
   projectIdentifier: Scalars["String"]["input"];
   taskName: Scalars["String"]["input"];
-};
-
-export type QueryCommitQueueArgs = {
-  projectIdentifier: Scalars["String"]["input"];
 };
 
 export type QueryDistroArgs = {

--- a/apps/spruce/src/pages/waterfall/useFilters.test.tsx
+++ b/apps/spruce/src/pages/waterfall/useFilters.test.tsx
@@ -30,7 +30,10 @@ describe("useFilters", () => {
           wrapper: createWrapper(),
         },
       );
-      expect(result.current).toMatchObject(waterfall);
+      expect(result.current).toStrictEqual({
+        ...waterfall,
+        activeVersionIds: ["b", "c"],
+      });
     });
 
     it("should move version into inactive versions list and drop build variant when filter is applied", () => {
@@ -50,6 +53,7 @@ describe("useFilters", () => {
       );
 
       const filteredWaterfall = {
+        activeVersionIds: [],
         buildVariants: [],
         versions: [
           {
@@ -59,7 +63,7 @@ describe("useFilters", () => {
         ],
       };
 
-      expect(result.current).toMatchObject(filteredWaterfall);
+      expect(result.current).toStrictEqual(filteredWaterfall);
     });
   });
 
@@ -81,6 +85,7 @@ describe("useFilters", () => {
 
       const pinnedWaterfall = {
         ...waterfall,
+        activeVersionIds: ["b", "c"],
         buildVariants: [
           waterfall.buildVariants[1],
           waterfall.buildVariants[2],
@@ -88,7 +93,7 @@ describe("useFilters", () => {
         ],
       };
 
-      expect(result.current).toMatchObject(pinnedWaterfall);
+      expect(result.current).toStrictEqual(pinnedWaterfall);
     });
   });
 
@@ -109,11 +114,17 @@ describe("useFilters", () => {
       );
 
       const filteredWaterfall = {
-        ...waterfall,
+        activeVersionIds: [],
         buildVariants: [],
+        versions: [
+          {
+            inactiveVersions: flattenedVersions,
+            version: null,
+          },
+        ],
       };
 
-      expect(result.current).toMatchObject(filteredWaterfall);
+      expect(result.current).toStrictEqual(filteredWaterfall);
     });
 
     it("build variant filters are added together", () => {
@@ -133,9 +144,10 @@ describe("useFilters", () => {
 
       const filteredWaterfall = {
         ...waterfall,
+        activeVersionIds: ["b", "c"],
       };
 
-      expect(result.current).toMatchObject(filteredWaterfall);
+      expect(result.current).toStrictEqual(filteredWaterfall);
     });
   });
 
@@ -156,7 +168,7 @@ describe("useFilters", () => {
       );
 
       const filteredWaterfall = {
-        ...waterfall,
+        activeVersionIds: ["b"],
         buildVariants: [
           {
             ...waterfall.buildVariants[0],
@@ -166,6 +178,20 @@ describe("useFilters", () => {
                 tasks: [waterfall.buildVariants[0].builds[1].tasks[1]],
               },
             ],
+          },
+        ],
+        versions: [
+          {
+            inactiveVersions: [flattenedVersions[0]],
+            version: null,
+          },
+          {
+            inactiveVersions: null,
+            version: flattenedVersions[1],
+          },
+          {
+            inactiveVersions: [flattenedVersions[2]],
+            version: null,
           },
         ],
       };
@@ -232,7 +258,12 @@ describe("useFilters", () => {
       );
 
       expect(result.current).toMatchObject({
-        ...waterfall,
+        versions: [
+          {
+            inactiveVersions: flattenedVersions,
+            version: null,
+          },
+        ],
         buildVariants: [],
       });
     });

--- a/apps/spruce/src/pages/waterfall/utils.test.ts
+++ b/apps/spruce/src/pages/waterfall/utils.test.ts
@@ -3,7 +3,7 @@ import { groupInactiveVersions } from "./utils";
 
 describe("groupInactiveVersions", () => {
   it("correctly groups inactive versions", () => {
-    const res = groupInactiveVersions(versions);
+    const res = groupInactiveVersions(versions, () => true);
 
     expect(res).toStrictEqual([
       {
@@ -38,6 +38,87 @@ describe("groupInactiveVersions", () => {
       },
       {
         inactiveVersions: [
+          {
+            id: "c",
+            author: "sophie.stadler",
+            activated: false,
+            createTime: new Date("2024-09-19T14:56:08Z"),
+            errors: [],
+            message: "foo",
+            requester: "gitter_request",
+            revision: "c",
+            order: 3,
+          },
+          {
+            id: "d",
+            author: "sophie.stadler",
+            activated: false,
+            createTime: new Date("2024-09-19T14:56:08Z"),
+            errors: [],
+            message: "foo",
+            requester: "gitter_request",
+            revision: "d",
+            order: 2,
+          },
+          {
+            id: "e",
+            author: "sophie.stadler",
+            activated: false,
+            createTime: new Date("2024-09-19T14:56:08Z"),
+            errors: [],
+            message: "foo",
+            requester: "gitter_request",
+            revision: "e",
+            order: 1,
+          },
+        ],
+        version: null,
+      },
+      {
+        inactiveVersions: null,
+        version: {
+          id: "f",
+          author: "sophie.stadler",
+          activated: true,
+          createTime: new Date("2024-09-19T14:56:08Z"),
+          errors: [],
+          message: "foo",
+          requester: "gitter_request",
+          revision: "f",
+          order: 0,
+        },
+      },
+    ]);
+  });
+
+  it("correctly groups inactive versions when some do not appear in builds", () => {
+    const res = groupInactiveVersions(versions, (id) => id !== "b");
+
+    expect(res).toStrictEqual([
+      {
+        inactiveVersions: [
+          {
+            id: "a",
+            author: "sophie.stadler",
+            activated: false,
+            createTime: new Date("2024-09-20T14:56:08Z"),
+            errors: [],
+            message: "bar",
+            requester: "gitter_request",
+            revision: "a",
+            order: 5,
+          },
+          {
+            id: "b",
+            author: "sophie.stadler",
+            activated: true,
+            createTime: new Date("2024-09-19T14:56:08Z"),
+            errors: [],
+            message: "foo",
+            requester: "gitter_request",
+            revision: "b",
+            order: 4,
+          },
           {
             id: "c",
             author: "sophie.stadler",

--- a/apps/spruce/src/pages/waterfall/utils.ts
+++ b/apps/spruce/src/pages/waterfall/utils.ts
@@ -1,28 +1,37 @@
 import { WaterfallVersionFragment } from "gql/generated/types";
 import { WaterfallVersion } from "./types";
 
-export const groupInactiveVersions = (versions: WaterfallVersionFragment[]) => {
-  const waterfallVersions: WaterfallVersion[] = [];
-  let i = 0;
+export const groupInactiveVersions = (
+  versions: WaterfallVersionFragment[],
+  versionHasActiveBuild: (versionId: string) => boolean,
+) => {
+  const filteredVersions: WaterfallVersion[] = [];
 
-  while (i < versions.length) {
-    if (versions[i].activated) {
-      waterfallVersions.push({
-        inactiveVersions: null,
-        version: versions[i],
-      });
-      i += 1;
-    } else {
-      const inactiveGroup: WaterfallVersionFragment[] = [];
-      while (i < versions.length && !versions[i].activated) {
-        inactiveGroup.push(versions[i]);
-        i += 1;
-      }
-      waterfallVersions.push({
-        inactiveVersions: inactiveGroup,
-        version: null,
-      });
+  const pushInactive = (v: WaterfallVersionFragment) => {
+    if (!filteredVersions?.[filteredVersions.length - 1]?.inactiveVersions) {
+      filteredVersions.push({ version: null, inactiveVersions: [] });
     }
-  }
-  return waterfallVersions;
+    filteredVersions[filteredVersions.length - 1].inactiveVersions?.push(v);
+  };
+
+  const pushActive = (v: WaterfallVersionFragment) => {
+    filteredVersions.push({
+      inactiveVersions: null,
+      version: v,
+    });
+  };
+
+  versions.forEach((version) => {
+    if (version.activated) {
+      if (versionHasActiveBuild(version.id)) {
+        pushActive(version);
+      } else {
+        pushInactive(version);
+      }
+    } else {
+      pushInactive(version);
+    }
+  });
+
+  return filteredVersions;
 };


### PR DESCRIPTION
DEVPROD-11705
<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
<!-- add description, context, thought process, etc -->
If a version has no active tasks due to filtering, collapse it by marking it as inactive and rendering it in the modal.

### Screenshots
<!-- add screenshots of visible changes -->
<img width="1455" alt="image" src="https://github.com/user-attachments/assets/3e65d47c-683c-4c1b-8c0e-95014a2e213c">

### Testing
<!-- add a description of how you tested it -->
Update useFilter unit tests, add test for grouping inactive versions

<!-- Have you have updated the analytics documentation if necessary?  
https://docs.google.com/spreadsheets/d/1s4_nq8ZiphXp5Uq_-9HT6GPqz-KOyaq6HuvmXYaSNzg/edit?usp=sharing -->

### Evergreen PR
<!-- link to a corresponding Evergreen PR if applicable -->
