### PR TITLE
DEVPROD-13825: Use displayStatusCache instead of displayStatus

### DIFF
--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -2784,6 +2784,7 @@ export type Task = {
   activatedTime?: Maybe<Scalars["Time"]["output"]>;
   ami?: Maybe<Scalars["String"]["output"]>;
   annotation?: Maybe<Annotation>;
+  /** This is a base task's display status. */
   baseStatus?: Maybe<Scalars["String"]["output"]>;
   baseTask?: Maybe<Task>;
   blocked: Scalars["Boolean"]["output"];
@@ -2806,6 +2807,7 @@ export type Task = {
   dispatchTime?: Maybe<Scalars["Time"]["output"]>;
   displayName: Scalars["String"]["output"];
   displayOnly?: Maybe<Scalars["Boolean"]["output"]>;
+  /** This is a task's display status and is what is commonly used on the UI. */
   displayStatus: Scalars["String"]["output"];
   displayTask?: Maybe<Task>;
   distroId: Scalars["String"]["output"];
@@ -2843,11 +2845,7 @@ export type Task = {
   scheduledTime?: Maybe<Scalars["Time"]["output"]>;
   spawnHostLink?: Maybe<Scalars["String"]["output"]>;
   startTime?: Maybe<Scalars["Time"]["output"]>;
-  /**
-   * This is a task's display status and is what is commonly used on the UI.
-   * In future releases this will be migrated to represent the original status of the task
-   * @deprecated use displayStatus instead. Status will be migrated to reflect the original status
-   */
+  /** This is a task's original status. It is the status stored in the database, and is distinct from the displayStatus. */
   status: Scalars["String"]["output"];
   stepbackInfo?: Maybe<StepbackInfo>;
   tags: Array<Scalars["String"]["output"]>;
@@ -3500,6 +3498,7 @@ export type WaterfallTask = {
   __typename?: "WaterfallTask";
   displayName: Scalars["String"]["output"];
   displayStatus: Scalars["String"]["output"];
+  displayStatusCache: Scalars["String"]["output"];
   execution: Scalars["Int"]["output"];
   id: Scalars["String"]["output"];
   status: Scalars["String"]["output"];
@@ -9779,7 +9778,7 @@ export type WaterfallQuery = {
         tasks: Array<{
           __typename?: "WaterfallTask";
           displayName: string;
-          displayStatus: string;
+          displayStatusCache: string;
           execution: number;
           id: string;
           status: string;

--- a/apps/spruce/src/gql/queries/waterfall.graphql
+++ b/apps/spruce/src/gql/queries/waterfall.graphql
@@ -9,7 +9,7 @@ query Waterfall($options: WaterfallOptions!) {
         id
         tasks {
           displayName
-          displayStatus
+          displayStatusCache
           execution
           id
           status

--- a/apps/spruce/src/pages/waterfall/BuildRow.tsx
+++ b/apps/spruce/src/pages/waterfall/BuildRow.tsx
@@ -118,18 +118,21 @@ const BuildGrid: React.FC<{
       );
     }}
   >
-    {build.tasks.map(({ displayName, displayStatus, execution, id }) => {
-      const taskStatus = displayStatus as TaskStatus;
-      return (
-        <SquareMemo
-          key={id}
-          data-tooltip={`${displayName} - ${taskStatusToCopy[taskStatus]}`}
-          isRightmostBuild={isRightmostBuild}
-          status={taskStatus}
-          to={getTaskRoute(id, { execution })}
-        />
-      );
-    })}
+    {build.tasks.map(
+      ({ displayName, displayStatusCache, execution, id, status }) => {
+        // Use status as backup for tasks created before displayStatusCache was introduced
+        const taskStatus = (displayStatusCache || status) as TaskStatus;
+        return (
+          <SquareMemo
+            key={id}
+            data-tooltip={`${displayName} - ${taskStatusToCopy[taskStatus]}`}
+            isRightmostBuild={isRightmostBuild}
+            status={taskStatus}
+            to={getTaskRoute(id, { execution })}
+          />
+        );
+      },
+    )}
   </BuildContainer>
 );
 

--- a/apps/spruce/src/pages/waterfall/useFilters.test.tsx
+++ b/apps/spruce/src/pages/waterfall/useFilters.test.tsx
@@ -442,14 +442,14 @@ const waterfall = {
           tasks: [
             {
               displayName: "Task 20",
-              displayStatus: "started",
+              displayStatusCache: "started",
               execution: 0,
               id: "task_20",
               status: "started",
             },
             {
               displayName: "Task 15",
-              displayStatus: "started",
+              displayStatusCache: "started",
               execution: 0,
               id: "task_15",
               status: "started",
@@ -471,7 +471,7 @@ const waterfall = {
           tasks: [
             {
               displayName: "Task 100",
-              displayStatus: "started",
+              displayStatusCache: "started",
               execution: 0,
               id: "task_100",
               status: "started",
@@ -493,14 +493,14 @@ const waterfall = {
           tasks: [
             {
               displayName: "Task 1",
-              displayStatus: "",
+              displayStatusCache: "",
               execution: 0,
               id: "task_1",
               status: "success",
             },
             {
               displayName: "Task 2",
-              displayStatus: "task-timed-out",
+              displayStatusCache: "task-timed-out",
               execution: 0,
               id: "task_2",
               status: "failed",

--- a/apps/spruce/src/pages/waterfall/useFilters.ts
+++ b/apps/spruce/src/pages/waterfall/useFilters.ts
@@ -175,7 +175,9 @@ const matchesStatuses = (
 ) =>
   statuses.length
     ? statuses.some((s) =>
-        task.displayStatus ? task.displayStatus === s : task.status === s,
+        task.displayStatusCache
+          ? task.displayStatusCache === s
+          : task.status === s,
       )
     : true;
 


### PR DESCRIPTION
DEVPROD-13825
<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
<!-- add description, context, thought process, etc -->
Use `displayStatusCache` instead of `displayStatus` field. Also use `status` as a fallback for tasks that lack `displayStatusCache`.

### Testing
<!-- add a description of how you tested it -->
Updated tests

<!-- Have you have updated the analytics documentation if necessary?  
https://docs.google.com/spreadsheets/d/1s4_nq8ZiphXp5Uq_-9HT6GPqz-KOyaq6HuvmXYaSNzg/edit?usp=sharing -->

### Evergreen PR
<!-- link to a corresponding Evergreen PR if applicable -->
https://github.com/evergreen-ci/evergreen/pull/8595