### PR TITLE
DEVPROD-13428: Reset Amboy database in e2e tests when mutations enqueue jobs

### DIFF
--- a/apps/parsley/cypress/support/index.ts
+++ b/apps/parsley/cypress/support/index.ts
@@ -142,8 +142,8 @@ declare global {
 
   afterEach(() => {
     if (mutationDispatched) {
-      cy.log("A mutation was detected. Restoring EVG.");
-      cy.exec("yarn evg-db-ops --restore");
+      cy.log("A mutation was detected. Restoring Evergreen.");
+      cy.exec("yarn evg-db-ops --restore evergreen");
     }
   });
 })();

--- a/apps/spruce/cypress/support/e2e.ts
+++ b/apps/spruce/cypress/support/e2e.ts
@@ -178,12 +178,12 @@ const hostMutations = ["ReprovisionToNew", "RestartJasper", "UpdateHostStatus"];
     cy.intercept("POST", "/graphql/query", (req) => {
       if (isMutation(req)) {
         mutationDispatched = true;
+        hostMutations.forEach((m) => {
+          if (hasOperationName(req, m)) {
+            clearAmboyDB = true;
+          }
+        });
       }
-      hostMutations.forEach((m) => {
-        if (hasOperationName(req, m)) {
-          clearAmboyDB = true;
-        }
-      });
     });
   });
 

--- a/scripts/evg-db-ops.sh
+++ b/scripts/evg-db-ops.sh
@@ -1,11 +1,14 @@
 #!/bin/bash
 
-DB_NAME="evergreen_local"
-URI="mongodb://localhost:27017/$DB_NAME"
-
-# Define paths for storing database dumps.
 DUMP_ROOT=${TMPDIR}evg_dump
-DUMP_FOLDER="$DUMP_ROOT/$DB_NAME"
+
+EVERGREEN_DB_NAME="evergreen_local"
+EVERGREEN_URI="mongodb://localhost:27017/$EVERGREEN_DB_NAME"
+EVERGREEN_DUMP_FOLDER="$DUMP_ROOT/$EVERGREEN_DB_NAME"
+
+AMBOY_DB_NAME="amboy_local"
+AMBOY_URI="mongodb://localhost:27017/$AMBOY_DB_NAME"
+AMBOY_DUMP_FOLDER="$DUMP_ROOT/$AMBOY_DB_NAME"
 
 RUNTIME_ENVIRONMENTS_SCRIPT_PATH="$(dirname "${BASH_SOURCE[0]}")/add-runtime-environments-creds.js"
 
@@ -15,8 +18,8 @@ clean_up() {
     echo "Cleaned up $DUMP_ROOT."
 }
 
