### PR TITLE
DEVPROD-14813 Update links to open internal links in the same tab

### DIFF
--- a/apps/parsley/src/components/DetailsMenu/DetailsMenuCard/ButtonRow/index.tsx
+++ b/apps/parsley/src/components/DetailsMenu/DetailsMenuCard/ButtonRow/index.tsx
@@ -60,7 +60,6 @@ const ButtonRow: React.FC = () => {
             href={jobLogsURL}
             leftGlyph={<Icon glyph="Export" />}
             onClick={() => sendEvent({ name: "Clicked job logs link" })}
-            target="_blank"
           >
             Job logs
           </Button>
@@ -78,7 +77,6 @@ const ButtonRow: React.FC = () => {
             href={rawLogURL}
             leftGlyph={<Icon glyph="Export" />}
             onClick={() => sendEvent({ name: "Clicked raw logs link" })}
-            target="_blank"
           >
             Raw
           </Button>
@@ -96,7 +94,6 @@ const ButtonRow: React.FC = () => {
             href={htmlLogURL}
             leftGlyph={<Icon glyph="Export" />}
             onClick={() => sendEvent({ name: "Clicked HTML logs link" })}
-            target="_blank"
           >
             HTML
           </Button>

--- a/apps/parsley/src/gql/generated/types.ts
+++ b/apps/parsley/src/gql/generated/types.ts
@@ -1924,7 +1924,6 @@ export type Project = {
   stepbackBisect?: Maybe<Scalars["Boolean"]["output"]>;
   stepbackDisabled?: Maybe<Scalars["Boolean"]["output"]>;
   taskAnnotationSettings: TaskAnnotationSettings;
-  taskSync: TaskSyncOptions;
   tracksPushEvents?: Maybe<Scalars["Boolean"]["output"]>;
   triggers?: Maybe<Array<TriggerAlias>>;
   versionControlEnabled?: Maybe<Scalars["Boolean"]["output"]>;
@@ -2060,7 +2059,6 @@ export type ProjectInput = {
   stepbackBisect?: InputMaybe<Scalars["Boolean"]["input"]>;
   stepbackDisabled?: InputMaybe<Scalars["Boolean"]["input"]>;
   taskAnnotationSettings?: InputMaybe<TaskAnnotationSettingsInput>;
-  taskSync?: InputMaybe<TaskSyncOptionsInput>;
   tracksPushEvents?: InputMaybe<Scalars["Boolean"]["input"]>;
   triggers?: InputMaybe<Array<TriggerAliasInput>>;
   versionControlEnabled?: InputMaybe<Scalars["Boolean"]["input"]>;
@@ -2423,7 +2421,6 @@ export type RepoRef = {
   stepbackBisect?: Maybe<Scalars["Boolean"]["output"]>;
   stepbackDisabled: Scalars["Boolean"]["output"];
   taskAnnotationSettings: TaskAnnotationSettings;
-  taskSync: RepoTaskSyncOptions;
   tracksPushEvents: Scalars["Boolean"]["output"];
   triggers: Array<TriggerAlias>;
   versionControlEnabled: Scalars["Boolean"]["output"];
@@ -2470,7 +2467,6 @@ export type RepoRefInput = {
   stepbackBisect?: InputMaybe<Scalars["Boolean"]["input"]>;
   stepbackDisabled?: InputMaybe<Scalars["Boolean"]["input"]>;
   taskAnnotationSettings?: InputMaybe<TaskAnnotationSettingsInput>;
-  taskSync?: InputMaybe<TaskSyncOptionsInput>;
   tracksPushEvents?: InputMaybe<Scalars["Boolean"]["input"]>;
   triggers?: InputMaybe<Array<TriggerAliasInput>>;
   versionControlEnabled?: InputMaybe<Scalars["Boolean"]["input"]>;
@@ -2501,12 +2497,6 @@ export type RepoSettingsInput = {
   repoId: Scalars["String"]["input"];
   subscriptions?: InputMaybe<Array<SubscriptionInput>>;
   vars?: InputMaybe<ProjectVarsInput>;
-};
-
-export type RepoTaskSyncOptions = {
-  __typename?: "RepoTaskSyncOptions";
-  configEnabled: Scalars["Boolean"]["output"];
-  patchEnabled: Scalars["Boolean"]["output"];
 };
 
 export type RepoWorkstationConfig = {
@@ -2667,7 +2657,6 @@ export type SpawnHostInput = {
   sleepSchedule?: InputMaybe<SleepScheduleInput>;
   spawnHostsStartedByTask?: InputMaybe<Scalars["Boolean"]["input"]>;
   taskId?: InputMaybe<Scalars["String"]["input"]>;
-  taskSync?: InputMaybe<Scalars["Boolean"]["input"]>;
   useProjectSetupScript?: InputMaybe<Scalars["Boolean"]["input"]>;
   useTaskConfig?: InputMaybe<Scalars["Boolean"]["input"]>;
   userDataScript?: InputMaybe<Scalars["String"]["input"]>;
@@ -2790,7 +2779,6 @@ export type Task = {
   canRestart: Scalars["Boolean"]["output"];
   canSchedule: Scalars["Boolean"]["output"];
   canSetPriority: Scalars["Boolean"]["output"];
-  canSync: Scalars["Boolean"]["output"];
   canUnschedule: Scalars["Boolean"]["output"];
   containerAllocatedTime?: Maybe<Scalars["Time"]["output"]>;
   createTime?: Maybe<Scalars["Time"]["output"]>;
@@ -3025,17 +3013,6 @@ export type TaskStats = {
   __typename?: "TaskStats";
   counts?: Maybe<Array<StatusCount>>;
   eta?: Maybe<Scalars["Time"]["output"]>;
-};
-
-export type TaskSyncOptions = {
-  __typename?: "TaskSyncOptions";
-  configEnabled?: Maybe<Scalars["Boolean"]["output"]>;
-  patchEnabled?: Maybe<Scalars["Boolean"]["output"]>;
-};
-
-export type TaskSyncOptionsInput = {
-  configEnabled?: InputMaybe<Scalars["Boolean"]["input"]>;
-  patchEnabled?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
 /**

--- a/apps/spruce/cypress/integration/task/files_tables.ts
+++ b/apps/spruce/cypress/integration/task/files_tables.ts
@@ -3,11 +3,6 @@ describe("files table", () => {
   const FILES_ROUTE_WITHOUT_FILES =
     "/task/evergreen_ubuntu1604_test_model_commitqueue_patch_5e823e1f28baeaa22ae00823d83e03082cd148ab_5e4ff3abe3c3317e352062e4_20_02_21_15_13_48/files";
 
-  it("File names under name column should link to a new tab", () => {
-    cy.visit(FILES_ROUTE);
-    cy.dataCy("file-link").should("have.attr", "target", "_blank");
-  });
-
   it("Searching for a non existent value yields 0 results, tables will not render and will display 'No files found'", () => {
     cy.visit(FILES_ROUTE);
     cy.dataCy("file-search-input").type("Hello world");

--- a/apps/spruce/src/components/CodeChanges/index.tsx
+++ b/apps/spruce/src/components/CodeChanges/index.tsx
@@ -90,7 +90,6 @@ export const CodeChanges: React.FC<CodeChangesProps> = ({ patchId }) => {
                 data-cy="html-diff-btn"
                 href={htmlLink}
                 size="small"
-                target="_blank"
                 title="Open diff as html file"
               >
                 HTML
@@ -99,7 +98,6 @@ export const CodeChanges: React.FC<CodeChangesProps> = ({ patchId }) => {
                 data-cy="raw-diff-btn"
                 href={rawLink}
                 size="small"
-                target="_blank"
                 title="Open diff as raw file"
               >
                 Raw

--- a/apps/spruce/src/components/CodeChangesTable/index.tsx
+++ b/apps/spruce/src/components/CodeChangesTable/index.tsx
@@ -43,12 +43,7 @@ const columns = [
         original: { diffLink },
       },
     }) => (
-      <StyledLink
-        data-cy="fileLink"
-        href={diffLink}
-        rel="noopener noreferrer"
-        target="_blank"
-      >
+      <StyledLink data-cy="fileLink" href={diffLink}>
         <WordBreak>{getValue()}</WordBreak>
       </StyledLink>
     ),

--- a/apps/spruce/src/components/WelcomeModal/WelcomeModal.tsx
+++ b/apps/spruce/src/components/WelcomeModal/WelcomeModal.tsx
@@ -104,10 +104,7 @@ const WelcomeModal: React.FC<WelcomeModalProps> = ({
             />
             <div>
               {carouselCards[activeSlide].href && (
-                <StyledLink
-                  href={carouselCards[activeSlide].href ?? ""}
-                  target="__blank"
-                >
+                <StyledLink href={carouselCards[activeSlide].href ?? ""}>
                   Learn more
                 </StyledLink>
               )}

--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -1924,7 +1924,6 @@ export type Project = {
   stepbackBisect?: Maybe<Scalars["Boolean"]["output"]>;
   stepbackDisabled?: Maybe<Scalars["Boolean"]["output"]>;
   taskAnnotationSettings: TaskAnnotationSettings;
-  taskSync: TaskSyncOptions;
   tracksPushEvents?: Maybe<Scalars["Boolean"]["output"]>;
   triggers?: Maybe<Array<TriggerAlias>>;
   versionControlEnabled?: Maybe<Scalars["Boolean"]["output"]>;
@@ -2060,7 +2059,6 @@ export type ProjectInput = {
   stepbackBisect?: InputMaybe<Scalars["Boolean"]["input"]>;
   stepbackDisabled?: InputMaybe<Scalars["Boolean"]["input"]>;
   taskAnnotationSettings?: InputMaybe<TaskAnnotationSettingsInput>;
-  taskSync?: InputMaybe<TaskSyncOptionsInput>;
   tracksPushEvents?: InputMaybe<Scalars["Boolean"]["input"]>;
   triggers?: InputMaybe<Array<TriggerAliasInput>>;
   versionControlEnabled?: InputMaybe<Scalars["Boolean"]["input"]>;
@@ -2423,7 +2421,6 @@ export type RepoRef = {
   stepbackBisect?: Maybe<Scalars["Boolean"]["output"]>;
   stepbackDisabled: Scalars["Boolean"]["output"];
   taskAnnotationSettings: TaskAnnotationSettings;
-  taskSync: RepoTaskSyncOptions;
   tracksPushEvents: Scalars["Boolean"]["output"];
   triggers: Array<TriggerAlias>;
   versionControlEnabled: Scalars["Boolean"]["output"];
@@ -2470,7 +2467,6 @@ export type RepoRefInput = {
   stepbackBisect?: InputMaybe<Scalars["Boolean"]["input"]>;
   stepbackDisabled?: InputMaybe<Scalars["Boolean"]["input"]>;
   taskAnnotationSettings?: InputMaybe<TaskAnnotationSettingsInput>;
-  taskSync?: InputMaybe<TaskSyncOptionsInput>;
   tracksPushEvents?: InputMaybe<Scalars["Boolean"]["input"]>;
   triggers?: InputMaybe<Array<TriggerAliasInput>>;
   versionControlEnabled?: InputMaybe<Scalars["Boolean"]["input"]>;
@@ -2501,12 +2497,6 @@ export type RepoSettingsInput = {
   repoId: Scalars["String"]["input"];
   subscriptions?: InputMaybe<Array<SubscriptionInput>>;
   vars?: InputMaybe<ProjectVarsInput>;
-};
-
-export type RepoTaskSyncOptions = {
-  __typename?: "RepoTaskSyncOptions";
-  configEnabled: Scalars["Boolean"]["output"];
-  patchEnabled: Scalars["Boolean"]["output"];
 };
 
 export type RepoWorkstationConfig = {
@@ -2667,7 +2657,6 @@ export type SpawnHostInput = {
   sleepSchedule?: InputMaybe<SleepScheduleInput>;
   spawnHostsStartedByTask?: InputMaybe<Scalars["Boolean"]["input"]>;
   taskId?: InputMaybe<Scalars["String"]["input"]>;
-  taskSync?: InputMaybe<Scalars["Boolean"]["input"]>;
   useProjectSetupScript?: InputMaybe<Scalars["Boolean"]["input"]>;
   useTaskConfig?: InputMaybe<Scalars["Boolean"]["input"]>;
   userDataScript?: InputMaybe<Scalars["String"]["input"]>;
@@ -2790,7 +2779,6 @@ export type Task = {
   canRestart: Scalars["Boolean"]["output"];
   canSchedule: Scalars["Boolean"]["output"];
   canSetPriority: Scalars["Boolean"]["output"];
-  canSync: Scalars["Boolean"]["output"];
   canUnschedule: Scalars["Boolean"]["output"];
   containerAllocatedTime?: Maybe<Scalars["Time"]["output"]>;
   createTime?: Maybe<Scalars["Time"]["output"]>;
@@ -3025,17 +3013,6 @@ export type TaskStats = {
   __typename?: "TaskStats";
   counts?: Maybe<Array<StatusCount>>;
   eta?: Maybe<Scalars["Time"]["output"]>;
-};
-
-export type TaskSyncOptions = {
-  __typename?: "TaskSyncOptions";
-  configEnabled?: Maybe<Scalars["Boolean"]["output"]>;
-  patchEnabled?: Maybe<Scalars["Boolean"]["output"]>;
-};
-
-export type TaskSyncOptionsInput = {
-  configEnabled?: InputMaybe<Scalars["Boolean"]["input"]>;
-  patchEnabled?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
 /**

--- a/apps/spruce/src/pages/jobLogs/Metadata.tsx
+++ b/apps/spruce/src/pages/jobLogs/Metadata.tsx
@@ -45,7 +45,6 @@ export const Metadata: React.FC<{
               "group.id": metadata.groupID,
             });
           }}
-          target="_blank"
         >
           Complete logs for all tests
         </StyledLink>

--- a/apps/spruce/src/pages/task/taskTabs/FileTable/GroupedFileTable/__snapshots__/GroupedFileTable_DefaultTable.storyshot
+++ b/apps/spruce/src/pages/task/taskTabs/FileTable/GroupedFileTable/__snapshots__/GroupedFileTable_DefaultTable.storyshot
@@ -86,7 +86,7 @@
                     class="lg-ui-0001 css-r79zk7-overrideStyles leafygreen-ui-16e7rxl"
                     data-cy="file-link"
                     href="some_link"
-                    target="_blank"
+                    target="_self"
                   >
                     <span>
                       some_file
@@ -97,7 +97,6 @@
                     class="lg-ui-button-0000 leafygreen-ui-ma515g"
                     data-cy="parsley-link"
                     data-lgid="lg-button"
-                    target="_blank"
                     type="button"
                   >
                     <div
@@ -138,7 +137,7 @@
                     class="lg-ui-0001 css-r79zk7-overrideStyles leafygreen-ui-16e7rxl"
                     data-cy="file-link"
                     href="another_link"
-                    target="_blank"
+                    target="_self"
                   >
                     <span>
                       another_file
@@ -150,7 +149,6 @@
                     data-cy="parsley-link"
                     data-lgid="lg-button"
                     href="parsley_link"
-                    target="_blank"
                   >
                     <div
                       class="leafygreen-ui-v038xi"

--- a/apps/spruce/src/pages/task/taskTabs/FileTable/GroupedFileTable/index.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/FileTable/GroupedFileTable/index.tsx
@@ -35,7 +35,6 @@ const columns = (
                 "file.name": fileName,
               });
             }}
-            target="_blank"
           >
             {fileName}
           </StyledLink>
@@ -55,7 +54,6 @@ const columns = (
                   });
                 }}
                 size="small"
-                target="_blank"
               >
                 Parsley
               </Button>

--- a/apps/spruce/src/pages/task/taskTabs/Logs.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/Logs.tsx
@@ -111,7 +111,6 @@ export const Logs: React.FC<Props> = ({ execution, logLinks, taskId }) => {
                     "log.viewer": "parsley",
                   })
                 }
-                target="_blank"
                 title="High-powered log viewer"
               >
                 Parsley
@@ -129,7 +128,6 @@ export const Logs: React.FC<Props> = ({ execution, logLinks, taskId }) => {
                     "log.viewer": "html",
                   })
                 }
-                target="_blank"
                 title="Plain, colorized log viewer"
               >
                 HTML
@@ -147,7 +145,6 @@ export const Logs: React.FC<Props> = ({ execution, logLinks, taskId }) => {
                     "log.viewer": "raw",
                   })
                 }
-                target="_blank"
                 title="Plain text log viewer"
               >
                 Raw

--- a/apps/spruce/src/pages/task/taskTabs/testsTable/LogsColumn.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/testsTable/LogsColumn.tsx
@@ -41,7 +41,6 @@ export const LogsColumn: React.FC<Props> = ({ task, testResult }) => {
             })
           }
           size="xsmall"
-          target="_blank"
           title="High-powered log viewer"
         >
           Parsley
@@ -59,7 +58,6 @@ export const LogsColumn: React.FC<Props> = ({ task, testResult }) => {
             })
           }
           size="xsmall"
-          target="_blank"
           title="Plain, colorized log viewer"
         >
           HTML
@@ -77,7 +75,6 @@ export const LogsColumn: React.FC<Props> = ({ task, testResult }) => {
             })
           }
           size="xsmall"
-          target="_blank"
           title="Plain text log viewer"
         >
           Raw

--- a/apps/spruce/src/pages/version/Tabs/TestAnalysis/GroupedTestMapList/FailedTestGroup/FailedTestGroupTable/index.tsx
+++ b/apps/spruce/src/pages/version/Tabs/TestAnalysis/GroupedTestMapList/FailedTestGroup/FailedTestGroupTable/index.tsx
@@ -59,7 +59,6 @@ const columns: LGColumnDef<TaskBuildVariantField>[] = [
         data-cy="failed-test-group-parsley-btn"
         href={row.original.logs.urlParsley}
         size="xsmall"
-        target="_blank"
       >
         Parsley
       </Button>


### PR DESCRIPTION
DEVPROD-14813
<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
This PR updates most links people usually interact with to open in the current browser tab. I kept some links such as links to external wikis or links that occur in forms the same so they don't accidentally overwrite what ever the user is working on.

