### PR TITLE
DEVPROD-14916: Update `graphql` and `@graphql-eslint/eslint-plugin`

### DIFF
--- a/apps/parsley/.graphqlrc
+++ b/apps/parsley/.graphqlrc
@@ -1,0 +1,2 @@
+documents: "src/gql/**/*.graphql"
+schema: "sdlschema/**/*.graphql"

--- a/apps/parsley/package.json
+++ b/apps/parsley/package.json
@@ -74,7 +74,7 @@
     "@sentry/react": "9.0.0",
     "@sentry/types": "9.0.0",
     "ansi_up": "6.0.2",
-    "graphql": "16.8.1",
+    "graphql": "16.10.0",
     "html-react-parser": "3.0.6",
     "js-cookie": "3.0.5",
     "jsdom": "24.0.0",

--- a/apps/parsley/src/gql/generated/types.ts
+++ b/apps/parsley/src/gql/generated/types.ts
@@ -1733,8 +1733,6 @@ export type Patches = {
 export type PatchesInput = {
   includeHidden?: InputMaybe<Scalars["Boolean"]["input"]>;
   limit?: Scalars["Int"]["input"];
-  /** @deprecated onlyCommitQueue is deprecated. Use onlyMergeQueue instead. */
-  onlyCommitQueue?: InputMaybe<Scalars["Boolean"]["input"]>;
   onlyMergeQueue?: InputMaybe<Scalars["Boolean"]["input"]>;
   page?: Scalars["Int"]["input"];
   patchName?: Scalars["String"]["input"];

--- a/apps/spruce/.graphqlrc
+++ b/apps/spruce/.graphqlrc
@@ -1,0 +1,2 @@
+documents: "src/gql/**/*.graphql"
+schema: "sdlschema/**/*.graphql"

--- a/apps/spruce/package.json
+++ b/apps/spruce/package.json
@@ -114,7 +114,7 @@
     "date-fns-tz": "3.2.0",
     "deep-object-diff": "1.1.9",
     "env-cmd": "10.1.0",
-    "graphql": "16.8.1",
+    "graphql": "16.10.0",
     "html-react-parser": "5.1.10",
     "js-cookie": "3.0.5",
     "jsdom": "24.0.0",

--- a/apps/spruce/src/gql/fragments/projectSettings/access.graphql
+++ b/apps/spruce/src/gql/fragments/projectSettings/access.graphql
@@ -1,9 +1,11 @@
 fragment ProjectAccessSettings on Project {
   admins
+  id
   restricted
 }
 
 fragment RepoAccessSettings on RepoRef {
   admins
+  id
   restricted
 }

--- a/apps/spruce/src/gql/fragments/projectSettings/appSettings.graphql
+++ b/apps/spruce/src/gql/fragments/projectSettings/appSettings.graphql
@@ -5,6 +5,7 @@ fragment ProjectAppSettings on ProjectSettings {
   }
   projectRef {
     githubPermissionGroupByRequester
+    id
   }
 }
 
@@ -15,6 +16,7 @@ fragment ProjectEventAppSettings on ProjectEventSettings {
   }
   projectRef {
     githubPermissionGroupByRequester
+    id
   }
 }
 
@@ -25,5 +27,6 @@ fragment RepoAppSettings on RepoSettings {
   }
   projectRef {
     githubPermissionGroupByRequester
+    id
   }
 }

--- a/apps/spruce/src/gql/fragments/projectSettings/containers.graphql
+++ b/apps/spruce/src/gql/fragments/projectSettings/containers.graphql
@@ -4,6 +4,7 @@ fragment ProjectContainerSettings on Project {
     memoryMb
     name
   }
+  id
 }
 
 fragment RepoContainerSettings on RepoRef {
@@ -12,4 +13,5 @@ fragment RepoContainerSettings on RepoRef {
     memoryMb
     name
   }
+  id
 }

