### PR TITLE
DEVPROD-13189: use GitHub dynamic token for downloading Go modules

### DIFF
--- a/.evergreen/scripts/generate-parallel-e2e-tasks.js
+++ b/.evergreen/scripts/generate-parallel-e2e-tasks.js
@@ -109,6 +109,7 @@ const generateParallelE2ETasks = (bv) => {
     name: `e2e_${bv}_${i}`,
     commands: [
       { func: "setup-mongodb" },
+      { func: "generate-token" },
       { func: "run-make-background", vars: { target: "local-evergreen" } },
       { func: "symlink" },
       { func: "seed-bucket-data" },

--- a/.evergreen/shared.yml
+++ b/.evergreen/shared.yml
@@ -25,6 +25,17 @@ functions:
       directory: ui
       shallow_clone: true
 
+  generate-token:
+    - command: github.generate_token
+      type: setup
+      params:
+        expansion_name: github_token
+    - command: shell.exec
+      params:
+        script: |
+          # Set GitHub app dynamic token to ensure it can clone non-public repos for Go modules.
+          git config --global url."https://x-access-token:${github_token}@github.com/evergreen-ci/".insteadOf https://github.com/evergreen-ci/
+
   run-make-background:
     command: subprocess.exec
     params:
@@ -270,6 +281,7 @@ tasks:
   - name: e2e
     commands:
       - func: setup-mongodb
+      - func: generate-token
       - func: run-make-background
         vars:
           target: local-evergreen


### PR DESCRIPTION
DEVPROD-13189

### Description
https://github.com/evergreen-ci/evergreen/pull/8710 introduces a new [non-public repo](https://github.com/evergreen-ci/test-selection-client) as a Go module. Since the UI compiles Evergreen as part of the e2e tests, it needs to have a GitHub token that can clone the non-public repo. I copied the relevant project YAML configuration for generating/setting the token from that PR and set up the GitHub app in the evergreen-ui project settings.

### Screenshots
N/A

### Testing
e2e tests pass.

### Evergreen PR
https://github.com/evergreen-ci/evergreen/pull/8710