### PR TITLE
DEVPROD-14935: Show metadata title while loading

### DIFF
--- a/apps/spruce/src/components/MetadataCard.tsx
+++ b/apps/spruce/src/components/MetadataCard.tsx
@@ -11,6 +11,7 @@ import { Divider } from "components/styles/divider";
 interface Props {
   error?: ApolloError;
   loading?: boolean;
+  title?: React.ReactNode;
   children: React.ReactNode;
 }
 
@@ -18,9 +19,16 @@ export const MetadataCard: React.FC<Props> = ({
   children,
   error,
   loading,
+  title,
   ...rest
 }) => (
   <SiderCard {...rest}>
+    {title && (
+      <div>
+        <Title weight="medium">{title}</Title>
+        <Divider />
+      </div>
+    )}
     {loading && !error && (
       <Skeleton active paragraph={{ rows: 4 }} title={false} />
     )}
@@ -29,15 +37,6 @@ export const MetadataCard: React.FC<Props> = ({
     )}
     {!loading && !error && children}
   </SiderCard>
-);
-
-export const MetadataTitle: React.FC<{ children: React.ReactNode }> = ({
-  children,
-}) => (
-  <div>
-    <Title weight="medium">{children}</Title>
-    <Divider />
-  </div>
 );
 
 interface ItemProps {

--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -3429,6 +3429,7 @@ export type Waterfall = {
 
 export type WaterfallBuild = {
   __typename?: "WaterfallBuild";
+  activated: Scalars["Boolean"]["output"];
   buildVariant: Scalars["String"]["output"];
   displayName: Scalars["String"]["output"];
   id: Scalars["String"]["output"];

--- a/apps/spruce/src/pages/configurePatch/configurePatchCore/index.tsx
+++ b/apps/spruce/src/pages/configurePatch/configurePatchCore/index.tsx
@@ -16,7 +16,6 @@ import {
   MetadataCard,
   MetadataItem,
   MetadataLabel,
-  MetadataTitle,
 } from "components/MetadataCard";
 import { PageContent, PageLayout, PageSider } from "components/styles";
 import { StyledTabs } from "components/styles/StyledTabs";
@@ -210,8 +209,7 @@ const ConfigurePatchCore: React.FC<ConfigurePatchCoreProps> = ({ patch }) => {
       </BannerContainer>
       <PageLayout hasSider>
         <PageSider>
-          <MetadataCard>
-            <MetadataTitle>Patch Metadata</MetadataTitle>
+          <MetadataCard title="Patch Metadata">
             <MetadataItem>
               <MetadataLabel>Submitted by:</MetadataLabel> {author}
             </MetadataItem>

--- a/apps/spruce/src/pages/container/Metadata/index.tsx
+++ b/apps/spruce/src/pages/container/Metadata/index.tsx
@@ -5,7 +5,6 @@ import {
   MetadataCard,
   MetadataItem,
   MetadataLabel,
-  MetadataTitle,
 } from "components/MetadataCard";
 import { getTaskRoute } from "constants/routes";
 import { PodQuery } from "gql/generated/types";
@@ -30,8 +29,7 @@ const Metadata: React.FC<{
   });
 
   return (
-    <MetadataCard error={error} loading={loading}>
-      <MetadataTitle>Container Details</MetadataTitle>
+    <MetadataCard error={error} loading={loading} title="Container Details">
       {runningTaskId !== "" && (
         <MetadataItem>
           <MetadataLabel>Running Task:</MetadataLabel>{" "}

--- a/apps/spruce/src/pages/host/Metadata.tsx
+++ b/apps/spruce/src/pages/host/Metadata.tsx
@@ -7,7 +7,6 @@ import {
   MetadataCard,
   MetadataItem,
   MetadataLabel,
-  MetadataTitle,
 } from "components/MetadataCard";
 import { MCI_USER } from "constants/hosts";
 import { getDistroSettingsRoute, getTaskRoute } from "constants/routes";
@@ -41,8 +40,7 @@ export const Metadata: React.FC<{
   const distroLink = getDistroSettingsRoute(distroId);
 
   return (
-    <MetadataCard error={error} loading={loading}>
-      <MetadataTitle>Host Details</MetadataTitle>
+    <MetadataCard error={error} loading={loading} title="Host Details">
       <MetadataItem>
         <MetadataLabel>User:</MetadataLabel> {user}
       </MetadataItem>

--- a/apps/spruce/src/pages/jobLogs/Metadata.tsx
+++ b/apps/spruce/src/pages/jobLogs/Metadata.tsx
@@ -4,7 +4,6 @@ import {
   MetadataCard,
   MetadataItem,
   MetadataLabel,
-  MetadataTitle,
 } from "components/MetadataCard";
 import { JobLogsMetadata } from "./types";
 
@@ -15,8 +14,7 @@ export const Metadata: React.FC<{
   const { sendEvent } = useJobLogsAnalytics(metadata.isLogkeeper);
 
   return (
-    <MetadataCard loading={loading}>
-      <MetadataTitle>Job log details</MetadataTitle>
+    <MetadataCard loading={loading} title="Job log details">
       {metadata.groupID && (
         <MetadataItem>
           <MetadataLabel>Group:</MetadataLabel> {metadata.groupID}

--- a/apps/spruce/src/pages/task/metadata/__snapshots__/Metadata_ContainerizedTask.storyshot
+++ b/apps/spruce/src/pages/task/metadata/__snapshots__/Metadata_ContainerizedTask.storyshot
@@ -139,7 +139,6 @@
           class="css-qqg5h5-Divider eb6szep0"
         />
       </div>
-       
       <p
         class="css-1xovdqa-Item-wordBreakCss e1ul56zb1 leafygreen-ui-1tb6tuo"
       >

--- a/apps/spruce/src/pages/task/metadata/__snapshots__/Metadata_Default.storyshot
+++ b/apps/spruce/src/pages/task/metadata/__snapshots__/Metadata_Default.storyshot
@@ -139,7 +139,6 @@
           class="css-qqg5h5-Divider eb6szep0"
         />
       </div>
-       
       <p
         class="css-1xovdqa-Item-wordBreakCss e1ul56zb1 leafygreen-ui-1tb6tuo"
       >

--- a/apps/spruce/src/pages/task/metadata/__snapshots__/Metadata_OOMTracker.storyshot
+++ b/apps/spruce/src/pages/task/metadata/__snapshots__/Metadata_OOMTracker.storyshot
@@ -135,7 +135,6 @@
           class="css-qqg5h5-Divider eb6szep0"
         />
       </div>
-       
       <p
         class="css-1xovdqa-Item-wordBreakCss e1ul56zb1 leafygreen-ui-1tb6tuo"
       >

--- a/apps/spruce/src/pages/task/metadata/__snapshots__/Metadata_WithAbortMessage.storyshot
+++ b/apps/spruce/src/pages/task/metadata/__snapshots__/Metadata_WithAbortMessage.storyshot
@@ -139,7 +139,6 @@
           class="css-qqg5h5-Divider eb6szep0"
         />
       </div>
-       
       <p
         class="css-1xovdqa-Item-wordBreakCss e1ul56zb1 leafygreen-ui-1tb6tuo"
       >

--- a/apps/spruce/src/pages/task/metadata/__snapshots__/Metadata_WithDependencies.storyshot
+++ b/apps/spruce/src/pages/task/metadata/__snapshots__/Metadata_WithDependencies.storyshot
@@ -139,7 +139,6 @@
           class="css-qqg5h5-Divider eb6szep0"
         />
       </div>
-       
       <p
         class="css-1xovdqa-Item-wordBreakCss e1ul56zb1 leafygreen-ui-1tb6tuo"
       >

--- a/apps/spruce/src/pages/task/metadata/index.tsx
+++ b/apps/spruce/src/pages/task/metadata/index.tsx
@@ -16,7 +16,6 @@ import ExpandedText from "components/ExpandedText";
 import {
   MetadataCard,
   MetadataItem,
-  MetadataTitle,
   MetadataLabel,
 } from "components/MetadataCard";
 import {
@@ -116,8 +115,8 @@ export const Metadata: React.FC<Props> = ({ error, loading, task, taskId }) => {
       <MetadataCard
         error={!task && error ? error : undefined}
         loading={loading}
+        title="Task Metadata"
       >
-        <MetadataTitle>Task Metadata</MetadataTitle>
         {versionID && buildVariant && (
           <MetadataItem data-cy="task-metadata-build-variant">
             <MetadataLabel>Build Variant:</MetadataLabel>{" "}
@@ -362,8 +361,7 @@ export const Metadata: React.FC<Props> = ({ error, loading, task, taskId }) => {
       </MetadataCard>
 
       {!isDisplayTask && (
-        <MetadataCard>
-          <MetadataTitle>Host Information</MetadataTitle>{" "}
+        <MetadataCard loading={loading} title="Host Information">
           {!isContainerTask && hostId && (
             <MetadataItem>
               <MetadataLabel>ID:</MetadataLabel>{" "}
@@ -461,8 +459,7 @@ export const Metadata: React.FC<Props> = ({ error, loading, task, taskId }) => {
       )}
 
       {dependsOn && dependsOn.length > 0 ? (
-        <MetadataCard>
-          <MetadataTitle>Depends On</MetadataTitle>
+        <MetadataCard title="Depends On">
           {dependsOn.map((dep) => (
             <DependsOn
               key={`dependOnPill_${dep.taskId}`}
@@ -477,8 +474,7 @@ export const Metadata: React.FC<Props> = ({ error, loading, task, taskId }) => {
       ) : null}
 
       {tags && tags.length > 0 ? (
-        <MetadataCard>
-          <MetadataTitle>Tags</MetadataTitle>
+        <MetadataCard title="Tags">
           <TagsContainer>
             {tags.map((t) => (
               <Chip

--- a/apps/spruce/src/pages/version/BuildVariantCard/index.tsx
+++ b/apps/spruce/src/pages/version/BuildVariantCard/index.tsx
@@ -1,7 +1,7 @@
 import { useQuery } from "@apollo/client";
 import styled from "@emotion/styled";
 import { size } from "@evg-ui/lib/constants/tokens";
-import { MetadataCard, MetadataTitle } from "components/MetadataCard";
+import { MetadataCard } from "components/MetadataCard";
 import { navBarHeight } from "components/styles/Layout";
 import { DEFAULT_POLL_INTERVAL } from "constants/index";
 import {
@@ -28,8 +28,7 @@ const BuildVariantCard: React.FC<BuildVariantCardProps> = ({ versionId }) => {
   const { version } = data || {};
 
   return (
-    <StickyMetadataCard error={error} loading={loading}>
-      <MetadataTitle>Build Variants</MetadataTitle>
+    <StickyMetadataCard error={error} loading={loading} title="Build Variants">
       <ScrollableBuildVariantStatsContainer data-cy="build-variants">
         {version?.buildVariantStats?.map(
           ({ displayName, statusCounts, variant }) => (

--- a/apps/spruce/src/pages/version/Metadata.tsx
+++ b/apps/spruce/src/pages/version/Metadata.tsx
@@ -5,7 +5,6 @@ import { useVersionAnalytics } from "analytics";
 import {
   MetadataCard,
   MetadataItem,
-  MetadataTitle,
   MetadataLabel,
 } from "components/MetadataCard";
 import {
@@ -63,11 +62,10 @@ export const Metadata: React.FC<Props> = ({ loading, version }) => {
   const isGithubMergePatch = requester === Requester.GitHubMergeQueue;
 
   return (
-    <MetadataCard loading={loading}>
-      <MetadataTitle>
-        {isPatch ? "Patch Metadata" : "Version Metadata"}
-      </MetadataTitle>
-
+    <MetadataCard
+      loading={loading}
+      title={isPatch ? "Patch Metadata" : "Version Metadata"}
+    >
       <MetadataItem>
         <MetadataLabel>Project:</MetadataLabel>{" "}
         {projectIdentifier ? (


### PR DESCRIPTION
DEVPROD-14935
<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
<!-- add description, context, thought process, etc -->
Convert `MetadataTitle` into a `title` prop for the `MetadataCard` component. This allows the card to still show the title while displaying the loading state, and is also a better pattern in general imo.

Would also like to combine `MetadataLabel` and `MetadataItem` in a similar way, but that feels like a different ticket.