### PR TITLE
DEVPROD-12987: Fix event log key renderer

### DIFF
--- a/apps/spruce/src/components/Settings/EventLog/eventLogDiffs.test.ts
+++ b/apps/spruce/src/components/Settings/EventLog/eventLogDiffs.test.ts
@@ -1,6 +1,6 @@
 import { Subset } from "@evg-ui/lib/types/utils";
 import { ProjectEventSettings } from "gql/generated/types";
-import { getEventDiffLines } from "./eventLogDiffs";
+import { formatArrayElements, getEventDiffLines } from "./eventLogDiffs";
 
 const beforeAddition: Subset<ProjectEventSettings> = {
   __typename: "ProjectEventSettings",
@@ -147,5 +147,19 @@ describe("should transform event diffs to key, before and after", () => {
         after: undefined,
       },
     ]);
+  });
+});
+
+describe("formatArrayElements", () => {
+  it("matches on numbers indicating array position", () => {
+    expect(formatArrayElements("foo.1.bar")).toEqual("foo[1].bar");
+  });
+
+  it("matches on array elements that end the string", () => {
+    expect(formatArrayElements("admins.1")).toEqual("admins[1]");
+  });
+
+  it("does not match on numbers in variable names", () => {
+    expect(formatArrayElements("foo.test123")).toEqual("foo.test123");
   });
 });

--- a/apps/spruce/src/components/Settings/EventLog/eventLogDiffs.ts
+++ b/apps/spruce/src/components/Settings/EventLog/eventLogDiffs.ts
@@ -24,8 +24,8 @@ const getDiffProperties = (eventObj: object): string[] => {
   return paths(eventObj);
 };
 
-const formatArrayElements = (eventKey: string): string =>
-  eventKey.replace(/.[0-9]./g, (x) => `[${x[1]}].`);
+export const formatArrayElements = (eventKey: string): string =>
+  eventKey.replace(/\.[0-9]/g, (x) => `[${x[1]}]`);
 
 const getNestedObject = (nestedObj: object, pathArr: string[]): EventValue =>
   // @ts-expect-error: FIXME. This comment was added by an automated script.


### PR DESCRIPTION
DEVPROD-12987
<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
<!-- add description, context, thought process, etc -->
Fix regex used to format event log entries that contain an array so that numbers in variable names are not incorrectly array-ified.

### Screenshots
<!-- add screenshots of visible changes -->
<img width="179" alt="image" src="https://github.com/user-attachments/assets/3cde8f5e-26e0-4fc0-bfec-9282089e6dc0">


### Testing
<!-- add a description of how you tested it -->
Add test that fails without change