### PR TITLE
DEVPROD-14645 Ensure profiler config is not leaked into non profiler builds

### DIFF
--- a/.evergreen/deploy.yml
+++ b/.evergreen/deploy.yml
@@ -35,8 +35,8 @@ functions:
           AWS_SESSION_TOKEN: ${AWS_SESSION_TOKEN}
         script: |
           ${PREPARE_SHELL}
-          # Add PROFILER to env if profiler patch parameter is set.
-          if [ -n "${profiler}" ]; then
+          # Add PROFILER to env if profiler patch parameter is set to true.
+          if [ "${profiler}" = "true" ]; then
               echo "PROFILER is set to true, adding profiler to the build"
               PROFILER=true PROFILE_HEAD="<script src=\"https://localhost:8097\"></script>" yarn env-cmd --no-override -e "${target}" yarn deploy-utils-build-and-push
           else

--- a/apps/spruce/config/injectVariablesInHTML.ts
+++ b/apps/spruce/config/injectVariablesInHTML.ts
@@ -1,18 +1,38 @@
+// config/injectVariablesInHTML.ts
 import pkg from "replace-in-file";
 
 const { sync } = pkg;
 
-type InjectVariablesInHTMLConfig = {
+export type InjectVariablesInHTMLConfig = {
   files: string | string[];
   variables: string[];
 };
-export default (options: InjectVariablesInHTMLConfig) => {
+
+/**
+ * `injectVariablesInHTML` is a Vite plugin that replaces variables in HTML files with environment variables.
+ * @param options - Configuration options for the plugin.
+ * @returns A Vite plugin that replaces variables in HTML files with environment variables.
+ */
+export default function injectVariablesInHTML(
+  options: InjectVariablesInHTMLConfig,
+) {
+  // Prepare regexes and replacement values
   const from = options.variables.map((v) => new RegExp(v, "g"));
   const to = options.variables.map(
     (v) => process.env[v.replace(/%/g, "")] || "",
   );
+
   return {
     name: "injectVariablesInHTML",
+    // This hook runs in dev mode when serving the HTML
+    transformIndexHtml(html: string) {
+      let updatedHtml = html;
+      from.forEach((regex, i) => {
+        updatedHtml = updatedHtml.replace(regex, to[i]);
+      });
+      return updatedHtml;
+    },
+    // This hook runs during the build, after the bundle has been written
     writeBundle: async () => {
       try {
         sync({
@@ -21,8 +41,8 @@ export default (options: InjectVariablesInHTMLConfig) => {
           to,
         });
       } catch (error) {
-        console.error("Error occurred:", error);
+        console.error("Error occurred while injecting variables:", error);
       }
     },
   };
-};
+}

--- a/apps/spruce/vite.config.ts
+++ b/apps/spruce/vite.config.ts
@@ -49,19 +49,6 @@ export default defineConfig({
     sourcemap: true,
     rollupOptions: {
       output: {
-        plugins: [
-          // Replace the variables in our HTML files.
-          injectVariablesInHTML({
-            files: "dist/index.html",
-            variables: [
-              "%APP_VERSION%",
-              "%GIT_SHA%",
-              "%REACT_APP_RELEASE_STAGE%",
-              "%NODE_ENV%",
-              "%PROFILE_HEAD%",
-            ],
-          }),
-        ],
         manualChunks: {
           vendor: [
             "react",
@@ -108,6 +95,17 @@ export default defineConfig({
       },
       // exclude storybook stories
       exclude: [/\.stories\.tsx?$/],
+    }),
+    // Replace the variables in our HTML files.
+    injectVariablesInHTML({
+      files: "dist/index.html",
+      variables: [
+        "%APP_VERSION%",
+        "%GIT_SHA%",
+        "%REACT_APP_RELEASE_STAGE%",
+        "%NODE_ENV%",
+        "%PROFILE_HEAD%",
+      ],
     }),
     // Dynamic imports of antd styles
     vitePluginImp({


### PR DESCRIPTION
DEVPROD-14645

### Description
#568 introduced a configuration to enable the deployment of profiler-ready builds. However, the YAML configuration only checked for the existence of a value, not whether it was `false`. This oversight caused profiler-ready builds to be deployed by default, despite the intended default being `false`.

This update also includes a fix to ensure environment variables are properly passed in, preventing template placeholders from being used with the development server.