-# Function to reseed the database with smoke test data.
-reseed_database() {
+# Function to reseed databases with smoke test data.
+reseed_databases() {
     # Change the current directory sdlschema symlink.
     if ! cd -- "$(dirname -- "$(readlink -- "sdlschema")")"; then
         echo "Unable to find Evergreen directory from the sdlschema symlink"
@@ -24,56 +27,64 @@ reseed_database() {
     fi
 
     # Load test data into the database.
-    ../bin/load-smoke-data -path ../testdata/local -dbName evergreen_local -amboyDBName amboy_local
+    ../bin/load-smoke-data -path ../testdata/local -dbName "$EVERGREEN_DB_NAME" -amboyDBName "$AMBOY_DB_NAME"
 
     cd -
 
     # Load credentials for the Image Visibility API.
     echo "Adding runtime environments credentials..."
     if [ "$CI" != 'true' ]; then
-        mongosh $DB_NAME --quiet $RUNTIME_ENVIRONMENTS_SCRIPT_PATH
+        mongosh $EVERGREEN_DB_NAME --quiet $RUNTIME_ENVIRONMENTS_SCRIPT_PATH
     else
-        ../../evergreen/mongosh/mongosh $DB_NAME --quiet $RUNTIME_ENVIRONMENTS_SCRIPT_PATH
+        ../../evergreen/mongosh/mongosh $EVERGREEN_DB_NAME --quiet $RUNTIME_ENVIRONMENTS_SCRIPT_PATH
     fi
     echo "Finished adding runtime environments credentials."
 
     cd - || exit
 }
 
-# Function to create a dump of the database.
-dump_database() {
-    clean_up
+# Helper function for dumping DBs.
+# Pass the DB name as the first argument and the database URI as the second argument.
+dump_db() {
     # Use 'mongodump' to create a database dump.
-    if ! mongodump --quiet --uri="$URI" -o "$DUMP_ROOT"; then
-        echo "Error creating dump from $DB_NAME db."
+    if ! mongodump --quiet --uri="$2" -o "$DUMP_ROOT"; then
+        echo "Error creating dump from $1 db."
         exit 1
     fi
-    echo "Dump successfully created in $DUMP_ROOT"
+    echo "$1 dump successfully created in $DUMP_ROOT"
 }
 
-# Function to reseed the database and then create a dump.
-reseed_and_dump_database() {
-    reseed_database
-    dump_database
+# Function to create dumps of the databases.
+dump_databases() {
+    clean_up
+    dump_db "$AMBOY_DB_NAME" "$AMBOY_URI"
+    dump_db "$EVERGREEN_DB_NAME" "$EVERGREEN_URI"
 }
 
-# Function to restore the database from a dump.
-restore_database() {
-    # Check if the specified dump folder exists.
-    if [ ! -d "$DUMP_FOLDER" ]; then
-        echo "Error: $DUMP_FOLDER does not exist. Ensure you have a valid dump before restoring."
-        exit 1
-    fi
+# Function to reseed the databases and then create dumps.
+reseed_and_dump_databases() {
+    reseed_databases
+    dump_databases
+}
 
+# Function to restore database from a dump.
+# Pass the dump folder as the first argument and the URI as the second argument.
+restore_db() {
     MAX_RETRIES=2
+
+    # Check if the specified dump folder exists.
+    if [ ! -d "$1" ]; then
+        echo "Error: $1 does not exist. Ensure you have a valid dump before restoring."
+        exit 1
+    fi
 
     # Use 'mongorestore' to restore the database from the dump.
     for ((retry=0; retry<=MAX_RETRIES; retry++)); do
-        if mongorestore --quiet --drop --uri="$URI" "$DUMP_FOLDER"; then
-            echo "Successfully restored the database from $DUMP_FOLDER."
-            exit 0
+        if mongorestore --quiet --drop --uri="$2" "$1"; then
+            echo "Successfully restored the database from $1."
+            break
         else
-            echo "Error restoring the database from $DUMP_FOLDER. Retry attempt: $retry"
+            echo "Error restoring the database from $1. Retry attempt: $retry"
             if [ $retry -eq $MAX_RETRIES ]; then
                 echo "Max retries reached. Exiting."
                 exit 1
@@ -86,22 +97,27 @@ restore_database() {
 # Check the command-line argument to determine the action to perform.
 case "$1" in
     --dump)
-        dump_database
+        dump_databases
         ;;
     --restore)
-        restore_database
+        if [ "$2" = "evergreen" ]; then
+            restore_db "$EVERGREEN_DUMP_FOLDER" "$EVERGREEN_URI"
+        fi
+        if [ "$2" = "amboy" ]; then
+            restore_db "$AMBOY_DUMP_FOLDER" "$AMBOY_URI"
+        fi
         ;;
     --clean-up)
         clean_up
         ;;
     --reseed)
-        reseed_database
+        reseed_databases
         ;;
     --reseed-and-dump)
-        reseed_and_dump_database
+        reseed_and_dump_databases
         ;;
     *)
-        echo "Usage: $0 {--dump|--restore|--clean-up|--reseed-and-dump}"
+        echo "Usage: $0 {--dump|--restore <evergreen|amboy>|--clean-up|--reseed-and-dump}"
         exit 1
         ;;
 esac

--- a/scripts/evg-db-ops.sh
+++ b/scripts/evg-db-ops.sh
@@ -44,7 +44,7 @@ reseed_databases() {
 }
 
 # Helper function for dumping DBs.
-# Pass the DB name as the first argument and the database URI as the second argument.
+# Pass the DB name as the first argument and the URI as the second argument.
 dump_db() {
     # Use 'mongodump' to create a database dump.
     if ! mongodump --quiet --uri="$2" -o "$DUMP_ROOT"; then


### PR DESCRIPTION
DEVPROD-13428
<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
#### Why does the test fail?
The tests in `host_buttons.ts` fail because the host is sometimes in a decommissioned state. You cannot reprovision or restart Jasper for a decommissioned host. 

#### But the host i-0d0ae8b83366d22be is defined as "running" in the local test data. That shouldn't happen.
True, it seems like this should be impossible because the database should reset after every test that executes a mutation.

#### What is happening then?
In all of the test failures linked in the corresponding JIRA ticket, the test that runs directly before is `host_update_status.ts`. This test calls a mutation that creates a job in Amboy called EnqueueTerminateHostJob.

I think the test was flaky due to a race condition. The two patterns would be:
*  Sometimes it would succeed because the Amboy job ran first and marked the host as decommissioned. Then we cleared the database and the host was reset correctly.
* Sometimes it would fail because we cleared the database first. Then the Amboy job got picked up and ran a second later, marking the host as decommissioned.

I think that clearing the Amboy database will help avoid future occurrences of similar bugs. By removing newly enqueued jobs from the Amboy database, we can ensure that the data will not change after we reset the Evergreen database.

