### PR TITLE
DEVPROD-14495: Clean up waterfall types

### DIFF
--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -9683,8 +9683,6 @@ export type WaterfallQuery = {
       version: string;
       builds: Array<{
         __typename?: "WaterfallBuild";
-        activated?: boolean | null;
-        displayName: string;
         id: string;
         version: string;
         tasks: Array<{

--- a/apps/spruce/src/gql/queries/waterfall.graphql
+++ b/apps/spruce/src/gql/queries/waterfall.graphql
@@ -4,8 +4,6 @@ query Waterfall($options: WaterfallOptions!) {
   waterfall(options: $options) {
     buildVariants {
       builds {
-        activated
-        displayName
         id
         tasks {
           displayName

--- a/apps/spruce/src/pages/waterfall/BuildRow.tsx
+++ b/apps/spruce/src/pages/waterfall/BuildRow.tsx
@@ -13,7 +13,6 @@ import { useWaterfallAnalytics } from "analytics";
 import Icon from "components/Icon";
 import VisibilityContainer from "components/VisibilityContainer";
 import { getTaskRoute, getVariantHistoryRoute } from "constants/routes";
-import { WaterfallBuild } from "gql/generated/types";
 import { useDimensions } from "hooks/useDimensions";
 import { useBuildVariantContext } from "./BuildVariantContext";
 import {
@@ -185,7 +184,7 @@ const calculateBVContainerHeight = ({
   builds,
   columnWidth,
 }: {
-  builds: WaterfallBuild[];
+  builds: Build[];
   columnWidth: number;
 }) => {
   const numTasks = Math.max(...builds.map((b) => b.tasks.length));

--- a/apps/spruce/src/pages/waterfall/types.ts
+++ b/apps/spruce/src/pages/waterfall/types.ts
@@ -1,5 +1,4 @@
-import { Unpacked } from "@evg-ui/lib/types/utils";
-import { WaterfallVersionFragment, WaterfallQuery } from "gql/generated/types";
+import { WaterfallVersionFragment } from "gql/generated/types";
 
 // Although this is pretty much a duplicate of the GraphQL type, it is
 // necessary to resolve type errors.
@@ -10,13 +9,23 @@ export type WaterfallVersion = {
   version: WaterfallVersionFragment | null;
 };
 
-export type Build = Unpacked<
-  Unpacked<WaterfallQuery["waterfall"]["buildVariants"]>["builds"]
->;
+export type Build = {
+  id: string;
+  tasks: Array<{
+    displayName: string;
+    displayStatusCache: string;
+    execution: number;
+    id: string;
+    status: string;
+  }>;
+  version: string;
+};
 
-export type BuildVariant = Unpacked<
-  WaterfallQuery["waterfall"]["buildVariants"]
->;
+export type BuildVariant = {
+  builds: Build[];
+  displayName: string;
+  id: string;
+};
 
 export enum WaterfallFilterOptions {
   BuildVariant = "buildVariants",

--- a/apps/spruce/src/pages/waterfall/useFilters.test.tsx
+++ b/apps/spruce/src/pages/waterfall/useFilters.test.tsx
@@ -1,6 +1,7 @@
 import { MemoryRouter } from "react-router-dom";
 import { renderHook } from "@evg-ui/lib/test_utils";
 import { WaterfallVersionFragment } from "gql/generated/types";
+import { BuildVariant } from "./types";
 import { useFilters } from "./useFilters";
 
 type WrapperProps = {
@@ -32,6 +33,20 @@ describe("useFilters", () => {
       );
       expect(result.current).toStrictEqual({
         ...waterfall,
+        versions: [
+          {
+            inactiveVersions: [flattenedVersions[0]],
+            version: null,
+          },
+          {
+            inactiveVersions: null,
+            version: flattenedVersions[1],
+          },
+          {
+            inactiveVersions: null,
+            version: flattenedVersions[2],
+          },
+        ],
         activeVersionIds: ["b", "c"],
       });
     });
@@ -85,6 +100,20 @@ describe("useFilters", () => {
 
       const pinnedWaterfall = {
         ...waterfall,
+        versions: [
+          {
+            inactiveVersions: [flattenedVersions[0]],
+            version: null,
+          },
+          {
+            inactiveVersions: null,
+            version: flattenedVersions[1],
+          },
+          {
+            inactiveVersions: null,
+            version: flattenedVersions[2],
+          },
+        ],
         activeVersionIds: ["b", "c"],
         buildVariants: [
           waterfall.buildVariants[1],
@@ -144,6 +173,20 @@ describe("useFilters", () => {
 
       const filteredWaterfall = {
         ...waterfall,
+        versions: [
+          {
+            inactiveVersions: [flattenedVersions[0]],
+            version: null,
+          },
+          {
+            inactiveVersions: null,
+            version: flattenedVersions[1],
+          },
+          {
+            inactiveVersions: null,
+            version: flattenedVersions[2],
+          },
+        ],
         activeVersionIds: ["b", "c"],
       };
 
@@ -216,6 +259,20 @@ describe("useFilters", () => {
 
       const filteredWaterfall = {
         ...waterfall,
+        versions: [
+          {
+            inactiveVersions: [flattenedVersions[0]],
+            version: null,
+          },
+          {
+            inactiveVersions: null,
+            version: flattenedVersions[1],
+          },
+          {
+            inactiveVersions: null,
+            version: flattenedVersions[2],
+          },
+        ],
         activeVersionIds: ["b", "c"],
         buildVariants: [
           {
@@ -421,23 +478,20 @@ const flattenedVersions: WaterfallVersionFragment[] = [
   },
 ];
 
-const waterfall = {
+const waterfall: {
+  buildVariants: BuildVariant[];
+} = {
   buildVariants: [
     {
       id: "1",
-      version: "a",
       displayName: "BV 1",
       builds: [
         {
-          activated: false,
-          displayName: "Build A",
           id: "i",
           tasks: [],
           version: "a",
         },
         {
-          activated: true,
-          displayName: "Build 12345",
           id: "ii",
           tasks: [
             {
@@ -462,11 +516,8 @@ const waterfall = {
     {
       id: "2",
       displayName: "BV 2",
-      version: "b",
       builds: [
         {
-          activated: true,
-          displayName: "Build B",
           id: "ii",
           tasks: [
             {
@@ -484,11 +535,8 @@ const waterfall = {
     {
       id: "3",
       displayName: "BV 3",
-      version: "c",
       builds: [
         {
-          activated: true,
-          displayName: "Build C",
           id: "iii",
           tasks: [
             {
@@ -509,20 +557,6 @@ const waterfall = {
           version: "c",
         },
       ],
-    },
-  ],
-  versions: [
-    {
-      inactiveVersions: [flattenedVersions[0]],
-      version: null,
-    },
-    {
-      inactiveVersions: null,
-      version: flattenedVersions[1],
-    },
-    {
-      inactiveVersions: null,
-      version: flattenedVersions[2],
     },
   ],
 };


### PR DESCRIPTION
DEVPROD-14495
<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
<!-- add description, context, thought process, etc -->
Ahead of some changes to the GraphQL schema to better support caching in DEVPROD-12696, clean up waterfall types. Using a few types that are not inferred from generated types will allow us to more easily make changes and ensure that the required data is still present.