### PR TITLE
DEVPROD-9579: Disable reconfigure button for GitHub merge queue patches

### DIFF
--- a/apps/spruce/src/components/PatchesPage/ListArea/PatchCard/DropdownMenu.tsx
+++ b/apps/spruce/src/components/PatchesPage/ListArea/PatchCard/DropdownMenu.tsx
@@ -10,11 +10,13 @@ import {
 
 interface Props {
   hasVersion: boolean;
+  isMergeQueuePatch: boolean;
   isPatchHidden: boolean;
   patchId: string;
 }
 export const DropdownMenu: React.FC<Props> = ({
   hasVersion,
+  isMergeQueuePatch,
   isPatchHidden,
   patchId,
 }) => {
@@ -22,6 +24,7 @@ export const DropdownMenu: React.FC<Props> = ({
   const dropdownItems = [
     <LinkToReconfigurePage
       key="reconfigure"
+      disabled={isMergeQueuePatch}
       hasVersion={hasVersion}
       patchId={patchId}
     />,

--- a/apps/spruce/src/components/PatchesPage/ListArea/PatchCard/index.tsx
+++ b/apps/spruce/src/components/PatchesPage/ListArea/PatchCard/index.tsx
@@ -8,6 +8,7 @@ import { GroupedTaskStatusBadge } from "components/GroupedTaskStatusBadge";
 import { PatchStatusBadge } from "components/PatchStatusBadge";
 import { StyledRouterLink } from "components/styles";
 import { unlinkedPRUsers } from "constants/patch";
+import { Requester } from "constants/requesters";
 import {
   getProjectPatchesRoute,
   getVersionRoute,
@@ -50,10 +51,11 @@ const PatchCard: React.FC<PatchCardProps> = ({ pageType, patch }) => {
   } = patch;
   // @ts-expect-error: FIXME. This comment was added by an automated script.
   const createDate = new Date(createTime);
-  const { id: versionId, taskStatusStats } = versionFull || {};
+  const { id: versionId, requester, taskStatusStats } = versionFull || {};
   const { stats } = groupStatusesByUmbrellaStatus(
     taskStatusStats?.counts ?? [],
   );
+  const isMergeQueuePatch = requester === Requester.GitHubMergeQueue;
 
   let patchProject = null;
   if (pageType === "project") {
@@ -127,6 +129,7 @@ const PatchCard: React.FC<PatchCardProps> = ({ pageType, patch }) => {
         {hidden && <Badge data-cy="hidden-badge">Hidden</Badge>}
         <DropdownMenu
           hasVersion={!!versionId}
+          isMergeQueuePatch={isMergeQueuePatch}
           isPatchHidden={hidden}
           patchId={id}
         />

--- a/apps/spruce/src/components/PatchesPage/ListArea/testData.ts
+++ b/apps/spruce/src/components/PatchesPage/ListArea/testData.ts
@@ -18,6 +18,7 @@ const patchData = {
   versionFull: {
     id: "667b2f7f7a878200076f23d1",
     status: "failed",
+    requester: "patch_request",
     taskStatusStats: {
       counts: [
         {

--- a/apps/spruce/src/gql/fragments/patchesPage.graphql
+++ b/apps/spruce/src/gql/fragments/patchesPage.graphql
@@ -18,6 +18,7 @@ fragment PatchesPagePatches on Patches {
     status
     versionFull {
       id
+      requester
       status
       taskStatusStats(options: {}) {
         counts {

--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -3802,6 +3802,7 @@ export type PatchesPagePatchesFragment = {
     versionFull?: {
       __typename?: "Version";
       id: string;
+      requester: string;
       status: string;
       taskStatusStats?: {
         __typename?: "TaskStats";
@@ -7730,6 +7731,7 @@ export type ProjectPatchesQuery = {
         versionFull?: {
           __typename?: "Version";
           id: string;
+          requester: string;
           status: string;
           taskStatusStats?: {
             __typename?: "TaskStats";
@@ -9388,6 +9390,7 @@ export type UserPatchesQuery = {
         versionFull?: {
           __typename?: "Version";
           id: string;
+          requester: string;
           status: string;
           taskStatusStats?: {
             __typename?: "TaskStats";

--- a/apps/spruce/src/pages/Version.tsx
+++ b/apps/spruce/src/pages/Version.tsx
@@ -10,6 +10,7 @@ import {
   PageLayout,
   PageSider,
 } from "components/styles";
+import { Requester } from "constants/requesters";
 import { slugs } from "constants/routes";
 import { useToastContext } from "context/toast";
 import { VersionQuery, VersionQueryVariables } from "gql/generated/types";
@@ -65,6 +66,7 @@ export const VersionPage: React.FC = () => {
     order,
     patch,
     projectIdentifier,
+    requester,
     revision,
     status,
     warnings,
@@ -102,10 +104,10 @@ export const VersionPage: React.FC = () => {
         badge={<PatchStatusBadge status={status} />}
         buttons={
           <ActionButtons
-            // @ts-expect-error: FIXME. This comment was added by an automated script.
-            canReconfigure={isPatch}
-            // @ts-expect-error: FIXME. This comment was added by an automated script.
-            isPatch={isPatch}
+            canReconfigure={
+              !!isPatch && requester !== Requester.GitHubMergeQueue
+            }
+            isPatch={!!isPatch}
             // @ts-expect-error: FIXME. This comment was added by an automated script.
             versionId={versionId}
           />


### PR DESCRIPTION
DEVPROD-9579
<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
Disable reconfiguring a patch if it is a GitHub merge queue patch.

### Screenshots
<!-- add screenshots of visible changes -->
<img width="540" alt="Screenshot 2024-12-09 at 2 49 10 PM" src="https://github.com/user-attachments/assets/c62d6d44-e590-4144-aaa2-1245a36949a5">

<img width="540" alt="Screenshot 2024-12-09 at 2 49 22 PM" src="https://github.com/user-attachments/assets/3ff1127a-0fc0-48e6-b5f2-c595af16dce3">



