### PR TITLE
DEVPROD-11708: Remove TODOs for dynamic commit count

### DIFF
--- a/apps/spruce/src/pages/waterfall/index.tsx
+++ b/apps/spruce/src/pages/waterfall/index.tsx
@@ -61,7 +61,6 @@ const Waterfall: React.FC = () => {
             startTransition(() => handleOnRemove(b));
           }}
         />
-        {/* TODO DEVPROD-11708: Use dynamic column limit in skeleton */}
         <Suspense
           fallback={
             <TableSkeleton

--- a/apps/spruce/src/pages/waterfall/styles.ts
+++ b/apps/spruce/src/pages/waterfall/styles.ts
@@ -9,7 +9,6 @@ const BUILD_VARIANT_WIDTH = 200;
 const INACTIVE_WIDTH = 80;
 export const SQUARE_SIZE = 16;
 
-// TODO DEVPROD-11708: Update with dynamic column count
 export const VERSION_LIMIT = 5;
 
 export const columnBasis = css`


### PR DESCRIPTION
DEVPROD-11708
<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
<!-- add description, context, thought process, etc -->
Based on feedback in the focus group Slack channel and a conversation with Will, users seem to actually prefer fewer commits and lots more space for build variants on a big screen. Our grid scales well enough to handle this, so this PR just removes the TODOs around a dynamic commit limit.