### PR TITLE
DEVPROD-10037 Indicate downstream patches have been scheduled

### DIFF
--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -5563,7 +5563,11 @@ export type SchedulePatchMutation = {
     description: string;
     id: string;
     status: string;
-    versionFull?: { __typename?: "Version"; id: string } | null;
+    versionFull?: {
+      __typename?: "Version";
+      id: string;
+      childVersions?: Array<{ __typename?: "Version"; id: string }> | null;
+    } | null;
     parameters: Array<{ __typename?: "Parameter"; key: string; value: string }>;
     variantsTasks: Array<{
       __typename?: "VariantTask";

--- a/apps/spruce/src/gql/mutations/schedule-patch.graphql
+++ b/apps/spruce/src/gql/mutations/schedule-patch.graphql
@@ -6,6 +6,9 @@ mutation SchedulePatch($patchId: String!, $configure: PatchConfigure!) {
     tasks
     variants
     versionFull {
+      childVersions {
+        id
+      }
       id
     }
   }

--- a/apps/spruce/src/pages/configurePatch/configurePatchCore/index.tsx
+++ b/apps/spruce/src/pages/configurePatch/configurePatchCore/index.tsx
@@ -121,7 +121,10 @@ const ConfigurePatchCore: React.FC<ConfigurePatchCoreProps> = ({ patch }) => {
   >(SCHEDULE_PATCH, {
     onCompleted(data) {
       const { schedulePatch: scheduledPatch } = data;
-      dispatchToast.success("Successfully scheduled the patch");
+      const hasChildPatch = scheduledPatch.versionFull?.childVersions?.length;
+      dispatchToast.success(
+        `Successfully scheduled the patch${hasChildPatch ? " and its child patches" : ""}`,
+      );
       // @ts-expect-error: FIXME. This comment was added by an automated script.
       navigate(getVersionRoute(scheduledPatch.versionFull.id));
     },

--- a/apps/spruce/src/pages/version/VersionTabs.tsx
+++ b/apps/spruce/src/pages/version/VersionTabs.tsx
@@ -63,6 +63,14 @@ const getDownstreamTabName = (
       />
     );
   }
+  return (
+    <TabLabelWithBadge
+      badgeText={0}
+      badgeVariant="lightgray"
+      dataCyBadge="downstream-tab-badge"
+      tabLabel="Downstream Projects"
+    />
+  );
 };
 
 const tabMap = ({


### PR DESCRIPTION
DEVPROD-10037
<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
Update the Schedule patches confirmation toast to indicate that child patches have been scheduled.
Also fix a bug where the downstream projects tab is initially empty. I think a combination of both of these lead to the confusion in the ticket.
### Screenshots
<img width="1424" alt="image" src="https://github.com/user-attachments/assets/2f2fa706-2d40-4c86-9976-42264d97d1e9">

