### PR TITLE
DPLATFORMS-390 add backstage entity description

### DIFF
--- a/.backstage.yml
+++ b/.backstage.yml
@@ -15,6 +15,8 @@ spec:
     - component:default/Sentry
     - component:default/Honeycomb
     - component:default/evergreen-backend
+  consumesApis:
+    - evergreen-api-graphql
 
 ---
 apiVersion: backstage.io/v1alpha1

--- a/.backstage.yml
+++ b/.backstage.yml
@@ -13,6 +13,7 @@ spec:
   system: evergreen
   dependsOn:
     - component:default/Sentry
+    - component:default/Honeycomb
     - component:default/evergreen-backend
 
 ---

--- a/.backstage.yml
+++ b/.backstage.yml
@@ -13,6 +13,7 @@ spec:
   system: evergreen
   dependsOn:
     - component:default/Sentry
+    - component:default/evergreen-backend
 
 ---
 apiVersion: backstage.io/v1alpha1

--- a/.backstage.yml
+++ b/.backstage.yml
@@ -1,0 +1,38 @@
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: evergreen-ui
+  description: UI for Evergreen
+  annotations:
+    evergreen/project-id: ui
+spec:
+  type: website
+  owner: evergreen-ui
+  lifecycle: production
+  system: evergreen
+
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: spruce
+spec:
+  type: website
+  owner: evergreen-ui
+  lifecycle: production
+  system: evergreen
+  subcomponentOf: evergreen-ui
+
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: parsley
+  description: Evergreen log viewer
+spec:
+  type: website
+  owner: evergreen-ui
+  lifecycle: production
+  system: evergreen
+  subcomponentOf: evergreen-ui

--- a/.backstage.yml
+++ b/.backstage.yml
@@ -12,7 +12,7 @@ spec:
   lifecycle: production
   system: evergreen
   dependsOn:
-    - Sentry
+    - component:default/Sentry
 
 ---
 apiVersion: backstage.io/v1alpha1

--- a/.backstage.yml
+++ b/.backstage.yml
@@ -11,6 +11,8 @@ spec:
   owner: evergreen-ui
   lifecycle: production
   system: evergreen
+  dependsOn:
+    - Sentry
 
 ---
 apiVersion: backstage.io/v1alpha1


### PR DESCRIPTION
[DPLATFORMS-390](https://jira.mongodb.org/browse/DPLATFORMS-390)

Description
Goes with https://github.com/10gen/devprod-idp/pull/21. The idea is to store the information about a backstage entity alongside the code that's responsible for it. The schema lives [here](https://backstage.io/docs/features/software-catalog/descriptor-format).

### Evergreen PR
https://github.com/evergreen-ci/evergreen/pull/8737
