### PR TITLE
DEVPROD-13928 Ensure displayStatus is used for ExecutionTasksTable

### DIFF
--- a/apps/spruce/src/components/TasksTable/Columns.tsx
+++ b/apps/spruce/src/components/TasksTable/Columns.tsx
@@ -103,7 +103,7 @@ export const getColumnsTemplate = ({
   },
   {
     id: TaskSortCategory.BaseStatus,
-    accessorKey: "baseStatus",
+    accessorKey: "baseTask.displayStatus",
     header: `${isPatch ? "Base" : "Previous"} Status`,
     cell: ({
       getValue,

--- a/apps/spruce/src/components/TasksTable/Columns.tsx
+++ b/apps/spruce/src/components/TasksTable/Columns.tsx
@@ -53,7 +53,7 @@ export const getColumnsTemplate = ({
     size: 300,
   },
   {
-    accessorKey: "status",
+    accessorKey: "displayStatus",
     id: TaskSortCategory.Status,
     header: "Task Status",
     cell: ({
@@ -103,7 +103,7 @@ export const getColumnsTemplate = ({
   },
   {
     id: TaskSortCategory.BaseStatus,
-    accessorKey: "baseTask.status",
+    accessorKey: "baseStatus",
     header: `${isPatch ? "Base" : "Previous"} Status`,
     cell: ({
       getValue,

--- a/apps/spruce/src/components/TasksTable/types.ts
+++ b/apps/spruce/src/components/TasksTable/types.ts
@@ -5,12 +5,12 @@ export type TaskTableInfo = {
     displayStatus: string;
   };
   buildVariant?: string;
-  buildVariantDisplayName?: string;
+  buildVariantDisplayName?: string | null;
   dependsOn?: Array<{ name: string }>;
   displayName: string;
   execution: number;
   executionTasksFull?: TaskTableInfo[];
   id: string;
-  projectIdentifier?: string;
+  projectIdentifier?: string | null;
   displayStatus: string;
 };

--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -2784,6 +2784,7 @@ export type Task = {
   activatedTime?: Maybe<Scalars["Time"]["output"]>;
   ami?: Maybe<Scalars["String"]["output"]>;
   annotation?: Maybe<Annotation>;
+  /** This is a base task's display status. */
   baseStatus?: Maybe<Scalars["String"]["output"]>;
   baseTask?: Maybe<Task>;
   blocked: Scalars["Boolean"]["output"];
@@ -2806,6 +2807,7 @@ export type Task = {
   dispatchTime?: Maybe<Scalars["Time"]["output"]>;
   displayName: Scalars["String"]["output"];
   displayOnly?: Maybe<Scalars["Boolean"]["output"]>;
+  /** This is a task's display status and is what is commonly used on the UI. */
   displayStatus: Scalars["String"]["output"];
   displayTask?: Maybe<Task>;
   distroId: Scalars["String"]["output"];
@@ -2843,11 +2845,7 @@ export type Task = {
   scheduledTime?: Maybe<Scalars["Time"]["output"]>;
   spawnHostLink?: Maybe<Scalars["String"]["output"]>;
   startTime?: Maybe<Scalars["Time"]["output"]>;
-  /**
-   * This is a task's display status and is what is commonly used on the UI.
-   * In future releases this will be migrated to represent the original status of the task
-   * @deprecated use displayStatus instead. Status will be migrated to reflect the original status
-   */
+  /** This is a task's original status. It is the status stored in the database, and is distinct from the displayStatus. */
   status: Scalars["String"]["output"];
   stepbackInfo?: Maybe<StepbackInfo>;
   tags: Array<Scalars["String"]["output"]>;
@@ -3500,6 +3498,7 @@ export type WaterfallTask = {
   __typename?: "WaterfallTask";
   displayName: Scalars["String"]["output"];
   displayStatus: Scalars["String"]["output"];
+  displayStatusCache: Scalars["String"]["output"];
   execution: Scalars["Int"]["output"];
   id: Scalars["String"]["output"];
   status: Scalars["String"]["output"];
@@ -9211,7 +9210,6 @@ export type TaskQuery = {
     } | null;
     executionTasksFull?: Array<{
       __typename?: "Task";
-      baseStatus?: string | null;
       buildVariant: string;
       buildVariantDisplayName?: string | null;
       displayName: string;
@@ -9219,6 +9217,7 @@ export type TaskQuery = {
       execution: number;
       id: string;
       projectIdentifier?: string | null;
+      revision?: string | null;
     }> | null;
     files: { __typename?: "TaskFiles"; fileCount: number };
     logs: {

--- a/apps/spruce/src/gql/queries/task.graphql
+++ b/apps/spruce/src/gql/queries/task.graphql
@@ -66,7 +66,7 @@ query Task($taskId: String!, $execution: Int) {
     distroId
     estimatedStart
     executionTasksFull {
-      baseStatus
+      ...BaseTask
       buildVariant
       buildVariantDisplayName
       displayName

--- a/apps/spruce/src/pages/task/taskTabs/ExecutionTasksTable/ExecutionTasksTable.stories.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/ExecutionTasksTable/ExecutionTasksTable.stories.tsx
@@ -29,7 +29,11 @@ export const MultipleExecutions: CustomStoryObj<typeof ExecutionTasksTable> = {
 const singleExecution = [
   {
     execution: 5,
-    baseStatus: "success",
+    baseTask: {
+      id: "some_id_5_base",
+      execution: 5,
+      displayStatus: "success",
+    },
     buildVariant: "Windows",
     buildVariantDisplayName: "Windows 97",
     displayName: "Some fancy execution task",
@@ -39,6 +43,11 @@ const singleExecution = [
   {
     execution: 5,
     baseStatus: "success",
+    baseTask: {
+      id: "some_id_6_base",
+      execution: 5,
+      displayStatus: "success",
+    },
     buildVariant: "Windows",
     buildVariantDisplayName: "Windows 97",
     displayName: "Another execution task",
@@ -50,7 +59,11 @@ const singleExecution = [
 const multipleExecutions = [
   {
     execution: 14,
-    baseStatus: "success",
+    baseTask: {
+      displayStatus: "failed",
+      id: "some_id_5_base",
+      execution: 1,
+    },
     buildVariant: "Windows",
     buildVariantDisplayName: "Windows 97",
     displayName: "Some fancy execution task",
@@ -59,7 +72,11 @@ const multipleExecutions = [
   },
   {
     execution: 12,
-    baseStatus: "success",
+    baseTask: {
+      displayStatus: "success",
+      id: "some_id_6_base",
+      execution: 1,
+    },
     buildVariant: "Windows",
     buildVariantDisplayName: "Windows 97",
     displayName: "Another execution task",

--- a/apps/spruce/src/pages/task/taskTabs/ExecutionTasksTable/ExecutionTasksTable.stories.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/ExecutionTasksTable/ExecutionTasksTable.stories.tsx
@@ -1,6 +1,6 @@
 import { CustomStoryObj, CustomMeta } from "@evg-ui/lib/test_utils/types";
 
-import { ExecutionTasksTable } from "./ExecutionTasksTable";
+import { ExecutionTasksTable } from ".";
 
 export default {
   component: ExecutionTasksTable,
@@ -34,7 +34,7 @@ const singleExecution = [
     buildVariantDisplayName: "Windows 97",
     displayName: "Some fancy execution task",
     id: "some_id_5",
-    status: "success",
+    displayStatus: "success",
   },
   {
     execution: 5,
@@ -43,7 +43,7 @@ const singleExecution = [
     buildVariantDisplayName: "Windows 97",
     displayName: "Another execution task",
     id: "some_id_6",
-    status: "success",
+    displayStatus: "success",
   },
 ];
 
@@ -55,7 +55,7 @@ const multipleExecutions = [
     buildVariantDisplayName: "Windows 97",
     displayName: "Some fancy execution task",
     id: "some_id_5",
-    status: "success",
+    displayStatus: "success",
   },
   {
     execution: 12,
@@ -64,6 +64,6 @@ const multipleExecutions = [
     buildVariantDisplayName: "Windows 97",
     displayName: "Another execution task",
     id: "some_id_6",
-    status: "success",
+    displayStatus: "success",
   },
 ];

--- a/apps/spruce/src/pages/task/taskTabs/ExecutionTasksTable/__snapshots__/ExecutionTasksTable_MultipleExecutions.storyshot
+++ b/apps/spruce/src/pages/task/taskTabs/ExecutionTasksTable/__snapshots__/ExecutionTasksTable_MultipleExecutions.storyshot
@@ -238,7 +238,14 @@
             <div
               class="leafygreen-ui-15rig1x"
               data-state="entered"
-            />
+            >
+              <div
+                class="css-o6pfbz-StyledBadge-badgeWidthMaxContent ehwsjr70 leafygreen-ui-1ciuhbt"
+                data-cy="task-status-badge"
+              >
+                Succeeded
+              </div>
+            </div>
           </td>
           <td
             class="leafygreen-ui-1by885u"
@@ -327,7 +334,14 @@
             <div
               class="leafygreen-ui-15rig1x"
               data-state="entered"
-            />
+            >
+              <div
+                class="css-o6pfbz-StyledBadge-badgeWidthMaxContent ehwsjr70 leafygreen-ui-1ciuhbt"
+                data-cy="task-status-badge"
+              >
+                Succeeded
+              </div>
+            </div>
           </td>
           <td
             class="leafygreen-ui-1by885u"

--- a/apps/spruce/src/pages/task/taskTabs/ExecutionTasksTable/__snapshots__/ExecutionTasksTable_MultipleExecutions.storyshot
+++ b/apps/spruce/src/pages/task/taskTabs/ExecutionTasksTable/__snapshots__/ExecutionTasksTable_MultipleExecutions.storyshot
@@ -239,12 +239,16 @@
               class="leafygreen-ui-15rig1x"
               data-state="entered"
             >
-              <div
-                class="css-o6pfbz-StyledBadge-badgeWidthMaxContent ehwsjr70 leafygreen-ui-1ciuhbt"
-                data-cy="task-status-badge"
+              <a
+                href="/task/some_id_5_base?execution=1"
               >
-                Succeeded
-              </div>
+                <div
+                  class="css-o6pfbz-StyledBadge-badgeWidthMaxContent ehwsjr70 leafygreen-ui-dhdzha"
+                  data-cy="task-status-badge"
+                >
+                  Failed
+                </div>
+              </a>
             </div>
           </td>
           <td
@@ -335,12 +339,16 @@
               class="leafygreen-ui-15rig1x"
               data-state="entered"
             >
-              <div
-                class="css-o6pfbz-StyledBadge-badgeWidthMaxContent ehwsjr70 leafygreen-ui-1ciuhbt"
-                data-cy="task-status-badge"
+              <a
+                href="/task/some_id_6_base?execution=1"
               >
-                Succeeded
-              </div>
+                <div
+                  class="css-o6pfbz-StyledBadge-badgeWidthMaxContent ehwsjr70 leafygreen-ui-1ciuhbt"
+                  data-cy="task-status-badge"
+                >
+                  Succeeded
+                </div>
+              </a>
             </div>
           </td>
           <td

--- a/apps/spruce/src/pages/task/taskTabs/ExecutionTasksTable/__snapshots__/ExecutionTasksTable_SingleExecution.storyshot
+++ b/apps/spruce/src/pages/task/taskTabs/ExecutionTasksTable/__snapshots__/ExecutionTasksTable_SingleExecution.storyshot
@@ -233,12 +233,16 @@
               class="leafygreen-ui-15rig1x"
               data-state="entered"
             >
-              <div
-                class="css-o6pfbz-StyledBadge-badgeWidthMaxContent ehwsjr70 leafygreen-ui-1ciuhbt"
-                data-cy="task-status-badge"
+              <a
+                href="/task/some_id_5_base?execution=5"
               >
-                Succeeded
-              </div>
+                <div
+                  class="css-o6pfbz-StyledBadge-badgeWidthMaxContent ehwsjr70 leafygreen-ui-1ciuhbt"
+                  data-cy="task-status-badge"
+                >
+                  Succeeded
+                </div>
+              </a>
             </div>
           </td>
           <td
@@ -323,12 +327,16 @@
               class="leafygreen-ui-15rig1x"
               data-state="entered"
             >
-              <div
-                class="css-o6pfbz-StyledBadge-badgeWidthMaxContent ehwsjr70 leafygreen-ui-1ciuhbt"
-                data-cy="task-status-badge"
+              <a
+                href="/task/some_id_6_base?execution=5"
               >
-                Succeeded
-              </div>
+                <div
+                  class="css-o6pfbz-StyledBadge-badgeWidthMaxContent ehwsjr70 leafygreen-ui-1ciuhbt"
+                  data-cy="task-status-badge"
+                >
+                  Succeeded
+                </div>
+              </a>
             </div>
           </td>
           <td

--- a/apps/spruce/src/pages/task/taskTabs/ExecutionTasksTable/__snapshots__/ExecutionTasksTable_SingleExecution.storyshot
+++ b/apps/spruce/src/pages/task/taskTabs/ExecutionTasksTable/__snapshots__/ExecutionTasksTable_SingleExecution.storyshot
@@ -232,7 +232,14 @@
             <div
               class="leafygreen-ui-15rig1x"
               data-state="entered"
-            />
+            >
+              <div
+                class="css-o6pfbz-StyledBadge-badgeWidthMaxContent ehwsjr70 leafygreen-ui-1ciuhbt"
+                data-cy="task-status-badge"
+              >
+                Succeeded
+              </div>
+            </div>
           </td>
           <td
             class="leafygreen-ui-1by885u"
@@ -315,7 +322,14 @@
             <div
               class="leafygreen-ui-15rig1x"
               data-state="entered"
-            />
+            >
+              <div
+                class="css-o6pfbz-StyledBadge-badgeWidthMaxContent ehwsjr70 leafygreen-ui-1ciuhbt"
+                data-cy="task-status-badge"
+              >
+                Succeeded
+              </div>
+            </div>
           </td>
           <td
             class="leafygreen-ui-1by885u"

--- a/apps/spruce/src/pages/task/taskTabs/ExecutionTasksTable/index.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/ExecutionTasksTable/index.tsx
@@ -25,8 +25,7 @@ const { getDefaultOptions: getDefaultSorting } = RowSorting;
 
 interface Props {
   execution: number;
-  // @ts-expect-error: FIXME. This comment was added by an automated script.
-  executionTasksFull: TaskQuery["task"]["executionTasksFull"];
+  executionTasksFull: NonNullable<TaskQuery["task"]>["executionTasksFull"];
   isPatch: boolean;
 }
 


### PR DESCRIPTION
DEVPROD-13928
<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
Display statuses weren't being populated for the Execution Tasks table due to https://github.com/evergreen-ci/ui/pull/534
### Screenshots
Before:
<img width="1506" alt="image" src="https://github.com/user-attachments/assets/e8111b38-980e-4b77-94e1-99adb1a00216" />

After:
<img width="1500" alt="image" src="https://github.com/user-attachments/assets/dee2614e-b31a-40f1-86ee-3e724f67fbd6" />



