### PR TITLE
DEVPROD-14702: Preserve Task Status filters when switching waterfall projects

### DIFF
--- a/apps/spruce/cypress/integration/waterfall/filters.ts
+++ b/apps/spruce/cypress/integration/waterfall/filters.ts
@@ -209,17 +209,15 @@ describe("project selection", () => {
   it("selects a project and applies current task filters", () => {
     cy.visit("/project/spruce/waterfall");
     cy.dataCy("status-filter").click();
-    cy.dataCy("failed-option").click();
     cy.dataCy("test-timed-out-option").click();
     cy.get("body").click();
     cy.dataCy("project-select").click();
-    cy.dataCy("project-select-options").should("be.visible");
     cy.dataCy("project-select-options")
       .contains("evergreen smoke test")
       .click();
     cy.location().should((loc) => {
       expect(loc.pathname).to.eq("/project/evergreen/waterfall");
-      expect(loc.search).to.eq("?statuses=failed,test-timed-out");
+      expect(loc.search).to.eq("?statuses=test-timed-out");
     });
   });
 });

--- a/apps/spruce/cypress/integration/waterfall/filters.ts
+++ b/apps/spruce/cypress/integration/waterfall/filters.ts
@@ -204,3 +204,22 @@ describe("revision filtering", () => {
       .invoke("attr", "data-highlighted", "true");
   });
 });
+
+describe("project selection", () => {
+  it("selects a project and applies current task filters", () => {
+    cy.visit("/project/spruce/waterfall");
+    cy.dataCy("status-filter").click();
+    cy.dataCy("failed-option").click();
+    cy.dataCy("test-timed-out-option").click();
+    cy.get("body").click();
+    cy.dataCy("project-select").click();
+    cy.dataCy("project-select-options").should("be.visible");
+    cy.dataCy("project-select-options")
+      .contains("evergreen smoke test")
+      .click();
+    cy.location().should((loc) => {
+      expect(loc.pathname).to.eq("/project/evergreen/waterfall");
+      expect(loc.search).to.eq("?statuses=failed,test-timed-out");
+    });
+  });
+});