--- a/apps/spruce/src/gql/fragments/projectSettings/general.graphql
+++ b/apps/spruce/src/gql/fragments/projectSettings/general.graphql
@@ -6,6 +6,7 @@ fragment ProjectGeneralSettings on Project {
   dispatchingDisabled
   displayName
   enabled
+  id
   owner
   patchingDisabled
   remotePath
@@ -23,6 +24,7 @@ fragment RepoGeneralSettings on RepoRef {
   disabledStatsCache
   dispatchingDisabled
   displayName
+  id
   owner
   patchingDisabled
   remotePath

--- a/apps/spruce/src/gql/fragments/projectSettings/githubCommitQueue.graphql
+++ b/apps/spruce/src/gql/fragments/projectSettings/githubCommitQueue.graphql
@@ -7,6 +7,7 @@ fragment ProjectGithubSettings on Project {
   gitTagAuthorizedTeams
   gitTagAuthorizedUsers
   gitTagVersionsEnabled
+  id
   manualPrTestingEnabled
   oldestAllowedMergeBase
   prTestingEnabled
@@ -21,6 +22,7 @@ fragment RepoGithubSettings on RepoRef {
   gitTagAuthorizedTeams
   gitTagAuthorizedUsers
   gitTagVersionsEnabled
+  id
   manualPrTestingEnabled
   oldestAllowedMergeBase
   prTestingEnabled

--- a/apps/spruce/src/gql/fragments/projectSettings/notifications.graphql
+++ b/apps/spruce/src/gql/fragments/projectSettings/notifications.graphql
@@ -3,10 +3,12 @@ fragment ProjectNotificationSettings on Project {
     text
     theme
   }
+  id
   notifyOnBuildFailure
 }
 
 fragment RepoNotificationSettings on RepoRef {
+  id
   notifyOnBuildFailure
 }
 

--- a/apps/spruce/src/gql/fragments/projectSettings/patchAliases.graphql
+++ b/apps/spruce/src/gql/fragments/projectSettings/patchAliases.graphql
@@ -1,5 +1,6 @@
 fragment ProjectPatchAliasSettings on Project {
   githubTriggerAliases
+  id
   patchTriggerAliases {
     alias
     childProjectIdentifier
@@ -16,6 +17,7 @@ fragment ProjectPatchAliasSettings on Project {
 
 fragment RepoPatchAliasSettings on RepoRef {
   githubTriggerAliases
+  id
   patchTriggerAliases {
     alias
     childProjectIdentifier

--- a/apps/spruce/src/gql/fragments/projectSettings/periodicBuilds.graphql
+++ b/apps/spruce/src/gql/fragments/projectSettings/periodicBuilds.graphql
@@ -1,4 +1,5 @@
 fragment ProjectPeriodicBuildsSettings on Project {
+  id
   periodicBuilds {
     alias
     configFile
@@ -11,6 +12,7 @@ fragment ProjectPeriodicBuildsSettings on Project {
 }
 
 fragment RepoPeriodicBuildsSettings on RepoRef {
+  id
   periodicBuilds {
     alias
     configFile

--- a/apps/spruce/src/gql/fragments/projectSettings/permissionGroups.graphql
+++ b/apps/spruce/src/gql/fragments/projectSettings/permissionGroups.graphql
@@ -8,6 +8,7 @@ fragment ProjectPermissionGroupSettings on ProjectSettings {
       permissions
     }
     githubPermissionGroupByRequester
+    id
   }
 }
 fragment ProjectEventPermissionGroupSettings on ProjectEventSettings {
@@ -20,6 +21,7 @@ fragment ProjectEventPermissionGroupSettings on ProjectEventSettings {
       permissions
     }
     githubPermissionGroupByRequester
+    id
   }
 }
 
@@ -33,5 +35,6 @@ fragment RepoPermissionGroupSettings on RepoSettings {
       permissions
     }
     githubPermissionGroupByRequester
+    id
   }
 }

--- a/apps/spruce/src/gql/fragments/projectSettings/plugins.graphql
+++ b/apps/spruce/src/gql/fragments/projectSettings/plugins.graphql
@@ -9,6 +9,7 @@ fragment ProjectPluginsSettings on Project {
     requesters
     urlTemplate
   }
+  id
   perfEnabled
   taskAnnotationSettings {
     fileTicketWebhook {
@@ -29,6 +30,7 @@ fragment RepoPluginsSettings on RepoRef {
     requesters
     urlTemplate
   }
+  id
   perfEnabled
   taskAnnotationSettings {
     fileTicketWebhook {

--- a/apps/spruce/src/gql/fragments/projectSettings/projectTriggers.graphql
+++ b/apps/spruce/src/gql/fragments/projectSettings/projectTriggers.graphql
@@ -1,4 +1,5 @@
 fragment ProjectTriggersSettings on Project {
+  id
   triggers {
     alias
     buildVariantRegex
@@ -13,6 +14,7 @@ fragment ProjectTriggersSettings on Project {
 }
 
 fragment RepoTriggersSettings on RepoRef {
+  id
   triggers {
     alias
     buildVariantRegex

--- a/apps/spruce/src/gql/fragments/projectSettings/viewsAndFilters.graphql
+++ b/apps/spruce/src/gql/fragments/projectSettings/viewsAndFilters.graphql
@@ -1,4 +1,5 @@
 fragment ProjectViewsAndFiltersSettings on Project {
+  id
   parsleyFilters {
     caseSensitive
     exactMatch
@@ -8,6 +9,7 @@ fragment ProjectViewsAndFiltersSettings on Project {
 }
 
 fragment RepoViewsAndFiltersSettings on RepoRef {
+  id
   parsleyFilters {
     caseSensitive
     exactMatch

--- a/apps/spruce/src/gql/fragments/projectSettings/virtualWorkstation.graphql
+++ b/apps/spruce/src/gql/fragments/projectSettings/virtualWorkstation.graphql
@@ -1,4 +1,5 @@
 fragment ProjectVirtualWorkstationSettings on Project {
+  id
   workstationConfig {
     gitClone
     setupCommands {
@@ -9,6 +10,7 @@ fragment ProjectVirtualWorkstationSettings on Project {
 }
 
 fragment RepoVirtualWorkstationSettings on RepoRef {
+  id
   workstationConfig {
     gitClone
     setupCommands {

--- a/apps/spruce/src/gql/fragments/upstreamProject.graphql
+++ b/apps/spruce/src/gql/fragments/upstreamProject.graphql
@@ -1,4 +1,5 @@
 fragment UpstreamProject on Version {
+  id
   upstreamProject {
     owner
     project

--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -1733,8 +1733,6 @@ export type Patches = {
 export type PatchesInput = {
   includeHidden?: InputMaybe<Scalars["Boolean"]["input"]>;
   limit?: Scalars["Int"]["input"];
-  /** @deprecated onlyCommitQueue is deprecated. Use onlyMergeQueue instead. */
-  onlyCommitQueue?: InputMaybe<Scalars["Boolean"]["input"]>;
   onlyMergeQueue?: InputMaybe<Scalars["Boolean"]["input"]>;
   page?: Scalars["Int"]["input"];
   patchName?: Scalars["String"]["input"];
@@ -3798,12 +3796,14 @@ export type PatchesPagePatchesFragment = {
 export type ProjectAccessSettingsFragment = {
   __typename?: "Project";
   admins?: Array<string> | null;
+  id: string;
   restricted?: boolean | null;
 };
 
 export type RepoAccessSettingsFragment = {
   __typename?: "RepoRef";
   admins: Array<string>;
+  id: string;
   restricted: boolean;
 };
 
@@ -3831,6 +3831,7 @@ export type ProjectAppSettingsFragment = {
   projectRef?: {
     __typename?: "Project";
     githubPermissionGroupByRequester?: { [key: string]: any } | null;
+    id: string;
   } | null;
 };
 
@@ -3844,6 +3845,7 @@ export type ProjectEventAppSettingsFragment = {
   projectRef?: {
     __typename?: "Project";
     githubPermissionGroupByRequester?: { [key: string]: any } | null;
+    id: string;
   } | null;
 };
 
@@ -3857,11 +3859,13 @@ export type RepoAppSettingsFragment = {
   projectRef?: {
     __typename?: "RepoRef";
     githubPermissionGroupByRequester?: { [key: string]: any } | null;
+    id: string;
   } | null;
 };
 
 export type ProjectContainerSettingsFragment = {
   __typename?: "Project";
+  id: string;
   containerSizeDefinitions?: Array<{
     __typename?: "ContainerResources";
     cpu: number;
@@ -3872,6 +3876,7 @@ export type ProjectContainerSettingsFragment = {
 
 export type RepoContainerSettingsFragment = {
   __typename?: "RepoRef";
+  id: string;
   containerSizeDefinitions?: Array<{
     __typename?: "ContainerResources";
     cpu: number;
@@ -3889,6 +3894,7 @@ export type ProjectGeneralSettingsFragment = {
   dispatchingDisabled?: boolean | null;
   displayName: string;
   enabled?: boolean | null;
+  id: string;
   owner: string;
   patchingDisabled?: boolean | null;
   remotePath: string;
@@ -3907,6 +3913,7 @@ export type RepoGeneralSettingsFragment = {
   disabledStatsCache: boolean;
   dispatchingDisabled: boolean;
   displayName: string;
+  id: string;
   owner: string;
   patchingDisabled: boolean;
   remotePath: string;
@@ -3925,6 +3932,7 @@ export type ProjectGithubSettingsFragment = {
   gitTagAuthorizedTeams?: Array<string> | null;
   gitTagAuthorizedUsers?: Array<string> | null;
   gitTagVersionsEnabled?: boolean | null;
+  id: string;
   manualPrTestingEnabled?: boolean | null;
   oldestAllowedMergeBase: string;
   prTestingEnabled?: boolean | null;
@@ -3938,6 +3946,7 @@ export type RepoGithubSettingsFragment = {
   gitTagAuthorizedTeams?: Array<string> | null;
   gitTagAuthorizedUsers?: Array<string> | null;
   gitTagVersionsEnabled: boolean;
+  id: string;
   manualPrTestingEnabled: boolean;
   oldestAllowedMergeBase: string;
   prTestingEnabled: boolean;
@@ -3954,6 +3963,7 @@ export type ProjectGithubCommitQueueFragment = {
     gitTagAuthorizedTeams?: Array<string> | null;
     gitTagAuthorizedUsers?: Array<string> | null;
     gitTagVersionsEnabled?: boolean | null;
+    id: string;
     manualPrTestingEnabled?: boolean | null;
     oldestAllowedMergeBase: string;
     prTestingEnabled?: boolean | null;
@@ -3971,6 +3981,7 @@ export type RepoGithubCommitQueueFragment = {
     gitTagAuthorizedTeams?: Array<string> | null;
     gitTagAuthorizedUsers?: Array<string> | null;
     gitTagVersionsEnabled: boolean;
+    id: string;
     manualPrTestingEnabled: boolean;
     oldestAllowedMergeBase: string;
     prTestingEnabled: boolean;
@@ -3988,6 +3999,7 @@ export type ProjectEventGithubCommitQueueFragment = {
     gitTagAuthorizedTeams?: Array<string> | null;
     gitTagAuthorizedUsers?: Array<string> | null;
     gitTagVersionsEnabled?: boolean | null;
+    id: string;
     manualPrTestingEnabled?: boolean | null;
     oldestAllowedMergeBase: string;
     prTestingEnabled?: boolean | null;
@@ -4403,6 +4415,7 @@ export type RepoSettingsFieldsFragment = {
 
 export type ProjectNotificationSettingsFragment = {
   __typename?: "Project";
+  id: string;
   notifyOnBuildFailure?: boolean | null;
   banner?: {
     __typename?: "ProjectBanner";
@@ -4413,6 +4426,7 @@ export type ProjectNotificationSettingsFragment = {
 
 export type RepoNotificationSettingsFragment = {
   __typename?: "RepoRef";
+  id: string;
   notifyOnBuildFailure: boolean;
 };
 
@@ -4475,6 +4489,7 @@ export type SubscriptionsFragment = {
 export type ProjectPatchAliasSettingsFragment = {
   __typename?: "Project";
   githubTriggerAliases?: Array<string> | null;
+  id: string;
   patchTriggerAliases?: Array<{
     __typename?: "PatchTriggerAlias";
     alias: string;
@@ -4494,6 +4509,7 @@ export type ProjectPatchAliasSettingsFragment = {
 export type RepoPatchAliasSettingsFragment = {
   __typename?: "RepoRef";
   githubTriggerAliases?: Array<string> | null;
+  id: string;
   patchTriggerAliases?: Array<{
     __typename?: "PatchTriggerAlias";
     alias: string;
@@ -4512,6 +4528,7 @@ export type RepoPatchAliasSettingsFragment = {
 
 export type ProjectPeriodicBuildsSettingsFragment = {
   __typename?: "Project";
+  id: string;
   periodicBuilds?: Array<{
     __typename?: "PeriodicBuild";
     alias: string;
@@ -4526,6 +4543,7 @@ export type ProjectPeriodicBuildsSettingsFragment = {
 
 export type RepoPeriodicBuildsSettingsFragment = {
   __typename?: "RepoRef";
+  id: string;
   periodicBuilds?: Array<{
     __typename?: "PeriodicBuild";
     alias: string;
@@ -4547,6 +4565,7 @@ export type ProjectPermissionGroupSettingsFragment = {
   projectRef?: {
     __typename?: "Project";
     githubPermissionGroupByRequester?: { [key: string]: any } | null;
+    id: string;
     githubDynamicTokenPermissionGroups: Array<{
       __typename?: "GitHubDynamicTokenPermissionGroup";
       name: string;
@@ -4564,6 +4583,7 @@ export type ProjectEventPermissionGroupSettingsFragment = {
   projectRef?: {
     __typename?: "Project";
     githubPermissionGroupByRequester?: { [key: string]: any } | null;
+    id: string;
     githubDynamicTokenPermissionGroups: Array<{
       __typename?: "GitHubDynamicTokenPermissionGroup";
       name: string;
@@ -4581,6 +4601,7 @@ export type RepoPermissionGroupSettingsFragment = {
   projectRef?: {
     __typename?: "RepoRef";
     githubPermissionGroupByRequester?: { [key: string]: any } | null;
+    id: string;
     githubDynamicTokenPermissionGroups: Array<{
       __typename?: "GitHubDynamicTokenPermissionGroup";
       name: string;
@@ -4591,6 +4612,7 @@ export type RepoPermissionGroupSettingsFragment = {
 
 export type ProjectPluginsSettingsFragment = {
   __typename?: "Project";
+  id: string;
   perfEnabled?: boolean | null;
   buildBaronSettings: {
     __typename?: "BuildBaronSettings";
@@ -4616,6 +4638,7 @@ export type ProjectPluginsSettingsFragment = {
 
 export type RepoPluginsSettingsFragment = {
   __typename?: "RepoRef";
+  id: string;
   perfEnabled: boolean;
   buildBaronSettings: {
     __typename?: "BuildBaronSettings";
@@ -4663,6 +4686,7 @@ export type ProjectEventSettingsFragment = {
     tracksPushEvents?: boolean | null;
     versionControlEnabled?: boolean | null;
     githubPermissionGroupByRequester?: { [key: string]: any } | null;
+    id: string;
     admins?: Array<string> | null;
     restricted?: boolean | null;
     batchTime: number;
@@ -4844,6 +4868,7 @@ export type ProjectEventSettingsFragment = {
 
 export type ProjectTriggersSettingsFragment = {
   __typename?: "Project";
+  id: string;
   triggers?: Array<{
     __typename?: "TriggerAlias";
     alias: string;
@@ -4860,6 +4885,7 @@ export type ProjectTriggersSettingsFragment = {
 
 export type RepoTriggersSettingsFragment = {
   __typename?: "RepoRef";
+  id: string;
   triggers: Array<{
     __typename?: "TriggerAlias";
     alias: string;
@@ -4883,6 +4909,7 @@ export type VariablesFragment = {
 
 export type ProjectViewsAndFiltersSettingsFragment = {
   __typename?: "Project";
+  id: string;
   projectHealthView: ProjectHealthView;
   parsleyFilters?: Array<{
     __typename?: "ParsleyFilter";
@@ -4894,6 +4921,7 @@ export type ProjectViewsAndFiltersSettingsFragment = {
 
 export type RepoViewsAndFiltersSettingsFragment = {
   __typename?: "RepoRef";
+  id: string;
   parsleyFilters?: Array<{
     __typename?: "ParsleyFilter";
     caseSensitive: boolean;
@@ -4904,6 +4932,7 @@ export type RepoViewsAndFiltersSettingsFragment = {
 
 export type ProjectVirtualWorkstationSettingsFragment = {
   __typename?: "Project";
+  id: string;
   workstationConfig: {
     __typename?: "WorkstationConfig";
     gitClone?: boolean | null;
@@ -4917,6 +4946,7 @@ export type ProjectVirtualWorkstationSettingsFragment = {
 
 export type RepoVirtualWorkstationSettingsFragment = {
   __typename?: "RepoRef";
+  id: string;
   workstationConfig: {
     __typename?: "RepoWorkstationConfig";
     gitClone: boolean;
@@ -4930,6 +4960,7 @@ export type RepoVirtualWorkstationSettingsFragment = {
 
 export type UpstreamProjectFragment = {
   __typename?: "Version";
+  id: string;
   upstreamProject?: {
     __typename?: "UpstreamProject";
     owner: string;
@@ -7192,6 +7223,7 @@ export type ProjectEventLogsQuery = {
           tracksPushEvents?: boolean | null;
           versionControlEnabled?: boolean | null;
           githubPermissionGroupByRequester?: { [key: string]: any } | null;
+          id: string;
           admins?: Array<string> | null;
           restricted?: boolean | null;
           batchTime: number;
@@ -7405,6 +7437,7 @@ export type ProjectEventLogsQuery = {
           tracksPushEvents?: boolean | null;
           versionControlEnabled?: boolean | null;
           githubPermissionGroupByRequester?: { [key: string]: any } | null;
+          id: string;
           admins?: Array<string> | null;
           restricted?: boolean | null;
           batchTime: number;
@@ -7958,6 +7991,7 @@ export type RepoEventLogsQuery = {
           tracksPushEvents?: boolean | null;
           versionControlEnabled?: boolean | null;
           githubPermissionGroupByRequester?: { [key: string]: any } | null;
+          id: string;
           admins?: Array<string> | null;
           restricted?: boolean | null;
           batchTime: number;
@@ -8171,6 +8205,7 @@ export type RepoEventLogsQuery = {
           tracksPushEvents?: boolean | null;
           versionControlEnabled?: boolean | null;
           githubPermissionGroupByRequester?: { [key: string]: any } | null;
+          id: string;
           admins?: Array<string> | null;
           restricted?: boolean | null;
           batchTime: number;

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -54,7 +54,7 @@ module.exports = {
           { some: ["nesting", "id"] },
         ],
         "react-hooks/exhaustive-deps": WARN,
-        "react/no-unknown-property": ["error", { ignore: ["css"] }],
+        "react/no-unknown-property": [ERROR, { ignore: ["css"] }],
         "react-hooks/rules-of-hooks": ERROR,
 
         // Disable some Airbnb rules
@@ -114,8 +114,12 @@ module.exports = {
         ],
         "@graphql-eslint/no-deprecated": WARN,
         "@graphql-eslint/selection-set-depth": [WARN, { maxDepth: 8 }],
-        // Following rule can possibly be removed after ESLint updates.
         "spaced-comment": OFF,
+
+        // The following two rules are disabled because Spruce and Parsley could have
+        // identical fragment and operation names.
+        "@graphql-eslint/unique-fragment-name": OFF,
+        "@graphql-eslint/unique-operation-name": OFF
       },
     },
   ],

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "dependencies": {
     "@emotion/eslint-plugin": "11.12.0",
-    "@graphql-eslint/eslint-plugin": "3.20.1",
+    "@graphql-eslint/eslint-plugin": "^4.3.0",
     "@typescript-eslint/eslint-plugin": "^8.24.0",
     "@typescript-eslint/parser": "^8.24.0",
     "eslint": "8.56.0",
@@ -21,7 +21,7 @@
     "eslint-plugin-sort-destructure-keys": "^2.0.0",
     "eslint-plugin-storybook": "0.8.0",
     "eslint-plugin-testing-library": "^6.2.2",
-    "graphql": "16.8.1",
+    "graphql": "16.10.0",
     "prettier": "3.3.3",
     "typescript": "5.1.3"
   }

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -24,7 +24,7 @@
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/auto-instrumentations-web": "^0.40.0",
     "@opentelemetry/instrumentation-user-interaction": "^0.41.0",
-    "graphql": "16.8.1",
+    "graphql": "16.10.0",
     "query-string": "9.1.1"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -264,7 +264,7 @@
   dependencies:
     node-fetch "^2.6.1"
 
-"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.18.6", "@babel/code-frame@^7.24.2", "@babel/code-frame@^7.24.7":
+"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.24.2", "@babel/code-frame@^7.24.7":
   version "7.24.7"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.24.7.tgz#882fd9e09e8ee324e496bd040401c6f046ef4465"
   integrity sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==
@@ -1453,22 +1453,19 @@
     parse-filepath "^1.0.2"
     tslib "~2.6.0"
 
-"@graphql-eslint/eslint-plugin@3.20.1":
-  version "3.20.1"
-  resolved "https://registry.yarnpkg.com/@graphql-eslint/eslint-plugin/-/eslint-plugin-3.20.1.tgz#5ae22ee54a5624b852a7cb5f52a103da6384c643"
-  integrity sha512-RbwVlz1gcYG62sECR1u0XqMh8w5e5XMCCZoMvPQ3nJzEBCTfXLGX727GBoRmSvY1x4gJmqNZ1lsOX7lZY14RIw==
+"@graphql-eslint/eslint-plugin@^4.3.0":
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/@graphql-eslint/eslint-plugin/-/eslint-plugin-4.3.0.tgz#88077ad15728419e56205ed1f0e83308481145fa"
+  integrity sha512-9UTJfYNGAK5GuFapsNvA+508ke8YPc9Yt6mgT4Lc+gS18p53oG5wmXd3jdmNeVOfxhUefJcJbn925vIrjg/8/g==
   dependencies:
-    "@babel/code-frame" "^7.18.6"
-    "@graphql-tools/code-file-loader" "^7.3.6"
-    "@graphql-tools/graphql-tag-pluck" "^7.3.6"
-    "@graphql-tools/utils" "^9.0.0"
-    chalk "^4.1.2"
+    "@graphql-tools/code-file-loader" "^8.0.0"
+    "@graphql-tools/graphql-tag-pluck" "^8.3.4"
+    "@graphql-tools/utils" "^10.0.0"
     debug "^4.3.4"
     fast-glob "^3.2.12"
-    graphql-config "^4.4.0"
+    graphql-config "^5.1.3"
     graphql-depth-limit "^1.1.0"
     lodash.lowercase "^4.3.0"
-    tslib "^2.4.1"
 
 "@graphql-tools/apollo-engine-loader@^8.0.0":
   version "8.0.1"
@@ -1480,16 +1477,6 @@
     "@whatwg-node/fetch" "^0.9.0"
     tslib "^2.4.0"
 
-"@graphql-tools/batch-execute@^8.5.22":
-  version "8.5.22"
-  resolved "https://registry.yarnpkg.com/@graphql-tools/batch-execute/-/batch-execute-8.5.22.tgz#a742aa9d138fe794e786d8fb6429665dc7df5455"
-  integrity sha512-hcV1JaY6NJQFQEwCKrYhpfLK8frSXDbtNMoTur98u10Cmecy1zrqNKSqhEyGetpgHxaJRqszGzKeI3RuroDN6A==
-  dependencies:
-    "@graphql-tools/utils" "^9.2.1"
-    dataloader "^2.2.2"
-    tslib "^2.4.0"
-    value-or-promise "^1.0.12"
-
 "@graphql-tools/batch-execute@^9.0.4":
   version "9.0.4"
   resolved "https://registry.yarnpkg.com/@graphql-tools/batch-execute/-/batch-execute-9.0.4.tgz#11601409c0c33491971fc82592de12390ec58be2"
@@ -1499,17 +1486,6 @@
     dataloader "^2.2.2"
     tslib "^2.4.0"
     value-or-promise "^1.0.12"
-
-"@graphql-tools/code-file-loader@^7.3.6":
-  version "7.3.23"
-  resolved "https://registry.yarnpkg.com/@graphql-tools/code-file-loader/-/code-file-loader-7.3.23.tgz#33793f9a1f8e74981f8ae6ec4ab7061f9713db15"
-  integrity sha512-8Wt1rTtyTEs0p47uzsPJ1vAtfAx0jmxPifiNdmo9EOCuUPyQGEbMaik/YkqZ7QUFIEYEQu+Vgfo8tElwOPtx5Q==
-  dependencies:
-    "@graphql-tools/graphql-tag-pluck" "7.5.2"
-    "@graphql-tools/utils" "^9.2.1"
-    globby "^11.0.3"
-    tslib "^2.4.0"
-    unixify "^1.0.0"
 
 "@graphql-tools/code-file-loader@^8.0.0":
   version "8.1.2"
@@ -1534,19 +1510,6 @@
     dataloader "^2.2.2"
     tslib "^2.5.0"
 
-"@graphql-tools/delegate@^9.0.31":
-  version "9.0.35"
-  resolved "https://registry.yarnpkg.com/@graphql-tools/delegate/-/delegate-9.0.35.tgz#94683f4bcec63520b4a6c8b2abf2e2e9324ea4f1"
-  integrity sha512-jwPu8NJbzRRMqi4Vp/5QX1vIUeUPpWmlQpOkXQD2r1X45YsVceyUUBnktCrlJlDB4jPRVy7JQGwmYo3KFiOBMA==
-  dependencies:
-    "@graphql-tools/batch-execute" "^8.5.22"
-    "@graphql-tools/executor" "^0.0.20"
-    "@graphql-tools/schema" "^9.0.19"
-    "@graphql-tools/utils" "^9.2.1"
-    dataloader "^2.2.2"
-    tslib "^2.5.0"
-    value-or-promise "^1.0.12"
-
 "@graphql-tools/documents@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@graphql-tools/documents/-/documents-1.0.0.tgz#e3ed97197cc22ec830ca227fd7d17e86d8424bdf"
@@ -1554,19 +1517,6 @@
   dependencies:
     lodash.sortby "^4.7.0"
     tslib "^2.4.0"
-
-"@graphql-tools/executor-graphql-ws@^0.0.14":
-  version "0.0.14"
-  resolved "https://registry.yarnpkg.com/@graphql-tools/executor-graphql-ws/-/executor-graphql-ws-0.0.14.tgz#e0f53fc4cfc8a06cc461b2bc1edb4bb9a8e837ed"
-  integrity sha512-P2nlkAsPZKLIXImFhj0YTtny5NQVGSsKnhi7PzXiaHSXc6KkzqbWZHKvikD4PObanqg+7IO58rKFpGXP7eeO+w==
-  dependencies:
-    "@graphql-tools/utils" "^9.2.1"
-    "@repeaterjs/repeater" "3.0.4"
-    "@types/ws" "^8.0.0"
-    graphql-ws "5.12.1"
-    isomorphic-ws "5.0.0"
-    tslib "^2.4.0"
-    ws "8.13.0"
 
 "@graphql-tools/executor-graphql-ws@^1.1.2":
   version "1.1.2"
@@ -1579,20 +1529,6 @@
     isomorphic-ws "^5.0.0"
     tslib "^2.4.0"
     ws "^8.13.0"
-
-"@graphql-tools/executor-http@^0.1.7":
-  version "0.1.10"
-  resolved "https://registry.yarnpkg.com/@graphql-tools/executor-http/-/executor-http-0.1.10.tgz#faf48e18e62a925796c9653c2f50cf2095bc8e6f"
-  integrity sha512-hnAfbKv0/lb9s31LhWzawQ5hghBfHS+gYWtqxME6Rl0Aufq9GltiiLBcl7OVVOnkLF0KhwgbYP1mB5VKmgTGpg==
-  dependencies:
-    "@graphql-tools/utils" "^9.2.1"
-    "@repeaterjs/repeater" "^3.0.4"
-    "@whatwg-node/fetch" "^0.8.1"
-    dset "^3.1.2"
-    extract-files "^11.0.0"
-    meros "^1.2.1"
-    tslib "^2.4.0"
-    value-or-promise "^1.0.12"
 
 "@graphql-tools/executor-http@^1.0.9":
   version "1.0.9"
@@ -1607,17 +1543,6 @@
     tslib "^2.4.0"
     value-or-promise "^1.0.12"
 
-"@graphql-tools/executor-legacy-ws@^0.0.11":
-  version "0.0.11"
-  resolved "https://registry.yarnpkg.com/@graphql-tools/executor-legacy-ws/-/executor-legacy-ws-0.0.11.tgz#a1e12be8279e92a363a23d4105461a34cd9e389e"
-  integrity sha512-4ai+NnxlNfvIQ4c70hWFvOZlSUN8lt7yc+ZsrwtNFbFPH/EroIzFMapAxM9zwyv9bH38AdO3TQxZ5zNxgBdvUw==
-  dependencies:
-    "@graphql-tools/utils" "^9.2.1"
-    "@types/ws" "^8.0.0"
-    isomorphic-ws "5.0.0"
-    tslib "^2.4.0"
-    ws "8.13.0"
-
 "@graphql-tools/executor-legacy-ws@^1.0.6":
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/@graphql-tools/executor-legacy-ws/-/executor-legacy-ws-1.0.6.tgz#4ed311b731db8fd5c99e66a66361afbf9c2109fc"
@@ -1628,17 +1553,6 @@
     isomorphic-ws "^5.0.0"
     tslib "^2.4.0"
     ws "^8.15.0"
-
-"@graphql-tools/executor@^0.0.20":
-  version "0.0.20"
-  resolved "https://registry.yarnpkg.com/@graphql-tools/executor/-/executor-0.0.20.tgz#d51d159696e839522dd49d936636af251670e425"
-  integrity sha512-GdvNc4vszmfeGvUqlcaH1FjBoguvMYzxAfT6tDd4/LgwymepHhinqLNA5otqwVLW+JETcDaK7xGENzFomuE6TA==
-  dependencies:
-    "@graphql-tools/utils" "^9.2.1"
-    "@graphql-typed-document-node/core" "3.2.0"
-    "@repeaterjs/repeater" "^3.0.4"
-    tslib "^2.4.0"
-    value-or-promise "^1.0.12"
 
 "@graphql-tools/executor@^1.2.1":
   version "1.2.6"
@@ -1676,17 +1590,6 @@
     tslib "^2.4.0"
     value-or-promise "^1.0.12"
 
-"@graphql-tools/graphql-file-loader@^7.3.7":
-  version "7.5.17"
-  resolved "https://registry.yarnpkg.com/@graphql-tools/graphql-file-loader/-/graphql-file-loader-7.5.17.tgz#7c281617ea3ab4db4d42a2bdb49850f2b937f0f9"
-  integrity sha512-hVwwxPf41zOYgm4gdaZILCYnKB9Zap7Ys9OhY1hbwuAuC4MMNY9GpUjoTU3CQc3zUiPoYStyRtUGkHSJZ3HxBw==
-  dependencies:
-    "@graphql-tools/import" "6.7.18"
-    "@graphql-tools/utils" "^9.2.1"
-    globby "^11.0.3"
-    tslib "^2.4.0"
-    unixify "^1.0.0"
-
 "@graphql-tools/graphql-file-loader@^8.0.0":
   version "8.0.1"
   resolved "https://registry.yarnpkg.com/@graphql-tools/graphql-file-loader/-/graphql-file-loader-8.0.1.tgz#03869b14cb91d0ef539df8195101279bb2df9c9e"
@@ -1697,18 +1600,6 @@
     globby "^11.0.3"
     tslib "^2.4.0"
     unixify "^1.0.0"
-
-"@graphql-tools/graphql-tag-pluck@7.5.2", "@graphql-tools/graphql-tag-pluck@^7.3.6":
-  version "7.5.2"
-  resolved "https://registry.yarnpkg.com/@graphql-tools/graphql-tag-pluck/-/graphql-tag-pluck-7.5.2.tgz#502f1e066e19d832ebdeba5f571d7636dc27572d"
-  integrity sha512-RW+H8FqOOLQw0BPXaahYepVSRjuOHw+7IL8Opaa5G5uYGOBxoXR7DceyQ7BcpMgktAOOmpDNQ2WtcboChOJSRA==
-  dependencies:
-    "@babel/parser" "^7.16.8"
-    "@babel/plugin-syntax-import-assertions" "^7.20.0"
-    "@babel/traverse" "^7.16.8"
-    "@babel/types" "^7.16.8"
-    "@graphql-tools/utils" "^9.2.1"
-    tslib "^2.4.0"
 
 "@graphql-tools/graphql-tag-pluck@8.3.1", "@graphql-tools/graphql-tag-pluck@^8.0.0":
   version "8.3.1"
@@ -1723,13 +1614,17 @@
     "@graphql-tools/utils" "^10.0.13"
     tslib "^2.4.0"
 
-"@graphql-tools/import@6.7.18":
-  version "6.7.18"
-  resolved "https://registry.yarnpkg.com/@graphql-tools/import/-/import-6.7.18.tgz#ad092d8a4546bb6ffc3e871e499eec7ac368680b"
-  integrity sha512-XQDdyZTp+FYmT7as3xRWH/x8dx0QZA2WZqfMF5EWb36a0PiH7WwlRQYIdyYXj8YCLpiWkeBXgBRHmMnwEYR8iQ==
+"@graphql-tools/graphql-tag-pluck@^8.3.4":
+  version "8.3.14"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/graphql-tag-pluck/-/graphql-tag-pluck-8.3.14.tgz#d4928837a954bfbe23523c3e4df3c97043507d8d"
+  integrity sha512-dRo5f5/VwLI8bHRfgxl0q11fGFB/K+0/8Z8goPRQOT/Olik1RYnHVPhnK5BGSTLAMVpE3E7F+5jntkXLmuHuRA==
   dependencies:
-    "@graphql-tools/utils" "^9.2.1"
-    resolve-from "5.0.0"
+    "@babel/core" "^7.22.9"
+    "@babel/parser" "^7.16.8"
+    "@babel/plugin-syntax-import-assertions" "^7.20.0"
+    "@babel/traverse" "^7.16.8"
+    "@babel/types" "^7.16.8"
+    "@graphql-tools/utils" "^10.8.1"
     tslib "^2.4.0"
 
 "@graphql-tools/import@7.0.1":
@@ -1741,16 +1636,6 @@
     resolve-from "5.0.0"
     tslib "^2.4.0"
 
-"@graphql-tools/json-file-loader@^7.3.7":
-  version "7.4.18"
-  resolved "https://registry.yarnpkg.com/@graphql-tools/json-file-loader/-/json-file-loader-7.4.18.tgz#d78ae40979bde51cfc59717757354afc9e35fba2"
-  integrity sha512-AJ1b6Y1wiVgkwsxT5dELXhIVUPs/u3VZ8/0/oOtpcoyO/vAeM5rOvvWegzicOOnQw8G45fgBRMkkRfeuwVt6+w==
-  dependencies:
-    "@graphql-tools/utils" "^9.2.1"
-    globby "^11.0.3"
-    tslib "^2.4.0"
-    unixify "^1.0.0"
-
 "@graphql-tools/json-file-loader@^8.0.0":
   version "8.0.1"
   resolved "https://registry.yarnpkg.com/@graphql-tools/json-file-loader/-/json-file-loader-8.0.1.tgz#3fcfe869f22d8129a74369da69bf491c0bff7c2d"
@@ -1760,16 +1645,6 @@
     globby "^11.0.3"
     tslib "^2.4.0"
     unixify "^1.0.0"
-
-"@graphql-tools/load@^7.5.5":
-  version "7.8.14"
-  resolved "https://registry.yarnpkg.com/@graphql-tools/load/-/load-7.8.14.tgz#f2356f9a5f658a42e33934ae036e4b2cadf2d1e9"
-  integrity sha512-ASQvP+snHMYm+FhIaLxxFgVdRaM0vrN9wW2BKInQpktwWTXVyk+yP5nQUCEGmn0RTdlPKrffBaigxepkEAJPrg==
-  dependencies:
-    "@graphql-tools/schema" "^9.0.18"
-    "@graphql-tools/utils" "^9.2.1"
-    p-limit "3.1.0"
-    tslib "^2.4.0"
 
 "@graphql-tools/load@^8.0.0":
   version "8.0.2"
@@ -1781,7 +1656,7 @@
     p-limit "3.1.0"
     tslib "^2.4.0"
 
-"@graphql-tools/merge@^8.2.6", "@graphql-tools/merge@^8.4.1":
+"@graphql-tools/merge@^8.4.1":
   version "8.4.2"
   resolved "https://registry.yarnpkg.com/@graphql-tools/merge/-/merge-8.4.2.tgz#95778bbe26b635e8d2f60ce9856b388f11fe8288"
   integrity sha512-XbrHAaj8yDuINph+sAfuq3QCZ/tKblrTLOpirK0+CAgNlZUCHs0Fa+xtMUURgwCVThLle1AF7svJCxFizygLsw==
@@ -1845,7 +1720,7 @@
     tslib "^2.4.0"
     value-or-promise "^1.0.12"
 
-"@graphql-tools/schema@^9.0.0", "@graphql-tools/schema@^9.0.18", "@graphql-tools/schema@^9.0.19":
+"@graphql-tools/schema@^9.0.0":
   version "9.0.19"
   resolved "https://registry.yarnpkg.com/@graphql-tools/schema/-/schema-9.0.19.tgz#c4ad373b5e1b8a0cf365163435b7d236ebdd06e7"
   integrity sha512-oBRPoNBtCkk0zbUsyP4GaIzCt8C0aCI4ycIRUL67KK5pOHljKLBBtGT+Jr6hkzA74C8Gco8bpZPe7aWFjiaK2w==
@@ -1854,25 +1729,6 @@
     "@graphql-tools/utils" "^9.2.1"
     tslib "^2.4.0"
     value-or-promise "^1.0.12"
-
-"@graphql-tools/url-loader@^7.9.7":
-  version "7.17.18"
-  resolved "https://registry.yarnpkg.com/@graphql-tools/url-loader/-/url-loader-7.17.18.tgz#3e253594d23483e4c0dd3a4c3dd2ad5cd0141192"
-  integrity sha512-ear0CiyTj04jCVAxi7TvgbnGDIN2HgqzXzwsfcqiVg9cvjT40NcMlZ2P1lZDgqMkZ9oyLTV8Bw6j+SyG6A+xPw==
-  dependencies:
-    "@ardatan/sync-fetch" "^0.0.1"
-    "@graphql-tools/delegate" "^9.0.31"
-    "@graphql-tools/executor-graphql-ws" "^0.0.14"
-    "@graphql-tools/executor-http" "^0.1.7"
-    "@graphql-tools/executor-legacy-ws" "^0.0.11"
-    "@graphql-tools/utils" "^9.2.1"
-    "@graphql-tools/wrap" "^9.4.2"
-    "@types/ws" "^8.0.0"
-    "@whatwg-node/fetch" "^0.8.0"
-    isomorphic-ws "^5.0.0"
-    tslib "^2.4.0"
-    value-or-promise "^1.0.11"
-    ws "^8.12.0"
 
 "@graphql-tools/url-loader@^8.0.0", "@graphql-tools/url-loader@^8.0.2":
   version "8.0.2"
@@ -1903,7 +1759,17 @@
     dset "^3.1.2"
     tslib "^2.4.0"
 
-"@graphql-tools/utils@^9.0.0", "@graphql-tools/utils@^9.2.1":
+"@graphql-tools/utils@^10.8.1":
+  version "10.8.1"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/utils/-/utils-10.8.1.tgz#701e35d3214ce5e7d95c38b745e9e9720014e96b"
+  integrity sha512-fI5NNuqeEAHyp7NuCDjvxWR5PTUXM4AqY9BoC59ZcX4nePAJje27ZsFHbAMS6EKDosY1K/D4ADxsO0P5+FH07A==
+  dependencies:
+    "@graphql-typed-document-node/core" "^3.1.1"
+    cross-inspect "1.0.1"
+    dset "^3.1.4"
+    tslib "^2.4.0"
+
+"@graphql-tools/utils@^9.2.1":
   version "9.2.1"
   resolved "https://registry.yarnpkg.com/@graphql-tools/utils/-/utils-9.2.1.tgz#1b3df0ef166cfa3eae706e3518b17d5922721c57"
   integrity sha512-WUw506Ql6xzmOORlriNrD6Ugx+HjVgYxt9KCXD9mHAak+eaXSwuGGPyE60hy9xaDEoXKBsG7SkG69ybitaVl6A==
@@ -1919,17 +1785,6 @@
     "@graphql-tools/delegate" "^10.0.4"
     "@graphql-tools/schema" "^10.0.3"
     "@graphql-tools/utils" "^10.1.1"
-    tslib "^2.4.0"
-    value-or-promise "^1.0.12"
-
-"@graphql-tools/wrap@^9.4.2":
-  version "9.4.2"
-  resolved "https://registry.yarnpkg.com/@graphql-tools/wrap/-/wrap-9.4.2.tgz#30835587c4c73be1780908a7cb077d8013aa2703"
-  integrity sha512-DFcd9r51lmcEKn0JW43CWkkI2D6T9XI1juW/Yo86i04v43O9w2/k4/nx2XTJv4Yv+iXwUw7Ok81PGltwGJSDSA==
-  dependencies:
-    "@graphql-tools/delegate" "^9.0.31"
-    "@graphql-tools/schema" "^9.0.18"
-    "@graphql-tools/utils" "^9.2.1"
     tslib "^2.4.0"
     value-or-promise "^1.0.12"
 
@@ -3370,33 +3225,6 @@
   dependencies:
     esbuild "^0.14.14"
 
-"@peculiar/asn1-schema@^2.3.8":
-  version "2.3.8"
-  resolved "https://registry.yarnpkg.com/@peculiar/asn1-schema/-/asn1-schema-2.3.8.tgz#04b38832a814e25731232dd5be883460a156da3b"
-  integrity sha512-ULB1XqHKx1WBU/tTFIA+uARuRoBVZ4pNdOA878RDrRbBfBGcSzi5HBkdScC6ZbHn8z7L8gmKCgPC1LHRrP46tA==
-  dependencies:
-    asn1js "^3.0.5"
-    pvtsutils "^1.3.5"
-    tslib "^2.6.2"
-
-"@peculiar/json-schema@^1.1.12":
-  version "1.1.12"
-  resolved "https://registry.yarnpkg.com/@peculiar/json-schema/-/json-schema-1.1.12.tgz#fe61e85259e3b5ba5ad566cb62ca75b3d3cd5339"
-  integrity sha512-coUfuoMeIB7B8/NMekxaDzLhaYmp0HZNPEjYRm9goRou8UZIC3z21s0sL9AWoCw4EG876QyO3kYrc61WNF9B/w==
-  dependencies:
-    tslib "^2.0.0"
-
-"@peculiar/webcrypto@^1.4.0":
-  version "1.4.6"
-  resolved "https://registry.yarnpkg.com/@peculiar/webcrypto/-/webcrypto-1.4.6.tgz#607af294c4f205efeeb172aa32cb20024fe4aecf"
-  integrity sha512-YBcMfqNSwn3SujUJvAaySy5tlYbYm6tVt9SKoXu8BaTdKGROiJDgPR3TXpZdAKUfklzm3lRapJEAltiMQtBgZg==
-  dependencies:
-    "@peculiar/asn1-schema" "^2.3.8"
-    "@peculiar/json-schema" "^1.1.12"
-    pvtsutils "^1.3.5"
-    tslib "^2.6.2"
-    webcrypto-core "^1.7.9"
-
 "@pkgjs/parseargs@^0.11.0":
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
@@ -3469,11 +3297,6 @@
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.11.0.tgz#e0e45ac3fff9d8a126916f166809825537e9f955"
   integrity sha512-BHdhcWgeiudl91HvVa2wxqZjSHbheSgIiDvxrF1VjFzBzpTtuDPkOdOi3Iqvc08kXtFkLjhbS+ML9aM8mJS+wQ==
-
-"@repeaterjs/repeater@3.0.4":
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/@repeaterjs/repeater/-/repeater-3.0.4.tgz#a04d63f4d1bf5540a41b01a921c9a7fddc3bd1ca"
-  integrity sha512-AW8PKd6iX3vAZ0vA43nOUOnbq/X5ihgU+mSXXqunMkeQADGiqw/PY0JNeYtD5sr0PAy51YPgAPbDoeapv9r8WA==
 
 "@repeaterjs/repeater@^3.0.4":
   version "3.0.6"
@@ -4640,11 +4463,6 @@
   dependencies:
     tslib "^2.6.3"
 
-"@whatwg-node/events@^0.0.3":
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/@whatwg-node/events/-/events-0.0.3.tgz#13a65dd4f5893f55280f766e29ae48074927acad"
-  integrity sha512-IqnKIDWfXBJkvy/k6tzskWTc2NK3LcqHlb+KHGCrjOCH4jfQckRX0NAiIcC/vIqQkzLYw2r2CTSwAxcrtcD6lA==
-
 "@whatwg-node/fetch@^0.10.0":
   version "0.10.3"
   resolved "https://registry.yarnpkg.com/@whatwg-node/fetch/-/fetch-0.10.3.tgz#b19883b8a1568c5ae09abd550589ec597e685f4b"
@@ -4653,17 +4471,6 @@
     "@whatwg-node/node-fetch" "^0.7.7"
     urlpattern-polyfill "^10.0.0"
 
-"@whatwg-node/fetch@^0.8.0", "@whatwg-node/fetch@^0.8.1":
-  version "0.8.8"
-  resolved "https://registry.yarnpkg.com/@whatwg-node/fetch/-/fetch-0.8.8.tgz#48c6ad0c6b7951a73e812f09dd22d75e9fa18cae"
-  integrity sha512-CdcjGC2vdKhc13KKxgsc6/616BQ7ooDIgPeTuAiE8qfCnS0mGzcfCOoZXypQSz73nxI+GWc7ZReIAVhxoE1KCg==
-  dependencies:
-    "@peculiar/webcrypto" "^1.4.0"
-    "@whatwg-node/node-fetch" "^0.3.6"
-    busboy "^1.6.0"
-    urlpattern-polyfill "^8.0.0"
-    web-streams-polyfill "^3.2.1"
-
 "@whatwg-node/fetch@^0.9.0":
   version "0.9.21"
   resolved "https://registry.yarnpkg.com/@whatwg-node/fetch/-/fetch-0.9.21.tgz#24a08c441126ae2d0f94544e718bdb4a8c2b5ad0"
@@ -4671,17 +4478,6 @@
   dependencies:
     "@whatwg-node/node-fetch" "^0.5.23"
     urlpattern-polyfill "^10.0.0"
-
-"@whatwg-node/node-fetch@^0.3.6":
-  version "0.3.6"
-  resolved "https://registry.yarnpkg.com/@whatwg-node/node-fetch/-/node-fetch-0.3.6.tgz#e28816955f359916e2d830b68a64493124faa6d0"
-  integrity sha512-w9wKgDO4C95qnXZRwZTfCmLWqyRnooGjcIwG0wADWjw9/HN0p7dtvtgSvItZtUyNteEvgTrd8QojNEqV6DAGTA==
-  dependencies:
-    "@whatwg-node/events" "^0.0.3"
-    busboy "^1.6.0"
-    fast-querystring "^1.1.1"
-    fast-url-parser "^1.1.3"
-    tslib "^2.3.1"
 
 "@whatwg-node/node-fetch@^0.5.23":
   version "0.5.26"
@@ -5118,15 +4914,6 @@ asn1@~0.2.3:
   integrity sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==
   dependencies:
     safer-buffer "~2.1.0"
-
-asn1js@^3.0.1, asn1js@^3.0.5:
-  version "3.0.5"
-  resolved "https://registry.yarnpkg.com/asn1js/-/asn1js-3.0.5.tgz#5ea36820443dbefb51cc7f88a2ebb5b462114f38"
-  integrity sha512-FVnvrKJwpt9LP2lAMl8qZswRNm3T4q9CON+bxldk2iwk3FFpuwhx2FfinyitizWHsVYyaY+y5JzDR0rCMV5yTQ==
-  dependencies:
-    pvtsutils "^1.3.2"
-    pvutils "^1.1.3"
-    tslib "^2.4.0"
 
 assert-plus@1.0.0, assert-plus@^1.0.0:
   version "1.0.0"
@@ -5996,16 +5783,6 @@ cors@^2.8.5:
     object-assign "^4"
     vary "^1"
 
-cosmiconfig@8.0.0:
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-8.0.0.tgz#e9feae014eab580f858f8a0288f38997a7bebe97"
-  integrity sha512-da1EafcpH6b/TD8vDRaWV7xFINlHlF6zKsGwS1TsuVJTZRkquaS5HTMq7uq6h31619QjbsYl21gVDOm32KM1vQ==
-  dependencies:
-    import-fresh "^3.2.1"
-    js-yaml "^4.1.0"
-    parse-json "^5.0.0"
-    path-type "^4.0.0"
-
 cosmiconfig@^7.0.0:
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-7.1.0.tgz#1443b9afa596b670082ea46cbd8f6a62b84635f6"
@@ -6017,7 +5794,7 @@ cosmiconfig@^7.0.0:
     path-type "^4.0.0"
     yaml "^1.10.0"
 
-cosmiconfig@^8.1.3:
+cosmiconfig@^8.1.0, cosmiconfig@^8.1.3:
   version "8.3.6"
   resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-8.3.6.tgz#060a2b871d66dba6c8538ea1118ba1ac16f5fae3"
   integrity sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==
@@ -6048,6 +5825,13 @@ cross-inspect@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/cross-inspect/-/cross-inspect-1.0.0.tgz#5fda1af759a148594d2d58394a9e21364f6849af"
   integrity sha512-4PFfn4b5ZN6FMNGSZlyb7wUhuN8wvj8t/VQHZdM4JsDcruGJ8L2kf9zao98QIrBPFCpdk27qst/AGTl7pL3ypQ==
+  dependencies:
+    tslib "^2.4.0"
+
+cross-inspect@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/cross-inspect/-/cross-inspect-1.0.1.tgz#15f6f65e4ca963cf4cc1a2b5fef18f6ca328712b"
+  integrity sha512-Pcw1JTvZLSJH83iiGWt6fRcT+BjZlCDRVwYLbUcHzv/CRpB7r0MlSrGbIyQvVSNyGnbt7G4AXuyCiDR3POvZ1A==
   dependencies:
     tslib "^2.4.0"
 
@@ -6547,6 +6331,11 @@ dset@^3.1.2:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/dset/-/dset-3.1.3.tgz#c194147f159841148e8e34ca41f638556d9542d2"
   integrity sha512-20TuZZHCEZ2O71q9/+8BwKwZ0QtD9D8ObhrihJPr+vLLYlSuAU3/zL4cSlgbfeoGHTjCSJBa7NGcrF9/Bx/WJQ==
+
+dset@^3.1.4:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/dset/-/dset-3.1.4.tgz#f8eaf5f023f068a036d08cd07dc9ffb7d0065248"
+  integrity sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA==
 
 dunder-proto@^1.0.0, dunder-proto@^1.0.1:
   version "1.0.1"
@@ -7617,7 +7406,7 @@ fast-querystring@^1.1.1:
   dependencies:
     fast-decode-uri-component "^1.0.1"
 
-fast-url-parser@1.1.3, fast-url-parser@^1.1.3:
+fast-url-parser@1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/fast-url-parser/-/fast-url-parser-1.1.3.tgz#f4af3ea9f34d8a271cf58ad2b3759f431f0b318d"
   integrity sha512-5jOCVXADYNuRkKFzNJ0dCCewsZiYo0dz8QNYljkOpFC6r2U4OBmKtvm/Tsuh4w1YYdDqDb31a8TVhBJ2OJKdqQ==
@@ -8076,23 +7865,6 @@ graphemer@^1.4.0:
   resolved "https://registry.yarnpkg.com/graphemer/-/graphemer-1.4.0.tgz#fb2f1d55e0e3a1849aeffc90c4fa0dd53a0e66c6"
   integrity sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==
 
-graphql-config@^4.4.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/graphql-config/-/graphql-config-4.5.0.tgz#257c2338950b8dce295a27f75c5f6c39f8f777b2"
-  integrity sha512-x6D0/cftpLUJ0Ch1e5sj1TZn6Wcxx4oMfmhaG9shM0DKajA9iR+j1z86GSTQ19fShbGvrSSvbIQsHku6aQ6BBw==
-  dependencies:
-    "@graphql-tools/graphql-file-loader" "^7.3.7"
-    "@graphql-tools/json-file-loader" "^7.3.7"
-    "@graphql-tools/load" "^7.5.5"
-    "@graphql-tools/merge" "^8.2.6"
-    "@graphql-tools/url-loader" "^7.9.7"
-    "@graphql-tools/utils" "^9.0.0"
-    cosmiconfig "8.0.0"
-    jiti "1.17.1"
-    minimatch "4.2.3"
-    string-env-interpolation "1.0.1"
-    tslib "^2.4.0"
-
 graphql-config@^5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/graphql-config/-/graphql-config-5.1.2.tgz#ecd7b59de27b706e4714720f550dbeb0caa1bc10"
@@ -8106,6 +7878,23 @@ graphql-config@^5.1.1:
     "@graphql-tools/utils" "^10.0.0"
     cosmiconfig "^9.0.0"
     jiti "^1.18.2"
+    minimatch "^9.0.5"
+    string-env-interpolation "^1.0.1"
+    tslib "^2.4.0"
+
+graphql-config@^5.1.3:
+  version "5.1.3"
+  resolved "https://registry.yarnpkg.com/graphql-config/-/graphql-config-5.1.3.tgz#343e2867dafd5b009cd97fe6b29a5e9604001819"
+  integrity sha512-RBhejsPjrNSuwtckRlilWzLVt2j8itl74W9Gke1KejDTz7oaA5kVd6wRn9zK9TS5mcmIYGxf7zN7a1ORMdxp1Q==
+  dependencies:
+    "@graphql-tools/graphql-file-loader" "^8.0.0"
+    "@graphql-tools/json-file-loader" "^8.0.0"
+    "@graphql-tools/load" "^8.0.0"
+    "@graphql-tools/merge" "^9.0.0"
+    "@graphql-tools/url-loader" "^8.0.0"
+    "@graphql-tools/utils" "^10.0.0"
+    cosmiconfig "^8.1.0"
+    jiti "^2.0.0"
     minimatch "^9.0.5"
     string-env-interpolation "^1.0.1"
     tslib "^2.4.0"
@@ -8132,20 +7921,15 @@ graphql-tag@^2.11.0, graphql-tag@^2.12.6, graphql-tag@^2.9.2:
   dependencies:
     tslib "^2.1.0"
 
-graphql-ws@5.12.1:
-  version "5.12.1"
-  resolved "https://registry.yarnpkg.com/graphql-ws/-/graphql-ws-5.12.1.tgz#c62d5ac54dbd409cc6520b0b39de374b3d59d0dd"
-  integrity sha512-umt4f5NnMK46ChM2coO36PTFhHouBrK9stWWBczERguwYrGnPNxJ9dimU6IyOBfOkC6Izhkg4H8+F51W/8CYDg==
-
 graphql-ws@^5.14.0:
   version "5.16.0"
   resolved "https://registry.yarnpkg.com/graphql-ws/-/graphql-ws-5.16.0.tgz#849efe02f384b4332109329be01d74c345842729"
   integrity sha512-Ju2RCU2dQMgSKtArPbEtsK5gNLnsQyTNIo/T7cZNp96niC1x0KdJNZV0TIoilceBPQwfb5itrGl8pkFeOUMl4A==
 
-graphql@16.8.1:
-  version "16.8.1"
-  resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.8.1.tgz#1930a965bef1170603702acdb68aedd3f3cf6f07"
-  integrity sha512-59LZHPdGZVh695Ud9lRzPBVTtlX9ZCV150Er2W43ro37wVof0ctenSaskPPjN7lVTIN8mSZt8PHUNKZuNQUuxw==
+graphql@16.10.0:
+  version "16.10.0"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.10.0.tgz#24c01ae0af6b11ea87bf55694429198aaa8e220c"
+  integrity sha512-AjqGKbDGUFRKIRCP9tCKiIGHyriz2oHEbPIbEtcSLSs4YjReZOIPQQWek4+6hjw62H9QShXHyaGivGiYVLeYFQ==
 
 harmony-reflect@^1.4.6:
   version "1.6.2"
@@ -8980,7 +8764,7 @@ isexe@^2.0.0:
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==
 
-isomorphic-ws@5.0.0, isomorphic-ws@^5.0.0:
+isomorphic-ws@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/isomorphic-ws/-/isomorphic-ws-5.0.0.tgz#e5529148912ecb9b451b46ed44d53dae1ce04bbf"
   integrity sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==
@@ -9019,15 +8803,15 @@ jest-canvas-mock@~2.5.2:
     cssfontparser "^1.2.1"
     moo-color "^1.0.2"
 
-jiti@1.17.1:
-  version "1.17.1"
-  resolved "https://registry.yarnpkg.com/jiti/-/jiti-1.17.1.tgz#264daa43ee89a03e8be28c3d712ccc4eb9f1e8ed"
-  integrity sha512-NZIITw8uZQFuzQimqjUxIrIcEdxYDFIe/0xYfIlVXTkiBjjyBEvgasj5bb0/cHtPRD/NziPbT312sFrkI5ALpw==
-
 jiti@^1.17.1, jiti@^1.18.2:
   version "1.21.0"
   resolved "https://registry.yarnpkg.com/jiti/-/jiti-1.21.0.tgz#7c97f8fe045724e136a397f7340475244156105d"
   integrity sha512-gFqAIbuKyyso/3G2qhiO2OM6shY6EPP/R0+mkDbyspxKazh8BXDC5FiFsUjlczgdNz/vfra0da2y+aHrusLG/Q==
+
+jiti@^2.0.0:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/jiti/-/jiti-2.4.2.tgz#d19b7732ebb6116b06e2038da74a55366faef560"
+  integrity sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==
 
 jose@^5.0.0:
   version "5.3.0"
@@ -9681,13 +9465,6 @@ minimatch@3.1.2, minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.1, minimatch
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
   integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
-  dependencies:
-    brace-expansion "^1.1.7"
-
-minimatch@4.2.3:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-4.2.3.tgz#b4dcece1d674dee104bb0fb833ebb85a78cbbca6"
-  integrity sha512-lIUdtK5hdofgCTu3aT0sOaHsYR37viUuIc0rwnnDXImbwFRcumyLMeZaM0t0I/fgxS6s6JMfu0rLD1Wz9pv1ng==
   dependencies:
     brace-expansion "^1.1.7"
 
@@ -10473,18 +10250,6 @@ punycode@^2.1.0, punycode@^2.1.1, punycode@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.1.tgz#027422e2faec0b25e1549c3e1bd8309b9133b6e5"
   integrity sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==
-
-pvtsutils@^1.3.2, pvtsutils@^1.3.5:
-  version "1.3.5"
-  resolved "https://registry.yarnpkg.com/pvtsutils/-/pvtsutils-1.3.5.tgz#b8705b437b7b134cd7fd858f025a23456f1ce910"
-  integrity sha512-ARvb14YB9Nm2Xi6nBq1ZX6dAM0FsJnuk+31aUp4TrcZEdKUlSqOqsxJHUPJDNE3qiIp+iUPEIeR6Je/tgV7zsA==
-  dependencies:
-    tslib "^2.6.1"
-
-pvutils@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/pvutils/-/pvutils-1.1.3.tgz#f35fc1d27e7cd3dfbd39c0826d173e806a03f5a3"
-  integrity sha512-pMpnA0qRdFp32b1sJl1wOJNxZLQ2cbQx+k6tjNtZ8CpvVhNqEPRgivZ2WOUev2YMajecdH7ctUPDvEe87nariQ==
 
 qs@6.13.0:
   version "6.13.0"
@@ -11888,7 +11653,7 @@ string-convert@^0.2.0:
   resolved "https://registry.yarnpkg.com/string-convert/-/string-convert-0.2.1.tgz#6982cc3049fbb4cd85f8b24568b9d9bf39eeff97"
   integrity sha512-u/1tdPl4yQnPBjnVrmdLo9gtuLvELKsAoRapekWggdiQNvvvum+jYF329d84NAa660KQw7pB2n36KrIKVoXa3A==
 
-string-env-interpolation@1.0.1, string-env-interpolation@^1.0.1:
+string-env-interpolation@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/string-env-interpolation/-/string-env-interpolation-1.0.1.tgz#ad4397ae4ac53fe6c91d1402ad6f6a52862c7152"
   integrity sha512-78lwMoCcn0nNu8LszbP1UA7g55OeE4v7rCeWnM5B453rnNr4aq+5it3FEYtZrSEiMvHZOZ9Jlqb0OD0M2VInqg==
@@ -12344,7 +12109,7 @@ tslib@^1.8.1:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.0.0, tslib@^2.0.1, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.3.0, tslib@^2.3.1, tslib@^2.4.0, tslib@^2.4.1, tslib@^2.5.0, tslib@^2.6.1, tslib@^2.6.2, tslib@^2.6.3:
+tslib@^2.0.1, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.3.0, tslib@^2.4.0, tslib@^2.5.0, tslib@^2.6.2, tslib@^2.6.3:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.7.0.tgz#d9b40c5c40ab59e8738f297df3087bf1a2690c01"
   integrity sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==
@@ -12657,11 +12422,6 @@ urlpattern-polyfill@^10.0.0:
   resolved "https://registry.yarnpkg.com/urlpattern-polyfill/-/urlpattern-polyfill-10.0.0.tgz#f0a03a97bfb03cdf33553e5e79a2aadd22cac8ec"
   integrity sha512-H/A06tKD7sS1O1X2SshBVeA5FLycRpjqiBeqGKmBwBDBy28EnRjORxTNe269KSSr5un5qyWi1iL61wLxpd+ZOg==
 
-urlpattern-polyfill@^8.0.0:
-  version "8.0.2"
-  resolved "https://registry.yarnpkg.com/urlpattern-polyfill/-/urlpattern-polyfill-8.0.2.tgz#99f096e35eff8bf4b5a2aa7d58a1523d6ebc7ce5"
-  integrity sha512-Qp95D4TPJl1kC9SKigDcqgyM2VDVO4RiJc2d4qe5GrYm+zbIQCWWKAFaJNQ4BhdFeDGwBmAxqJBwWSJDb9T3BQ==
-
 util-deprecate@^1.0.1, util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
@@ -12931,26 +12691,10 @@ wcwidth@^1.0.1:
   dependencies:
     defaults "^1.0.3"
 
-web-streams-polyfill@^3.2.1:
-  version "3.3.3"
-  resolved "https://registry.yarnpkg.com/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz#2073b91a2fdb1fbfbd401e7de0ac9f8214cecb4b"
-  integrity sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==
-
 web-vitals@^4.0.0:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/web-vitals/-/web-vitals-4.2.2.tgz#e883245180b95e175eb75a5ca8903b1a11597d7a"
   integrity sha512-nYfoOqb4EmElljyXU2qdeE76KsvoHdftQKY4DzA9Aw8DervCg2bG634pHLrJ/d6+B4mE3nWTSJv8Mo7B2mbZkw==
-
-webcrypto-core@^1.7.9:
-  version "1.7.9"
-  resolved "https://registry.yarnpkg.com/webcrypto-core/-/webcrypto-core-1.7.9.tgz#a585f0032dbc88d202cff4f266cbef02ba48bd7a"
-  integrity sha512-FE+a4PPkOmBbgNDIyRmcHhgXn+2ClRl3JzJdDu/P4+B8y81LqKe6RAsI9b3lAOHe1T1BMkSjsRHTYRikImZnVA==
-  dependencies:
-    "@peculiar/asn1-schema" "^2.3.8"
-    "@peculiar/json-schema" "^1.1.12"
-    asn1js "^3.0.1"
-    pvtsutils "^1.3.5"
-    tslib "^2.6.2"
 
 webidl-conversions@^3.0.0:
   version "3.0.1"
@@ -13161,11 +12905,6 @@ wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
-
-ws@8.13.0:
-  version "8.13.0"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-8.13.0.tgz#9a9fb92f93cf41512a0735c8f4dd09b8a1211cd0"
-  integrity sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==
 
 ws@^8.12.0, ws@^8.13.0, ws@^8.15.0, ws@^8.16.0, ws@^8.2.3:
   version "8.17.0"


### PR DESCRIPTION
DEVPROD-14916
<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
Upgrades `@graphql-eslint/eslint-plugin` (and `graphql` because it didn't work unless I upgraded that too).

Also reintroduces `.graphqlrc` files so that you can Command + Click to the schema files
