### PR TITLE
DEVPROD-13931 Ensure mainline commits are defined before trying to get task data

### DIFF
--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -2784,6 +2784,7 @@ export type Task = {
   activatedTime?: Maybe<Scalars["Time"]["output"]>;
   ami?: Maybe<Scalars["String"]["output"]>;
   annotation?: Maybe<Annotation>;
+  /** This is a base task's display status. */
   baseStatus?: Maybe<Scalars["String"]["output"]>;
   baseTask?: Maybe<Task>;
   blocked: Scalars["Boolean"]["output"];
@@ -2806,6 +2807,7 @@ export type Task = {
   dispatchTime?: Maybe<Scalars["Time"]["output"]>;
   displayName: Scalars["String"]["output"];
   displayOnly?: Maybe<Scalars["Boolean"]["output"]>;
+  /** This is a task's display status and is what is commonly used on the UI. */
   displayStatus: Scalars["String"]["output"];
   displayTask?: Maybe<Task>;
   distroId: Scalars["String"]["output"];
@@ -2843,11 +2845,7 @@ export type Task = {
   scheduledTime?: Maybe<Scalars["Time"]["output"]>;
   spawnHostLink?: Maybe<Scalars["String"]["output"]>;
   startTime?: Maybe<Scalars["Time"]["output"]>;
-  /**
-   * This is a task's display status and is what is commonly used on the UI.
-   * In future releases this will be migrated to represent the original status of the task
-   * @deprecated use displayStatus instead. Status will be migrated to reflect the original status
-   */
+  /** This is a task's original status. It is the status stored in the database, and is distinct from the displayStatus. */
   status: Scalars["String"]["output"];
   stepbackInfo?: Maybe<StepbackInfo>;
   tags: Array<Scalars["String"]["output"]>;
@@ -3500,6 +3498,7 @@ export type WaterfallTask = {
   __typename?: "WaterfallTask";
   displayName: Scalars["String"]["output"];
   displayStatus: Scalars["String"]["output"];
+  displayStatusCache: Scalars["String"]["output"];
   execution: Scalars["Int"]["output"];
   id: Scalars["String"]["output"];
   status: Scalars["String"]["output"];

--- a/apps/spruce/src/hooks/useBreakingTask/index.ts
+++ b/apps/spruce/src/hooks/useBreakingTask/index.ts
@@ -56,8 +56,9 @@ export const useBreakingTask = (taskId: string) => {
       },
     },
   });
-  // @ts-expect-error: FIXME. This comment was added by an automated script.
-  const task = getTaskFromMainlineCommitsQuery(breakingTaskData);
+  const task = breakingTaskData
+    ? getTaskFromMainlineCommitsQuery(breakingTaskData)
+    : undefined;
 
   return {
     task,

--- a/apps/spruce/src/hooks/useLastExecutedTask/index.ts
+++ b/apps/spruce/src/hooks/useLastExecutedTask/index.ts
@@ -49,8 +49,9 @@ export const useLastExecutedTask = (taskId: string) => {
       },
     },
   });
-  // @ts-expect-error: FIXME. This comment was added by an automated script.
-  const task = getTaskFromMainlineCommitsQuery(lastExecutedTaskData);
+  const task = lastExecutedTaskData
+    ? getTaskFromMainlineCommitsQuery(lastExecutedTaskData)
+    : undefined;
 
   return {
     task,

--- a/apps/spruce/src/hooks/useLastPassingTask/index.ts
+++ b/apps/spruce/src/hooks/useLastPassingTask/index.ts
@@ -48,8 +48,9 @@ export const useLastPassingTask = (taskId: string) => {
       },
     },
   });
-  // @ts-expect-error: FIXME. This comment was added by an automated script.
-  const task = getTaskFromMainlineCommitsQuery(lastPassingTaskData);
+  const task = lastPassingTaskData
+    ? getTaskFromMainlineCommitsQuery(lastPassingTaskData)
+    : undefined;
 
   return {
     task,

--- a/apps/spruce/src/hooks/useParentTask/index.ts
+++ b/apps/spruce/src/hooks/useParentTask/index.ts
@@ -48,8 +48,9 @@ export const useParentTask = (taskId: string) => {
       },
     },
   });
-  // @ts-expect-error: FIXME. This comment was added by an automated script.
-  const task = getTaskFromMainlineCommitsQuery(parentTaskData);
+  const task = parentTaskData
+    ? getTaskFromMainlineCommitsQuery(parentTaskData)
+    : undefined;
 
   return {
     task: task ?? baseTask,

--- a/apps/spruce/src/utils/getTaskFromMainlineCommitsQuery.ts
+++ b/apps/spruce/src/utils/getTaskFromMainlineCommitsQuery.ts
@@ -5,14 +5,9 @@ import { reportError } from "utils/errorReporting";
 // The return value from GetLastMainlineCommitQuery has a lot of nested fields that may or may
 // not exist. The logic to extract the task from it is written in this function.
 export const getTaskFromMainlineCommitsQuery = (
-  data: LastMainlineCommitQuery,
+  data: NonNullable<LastMainlineCommitQuery>,
 ): CommitTask | undefined => {
-  const { mainlineCommits } = data ?? {};
-  if (mainlineCommits === null || mainlineCommits === undefined) {
-    reportError(new Error("mainlineCommits is undefined")).warning();
-    return;
-  }
-  const mainlineCommitVersions = mainlineCommits.versions;
+  const mainlineCommitVersions = data.mainlineCommits?.versions;
   if (mainlineCommitVersions === null || mainlineCommitVersions === undefined) {
     reportError(new Error("mainlineCommits.versions is undefined")).warning();
     return;

--- a/apps/spruce/src/utils/getTaskFromMainlineCommitsQuery.ts
+++ b/apps/spruce/src/utils/getTaskFromMainlineCommitsQuery.ts
@@ -7,6 +7,7 @@ import { reportError } from "utils/errorReporting";
 export const getTaskFromMainlineCommitsQuery = (
   data: LastMainlineCommitQuery,
 ): CommitTask | undefined => {
+  console.log({ data });
   const { mainlineCommits } = data ?? {};
   if (mainlineCommits === null || mainlineCommits === undefined) {
     reportError(new Error("mainlineCommits is undefined")).warning();

--- a/apps/spruce/src/utils/getTaskFromMainlineCommitsQuery.ts
+++ b/apps/spruce/src/utils/getTaskFromMainlineCommitsQuery.ts
@@ -7,7 +7,6 @@ import { reportError } from "utils/errorReporting";
 export const getTaskFromMainlineCommitsQuery = (
   data: LastMainlineCommitQuery,
 ): CommitTask | undefined => {
-  console.log({ data });
   const { mainlineCommits } = data ?? {};
   if (mainlineCommits === null || mainlineCommits === undefined) {
     reportError(new Error("mainlineCommits is undefined")).warning();


### PR DESCRIPTION
DEVPROD-13931
<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
Adds an additional check that validates that the mainline commits query has returned data before trying to access it.
### Screenshots
<!-- add screenshots of visible changes -->

### Testing
No longer errors

### Evergreen PR
<!-- link to a corresponding Evergreen PR if applicable -->
