### PR TITLE
DEVPROD-14682: Make success banner look more like an announcement

### DIFF
--- a/apps/spruce/src/components/Banners/SiteBanner.tsx
+++ b/apps/spruce/src/components/Banners/SiteBanner.tsx
@@ -1,8 +1,13 @@
 import { useState } from "react";
+import styled from "@emotion/styled";
 import Banner, { Variant } from "@leafygreen-ui/banner";
+import { palette } from "@leafygreen-ui/palette";
 import Cookies from "js-cookie";
+import Icon from "components/Icon";
 import { useSpruceConfig } from "hooks";
 import { jiraLinkify } from "utils/string";
+
+const { green } = palette;
 
 export interface SiteBannerProps {
   text: string;
@@ -27,6 +32,12 @@ export const SiteBanner: React.FC<SiteBannerProps> = ({ text, theme }) => {
     <Banner
       data-cy={`sitewide-banner-${variant}`}
       dismissible
+      image={
+        // We want the green banner to align more with legacy Evergreen's announcement banner
+        variant === Variant.Success ? (
+          <StyledIcon color={green.dark1} glyph="Megaphone" />
+        ) : undefined
+      }
       onClose={hideBanner}
       variant={variant}
     >
@@ -42,3 +53,9 @@ const mapThemeToVariant: Record<string, Variant> = {
   warning: Variant.Warning,
   important: Variant.Danger,
 };
+
+// It's unclear why using the size prop on the component doesn't work, but we can do this instead.
+const StyledIcon = styled(Icon)`
+  width: 16px;
+  height: 16px;
+`;


### PR DESCRIPTION
DEVPROD-NNNNN
<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
<!-- add description, context, thought process, etc -->
Align Spruce's green banner to look more like Evergreen's by using the announcement icon. A sitewide success banner has a limited use case anyway.

### Screenshots
<!-- add screenshots of visible changes -->
<img width="1515" alt="image" src="https://github.com/user-attachments/assets/a7a48fb9-71dd-493e-9b59-8f1af1464b8b" />