### PR TITLE
DEVPROD-14715: Fix build variant sorting

### DIFF
--- a/apps/spruce/src/pages/waterfall/utils.test.ts
+++ b/apps/spruce/src/pages/waterfall/utils.test.ts
@@ -58,6 +58,83 @@ describe("groupBuildVariants", () => {
   it("correctly groups build variants from versions", () => {
     expect(groupBuildVariants(versions)).toStrictEqual(buildVariants);
   });
+
+  it("sorts display names in an expected order", () => {
+    const symbolVersions = [
+      {
+        activated: true,
+        id: "version_1",
+        waterfallBuilds: [
+          {
+            id: "id_a",
+            buildVariant: "bv_a",
+            displayName: "a",
+          },
+          {
+            id: "id_b",
+            buildVariant: "bv_b",
+            displayName: "1",
+          },
+          {
+            id: "id_c",
+            buildVariant: "bv_c",
+            displayName: "!",
+          },
+          {
+            id: "id_d",
+            buildVariant: "bv_d",
+            displayName: "~",
+          },
+        ],
+      },
+    ] as Version[];
+    expect(groupBuildVariants(symbolVersions)).toStrictEqual([
+      {
+        displayName: "!",
+        id: "bv_c",
+        builds: [
+          {
+            id: "id_c",
+            tasks: [],
+            version: "version_1",
+          },
+        ],
+      },
+      {
+        displayName: "1",
+        id: "bv_b",
+        builds: [
+          {
+            id: "id_b",
+            tasks: [],
+            version: "version_1",
+          },
+        ],
+      },
+      {
+        displayName: "a",
+        id: "bv_a",
+        builds: [
+          {
+            id: "id_a",
+            tasks: [],
+            version: "version_1",
+          },
+        ],
+      },
+      {
+        displayName: "~",
+        id: "bv_d",
+        builds: [
+          {
+            id: "id_d",
+            tasks: [],
+            version: "version_1",
+          },
+        ],
+      },
+    ]);
+  });
 });
 
 const versions: Version[] = [

--- a/apps/spruce/src/pages/waterfall/utils.ts
+++ b/apps/spruce/src/pages/waterfall/utils.ts
@@ -61,9 +61,15 @@ export const groupBuildVariants = (
   });
 
   // Although each version's build variants are sorted, we need to make sure the whole list is sorted once combined.
-  const arr: BuildVariant[] = Array.from(bvs.values()).sort((a, b) =>
-    a.displayName.localeCompare(b.displayName),
-  );
+  const arr: BuildVariant[] = Array.from(bvs.values()).sort((a, b) => {
+    if (a.displayName < b.displayName) {
+      return -1;
+    }
+    if (a.displayName > b.displayName) {
+      return 1;
+    }
+    return 0;
+  });
 
   return arr;
 };


### PR DESCRIPTION
DEVPROD-14715
<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
<!-- add description, context, thought process, etc -->
Turns out localeCompare sorts symbols differently than plain `.sort()`. Implement that sorting mechanism when sorting build variant display names. As a bonus, it should be faster.

### Testing
<!-- add a description of how you tested it -->
Add test that fails using localeCompare