### PR TITLE
DEVPROD-12595: Remove transition for date selector

### DIFF
--- a/apps/spruce/src/pages/waterfall/DateFilter/index.tsx
+++ b/apps/spruce/src/pages/waterfall/DateFilter/index.tsx
@@ -1,4 +1,3 @@
-import { useTransition } from "react";
 import { DatePicker } from "@leafygreen-ui/date-picker";
 import { DateType } from "@leafygreen-ui/date-utils";
 import { useWaterfallAnalytics } from "analytics";
@@ -7,7 +6,6 @@ import { WaterfallFilterOptions } from "../types";
 
 export const DateFilter = () => {
   const { sendEvent } = useWaterfallAnalytics();
-  const [, startTransition] = useTransition();
 
   const [queryParams, setQueryParams] = useQueryParams();
   const [date] = useQueryParam<string>(WaterfallFilterOptions.Date, "");
@@ -19,13 +17,11 @@ export const DateFilter = () => {
       const month = value.getUTCMonth() + 1;
       const day = value.getUTCDate();
       const utcDate = `${year}-${month.toString().padStart(2, "0")}-${day.toString().padStart(2, "0")}`;
-      startTransition(() => {
-        setQueryParams({
-          ...queryParams,
-          [WaterfallFilterOptions.MaxOrder]: undefined,
-          [WaterfallFilterOptions.MinOrder]: undefined,
-          [WaterfallFilterOptions.Date]: utcDate,
-        });
+      setQueryParams({
+        ...queryParams,
+        [WaterfallFilterOptions.MaxOrder]: undefined,
+        [WaterfallFilterOptions.MinOrder]: undefined,
+        [WaterfallFilterOptions.Date]: utcDate,
       });
       sendEvent({ name: "Filtered by date" });
     }


### PR DESCRIPTION
DEVPROD-12595
<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
<!-- add description, context, thought process, etc -->
This should have been done in #561, but for the same reasons, remove the React transition from the date selector. A loading state is more effective here.