### PR TITLE
DEVPROD-15032

### DIFF
--- a/apps/spruce/src/analytics/version/useVersionAnalytics.ts
+++ b/apps/spruce/src/analytics/version/useVersionAnalytics.ts
@@ -34,7 +34,7 @@ type Action =
   | { name: "Viewed notification modal" }
   | { name: "Viewed schedule tasks modal" }
   | { name: "Clicked restart tasks button"; abort: boolean }
-  | { name: "Clicked schedule tasks button" }
+  | { name: "Clicked schedule tasks button"; "tasks_scheduled.count": number }
   | { name: "Clicked patch reconfigure link" }
   | { name: "Changed version priority"; "version.priority": number }
   | {

--- a/apps/spruce/src/components/LinkToReconfigurePage.tsx
+++ b/apps/spruce/src/components/LinkToReconfigurePage.tsx
@@ -22,6 +22,11 @@ export const LinkToReconfigurePage: React.FC<{
           sendEvent({ name: "Clicked patch reconfigure link" });
         }
       }}
+      title={
+        disabled
+          ? "This is not a reconfigurable patch use the schedule button instead to schedule tasks"
+          : ""
+      }
       to={getPatchRoute(patchId, { configure: true })}
     >
       Reconfigure tasks/variants

--- a/apps/spruce/src/components/ScheduleTasksModal/index.tsx
+++ b/apps/spruce/src/components/ScheduleTasksModal/index.tsx
@@ -6,6 +6,7 @@ import { Body } from "@leafygreen-ui/typography";
 import { Skeleton } from "antd";
 import { size } from "@evg-ui/lib/constants/tokens";
 import { useToastContext } from "@evg-ui/lib/context/toast";
+import { useVersionAnalytics } from "analytics";
 import { Accordion } from "components/Accordion";
 import { TaskSchedulingWarningBanner } from "components/Banners/TaskSchedulingWarningBanner";
 import { ConfirmationModal } from "components/ConfirmationModal";
@@ -37,6 +38,7 @@ export const ScheduleTasksModal: React.FC<ScheduleTasksModalProps> = ({
     setOpen(false);
   };
   const dispatchToast = useToastContext();
+  const { sendEvent } = useVersionAnalytics(versionId);
   const [scheduleTasks, { loading: loadingScheduleTasksMutation }] =
     useMutation<ScheduleTasksMutation, ScheduleTasksMutationVariables>(
       SCHEDULE_TASKS,
@@ -81,18 +83,28 @@ export const ScheduleTasksModal: React.FC<ScheduleTasksModalProps> = ({
 
   return (
     <ConfirmationModal
-      buttonText="Schedule"
-      data-cy="schedule-tasks-modal"
-      onCancel={closeModal}
-      onConfirm={() => {
-        scheduleTasks({
-          variables: { taskIds: Array.from(selectedTasks), versionId },
-        });
+      cancelButtonProps={{
+        children: "Cancel",
+        onClick: closeModal,
       }}
+      confirmButtonProps={{
+        children: "Schedule",
+        disabled:
+          loadingTaskData ||
+          loadingScheduleTasksMutation ||
+          !selectedTasks.size,
+        onClick: () => {
+          sendEvent({
+            name: "Clicked schedule tasks button",
+            "tasks_scheduled.count": selectedTasks.size,
+          });
+          scheduleTasks({
+            variables: { taskIds: Array.from(selectedTasks), versionId },
+          });
+        },
+      }}
+      data-cy="schedule-tasks-modal"
       open={open}
-      submitDisabled={
-        loadingTaskData || loadingScheduleTasksMutation || !selectedTasks.size
-      }
       title="Schedule Tasks"
     >
       <ContentWrapper>


### PR DESCRIPTION
DEVPROD-15032
<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
This issue in this slack [thread](https://mongodb.slack.com/archives/C0V896UV8/p1739902944738679) stemmed from confusion around the differences between scheduling tasks in a version and configuring a patch. 
This PR adds a title attribute to the button to hopefully clarify why its disabled and point users to the correct button. 
Also while investigating the issue I noticed the analytics events weren't as useful as I expected so I am adding some more attributes to make them more useful.

### Screenshots
<!-- add screenshots of visible changes -->

### Testing
<!-- add a description of how you tested it -->

Have you have updated the analytics documentation if necessary?  
https://docs.google.com/spreadsheets/d/1s4_nq8ZiphXp5Uq_-9HT6GPqz-KOyaq6HuvmXYaSNzg/edit?usp=sharing 

Yes

### Evergreen PR
<!-- link to a corresponding Evergreen PR if applicable -->
