### PR TITLE
DEVPROD-14367: Don't make entire build variant row clickable

### DIFF
--- a/apps/spruce/src/pages/waterfall/styles.ts
+++ b/apps/spruce/src/pages/waterfall/styles.ts
@@ -28,6 +28,7 @@ export const BuildVariantTitle = styled.div`
   flex-grow: 0;
   flex-shrink: 0;
   gap: ${size.xxs};
+  height: min-content;
   width: ${BUILD_VARIANT_WIDTH}px;
 `;
 


### PR DESCRIPTION
DEVPROD-14367
<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
<!-- add description, context, thought process, etc -->
Only the build variant name, not the entire div section, should be a clickable link