### PR TITLE
DEVPROD-13969: Remove task sync project settings [minor]

### DIFF
--- a/apps/parsley/src/gql/generated/types.ts
+++ b/apps/parsley/src/gql/generated/types.ts
@@ -1931,6 +1931,7 @@ export type Project = {
   stepbackBisect?: Maybe<Scalars["Boolean"]["output"]>;
   stepbackDisabled?: Maybe<Scalars["Boolean"]["output"]>;
   taskAnnotationSettings: TaskAnnotationSettings;
+  taskSync: TaskSyncOptions;
   tracksPushEvents?: Maybe<Scalars["Boolean"]["output"]>;
   triggers?: Maybe<Array<TriggerAlias>>;
   versionControlEnabled?: Maybe<Scalars["Boolean"]["output"]>;
@@ -2066,6 +2067,7 @@ export type ProjectInput = {
   stepbackBisect?: InputMaybe<Scalars["Boolean"]["input"]>;
   stepbackDisabled?: InputMaybe<Scalars["Boolean"]["input"]>;
   taskAnnotationSettings?: InputMaybe<TaskAnnotationSettingsInput>;
+  taskSync?: InputMaybe<TaskSyncOptionsInput>;
   tracksPushEvents?: InputMaybe<Scalars["Boolean"]["input"]>;
   triggers?: InputMaybe<Array<TriggerAliasInput>>;
   versionControlEnabled?: InputMaybe<Scalars["Boolean"]["input"]>;
@@ -2429,6 +2431,7 @@ export type RepoRef = {
   stepbackBisect?: Maybe<Scalars["Boolean"]["output"]>;
   stepbackDisabled: Scalars["Boolean"]["output"];
   taskAnnotationSettings: TaskAnnotationSettings;
+  taskSync: RepoTaskSyncOptions;
   tracksPushEvents: Scalars["Boolean"]["output"];
   triggers: Array<TriggerAlias>;
   versionControlEnabled: Scalars["Boolean"]["output"];
@@ -2475,6 +2478,7 @@ export type RepoRefInput = {
   stepbackBisect?: InputMaybe<Scalars["Boolean"]["input"]>;
   stepbackDisabled?: InputMaybe<Scalars["Boolean"]["input"]>;
   taskAnnotationSettings?: InputMaybe<TaskAnnotationSettingsInput>;
+  taskSync?: InputMaybe<TaskSyncOptionsInput>;
   tracksPushEvents?: InputMaybe<Scalars["Boolean"]["input"]>;
   triggers?: InputMaybe<Array<TriggerAliasInput>>;
   versionControlEnabled?: InputMaybe<Scalars["Boolean"]["input"]>;
@@ -2505,6 +2509,12 @@ export type RepoSettingsInput = {
   repoId: Scalars["String"]["input"];
   subscriptions?: InputMaybe<Array<SubscriptionInput>>;
   vars?: InputMaybe<ProjectVarsInput>;
+};
+
+export type RepoTaskSyncOptions = {
+  __typename?: "RepoTaskSyncOptions";
+  configEnabled: Scalars["Boolean"]["output"];
+  patchEnabled: Scalars["Boolean"]["output"];
 };
 
 export type RepoWorkstationConfig = {
@@ -2665,6 +2675,7 @@ export type SpawnHostInput = {
   sleepSchedule?: InputMaybe<SleepScheduleInput>;
   spawnHostsStartedByTask?: InputMaybe<Scalars["Boolean"]["input"]>;
   taskId?: InputMaybe<Scalars["String"]["input"]>;
+  taskSync?: InputMaybe<Scalars["Boolean"]["input"]>;
   useProjectSetupScript?: InputMaybe<Scalars["Boolean"]["input"]>;
   useTaskConfig?: InputMaybe<Scalars["Boolean"]["input"]>;
   userDataScript?: InputMaybe<Scalars["String"]["input"]>;
@@ -2787,6 +2798,7 @@ export type Task = {
   canRestart: Scalars["Boolean"]["output"];
   canSchedule: Scalars["Boolean"]["output"];
   canSetPriority: Scalars["Boolean"]["output"];
+  canSync: Scalars["Boolean"]["output"];
   canUnschedule: Scalars["Boolean"]["output"];
   containerAllocatedTime?: Maybe<Scalars["Time"]["output"]>;
   createTime?: Maybe<Scalars["Time"]["output"]>;
@@ -3021,6 +3033,17 @@ export type TaskStats = {
   __typename?: "TaskStats";
   counts?: Maybe<Array<StatusCount>>;
   eta?: Maybe<Scalars["Time"]["output"]>;
+};
+
+export type TaskSyncOptions = {
+  __typename?: "TaskSyncOptions";
+  configEnabled?: Maybe<Scalars["Boolean"]["output"]>;
+  patchEnabled?: Maybe<Scalars["Boolean"]["output"]>;
+};
+
+export type TaskSyncOptionsInput = {
+  configEnabled?: InputMaybe<Scalars["Boolean"]["input"]>;
+  patchEnabled?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
 /**

--- a/apps/parsley/src/gql/generated/types.ts
+++ b/apps/parsley/src/gql/generated/types.ts
@@ -1931,7 +1931,6 @@ export type Project = {
   stepbackBisect?: Maybe<Scalars["Boolean"]["output"]>;
   stepbackDisabled?: Maybe<Scalars["Boolean"]["output"]>;
   taskAnnotationSettings: TaskAnnotationSettings;
-  taskSync: TaskSyncOptions;
   tracksPushEvents?: Maybe<Scalars["Boolean"]["output"]>;
   triggers?: Maybe<Array<TriggerAlias>>;
   versionControlEnabled?: Maybe<Scalars["Boolean"]["output"]>;
@@ -2067,7 +2066,6 @@ export type ProjectInput = {
   stepbackBisect?: InputMaybe<Scalars["Boolean"]["input"]>;
   stepbackDisabled?: InputMaybe<Scalars["Boolean"]["input"]>;
   taskAnnotationSettings?: InputMaybe<TaskAnnotationSettingsInput>;
-  taskSync?: InputMaybe<TaskSyncOptionsInput>;
   tracksPushEvents?: InputMaybe<Scalars["Boolean"]["input"]>;
   triggers?: InputMaybe<Array<TriggerAliasInput>>;
   versionControlEnabled?: InputMaybe<Scalars["Boolean"]["input"]>;
@@ -2431,7 +2429,6 @@ export type RepoRef = {
   stepbackBisect?: Maybe<Scalars["Boolean"]["output"]>;
   stepbackDisabled: Scalars["Boolean"]["output"];
   taskAnnotationSettings: TaskAnnotationSettings;
-  taskSync: RepoTaskSyncOptions;
   tracksPushEvents: Scalars["Boolean"]["output"];
   triggers: Array<TriggerAlias>;
   versionControlEnabled: Scalars["Boolean"]["output"];
@@ -2478,7 +2475,6 @@ export type RepoRefInput = {
   stepbackBisect?: InputMaybe<Scalars["Boolean"]["input"]>;
   stepbackDisabled?: InputMaybe<Scalars["Boolean"]["input"]>;
   taskAnnotationSettings?: InputMaybe<TaskAnnotationSettingsInput>;
-  taskSync?: InputMaybe<TaskSyncOptionsInput>;
   tracksPushEvents?: InputMaybe<Scalars["Boolean"]["input"]>;
   triggers?: InputMaybe<Array<TriggerAliasInput>>;
   versionControlEnabled?: InputMaybe<Scalars["Boolean"]["input"]>;
@@ -2509,12 +2505,6 @@ export type RepoSettingsInput = {
   repoId: Scalars["String"]["input"];
   subscriptions?: InputMaybe<Array<SubscriptionInput>>;
   vars?: InputMaybe<ProjectVarsInput>;
-};
-
-export type RepoTaskSyncOptions = {
-  __typename?: "RepoTaskSyncOptions";
-  configEnabled: Scalars["Boolean"]["output"];
-  patchEnabled: Scalars["Boolean"]["output"];
 };
 
 export type RepoWorkstationConfig = {
@@ -2675,7 +2665,6 @@ export type SpawnHostInput = {
   sleepSchedule?: InputMaybe<SleepScheduleInput>;
   spawnHostsStartedByTask?: InputMaybe<Scalars["Boolean"]["input"]>;
   taskId?: InputMaybe<Scalars["String"]["input"]>;
-  taskSync?: InputMaybe<Scalars["Boolean"]["input"]>;
   useProjectSetupScript?: InputMaybe<Scalars["Boolean"]["input"]>;
   useTaskConfig?: InputMaybe<Scalars["Boolean"]["input"]>;
   userDataScript?: InputMaybe<Scalars["String"]["input"]>;
@@ -2798,7 +2787,6 @@ export type Task = {
   canRestart: Scalars["Boolean"]["output"];
   canSchedule: Scalars["Boolean"]["output"];
   canSetPriority: Scalars["Boolean"]["output"];
-  canSync: Scalars["Boolean"]["output"];
   canUnschedule: Scalars["Boolean"]["output"];
   containerAllocatedTime?: Maybe<Scalars["Time"]["output"]>;
   createTime?: Maybe<Scalars["Time"]["output"]>;
@@ -3033,17 +3021,6 @@ export type TaskStats = {
   __typename?: "TaskStats";
   counts?: Maybe<Array<StatusCount>>;
   eta?: Maybe<Scalars["Time"]["output"]>;
-};
-
-export type TaskSyncOptions = {
-  __typename?: "TaskSyncOptions";
-  configEnabled?: Maybe<Scalars["Boolean"]["output"]>;
-  patchEnabled?: Maybe<Scalars["Boolean"]["output"]>;
-};
-
-export type TaskSyncOptionsInput = {
-  configEnabled?: InputMaybe<Scalars["Boolean"]["input"]>;
-  patchEnabled?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
 /**

--- a/apps/spruce/cypress/integration/spawn/host.ts
+++ b/apps/spruce/cypress/integration/spawn/host.ts
@@ -144,7 +144,6 @@ describe("Navigating to Spawn Host page", () => {
         "Load data for dist on ubuntu1604",
       );
       cy.dataCy("spawn-host-modal").should("contain.text", label2);
-      cy.dataCy("spawn-host-modal").should("contain.text", label3);
     });
 
     it("Unchecking 'Load data for dist' hides nested checkbox selections and checking shows them.", () => {
@@ -155,13 +154,11 @@ describe("Navigating to Spawn Host page", () => {
       cy.dataCy("load-data-checkbox").should("be.checked");
       cy.contains(label1).should("be.visible");
       cy.contains(label2).should("be.visible");
-      cy.contains(label3).should("be.visible");
 
       cy.dataCy("load-data-checkbox").click({ force: true });
       cy.dataCy("load-data-checkbox").should("not.be.checked");
       cy.contains(label1).should("not.exist");
       cy.contains(label2).should("not.exist");
-      cy.contains(label3).should("not.exist");
     });
 
     it("Visiting the spawn host page with a task and distro supplied in the url should populate the distro input", () => {
@@ -241,8 +238,7 @@ describe("Navigating to Spawn Host page", () => {
       );
     });
     const label1 = "Use project-specific setup script defined at /path";
-    const label2 = "Load from task sync";
-    const label3 = "Also start any hosts this task started (if applicable)";
+    const label2 = "Also start any hosts this task started (if applicable)";
   });
 
   it("Allows editing a modal with sleep schedule enabled and validates dates", () => {

--- a/apps/spruce/src/components/Spawn/spawnHostModal/getFormSchema.tsx
+++ b/apps/spruce/src/components/Spawn/spawnHostModal/getFormSchema.tsx
@@ -63,7 +63,6 @@ export const getFormSchema = ({
 }: Props): ReturnType<GetFormSchema> => {
   const {
     buildVariant,
-    canSync,
     displayName: taskDisplayName,
     project,
     revision,
@@ -218,10 +217,6 @@ export const getFormSchema = ({
                       runProjectSpecificSetupScript: {
                         type: "boolean" as "boolean",
                         title: `Use project-specific setup script defined at ${project?.spawnHostScriptPath}`,
-                      },
-                      taskSync: {
-                        type: "boolean" as "boolean",
-                        title: "Load from task sync",
                       },
                       startHosts: {
                         type: "boolean" as "boolean",
@@ -395,11 +390,6 @@ export const getFormSchema = ({
                 : "hidden",
             "ui:disabled": useSetupScript,
             "ui:data-cy": "project-setup-script-checkbox",
-            "ui:elementWrapperCSS": childCheckboxCSS,
-          },
-          taskSync: {
-            "ui:widget":
-              hasValidTask && canSync ? widgets.CheckboxWidget : "hidden",
             "ui:elementWrapperCSS": childCheckboxCSS,
           },
           startHosts: {

--- a/apps/spruce/src/components/Spawn/spawnHostModal/transformer.test.ts
+++ b/apps/spruce/src/components/Spawn/spawnHostModal/transformer.test.ts
@@ -88,7 +88,6 @@ const data: Array<{ formData: FormState; mutationInput: SpawnHostInput }> = [
       useProjectSetupScript: false,
       setUpScript: "setup!!!",
       spawnHostsStartedByTask: false,
-      taskSync: false,
       sleepSchedule: null,
     },
   },
@@ -140,7 +139,6 @@ const data: Array<{ formData: FormState; mutationInput: SpawnHostInput }> = [
       useProjectSetupScript: false,
       setUpScript: null,
       spawnHostsStartedByTask: false,
-      taskSync: false,
       sleepSchedule: {
         dailyStartTime: "08:00",
         dailyStopTime: "20:00",

--- a/apps/spruce/src/components/Spawn/spawnHostModal/transformer.ts
+++ b/apps/spruce/src/components/Spawn/spawnHostModal/transformer.ts
@@ -95,6 +95,5 @@ export const formToGql = ({
     spawnHostsStartedByTask: !!(
       loadData?.loadDataOntoHostAtStartup && loadData?.startHosts
     ),
-    taskSync: !!(loadData?.loadDataOntoHostAtStartup && loadData?.taskSync),
   };
 };

--- a/apps/spruce/src/components/Spawn/spawnHostModal/types.ts
+++ b/apps/spruce/src/components/Spawn/spawnHostModal/types.ts
@@ -33,7 +33,6 @@ export type FormState = {
   loadData?: {
     loadDataOntoHostAtStartup: boolean;
     runProjectSpecificSetupScript?: boolean;
-    taskSync?: boolean;
     startHosts?: boolean;
   };
 };

--- a/apps/spruce/src/gql/fragments/projectSettings/general.graphql
+++ b/apps/spruce/src/gql/fragments/projectSettings/general.graphql
@@ -14,10 +14,6 @@ fragment ProjectGeneralSettings on Project {
   spawnHostScriptPath
   stepbackBisect
   stepbackDisabled
-  taskSync {
-    configEnabled
-    patchEnabled
-  }
   versionControlEnabled
 }
 
@@ -35,9 +31,5 @@ fragment RepoGeneralSettings on RepoRef {
   spawnHostScriptPath
   stepbackBisect
   stepbackDisabled
-  taskSync {
-    configEnabled
-    patchEnabled
-  }
   versionControlEnabled
 }

--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -1931,6 +1931,7 @@ export type Project = {
   stepbackBisect?: Maybe<Scalars["Boolean"]["output"]>;
   stepbackDisabled?: Maybe<Scalars["Boolean"]["output"]>;
   taskAnnotationSettings: TaskAnnotationSettings;
+  taskSync: TaskSyncOptions;
   tracksPushEvents?: Maybe<Scalars["Boolean"]["output"]>;
   triggers?: Maybe<Array<TriggerAlias>>;
   versionControlEnabled?: Maybe<Scalars["Boolean"]["output"]>;
@@ -2066,6 +2067,7 @@ export type ProjectInput = {
   stepbackBisect?: InputMaybe<Scalars["Boolean"]["input"]>;
   stepbackDisabled?: InputMaybe<Scalars["Boolean"]["input"]>;
   taskAnnotationSettings?: InputMaybe<TaskAnnotationSettingsInput>;
+  taskSync?: InputMaybe<TaskSyncOptionsInput>;
   tracksPushEvents?: InputMaybe<Scalars["Boolean"]["input"]>;
   triggers?: InputMaybe<Array<TriggerAliasInput>>;
   versionControlEnabled?: InputMaybe<Scalars["Boolean"]["input"]>;
@@ -2429,6 +2431,7 @@ export type RepoRef = {
   stepbackBisect?: Maybe<Scalars["Boolean"]["output"]>;
   stepbackDisabled: Scalars["Boolean"]["output"];
   taskAnnotationSettings: TaskAnnotationSettings;
+  taskSync: RepoTaskSyncOptions;
   tracksPushEvents: Scalars["Boolean"]["output"];
   triggers: Array<TriggerAlias>;
   versionControlEnabled: Scalars["Boolean"]["output"];
@@ -2475,6 +2478,7 @@ export type RepoRefInput = {
   stepbackBisect?: InputMaybe<Scalars["Boolean"]["input"]>;
   stepbackDisabled?: InputMaybe<Scalars["Boolean"]["input"]>;
   taskAnnotationSettings?: InputMaybe<TaskAnnotationSettingsInput>;
+  taskSync?: InputMaybe<TaskSyncOptionsInput>;
   tracksPushEvents?: InputMaybe<Scalars["Boolean"]["input"]>;
   triggers?: InputMaybe<Array<TriggerAliasInput>>;
   versionControlEnabled?: InputMaybe<Scalars["Boolean"]["input"]>;
@@ -2505,6 +2509,12 @@ export type RepoSettingsInput = {
   repoId: Scalars["String"]["input"];
   subscriptions?: InputMaybe<Array<SubscriptionInput>>;
   vars?: InputMaybe<ProjectVarsInput>;
+};
+
+export type RepoTaskSyncOptions = {
+  __typename?: "RepoTaskSyncOptions";
+  configEnabled: Scalars["Boolean"]["output"];
+  patchEnabled: Scalars["Boolean"]["output"];
 };
 
 export type RepoWorkstationConfig = {
@@ -2665,6 +2675,7 @@ export type SpawnHostInput = {
   sleepSchedule?: InputMaybe<SleepScheduleInput>;
   spawnHostsStartedByTask?: InputMaybe<Scalars["Boolean"]["input"]>;
   taskId?: InputMaybe<Scalars["String"]["input"]>;
+  taskSync?: InputMaybe<Scalars["Boolean"]["input"]>;
   useProjectSetupScript?: InputMaybe<Scalars["Boolean"]["input"]>;
   useTaskConfig?: InputMaybe<Scalars["Boolean"]["input"]>;
   userDataScript?: InputMaybe<Scalars["String"]["input"]>;
@@ -2787,6 +2798,7 @@ export type Task = {
   canRestart: Scalars["Boolean"]["output"];
   canSchedule: Scalars["Boolean"]["output"];
   canSetPriority: Scalars["Boolean"]["output"];
+  canSync: Scalars["Boolean"]["output"];
   canUnschedule: Scalars["Boolean"]["output"];
   containerAllocatedTime?: Maybe<Scalars["Time"]["output"]>;
   createTime?: Maybe<Scalars["Time"]["output"]>;
@@ -3021,6 +3033,17 @@ export type TaskStats = {
   __typename?: "TaskStats";
   counts?: Maybe<Array<StatusCount>>;
   eta?: Maybe<Scalars["Time"]["output"]>;
+};
+
+export type TaskSyncOptions = {
+  __typename?: "TaskSyncOptions";
+  configEnabled?: Maybe<Scalars["Boolean"]["output"]>;
+  patchEnabled?: Maybe<Scalars["Boolean"]["output"]>;
+};
+
+export type TaskSyncOptionsInput = {
+  configEnabled?: InputMaybe<Scalars["Boolean"]["input"]>;
+  patchEnabled?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
 /**

--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -1931,7 +1931,6 @@ export type Project = {
   stepbackBisect?: Maybe<Scalars["Boolean"]["output"]>;
   stepbackDisabled?: Maybe<Scalars["Boolean"]["output"]>;
   taskAnnotationSettings: TaskAnnotationSettings;
-  taskSync: TaskSyncOptions;
   tracksPushEvents?: Maybe<Scalars["Boolean"]["output"]>;
   triggers?: Maybe<Array<TriggerAlias>>;
   versionControlEnabled?: Maybe<Scalars["Boolean"]["output"]>;
@@ -2067,7 +2066,6 @@ export type ProjectInput = {
   stepbackBisect?: InputMaybe<Scalars["Boolean"]["input"]>;
   stepbackDisabled?: InputMaybe<Scalars["Boolean"]["input"]>;
   taskAnnotationSettings?: InputMaybe<TaskAnnotationSettingsInput>;
-  taskSync?: InputMaybe<TaskSyncOptionsInput>;
   tracksPushEvents?: InputMaybe<Scalars["Boolean"]["input"]>;
   triggers?: InputMaybe<Array<TriggerAliasInput>>;
   versionControlEnabled?: InputMaybe<Scalars["Boolean"]["input"]>;
@@ -2431,7 +2429,6 @@ export type RepoRef = {
   stepbackBisect?: Maybe<Scalars["Boolean"]["output"]>;
   stepbackDisabled: Scalars["Boolean"]["output"];
   taskAnnotationSettings: TaskAnnotationSettings;
-  taskSync: RepoTaskSyncOptions;
   tracksPushEvents: Scalars["Boolean"]["output"];
   triggers: Array<TriggerAlias>;
   versionControlEnabled: Scalars["Boolean"]["output"];
@@ -2478,7 +2475,6 @@ export type RepoRefInput = {
   stepbackBisect?: InputMaybe<Scalars["Boolean"]["input"]>;
   stepbackDisabled?: InputMaybe<Scalars["Boolean"]["input"]>;
   taskAnnotationSettings?: InputMaybe<TaskAnnotationSettingsInput>;
-  taskSync?: InputMaybe<TaskSyncOptionsInput>;
   tracksPushEvents?: InputMaybe<Scalars["Boolean"]["input"]>;
   triggers?: InputMaybe<Array<TriggerAliasInput>>;
   versionControlEnabled?: InputMaybe<Scalars["Boolean"]["input"]>;
@@ -2509,12 +2505,6 @@ export type RepoSettingsInput = {
   repoId: Scalars["String"]["input"];
   subscriptions?: InputMaybe<Array<SubscriptionInput>>;
   vars?: InputMaybe<ProjectVarsInput>;
-};
-
-export type RepoTaskSyncOptions = {
-  __typename?: "RepoTaskSyncOptions";
-  configEnabled: Scalars["Boolean"]["output"];
-  patchEnabled: Scalars["Boolean"]["output"];
 };
 
 export type RepoWorkstationConfig = {
@@ -2675,7 +2665,6 @@ export type SpawnHostInput = {
   sleepSchedule?: InputMaybe<SleepScheduleInput>;
   spawnHostsStartedByTask?: InputMaybe<Scalars["Boolean"]["input"]>;
   taskId?: InputMaybe<Scalars["String"]["input"]>;
-  taskSync?: InputMaybe<Scalars["Boolean"]["input"]>;
   useProjectSetupScript?: InputMaybe<Scalars["Boolean"]["input"]>;
   useTaskConfig?: InputMaybe<Scalars["Boolean"]["input"]>;
   userDataScript?: InputMaybe<Scalars["String"]["input"]>;
@@ -2798,7 +2787,6 @@ export type Task = {
   canRestart: Scalars["Boolean"]["output"];
   canSchedule: Scalars["Boolean"]["output"];
   canSetPriority: Scalars["Boolean"]["output"];
-  canSync: Scalars["Boolean"]["output"];
   canUnschedule: Scalars["Boolean"]["output"];
   containerAllocatedTime?: Maybe<Scalars["Time"]["output"]>;
   createTime?: Maybe<Scalars["Time"]["output"]>;
@@ -3033,17 +3021,6 @@ export type TaskStats = {
   __typename?: "TaskStats";
   counts?: Maybe<Array<StatusCount>>;
   eta?: Maybe<Scalars["Time"]["output"]>;
-};
-
-export type TaskSyncOptions = {
-  __typename?: "TaskSyncOptions";
-  configEnabled?: Maybe<Scalars["Boolean"]["output"]>;
-  patchEnabled?: Maybe<Scalars["Boolean"]["output"]>;
-};
-
-export type TaskSyncOptionsInput = {
-  configEnabled?: InputMaybe<Scalars["Boolean"]["input"]>;
-  patchEnabled?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
 /**
@@ -3926,11 +3903,6 @@ export type ProjectGeneralSettingsFragment = {
   stepbackBisect?: boolean | null;
   stepbackDisabled?: boolean | null;
   versionControlEnabled?: boolean | null;
-  taskSync: {
-    __typename?: "TaskSyncOptions";
-    configEnabled?: boolean | null;
-    patchEnabled?: boolean | null;
-  };
 };
 
 export type RepoGeneralSettingsFragment = {
@@ -3949,11 +3921,6 @@ export type RepoGeneralSettingsFragment = {
   stepbackBisect?: boolean | null;
   stepbackDisabled: boolean;
   versionControlEnabled: boolean;
-  taskSync: {
-    __typename?: "RepoTaskSyncOptions";
-    configEnabled: boolean;
-    patchEnabled: boolean;
-  };
 };
 
 export type ProjectGithubSettingsFragment = {
@@ -4095,11 +4062,6 @@ export type ProjectSettingsFieldsFragment = {
       memoryMb: number;
       name: string;
     }> | null;
-    taskSync: {
-      __typename?: "TaskSyncOptions";
-      configEnabled?: boolean | null;
-      patchEnabled?: boolean | null;
-    };
     banner?: {
       __typename?: "ProjectBanner";
       text: string;
@@ -4303,11 +4265,6 @@ export type RepoSettingsFieldsFragment = {
       memoryMb: number;
       name: string;
     }> | null;
-    taskSync: {
-      __typename?: "RepoTaskSyncOptions";
-      configEnabled: boolean;
-      patchEnabled: boolean;
-    };
     patchTriggerAliases?: Array<{
       __typename?: "PatchTriggerAlias";
       alias: string;
@@ -4744,11 +4701,6 @@ export type ProjectEventSettingsFragment = {
       name: string;
       permissions: { [key: string]: any };
     }>;
-    taskSync: {
-      __typename?: "TaskSyncOptions";
-      configEnabled?: boolean | null;
-      patchEnabled?: boolean | null;
-    };
     banner?: {
       __typename?: "ProjectBanner";
       text: string;
@@ -7311,11 +7263,6 @@ export type ProjectEventLogsQuery = {
             name: string;
             permissions: { [key: string]: any };
           }>;
-          taskSync: {
-            __typename?: "TaskSyncOptions";
-            configEnabled?: boolean | null;
-            patchEnabled?: boolean | null;
-          };
           banner?: {
             __typename?: "ProjectBanner";
             text: string;
@@ -7529,11 +7476,6 @@ export type ProjectEventLogsQuery = {
             name: string;
             permissions: { [key: string]: any };
           }>;
-          taskSync: {
-            __typename?: "TaskSyncOptions";
-            configEnabled?: boolean | null;
-            patchEnabled?: boolean | null;
-          };
           banner?: {
             __typename?: "ProjectBanner";
             text: string;
@@ -7826,11 +7768,6 @@ export type ProjectSettingsQuery = {
         memoryMb: number;
         name: string;
       }> | null;
-      taskSync: {
-        __typename?: "TaskSyncOptions";
-        configEnabled?: boolean | null;
-        patchEnabled?: boolean | null;
-      };
       banner?: {
         __typename?: "ProjectBanner";
         text: string;
@@ -8092,11 +8029,6 @@ export type RepoEventLogsQuery = {
             name: string;
             permissions: { [key: string]: any };
           }>;
-          taskSync: {
-            __typename?: "TaskSyncOptions";
-            configEnabled?: boolean | null;
-            patchEnabled?: boolean | null;
-          };
           banner?: {
             __typename?: "ProjectBanner";
             text: string;
@@ -8310,11 +8242,6 @@ export type RepoEventLogsQuery = {
             name: string;
             permissions: { [key: string]: any };
           }>;
-          taskSync: {
-            __typename?: "TaskSyncOptions";
-            configEnabled?: boolean | null;
-            patchEnabled?: boolean | null;
-          };
           banner?: {
             __typename?: "ProjectBanner";
             text: string;
@@ -8538,11 +8465,6 @@ export type RepoSettingsQuery = {
         memoryMb: number;
         name: string;
       }> | null;
-      taskSync: {
-        __typename?: "RepoTaskSyncOptions";
-        configEnabled: boolean;
-        patchEnabled: boolean;
-      };
       patchTriggerAliases?: Array<{
         __typename?: "PatchTriggerAlias";
         alias: string;
@@ -8733,7 +8655,6 @@ export type SpawnTaskQuery = {
   __typename?: "Query";
   task?: {
     __typename?: "Task";
-    canSync: boolean;
     buildVariant: string;
     buildVariantDisplayName?: string | null;
     displayName: string;

--- a/apps/spruce/src/gql/queries/spawn-task.graphql
+++ b/apps/spruce/src/gql/queries/spawn-task.graphql
@@ -3,7 +3,6 @@
 query SpawnTask($taskId: String!) {
   task(taskId: $taskId, execution: 0) {
     ...BaseTask
-    canSync
     project {
       id
       spawnHostScriptPath

--- a/apps/spruce/src/pages/projectSettings/CopyProjectModal.test.tsx
+++ b/apps/spruce/src/pages/projectSettings/CopyProjectModal.test.tsx
@@ -316,11 +316,6 @@ const projectSettingsMock: ApolloMock<
           stepbackDisabled: null,
           stepbackBisect: null,
           patchingDisabled: false,
-          taskSync: {
-            configEnabled: false,
-            patchEnabled: false,
-            __typename: "TaskSyncOptions",
-          },
           disabledStatsCache: false,
           restricted: false,
           admins: ["admin"],

--- a/apps/spruce/src/pages/projectSettings/tabs/EventLogTab/EventLogTab.test.tsx
+++ b/apps/spruce/src/pages/projectSettings/tabs/EventLogTab/EventLogTab.test.tsx
@@ -111,11 +111,6 @@ const projectEventsQuery: ProjectEventLogsQuery = {
             stepbackDisabled: null,
             stepbackBisect: null,
             patchingDisabled: false,
-            taskSync: {
-              configEnabled: false,
-              patchEnabled: false,
-              __typename: "TaskSyncOptions",
-            },
             disabledStatsCache: false,
             restricted: false,
             admins: ["rsatsrt"],
@@ -196,11 +191,6 @@ const projectEventsQuery: ProjectEventLogsQuery = {
             stepbackDisabled: null,
             stepbackBisect: null,
             patchingDisabled: false,
-            taskSync: {
-              configEnabled: false,
-              patchEnabled: false,
-              __typename: "TaskSyncOptions",
-            },
             disabledStatsCache: false,
             restricted: false,
             admins: ["arstastr", "asrt", "ata", "oienrsat"],

--- a/apps/spruce/src/pages/projectSettings/tabs/GeneralTab/getFormSchema.tsx
+++ b/apps/spruce/src/pages/projectSettings/tabs/GeneralTab/getFormSchema.tsx
@@ -208,30 +208,6 @@ export const getFormSchema = (
               },
             },
           },
-          taskSync: {
-            type: "object" as "object",
-            title: "Task Sync",
-            properties: {
-              configEnabled: {
-                type: ["boolean", "null"],
-                title: "Project Config Commands",
-                oneOf: radioBoxOptions(
-                  ["Enabled", "Disabled"],
-                  // @ts-expect-error: FIXME. This comment was added by an automated script.
-                  repoData?.projectFlags?.taskSync.configEnabled,
-                ),
-              },
-              patchEnabled: {
-                type: ["boolean", "null"],
-                title: "Task in Patches",
-                oneOf: radioBoxOptions(
-                  ["Enabled", "Disabled"],
-                  // @ts-expect-error: FIXME. This comment was added by an automated script.
-                  repoData?.projectFlags?.taskSync.patchEnabled,
-                ),
-              },
-            },
-          },
         },
       },
       historicalTaskDataCaching: {
@@ -390,18 +366,6 @@ export const getFormSchema = (
         patchingDisabled: {
           "ui:widget": widgets.RadioBoxWidget,
           "ui:showLabel": false,
-        },
-      },
-      taskSync: {
-        configEnabled: {
-          "ui:widget": widgets.RadioBoxWidget,
-          "ui:description":
-            "Enable commands (e.g. s3.push, s3.pull) to sync the task directory in S3 from the config file.",
-        },
-        patchEnabled: {
-          "ui:widget": widgets.RadioBoxWidget,
-          "ui:description":
-            "Users can create patches that sync the task directory to S3 at the end of any task.",
         },
       },
     },

--- a/apps/spruce/src/pages/projectSettings/tabs/GeneralTab/transformers.test.ts
+++ b/apps/spruce/src/pages/projectSettings/tabs/GeneralTab/transformers.test.ts
@@ -59,10 +59,6 @@ const repoForm: GeneralFormState = {
     patch: {
       patchingDisabled: false,
     },
-    taskSync: {
-      configEnabled: true,
-      patchEnabled: true,
-    },
   },
   historicalTaskDataCaching: {
     disabledStatsCache: false,
@@ -86,10 +82,6 @@ const repoResult: Pick<RepoSettingsInput, "repoId" | "projectRef"> = {
     patchingDisabled: false,
     stepbackDisabled: true,
     stepbackBisect: true,
-    taskSync: {
-      configEnabled: true,
-      patchEnabled: true,
-    },
     disabledStatsCache: false,
   },
 };
@@ -130,10 +122,6 @@ const projectForm: GeneralFormState = {
     patch: {
       patchingDisabled: null,
     },
-    taskSync: {
-      configEnabled: null,
-      patchEnabled: null,
-    },
   },
   historicalTaskDataCaching: {
     disabledStatsCache: null,
@@ -160,10 +148,6 @@ const projectResult: Pick<ProjectSettingsInput, "projectId" | "projectRef"> = {
     patchingDisabled: null,
     stepbackDisabled: null,
     stepbackBisect: null,
-    taskSync: {
-      configEnabled: null,
-      patchEnabled: null,
-    },
     disabledStatsCache: null,
   },
 };

--- a/apps/spruce/src/pages/projectSettings/tabs/GeneralTab/transformers.ts
+++ b/apps/spruce/src/pages/projectSettings/tabs/GeneralTab/transformers.ts
@@ -69,12 +69,6 @@ export const gqlToForm = ((data, options = {}) => {
         // @ts-expect-error: FIXME. This comment was added by an automated script.
         patchingDisabled: projectRef.patchingDisabled,
       },
-      taskSync: {
-        // @ts-expect-error: FIXME. This comment was added by an automated script.
-        configEnabled: projectRef.taskSync.configEnabled,
-        // @ts-expect-error: FIXME. This comment was added by an automated script.
-        patchEnabled: projectRef.taskSync.patchEnabled,
-      },
     },
     historicalTaskDataCaching: {
       // @ts-expect-error: FIXME. This comment was added by an automated script.
@@ -118,10 +112,6 @@ export const formToGql = ((
     stepbackDisabled: projectFlags.scheduling.stepbackDisabled,
     stepbackBisect: projectFlags.scheduling.stepbackBisection,
     patchingDisabled: projectFlags.patch.patchingDisabled,
-    taskSync: {
-      configEnabled: projectFlags.taskSync.configEnabled,
-      patchEnabled: projectFlags.taskSync.patchEnabled,
-    },
     disabledStatsCache,
   };
 

--- a/apps/spruce/src/pages/projectSettings/tabs/GeneralTab/types.ts
+++ b/apps/spruce/src/pages/projectSettings/tabs/GeneralTab/types.ts
@@ -32,10 +32,6 @@ export interface GeneralFormState {
     patch: {
       patchingDisabled: boolean | null;
     };
-    taskSync: {
-      configEnabled: boolean | null;
-      patchEnabled: boolean | null;
-    };
   };
   historicalTaskDataCaching: {
     disabledStatsCache: boolean | null;

--- a/apps/spruce/src/pages/projectSettings/tabs/testData.ts
+++ b/apps/spruce/src/pages/projectSettings/tabs/testData.ts
@@ -60,10 +60,6 @@ const projectBase: ProjectSettingsQuery["projectSettings"] = {
     patchingDisabled: null,
     stepbackDisabled: null,
     stepbackBisect: null,
-    taskSync: {
-      configEnabled: null,
-      patchEnabled: null,
-    },
     disabledStatsCache: null,
     restricted: true,
     admins: [],
@@ -214,10 +210,6 @@ const repoBase: RepoSettingsQuery["repoSettings"] = {
     patchingDisabled: false,
     stepbackDisabled: true,
     stepbackBisect: true,
-    taskSync: {
-      configEnabled: true,
-      patchEnabled: true,
-    },
     disabledStatsCache: false,
     restricted: true,
     admins: ["admin"],


### PR DESCRIPTION
DEVPROD-13969
<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
This removes the task sync project settings and the checkbox for spawnhosts.

I'm not that familiar with the UI codebase so please feel free to nitpick or anything! 

### Screenshots
New:
<img width="732" alt="Screenshot 2025-01-15 at 1 39 06 PM" src="https://github.com/user-attachments/assets/26b5ff36-1cdd-45df-b925-722949c4de24" />
Old:
<img width="739" alt="Screenshot 2025-01-15 at 1 39 20 PM" src="https://github.com/user-attachments/assets/a7a4555d-36e5-43fa-ab73-0c839a888f04" />

### Testing
Saved settings and it worked as normal.

<!-- Have you have updated the analytics documentation if necessary?  
https://docs.google.com/spreadsheets/d/1s4_nq8ZiphXp5Uq_-9HT6GPqz-KOyaq6HuvmXYaSNzg/edit?usp=sharing -->

### Evergreen PR
[#8637](https://github.com/evergreen-ci/evergreen/pull/8637) has to be merged after this change.
