### PR TITLE
DEVPROD-12594: Clear order params when reaching the first page

### DIFF
--- a/apps/spruce/cypress/integration/waterfall/pagination.ts
+++ b/apps/spruce/cypress/integration/waterfall/pagination.ts
@@ -111,4 +111,15 @@ describe("pagination", () => {
       cy.location("search").should("not.contain", "minOrder");
     });
   });
+
+  it("clears minOrder and maxOrder params when reaching the first page", () => {
+    cy.dataCy("next-page-button").click();
+    cy.dataCy("version-labels").children().should("have.length", 5);
+    cy.location("search").should("contain", "maxOrder");
+
+    cy.dataCy("prev-page-button").click();
+    cy.dataCy("version-labels").children().should("have.length", 6);
+    cy.location("search").should("not.contain", "maxOrder");
+    cy.location("search").should("not.contain", "minOrder");
+  });
 });

--- a/apps/spruce/src/pages/waterfall/caching/caching.test.ts
+++ b/apps/spruce/src/pages/waterfall/caching/caching.test.ts
@@ -329,4 +329,38 @@ describe("readVersions", () => {
       ),
     ).toBe(undefined);
   });
+
+  it("returns first page if it exists in cache, even if minOrder and maxOrder are undefined", () => {
+    expect(
+      readVersions(
+        {
+          flattenedVersions: versions,
+          // @ts-expect-error: only mostRecentVersionOrder affects reading versions
+          pagination: {
+            mostRecentVersionOrder: 5,
+          },
+        },
+        // @ts-expect-error: for tests we can omit unused fields from the args
+        {
+          args: {
+            options: {
+              maxOrder: undefined,
+              minOrder: undefined,
+              limit: 3,
+            },
+          },
+          readField,
+        } as FieldFunctionOptions,
+      ),
+    ).toStrictEqual({
+      flattenedVersions: versions,
+      pagination: {
+        hasPrevPage: false,
+        hasNextPage: false,
+        mostRecentVersionOrder: 5,
+        prevPageOrder: 0,
+        nextPageOrder: 0,
+      },
+    });
+  });
 });

--- a/apps/spruce/src/pages/waterfall/caching/index.ts
+++ b/apps/spruce/src/pages/waterfall/caching/index.ts
@@ -8,13 +8,21 @@ export const readVersions = ((existing, { args, readField }) => {
   }
 
   const minOrder = args?.options?.minOrder ?? 0;
-  const maxOrder = args?.options?.maxOrder ?? 0;
+  let maxOrder = args?.options?.maxOrder ?? 0;
   const limit = args?.options?.limit ?? VERSION_LIMIT;
+  const date = args?.options?.date ?? "";
+  const revision = args?.options?.revision ?? "";
+
   const { mostRecentVersionOrder = 0 } =
     readField<WaterfallQuery["waterfall"]["pagination"]>(
       "pagination",
       existing,
     ) ?? {};
+
+  // Try to leverage cache if there are no input params.
+  if (minOrder === 0 && maxOrder === 0 && !date && !revision) {
+    maxOrder = mostRecentVersionOrder + 1;
+  }
 
   const existingVersions =
     readField<WaterfallQuery["waterfall"]["flattenedVersions"]>(
@@ -88,6 +96,7 @@ export const readVersions = ((existing, { args, readField }) => {
   const zerothOrder = readField<number>("order", flattenedVersions[0]) ?? 0;
   const prevOrderNumber =
     mostRecentVersionOrder === zerothOrder ? 0 : zerothOrder;
+
   const lastVersionOrder =
     readField<number>(
       "order",


### PR DESCRIPTION
DEVPROD-12594
<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
I think that the current behavior of the page is technically correct. If the `minOrder` lower bound is in place, it should only show versions above that lower bound. If we were to show more versions, we would not be correctly obeying the `minOrder` parameter because the additional versions would not satisfy the lower bound. 

So in this PR, I clear the order params when the user reaches the first page. This means we'll fetch the first LIMIT versions without having to worry about any bounds.

### Screenshots
<!-- add screenshots of visible changes -->

https://github.com/user-attachments/assets/f518ff59-5624-46cf-92be-053726df9ec0

### Testing
- Added unit and Cypress tests
- Confirmed it worked on mms when a new commit had come in

<!-- Have you have updated the analytics documentation if necessary?  
https://docs.google.com/spreadsheets/d/1s4_nq8ZiphXp5Uq_-9HT6GPqz-KOyaq6HuvmXYaSNzg/edit?usp=sharing -->
