### PR TITLE
DEVPROD-14335 Remove error logging for missing build variants

### DIFF
--- a/apps/parsley/src/gql/generated/types.ts
+++ b/apps/parsley/src/gql/generated/types.ts
@@ -3348,6 +3348,7 @@ export type Version = {
   upstreamProject?: Maybe<UpstreamProject>;
   versionTiming?: Maybe<VersionTiming>;
   warnings: Array<Scalars["String"]["output"]>;
+  waterfallBuilds?: Maybe<Array<WaterfallBuild>>;
 };
 
 /** Version models a commit within a project. */
@@ -3428,7 +3429,7 @@ export type Waterfall = {
 
 export type WaterfallBuild = {
   __typename?: "WaterfallBuild";
-  activated?: Maybe<Scalars["Boolean"]["output"]>;
+  buildVariant: Scalars["String"]["output"];
   displayName: Scalars["String"]["output"];
   id: Scalars["String"]["output"];
   tasks: Array<WaterfallTask>;

--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -3348,6 +3348,7 @@ export type Version = {
   upstreamProject?: Maybe<UpstreamProject>;
   versionTiming?: Maybe<VersionTiming>;
   warnings: Array<Scalars["String"]["output"]>;
+  waterfallBuilds?: Maybe<Array<WaterfallBuild>>;
 };
 
 /** Version models a commit within a project. */
@@ -3428,7 +3429,7 @@ export type Waterfall = {
 
 export type WaterfallBuild = {
   __typename?: "WaterfallBuild";
-  activated?: Maybe<Scalars["Boolean"]["output"]>;
+  buildVariant: Scalars["String"]["output"];
   displayName: Scalars["String"]["output"];
   id: Scalars["String"]["output"];
   tasks: Array<WaterfallTask>;

--- a/apps/spruce/src/utils/getTaskFromMainlineCommitsQuery.ts
+++ b/apps/spruce/src/utils/getTaskFromMainlineCommitsQuery.ts
@@ -23,7 +23,6 @@ export const getTaskFromMainlineCommitsQuery = (
   }
   const buildVariant = buildVariants[0];
   if (buildVariant === null || buildVariant === undefined) {
-    reportError(new Error("buildVariant is undefined")).warning();
     return;
   }
   if (!buildVariant.tasks) {

--- a/apps/spruce/src/utils/getTaskFromMainlineCommitsQuery.ts
+++ b/apps/spruce/src/utils/getTaskFromMainlineCommitsQuery.ts
@@ -26,13 +26,9 @@ export const getTaskFromMainlineCommitsQuery = (
     return;
   }
   if (!buildVariant.tasks) {
-    reportError(new Error("buildVariant.tasks is undefined")).warning();
     return;
   }
   if (buildVariant.tasks.length > 1) {
-    reportError(
-      new Error("Multiple tasks matched previous commit search."),
-    ).warning();
     return;
   }
   return buildVariant.tasks[0];

--- a/packages/lib/src/components/styles/Link.tsx
+++ b/packages/lib/src/components/styles/Link.tsx
@@ -1,3 +1,4 @@
+import { forwardRef } from "react";
 import { css } from "@emotion/react";
 import { Link, LinkProps } from "@leafygreen-ui/typography";
 import {
@@ -17,14 +18,12 @@ const StyledLink = (props: LinkProps<"a">) => (
   <Link css={overrideStyles} hideExternalIcon {...props} />
 );
 
-const StyledRouterLink = (props: LinkProps<"span"> & RouterLinkProps) => (
+const StyledRouterLink = forwardRef<
+  HTMLSpanElement,
+  LinkProps<"span"> & RouterLinkProps
+>((props, ref) => (
   // @ts-ignore-error: An internal LeafyGreen type causes this error.
-  <Link
-    // @ts-expect-error
-    as={RouterLink}
-    css={overrideStyles}
-    {...props}
-  />
-);
+  <Link ref={ref} as={RouterLink} css={overrideStyles} {...props} />
+));
 
 export { StyledLink, StyledRouterLink };


### PR DESCRIPTION
DEVPROD-14335
<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
This error has been very noisy and occurs because sometimes tasks just don't have a last passing version especially if they are newly created so this query will silently error in the background. I removed the error log since this is an acceptable scenario.
* Also fixed a random ref error I saw while I was investigating this also
### Screenshots
<!-- add screenshots of visible changes -->

### Testing
No more errors in the console
