### PR TITLE
DEVPROD-13093: Remove userSettings query

### DIFF
--- a/apps/spruce/src/components/Banners/GithubUsernameBanner.tsx
+++ b/apps/spruce/src/components/Banners/GithubUsernameBanner.tsx
@@ -1,14 +1,10 @@
-import { useQuery } from "@apollo/client";
 import Banner from "@leafygreen-ui/banner";
 import { StyledRouterLink } from "@evg-ui/lib/components/styles";
 import { getPreferencesRoute, PreferencesTabRoutes } from "constants/routes";
-import { UserSettingsQuery } from "gql/generated/types";
-import { USER_SETTINGS } from "gql/queries";
+import { useUserSettings } from "hooks";
 
 export const GithubUsernameBanner = () => {
-  // USER SETTINGS QUERY
-  const { data: userSettingsData } = useQuery<UserSettingsQuery>(USER_SETTINGS);
-  const { userSettings } = userSettingsData || {};
+  const { userSettings } = useUserSettings();
   const { githubUser } = userSettings || {};
   const { lastKnownAs } = githubUser || {};
   const hasNoGithubUser = lastKnownAs === "";

--- a/apps/spruce/src/components/Banners/SlackNotificationBanner.tsx
+++ b/apps/spruce/src/components/Banners/SlackNotificationBanner.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useMutation, useQuery } from "@apollo/client";
+import { useMutation } from "@apollo/client";
 import styled from "@emotion/styled";
 import Banner from "@leafygreen-ui/banner";
 import { palette } from "@leafygreen-ui/palette";
@@ -12,10 +12,9 @@ import { SLACK_NOTIFICATION_BANNER } from "constants/cookies";
 import {
   UpdateUserSettingsMutation,
   UpdateUserSettingsMutationVariables,
-  UserSettingsQuery,
 } from "gql/generated/types";
 import { UPDATE_USER_SETTINGS } from "gql/mutations";
-import { USER_SETTINGS } from "gql/queries";
+import { useUserSettings } from "hooks";
 
 const { blue } = palette;
 
@@ -40,9 +39,7 @@ export const SlackNotificationBanner = () => {
       refetchQueries: ["UserSettings"],
     });
 
-  // USER SETTINGS QUERY
-  const { data: userSettingsData } = useQuery<UserSettingsQuery>(USER_SETTINGS);
-  const { userSettings } = userSettingsData || {};
+  const { userSettings } = useUserSettings();
   const { notifications, slackUsername: defaultSlackUsername } =
     userSettings || {};
   const { patchFinish, patchFirstFailure } = notifications || {};

--- a/apps/spruce/src/components/Spawn/spawnHostModal/useLoadFormSchemaData.ts
+++ b/apps/spruce/src/components/Spawn/spawnHostModal/useLoadFormSchemaData.ts
@@ -4,20 +4,17 @@ import {
   DistrosQueryVariables,
   AwsRegionsQuery,
   AwsRegionsQueryVariables,
-  UserSettingsQuery,
   MyPublicKeysQuery,
   MyPublicKeysQueryVariables,
   MyVolumesQuery,
   MyHostsQueryVariables,
 } from "gql/generated/types";
