### PR TITLE
DEVPROD-13059 Add confirmation prompt for deploys

### DIFF
--- a/apps/parsley/src/gql/generated/types.ts
+++ b/apps/parsley/src/gql/generated/types.ts
@@ -230,29 +230,6 @@ export type CloudProviderConfig = {
   aws?: Maybe<AwsConfig>;
 };
 
-/**
- * CommitQueue is returned by the commitQueue query.
- * It contains information about the patches on the commit queue (e.g. author, code changes) for a given project.
- */
-export type CommitQueue = {
-  __typename?: "CommitQueue";
-  message?: Maybe<Scalars["String"]["output"]>;
-  owner?: Maybe<Scalars["String"]["output"]>;
-  projectId?: Maybe<Scalars["String"]["output"]>;
-  queue?: Maybe<Array<CommitQueueItem>>;
-  repo?: Maybe<Scalars["String"]["output"]>;
-};
-
-export type CommitQueueItem = {
-  __typename?: "CommitQueueItem";
-  enqueueTime?: Maybe<Scalars["Time"]["output"]>;
-  issue?: Maybe<Scalars["String"]["output"]>;
-  modules?: Maybe<Array<Module>>;
-  patch?: Maybe<Patch>;
-  source?: Maybe<Scalars["String"]["output"]>;
-  version?: Maybe<Scalars["String"]["output"]>;
-};
-
 export type CommitQueueParams = {
   __typename?: "CommitQueueParams";
   enabled?: Maybe<Scalars["Boolean"]["output"]>;
@@ -1202,12 +1179,6 @@ export type MetadataLinkInput = {
   url: Scalars["String"]["input"];
 };
 
-export type Module = {
-  __typename?: "Module";
-  issue?: Maybe<Scalars["String"]["output"]>;
-  module?: Maybe<Scalars["String"]["output"]>;
-};
-
 export type ModuleCodeChange = {
   __typename?: "ModuleCodeChange";
   branchName: Scalars["String"]["output"];
@@ -1251,7 +1222,6 @@ export type Mutation = {
   detachVolumeFromHost: Scalars["Boolean"]["output"];
   editAnnotationNote: Scalars["Boolean"]["output"];
   editSpawnHost: Host;
-  enqueuePatch: Patch;
   forceRepotrackerRun: Scalars["Boolean"]["output"];
   migrateVolume: Scalars["Boolean"]["output"];
   moveAnnotationIssue: Scalars["Boolean"]["output"];
@@ -1259,7 +1229,6 @@ export type Mutation = {
   promoteVarsToRepo: Scalars["Boolean"]["output"];
   removeAnnotationIssue: Scalars["Boolean"]["output"];
   removeFavoriteProject: Project;
-  removeItemFromCommitQueue?: Maybe<Scalars["String"]["output"]>;
   removePublicKey: Array<PublicKey>;
   removeVolume: Scalars["Boolean"]["output"];
   reprovisionToNew: Scalars["Int"]["output"];
@@ -1389,11 +1358,6 @@ export type MutationEditSpawnHostArgs = {
   spawnHost?: InputMaybe<EditSpawnHostInput>;
 };
 
-export type MutationEnqueuePatchArgs = {
-  commitMessage?: InputMaybe<Scalars["String"]["input"]>;
-  patchId: Scalars["String"]["input"];
-};
-
 export type MutationForceRepotrackerRunArgs = {
   projectId: Scalars["String"]["input"];
 };
@@ -1427,11 +1391,6 @@ export type MutationRemoveAnnotationIssueArgs = {
 
 export type MutationRemoveFavoriteProjectArgs = {
   opts: RemoveFavoriteProjectInput;
-};
-
-export type MutationRemoveItemFromCommitQueueArgs = {
-  commitQueueId: Scalars["String"]["input"];
-  issue: Scalars["String"]["input"];
 };
 
 export type MutationRemovePublicKeyArgs = {
@@ -1686,10 +1645,8 @@ export type Patch = {
   authorDisplayName: Scalars["String"]["output"];
   baseTaskStatuses: Array<Scalars["String"]["output"]>;
   builds: Array<Build>;
-  canEnqueueToCommitQueue: Scalars["Boolean"]["output"];
   childPatchAliases?: Maybe<Array<ChildPatchAlias>>;
   childPatches?: Maybe<Array<Patch>>;
-  commitQueuePosition?: Maybe<Scalars["Int"]["output"]>;
   createTime?: Maybe<Scalars["Time"]["output"]>;
   description: Scalars["String"]["output"];
   duration?: Maybe<PatchDuration>;
@@ -2224,7 +2181,6 @@ export type Query = {
   buildBaron: BuildBaron;
   buildVariantsForTaskName?: Maybe<Array<BuildVariantTuple>>;
   clientConfig?: Maybe<ClientConfig>;
-  commitQueue: CommitQueue;
   distro?: Maybe<Distro>;
   distroEvents: DistroEventsPayload;
   distroTaskQueue: Array<TaskQueueItem>;
@@ -2279,10 +2235,6 @@ export type QueryBuildBaronArgs = {
 export type QueryBuildVariantsForTaskNameArgs = {
   projectIdentifier: Scalars["String"]["input"];
   taskName: Scalars["String"]["input"];
-};
-
-export type QueryCommitQueueArgs = {
-  projectIdentifier: Scalars["String"]["input"];
 };
 
 export type QueryDistroArgs = {

--- a/packages/deploy-utils/src/prepare-prod-deploy/index.ts
+++ b/packages/deploy-utils/src/prepare-prod-deploy/index.ts
@@ -69,5 +69,17 @@ export const prepareProdDeploy = async () => {
 
   const version = getReleaseVersion(commitMessages);
   console.log(`This deploy is a ${version} release.`);
+
+  const { value: shouldDeploy } = await prompts({
+    type: "confirm",
+    name: "value",
+    message: "Do you want to deploy?",
+    initial: true,
+  });
+  if (!shouldDeploy) {
+    console.log("Deploy cancelled.");
+    return;
+  }
+
   createTagAndPush(version);
 };

--- a/packages/deploy-utils/src/prepare-prod-deploy/prepare-prod-deploy.test.ts
+++ b/packages/deploy-utils/src/prepare-prod-deploy/prepare-prod-deploy.test.ts
@@ -83,7 +83,6 @@ my commit messages`,
       expect(consoleSpy).toHaveBeenCalledWith(
         "This deploy is a patch release.",
       );
-
       expect(vi.mocked(createTagAndPush)).toHaveBeenCalledTimes(1);
       expect(vi.mocked(createTagAndPush)).toHaveBeenCalledWith("patch");
     });

--- a/packages/deploy-utils/src/prepare-prod-deploy/prepare-prod-deploy.test.ts
+++ b/packages/deploy-utils/src/prepare-prod-deploy/prepare-prod-deploy.test.ts
@@ -61,6 +61,7 @@ describe("prepareProdDeploy", () => {
 
     it("creates tag with patch", async () => {
       const consoleSpy = vi.spyOn(console, "log").mockImplementation(vi.fn());
+      vi.mocked(prompts).mockResolvedValueOnce({ value: true });
       await prepareProdDeploy();
       expect(vi.mocked(getCurrentlyDeployedCommit)).toHaveBeenCalledWith(
         "spruce",
@@ -82,6 +83,7 @@ my commit messages`,
       expect(consoleSpy).toHaveBeenCalledWith(
         "This deploy is a patch release.",
       );
+
       expect(vi.mocked(createTagAndPush)).toHaveBeenCalledTimes(1);
       expect(vi.mocked(createTagAndPush)).toHaveBeenCalledWith("patch");
     });


### PR DESCRIPTION
DEVPROD-13059
<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
Its a little scary when it jumps straight through the deploy without giving you a chance to even read what commits are in it. This adds a safeguard and prompts the user to confirm or cancel the prompt after telling them what is in the deploy.