--- a/apps/spruce/src/constants/routes.test.ts
+++ b/apps/spruce/src/constants/routes.test.ts
@@ -127,7 +127,7 @@ describe("getWaterfallRoute", () => {
   it("generates a link to the waterfall page", () => {
     expect(getWaterfallRoute("someProject")).toBe("/waterfall/someProject");
   });
-  it("generates a link with task filters", () => {
+  it("generates a waterfall page link with task filters", () => {
     expect(
       getWaterfallRoute("someProject", {
         taskFilters: ["someTaskFilter"],

--- a/apps/spruce/src/constants/routes.test.ts
+++ b/apps/spruce/src/constants/routes.test.ts
@@ -9,6 +9,7 @@ import {
   getVariantHistoryRoute,
   getProjectPatchesRoute,
   getCommitsRoute,
+  getWaterfallRoute,
 } from "./routes";
 
 const identifierWithSpecialCharacters = "!?identifier@";
@@ -122,6 +123,25 @@ describe("getPatchRoute", () => {
   });
 });
 
+describe("getWaterfallRoute", () => {
+  it("generates a link to the waterfall page", () => {
+    expect(getWaterfallRoute("someProject")).toBe("/waterfall/someProject");
+  });
+  it("generates a link with task filters", () => {
+    expect(
+      getWaterfallRoute("someProject", {
+        taskFilters: ["someTaskFilter"],
+      }),
+    ).toBe("/waterfall/someProject?statuses=someTaskFilter");
+    expect(
+      getWaterfallRoute("someProject", {
+        taskFilters: ["someTaskFilter", "someOtherTaskFilter"],
+      }),
+    ).toBe(
+      "/waterfall/someProject?statuses=someTaskFilter,someOtherTaskFilter",
+    );
+  });
+});
 describe("getTaskHistoryRoute", () => {
   it("generates a link to the task history page", () => {
     expect(getTaskHistoryRoute("someProject", "someTaskId")).toBe(

--- a/apps/spruce/src/constants/routes.test.ts
+++ b/apps/spruce/src/constants/routes.test.ts
@@ -124,22 +124,22 @@ describe("getPatchRoute", () => {
 });
 
 describe("getWaterfallRoute", () => {
-  it("generates a link to the waterfall page", () => {
-    expect(getWaterfallRoute("someProject")).toBe("/waterfall/someProject");
+  it("generates a waterfall page link", () => {
+    expect(getWaterfallRoute("someProject")).toBe(
+      "/project/someProject/waterfall",
+    );
   });
   it("generates a waterfall page link with task filters", () => {
     expect(
       getWaterfallRoute("someProject", {
-        taskFilters: ["someTaskFilter"],
+        taskFilters: ["failed"],
       }),
-    ).toBe("/waterfall/someProject?statuses=someTaskFilter");
+    ).toBe("/project/someProject/waterfall?statuses=failed");
     expect(
       getWaterfallRoute("someProject", {
-        taskFilters: ["someTaskFilter", "someOtherTaskFilter"],
+        taskFilters: ["failed", "test-timed-out"],
       }),
-    ).toBe(
-      "/waterfall/someProject?statuses=someTaskFilter,someOtherTaskFilter",
-    );
+    ).toBe("/project/someProject/waterfall?statuses=failed,test-timed-out");
   });
 });
 describe("getTaskHistoryRoute", () => {

--- a/apps/spruce/src/constants/routes.ts
+++ b/apps/spruce/src/constants/routes.ts
@@ -1,5 +1,6 @@
 import { stringifyQuery } from "@evg-ui/lib/src/utils/query-string";
 import { getGithubCommitUrl } from "constants/externalResources";
+import { WaterfallFilterOptions } from "pages/waterfall/types";
 import { TestStatus, HistoryQueryParams } from "types/history";
 import { ConfigurePatchPageTabs, VersionPageTabs } from "types/patch";
 import { TaskTab } from "types/task";
@@ -287,8 +288,16 @@ export const getDistroSettingsRoute = (
 export const getCommitsRoute = (projectIdentifier: string = "") =>
   `${paths.commits}/${encodeURIComponent(projectIdentifier)}`;
 
-export const getWaterfallRoute = (projectIdentifier: string = "") =>
-  `${paths.project}/${encodeURIComponent(projectIdentifier)}${paths.waterfall}`;
+export const getWaterfallRoute = (
+  projectIdentifier: string,
+  options?: { taskFilters?: string[] },
+) => {
+  const { taskFilters } = options || {};
+  const queryParams = stringifyQuery({
+    [WaterfallFilterOptions.Statuses]: taskFilters,
+  });
+  return `${paths.project}/${encodeURIComponent(projectIdentifier)}${paths.waterfall}${queryParams ? `?${queryParams}` : ""}`;
+};
 
 const getHistoryRoute = (
   basePath: string,

--- a/apps/spruce/src/constants/routes.ts
+++ b/apps/spruce/src/constants/routes.ts
@@ -289,14 +289,14 @@ export const getCommitsRoute = (projectIdentifier: string = "") =>
   `${paths.commits}/${encodeURIComponent(projectIdentifier)}`;
 
 export const getWaterfallRoute = (
-  projectIdentifier: string,
+  projectIdentifier?: string,
   options?: { taskFilters?: string[] },
 ) => {
   const { taskFilters } = options || {};
   const queryParams = stringifyQuery({
     [WaterfallFilterOptions.Statuses]: taskFilters,
   });
-  return `${paths.project}/${encodeURIComponent(projectIdentifier)}${paths.waterfall}${queryParams ? `?${queryParams}` : ""}`;
+  return `${paths.project}/${encodeURIComponent(projectIdentifier ?? "")}${paths.waterfall}${queryParams ? `?${queryParams}` : ""}`;
 };
 
 const getHistoryRoute = (

--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -3192,6 +3192,7 @@ export type UpdateVolumeInput = {
   expiration?: InputMaybe<Scalars["Time"]["input"]>;
   name?: InputMaybe<Scalars["String"]["input"]>;
   noExpiration?: InputMaybe<Scalars["Boolean"]["input"]>;
+  size?: InputMaybe<Scalars["Int"]["input"]>;
   volumeId: Scalars["String"]["input"];
 };
 

--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -3429,6 +3429,7 @@ export type Waterfall = {
 
 export type WaterfallBuild = {
   __typename?: "WaterfallBuild";
+  activated: Scalars["Boolean"]["output"];
   buildVariant: Scalars["String"]["output"];
   displayName: Scalars["String"]["output"];
   id: Scalars["String"]["output"];

--- a/apps/spruce/src/pages/waterfall/WaterfallFilters.tsx
+++ b/apps/spruce/src/pages/waterfall/WaterfallFilters.tsx
@@ -1,14 +1,16 @@
+import { useCallback } from "react";
 import styled from "@emotion/styled";
 import { useWaterfallAnalytics } from "analytics";
 import { ProjectSelect } from "components/ProjectSelect";
 import { getWaterfallRoute } from "constants/routes";
+import { useQueryParam } from "hooks/useQueryParam";
 import { BuildVariantFilter } from "./BuildVariantFilter";
 import { DateFilter } from "./DateFilter";
 import { PaginationButtons } from "./PaginationButtons";
 import { RequesterFilter } from "./RequesterFilter";
 import { StatusFilter } from "./StatusFilter";
 import { TaskFilter } from "./TaskFilter";
-import { Pagination } from "./types";
+import { Pagination, WaterfallFilterOptions } from "./types";
 import { WaterfallMenu } from "./WaterfallMenu";
 
 type WaterfallFiltersProps = {
@@ -20,6 +22,16 @@ export const WaterfallFilters: React.FC<WaterfallFiltersProps> = ({
   projectIdentifier,
 }) => {
   const { sendEvent } = useWaterfallAnalytics();
+  const [statuses] = useQueryParam<string[]>(
+    WaterfallFilterOptions.Statuses,
+    [],
+  );
+
+  const projectSelectRoute = useCallback(
+    (identifier: string) =>
+      getWaterfallRoute(identifier, { taskFilters: statuses }),
+    [statuses],
+  );
 
   return (
     <Container>
@@ -40,7 +52,7 @@ export const WaterfallFilters: React.FC<WaterfallFiltersProps> = ({
       </DateFilterItem>
       <ProjectFilterItem>
         <ProjectSelect
-          getRoute={getWaterfallRoute}
+          getRoute={projectSelectRoute}
           onSubmit={(project: string) => {
             sendEvent({
               name: "Changed project",


### PR DESCRIPTION
DEVPROD-14702

### Description
These code changes apply the current waterfall task filters when selecting a new project
