### PR TITLE
DEVPROD-13116 Remove deprecated legacy success status

### DIFF
--- a/apps/spruce/cypress/integration/myPatches/my_patches.ts
+++ b/apps/spruce/cypress/integration/myPatches/my_patches.ts
@@ -174,7 +174,7 @@ describe("My Patches Page", () => {
         checkboxDisplayName: "All",
         pathname: MY_PATCHES_ROUTE,
         paramName: "statuses",
-        search: "all,created,started,success,failed",
+        search: "all,success,created,started,failed",
       });
     });
   });

--- a/apps/spruce/cypress/integration/myPatches/my_patches.ts
+++ b/apps/spruce/cypress/integration/myPatches/my_patches.ts
@@ -154,7 +154,7 @@ describe("My Patches Page", () => {
     const statuses = [
       { display: "Created/Unconfigured", key: "created" },
       { display: "Running", key: "started" },
-      { display: "Succeeded", key: "succeeded" },
+      { display: "Succeeded", key: "success" },
       { display: "Failed", key: "failed" },
     ];
 
@@ -174,7 +174,7 @@ describe("My Patches Page", () => {
         checkboxDisplayName: "All",
         pathname: MY_PATCHES_ROUTE,
         paramName: "statuses",
-        search: "all,created,started,succeeded,failed",
+        search: "all,created,started,success,failed",
       });
     });
   });

--- a/apps/spruce/src/components/PatchStatusBadge.tsx
+++ b/apps/spruce/src/components/PatchStatusBadge.tsx
@@ -16,7 +16,6 @@ const statusToBadgeVariant = {
   [PatchStatus.Created]: Variant.LightGray,
   [PatchStatus.Failed]: Variant.Red,
   [PatchStatus.Started]: Variant.Yellow,
-  [PatchStatus.LegacySucceeded]: Variant.Green,
   [PatchStatus.Success]: Variant.Green,
   [PatchStatus.Aborted]: Variant.LightGray,
 };
@@ -26,7 +25,6 @@ const patchStatusToCopy = {
   [PatchStatus.Created]: "Created",
   [PatchStatus.Failed]: "Failed",
   [PatchStatus.Started]: "Running",
-  [PatchStatus.LegacySucceeded]: "Succeeded",
   [PatchStatus.Success]: "Succeeded",
   [PatchStatus.Aborted]: "Aborted",
 };

