### PR TITLE
DEVPROD-15077: Fix menu collapsed state

### DIFF
--- a/apps/parsley/cypress/support/commands.ts
+++ b/apps/parsley/cypress/support/commands.ts
@@ -167,7 +167,7 @@ Cypress.Commands.add("logout", () => {
 });
 
 Cypress.Commands.add("resetDrawerState", () => {
-  cy.clearCookie("has-opened-drawer");
+  cy.setCookie("drawer-opened", "false");
 });
 
 Cypress.Commands.add("toggleDetailsPanel", (open: boolean) => {

--- a/apps/parsley/cypress/support/index.ts
+++ b/apps/parsley/cypress/support/index.ts
@@ -128,7 +128,7 @@ declare global {
   let mutationDispatched: boolean;
   beforeEach(() => {
     cy.login();
-    cy.setCookie("has-opened-drawer", "true");
+    cy.setCookie("drawer-opened", "true");
     cy.setCookie("has-seen-searchbar-guide-cue", "true");
     cy.setCookie("has-seen-sections-prod-feature-modal", "true");
     mutationDispatched = false;

--- a/apps/parsley/src/components/SidePanel/index.tsx
+++ b/apps/parsley/src/components/SidePanel/index.tsx
@@ -3,7 +3,7 @@ import styled from "@emotion/styled";
 import { SideNav } from "@leafygreen-ui/side-nav";
 import Cookie from "js-cookie";
 import { size, zIndex } from "@evg-ui/lib/constants/tokens";
-import { HAS_OPENED_DRAWER } from "constants/cookies";
+import { DRAWER_OPENED } from "constants/cookies";
 import { ExpandedLines } from "types/logs";
 import {
   ExpandedNavGroup,
@@ -24,8 +24,8 @@ const SidePanel: React.FC<SidePanelProps> = ({
   "data-cy": dataCy,
   expandedLines,
 }) => {
-  const [collapsed, setCollapsed] = useState(
-    Cookie.get(HAS_OPENED_DRAWER) === "true",
+  const [collapsed, setCollapsed] = useState<boolean>(
+    Cookie.get(DRAWER_OPENED) === "true",
   );
 
   return (
@@ -34,8 +34,11 @@ const SidePanel: React.FC<SidePanelProps> = ({
       collapsed={collapsed}
       data-cy={dataCy}
       setCollapsed={(collapse) => {
+        // collapsed represents the initial state of the sidenav
+        Cookie.set(DRAWER_OPENED, collapsed ? "false" : "true", {
+          expires: 365,
+        });
         setCollapsed(collapse);
-        Cookie.set(HAS_OPENED_DRAWER, "true", { expires: 365 });
       }}
       widthOverride={290}
     >

--- a/apps/parsley/src/constants/cookies.ts
+++ b/apps/parsley/src/constants/cookies.ts
@@ -8,7 +8,7 @@ export const WRAP = "wrap";
 export const WRAP_FORMAT = "wrap-format";
 export const ZEBRA_STRIPING = "zebra-striping";
 
-export const HAS_OPENED_DRAWER = "has-opened-drawer";
+export const DRAWER_OPENED = "drawer-opened";
 export const HAS_SEEN_SEARCHBAR_GUIDE_CUE = "has-seen-searchbar-guide-cue";
 
 export const LAST_SELECTED_LOG_TYPE = "last-selected-log-type";

--- a/apps/parsley/src/gql/generated/types.ts
+++ b/apps/parsley/src/gql/generated/types.ts
@@ -3429,6 +3429,7 @@ export type Waterfall = {
 
 export type WaterfallBuild = {
   __typename?: "WaterfallBuild";
+  activated: Scalars["Boolean"]["output"];
   buildVariant: Scalars["String"]["output"];
   displayName: Scalars["String"]["output"];
   id: Scalars["String"]["output"];


### PR DESCRIPTION
DEVPROD-15077
<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
<!-- add description, context, thought process, etc -->
Use new cookie that doesn't behave like a flag to set the sidenav's open state when the user collapses or expands it.