### PR TITLE
DEVPROD-14877: Use `status` if version was created before `displayStatusCache` was added

### DIFF
--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -3192,6 +3192,7 @@ export type UpdateVolumeInput = {
   expiration?: InputMaybe<Scalars["Time"]["input"]>;
   name?: InputMaybe<Scalars["String"]["input"]>;
   noExpiration?: InputMaybe<Scalars["Boolean"]["input"]>;
+  size?: InputMaybe<Scalars["Int"]["input"]>;
   volumeId: Scalars["String"]["input"];
 };
 

--- a/apps/spruce/src/pages/waterfall/BuildRow.tsx
+++ b/apps/spruce/src/pages/waterfall/BuildRow.tsx
@@ -15,7 +15,11 @@ import VisibilityContainer from "components/VisibilityContainer";
 import { getTaskRoute, getVariantHistoryRoute } from "constants/routes";
 import { useDimensions } from "hooks/useDimensions";
 import { useBuildVariantContext } from "./BuildVariantContext";
-import { walkthroughSteps, waterfallGuideId } from "./constants";
+import {
+  walkthroughSteps,
+  waterfallGuideId,
+  displayStatusCacheAddedDate,
+} from "./constants";
 import {
   BuildVariantTitle,
   columnBasis,
@@ -133,6 +137,8 @@ export const BuildRow: React.FC<Props> = ({
         Builds are sorted in descending revision order and so match the versions' sort order. */
           if (version && version.id === builds?.[buildIndex]?.version) {
             const b = builds[buildIndex];
+            const useCachedStatus =
+              version.createTime > displayStatusCacheAddedDate;
             buildIndex += 1;
             return (
               <BuildGrid
@@ -141,6 +147,7 @@ export const BuildRow: React.FC<Props> = ({
                 firstActiveTaskId={firstActiveTaskId}
                 handleTaskClick={handleTaskClick}
                 isRightmostBuild={b.version === lastActiveVersionId}
+                useCachedStatus={useCachedStatus}
               />
             );
           }
@@ -156,7 +163,14 @@ const BuildGrid: React.FC<{
   firstActiveTaskId: string;
   handleTaskClick: (s: string) => () => void;
   isRightmostBuild: boolean;
-}> = ({ build, firstActiveTaskId, handleTaskClick, isRightmostBuild }) => {
+  useCachedStatus: boolean;
+}> = ({
+  build,
+  firstActiveTaskId,
+  handleTaskClick,
+  isRightmostBuild,
+  useCachedStatus,
+}) => {
   const rowRef = useRef<HTMLDivElement>(null);
   const { width } = useDimensions<HTMLDivElement>(rowRef);
 
@@ -182,8 +196,9 @@ const BuildGrid: React.FC<{
             id === firstActiveTaskId
               ? { [waterfallGuideId]: walkthroughSteps[0].targetId }
               : {};
-          // Use status as backup for tasks created before displayStatusCache was introduced
-          const taskStatus = (displayStatusCache || status) as TaskStatus;
+          const taskStatus = (
+            useCachedStatus ? displayStatusCache : status
+          ) as TaskStatus;
           return (
             <SquareMemo
               key={id}

--- a/apps/spruce/src/pages/waterfall/BuildRow.tsx
+++ b/apps/spruce/src/pages/waterfall/BuildRow.tsx
@@ -138,7 +138,7 @@ export const BuildRow: React.FC<Props> = ({
           if (version && version.id === builds?.[buildIndex]?.version) {
             const b = builds[buildIndex];
             const useCachedStatus =
-              version.createTime > displayStatusCacheAddedDate;
+              new Date(version.createTime) > displayStatusCacheAddedDate;
             buildIndex += 1;
             return (
               <BuildGrid

--- a/apps/spruce/src/pages/waterfall/constants.ts
+++ b/apps/spruce/src/pages/waterfall/constants.ts
@@ -64,5 +64,6 @@ export const tupleSelectOptions = [
 
 /**
  * Timestamp of the last deploy that made changes to `displayStatusCache`, in UTC.
+ * TODO: Remove in DEVPROD-15269.
  */
 export const displayStatusCacheAddedDate = new Date("2025-01-21T03:05:00");

--- a/apps/spruce/src/pages/waterfall/constants.ts
+++ b/apps/spruce/src/pages/waterfall/constants.ts
@@ -61,3 +61,8 @@ export const tupleSelectOptions = [
     validator: () => true,
   },
 ];
+
+/**
+ * Timestamp of the last deploy that made changes to `displayStatusCache`, in UTC.
+ */
+export const displayStatusCacheAddedDate = new Date("2025-01-21T03:05:00");

--- a/apps/spruce/src/pages/waterfall/constants.ts
+++ b/apps/spruce/src/pages/waterfall/constants.ts
@@ -67,4 +67,6 @@ export const tupleSelectOptions = [
  * This timestamp should correspond to 2025/01/21 10:05AM EST.
  * TODO: Remove in DEVPROD-15269.
  */
-export const displayStatusCacheAddedDate = new Date("2025-01-21T15:05:00");
+export const displayStatusCacheAddedDate = new Date(
+  Date.UTC(2025, 0, 21, 15, 5),
+);

--- a/apps/spruce/src/pages/waterfall/constants.ts
+++ b/apps/spruce/src/pages/waterfall/constants.ts
@@ -64,6 +64,7 @@ export const tupleSelectOptions = [
 
 /**
  * Timestamp of the last deploy that made changes to `displayStatusCache`, in UTC.
+ * This timestamp should correspond to 2025/01/21 10:05AM EST.
  * TODO: Remove in DEVPROD-15269.
  */
-export const displayStatusCacheAddedDate = new Date("2025-01-21T03:05:00");
+export const displayStatusCacheAddedDate = new Date("2025-01-21T15:05:00");


### PR DESCRIPTION
DEVPROD-14877
<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description

Prioritizes `status` over `displayStatusCache` if the version was created before the `displayStatusCache` changes were finalized. It can be removed after a year (task TTL).

I based the timestamp off of evergreen-ci/evergreen/pull/8644, because it's the last change, but let me know if that's wrong 😅

### Testing
- Tasks mentioned in the ticket now correctly show as succeeded