+import { AWS_REGIONS, DISTROS, MY_PUBLIC_KEYS, MY_VOLUMES } from "gql/queries";
 import {
-  AWS_REGIONS,
-  DISTROS,
-  MY_PUBLIC_KEYS,
-  MY_VOLUMES,
-  USER_SETTINGS,
-} from "gql/queries";
-import { useDisableSpawnExpirationCheckbox, useSpruceConfig } from "hooks";
+  useDisableSpawnExpirationCheckbox,
+  useSpruceConfig,
+  useUserSettings,
+} from "hooks";
 import { getNoExpirationCheckboxTooltipCopy } from "../utils";
 
 interface Props {
@@ -45,8 +42,8 @@ export const useLoadFormSchemaData = (p?: Props) => {
 
   const spruceConfig = useSpruceConfig();
 
-  const { data: userSettingsData } = useQuery<UserSettingsQuery>(USER_SETTINGS);
-  const { region: userAwsRegion } = userSettingsData?.userSettings ?? {};
+  const { userSettings } = useUserSettings();
+  const { region: userAwsRegion } = userSettings ?? {};
 
   const { data: volumesData, loading: volumesLoading } = useQuery<
     MyVolumesQuery,

--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -3429,6 +3429,7 @@ export type Waterfall = {
 
 export type WaterfallBuild = {
   __typename?: "WaterfallBuild";
+  activated: Scalars["Boolean"]["output"];
   buildVariant: Scalars["String"]["output"];
   displayName: Scalars["String"]["output"];
   id: Scalars["String"]["output"];
@@ -9372,33 +9373,36 @@ export type UserSettingsQueryVariables = Exact<{ [key: string]: never }>;
 
 export type UserSettingsQuery = {
   __typename?: "Query";
-  userSettings?: {
-    __typename?: "UserSettings";
-    dateFormat?: string | null;
-    region?: string | null;
-    slackMemberId?: string | null;
-    slackUsername?: string | null;
-    timeFormat?: string | null;
-    timezone?: string | null;
-    githubUser?: {
-      __typename?: "GithubUser";
-      lastKnownAs?: string | null;
-    } | null;
-    notifications?: {
-      __typename?: "Notifications";
-      buildBreak?: string | null;
-      patchFinish?: string | null;
-      patchFirstFailure?: string | null;
-      spawnHostExpiration?: string | null;
-      spawnHostOutcome?: string | null;
-    } | null;
-    useSpruceOptions?: {
-      __typename?: "UseSpruceOptions";
-      hasUsedMainlineCommitsBefore?: boolean | null;
-      hasUsedSpruceBefore?: boolean | null;
-      spruceV1?: boolean | null;
-    } | null;
-  } | null;
+  user: {
+    __typename?: "User";
+    settings: {
+      __typename?: "UserSettings";
+      dateFormat?: string | null;
+      region?: string | null;
+      slackMemberId?: string | null;
+      slackUsername?: string | null;
+      timeFormat?: string | null;
+      timezone?: string | null;
+      githubUser?: {
+        __typename?: "GithubUser";
+        lastKnownAs?: string | null;
+      } | null;
+      notifications?: {
+        __typename?: "Notifications";
+        buildBreak?: string | null;
+        patchFinish?: string | null;
+        patchFirstFailure?: string | null;
+        spawnHostExpiration?: string | null;
+        spawnHostOutcome?: string | null;
+      } | null;
+      useSpruceOptions?: {
+        __typename?: "UseSpruceOptions";
+        hasUsedMainlineCommitsBefore?: boolean | null;
+        hasUsedSpruceBefore?: boolean | null;
+        spruceV1?: boolean | null;
+      } | null;
+    };
+  };
 };
 
 export type UserSubscriptionsQueryVariables = Exact<{ [key: string]: never }>;

--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -9375,6 +9375,7 @@ export type UserSettingsQuery = {
   __typename?: "Query";
   user: {
     __typename?: "User";
+    userId: string;
     settings: {
       __typename?: "UserSettings";
       dateFormat?: string | null;

--- a/apps/spruce/src/gql/mocks/getSpruceConfig.ts
+++ b/apps/spruce/src/gql/mocks/getSpruceConfig.ts
@@ -73,9 +73,16 @@ export const getUserSettingsMock: ApolloMock<
   result: {
     data: {
       user: {
+        __typename: "User",
+        userId: "user.id",
         settings: {
           __typename: "UserSettings",
           dateFormat: "MM/dd/yyyy",
+          region: "us-east-1",
+          slackMemberId: "1234",
+          slackUsername: "user",
+          timeFormat: "H:mm:ss",
+          timezone: "America/New_York",
           githubUser: {
             lastKnownAs: "user",
             __typename: "GithubUser",
@@ -88,11 +95,6 @@ export const getUserSettingsMock: ApolloMock<
             spawnHostExpiration: "",
             spawnHostOutcome: "",
           },
-          region: "us-east-1",
-          slackMemberId: "1234",
-          slackUsername: "user",
-          timeFormat: "H:mm:ss",
-          timezone: "America/New_York",
           useSpruceOptions: {
             __typename: "UseSpruceOptions",
             hasUsedMainlineCommitsBefore: true,

--- a/apps/spruce/src/gql/mocks/getSpruceConfig.ts
+++ b/apps/spruce/src/gql/mocks/getSpruceConfig.ts
@@ -72,31 +72,33 @@ export const getUserSettingsMock: ApolloMock<
   },
   result: {
     data: {
-      userSettings: {
-        __typename: "UserSettings",
-        dateFormat: "MM/dd/yyyy",
-        githubUser: {
-          lastKnownAs: "user",
-          __typename: "GithubUser",
-        },
-        notifications: {
-          __typename: "Notifications",
-          buildBreak: "",
-          patchFinish: "",
-          patchFirstFailure: "",
-          spawnHostExpiration: "",
-          spawnHostOutcome: "",
-        },
-        region: "us-east-1",
-        slackMemberId: "1234",
-        slackUsername: "user",
-        timeFormat: "H:mm:ss",
-        timezone: "America/New_York",
-        useSpruceOptions: {
-          __typename: "UseSpruceOptions",
-          hasUsedMainlineCommitsBefore: true,
-          spruceV1: true,
-          hasUsedSpruceBefore: true,
+      user: {
+        settings: {
+          __typename: "UserSettings",
+          dateFormat: "MM/dd/yyyy",
+          githubUser: {
+            lastKnownAs: "user",
+            __typename: "GithubUser",
+          },
+          notifications: {
+            __typename: "Notifications",
+            buildBreak: "",
+            patchFinish: "",
+            patchFirstFailure: "",
+            spawnHostExpiration: "",
+            spawnHostOutcome: "",
+          },
+          region: "us-east-1",
+          slackMemberId: "1234",
+          slackUsername: "user",
+          timeFormat: "H:mm:ss",
+          timezone: "America/New_York",
+          useSpruceOptions: {
+            __typename: "UseSpruceOptions",
+            hasUsedMainlineCommitsBefore: true,
+            spruceV1: true,
+            hasUsedSpruceBefore: true,
+          },
         },
       },
     },

--- a/apps/spruce/src/gql/queries/user-settings.graphql
+++ b/apps/spruce/src/gql/queries/user-settings.graphql
@@ -1,25 +1,27 @@
 query UserSettings {
-  userSettings {
-    dateFormat
-    githubUser {
-      lastKnownAs
-    }
-    notifications {
-      buildBreak
-      patchFinish
-      patchFirstFailure
-      spawnHostExpiration
-      spawnHostOutcome
-    }
-    region
-    slackMemberId
-    slackUsername
-    timeFormat
-    timezone
-    useSpruceOptions {
-      hasUsedMainlineCommitsBefore
-      hasUsedSpruceBefore
-      spruceV1
+  user {
+    settings {
+      dateFormat
+      githubUser {
+        lastKnownAs
+      }
+      notifications {
+        buildBreak
+        patchFinish
+        patchFirstFailure
+        spawnHostExpiration
+        spawnHostOutcome
+      }
+      region
+      slackMemberId
+      slackUsername
+      timeFormat
+      timezone
+      useSpruceOptions {
+        hasUsedMainlineCommitsBefore
+        hasUsedSpruceBefore
+        spruceV1
+      }
     }
   }
 }

--- a/apps/spruce/src/gql/queries/user-settings.graphql
+++ b/apps/spruce/src/gql/queries/user-settings.graphql
@@ -23,5 +23,6 @@ query UserSettings {
         spruceV1
       }
     }
+    userId
   }
 }

--- a/apps/spruce/src/hooks/useUserSettings/index.ts
+++ b/apps/spruce/src/hooks/useUserSettings/index.ts
@@ -18,6 +18,6 @@ export const useUserSettings = (options?: UseUserSettingsOptions) => {
       options?.onError?.(err);
     },
   });
-  const { userSettings } = data || {};
-  return { userSettings, loading };
+  const { user } = data || {};
+  return { userSettings: user?.settings ?? {}, loading };
 };

--- a/apps/spruce/src/hooks/useUserTimeZone/index.ts
+++ b/apps/spruce/src/hooks/useUserTimeZone/index.ts
@@ -1,9 +1,7 @@
-import { useQuery } from "@apollo/client";
-import { UserSettingsQuery } from "gql/generated/types";
-import { USER_SETTINGS } from "gql/queries";
+import { useUserSettings } from "../useUserSettings";
 
 // get the timezone for the user
 export const useUserTimeZone = () => {
-  const { data } = useQuery<UserSettingsQuery>(USER_SETTINGS);
-  return data?.userSettings?.timezone ?? undefined;
+  const { userSettings } = useUserSettings();
+  return userSettings?.timezone ?? undefined;
 };


### PR DESCRIPTION
DEVPROD-13093
<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
<!-- add description, context, thought process, etc -->
Replace `userSettings` query with `user.settings`. I'll open an evergreen PR to remove the resolver as well, and merge it once this is deployed for simple revertability.