--- a/apps/spruce/src/components/PatchesPage/StatusSelector.tsx
+++ b/apps/spruce/src/components/PatchesPage/StatusSelector.tsx
@@ -35,6 +35,7 @@ export const StatusSelector: React.FC = () => {
 const statusValToCopy = {
   [ALL_PATCH_STATUS]: "All",
   [PatchStatus.Created]: "Created/Unconfigured",
+  [PatchStatus.Success]: "Succeeded",
   [PatchStatus.Failed]: "Failed",
   [PatchStatus.Started]: "Running",
 };
@@ -44,6 +45,11 @@ const treeData = [
     title: statusValToCopy[ALL_PATCH_STATUS],
     value: ALL_PATCH_STATUS,
     key: ALL_PATCH_STATUS,
+  },
+  {
+    title: statusValToCopy[PatchStatus.Success],
+    value: PatchStatus.Success,
+    key: PatchStatus.Success,
   },
   {
     title: statusValToCopy[PatchStatus.Created],

--- a/apps/spruce/src/components/PatchesPage/StatusSelector.tsx
+++ b/apps/spruce/src/components/PatchesPage/StatusSelector.tsx
@@ -37,7 +37,6 @@ const statusValToCopy = {
   [PatchStatus.Created]: "Created/Unconfigured",
   [PatchStatus.Failed]: "Failed",
   [PatchStatus.Started]: "Running",
-  [PatchStatus.LegacySucceeded]: "Succeeded",
 };
 
 const treeData = [
@@ -55,11 +54,6 @@ const treeData = [
     title: statusValToCopy[PatchStatus.Started],
     value: PatchStatus.Started,
     key: PatchStatus.Started,
-  },
-  {
-    title: statusValToCopy[PatchStatus.LegacySucceeded],
-    value: PatchStatus.LegacySucceeded,
-    key: PatchStatus.LegacySucceeded,
   },
   {
     title: statusValToCopy[PatchStatus.Failed],

--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -387,6 +387,7 @@ export type Distro = {
   disableShallowClone: Scalars["Boolean"]["output"];
   disabled: Scalars["Boolean"]["output"];
   dispatcherSettings: DispatcherSettings;
+  execUser: Scalars["String"]["output"];
   expansions: Array<Expansion>;
   finderSettings: FinderSettings;
   homeVolumeSettings: HomeVolumeSettings;
@@ -395,7 +396,7 @@ export type Distro = {
   imageId: Scalars["String"]["output"];
   isCluster: Scalars["Boolean"]["output"];
   isVirtualWorkStation: Scalars["Boolean"]["output"];
-  mountpoints?: Maybe<Array<Scalars["String"]["output"]>>;
+  mountpoints: Array<Scalars["String"]["output"]>;
   name: Scalars["String"]["output"];
   note: Scalars["String"]["output"];
   plannerSettings: PlannerSettings;
@@ -453,6 +454,7 @@ export type DistroInput = {
   disableShallowClone: Scalars["Boolean"]["input"];
   disabled: Scalars["Boolean"]["input"];
   dispatcherSettings: DispatcherSettingsInput;
+  execUser?: InputMaybe<Scalars["String"]["input"]>;
   expansions: Array<ExpansionInput>;
   finderSettings: FinderSettingsInput;
   homeVolumeSettings: HomeVolumeSettingsInput;
@@ -771,11 +773,6 @@ export type Host = {
 export type HostEventsArgs = {
   opts: HostEventsInput;
 };
-
-export enum HostAccessLevel {
-  Edit = "EDIT",
-  View = "VIEW",
-}
 
 export type HostAllocatorSettings = {
   __typename?: "HostAllocatorSettings";
@@ -6136,7 +6133,7 @@ export type DistroQuery = {
     imageId: string;
     isCluster: boolean;
     isVirtualWorkStation: boolean;
-    mountpoints?: Array<string> | null;
+    mountpoints: Array<string>;
     name: string;
     note: string;
     provider: Provider;

--- a/apps/spruce/src/pages/projectSettings/tabs/PatchAliasesTab/transformers.ts
+++ b/apps/spruce/src/pages/projectSettings/tabs/PatchAliasesTab/transformers.ts
@@ -1,5 +1,4 @@
 import { ProjectSettingsTabRoutes } from "constants/routes";
-import { PatchStatus } from "types/patch";
 import { FormToGqlFunction, GqlToFormFunction } from "../types";
 import { alias as aliasUtils, ProjectType } from "../utils";
 import { TaskSpecifier } from "./types";
@@ -7,15 +6,6 @@ import { TaskSpecifier } from "./types";
 const { sortAliases, transformAliases } = aliasUtils;
 
 type Tab = ProjectSettingsTabRoutes.PatchAliases;
-
-// Ensure that the front end can ingest patch trigger alias status filters that use either "success" or "succeeded" and convert them to "success".
-// TODO EVG-20032: Remove conversion.
-const migrateSuccessStatus = (status: string) => {
-  if (status === PatchStatus.LegacySucceeded) {
-    return PatchStatus.Success;
-  }
-  return status ?? "";
-};
 
 // @ts-expect-error: FIXME. This comment was added by an automated script.
 export const gqlToForm: GqlToFormFunction<Tab> = ((data, options) => {
@@ -55,7 +45,7 @@ export const gqlToForm: GqlToFormFunction<Tab> = ((data, options) => {
                 ? TaskSpecifier.PatchAlias
                 : TaskSpecifier.VariantTask,
             })) ?? [],
-          status: migrateSuccessStatus(p.status),
+          status: p.status,
           parentAsModule: p.parentAsModule ?? "",
           downstreamRevision: p.downstreamRevision ?? "",
           isGithubTriggerAlias: githubTriggerAliases?.includes(p.alias),

--- a/apps/spruce/src/pages/projectSettings/tabs/utils/types.ts
+++ b/apps/spruce/src/pages/projectSettings/tabs/utils/types.ts
@@ -10,7 +10,6 @@ export enum ProjectType {
 
 export const PatchTriggerAliasStatus = {
   "*": "Any completed status",
-  [PatchStatus.LegacySucceeded]: "Success",
   [PatchStatus.Success]: "Success",
   [PatchStatus.Failed]: "Failure",
 } as const;

--- a/apps/spruce/src/types/patch.ts
+++ b/apps/spruce/src/types/patch.ts
@@ -13,8 +13,6 @@ export enum PatchStatus {
   Created = "created",
   Failed = "failed",
   Started = "started",
-  // TODO EVG-20032: Remove legacy status
-  LegacySucceeded = "succeeded",
   Success = "success",
   Aborted = "aborted",
 }


### PR DESCRIPTION
DEVPROD-13116
<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
I found some todos that were left over from https://jira.mongodb.org/browse/DEVPROD-650 around removing a legacy success status. It looks like the backend ticket was completed but the frontend TODO's remained


### Evergreen PR
Some backend data will need to change 
https://github.com/evergreen-ci/evergreen/pull/8514