### PR TITLE
DEVPROD-12122 Move schedule task warning banner to a fixed position

### DIFF
--- a/apps/spruce/src/components/ScheduleTasksModal/index.tsx
+++ b/apps/spruce/src/components/ScheduleTasksModal/index.tsx
@@ -107,6 +107,7 @@ export const ScheduleTasksModal: React.FC<ScheduleTasksModalProps> = ({
       open={open}
       title="Schedule Tasks"
     >
+      <TaskSchedulingWarningBanner totalTasks={estimatedActivatedTasksCount} />
       <ContentWrapper>
         {loadingTaskData ? (
           <Skeleton data-cy="loading-skeleton" />
@@ -180,9 +181,6 @@ export const ScheduleTasksModal: React.FC<ScheduleTasksModalProps> = ({
                 );
               },
             )}
-            <TaskSchedulingWarningBanner
-              totalTasks={estimatedActivatedTasksCount}
-            />
           </>
         )}
         {!loadingTaskData && !sortedBuildVariantGroups.length && (

--- a/apps/spruce/src/components/VersionRestartModal/VersionRestartModal.tsx
+++ b/apps/spruce/src/components/VersionRestartModal/VersionRestartModal.tsx
@@ -132,6 +132,8 @@ const VersionRestartModal: React.FC<VersionRestartModalProps> = ({
       open={visible}
       title="Modify Version"
     >
+      <TaskSchedulingWarningBanner totalTasks={estimatedActivatedTasksCount} />
+
       {loading ? (
         <Skeleton active />
       ) : (
@@ -175,9 +177,6 @@ const VersionRestartModal: React.FC<VersionRestartModalProps> = ({
               <br />
             </div>
           )}
-          <TaskSchedulingWarningBanner
-            totalTasks={estimatedActivatedTasksCount}
-          />
           <ConfirmationMessage data-cy="confirmation-message" weight="medium">
             Are you sure you want to restart the {selectedTotal} selected tasks?
           </ConfirmationMessage>


### PR DESCRIPTION
DEVPROD-12122
<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
Freeze the schedule task banner warning to the top of the schedule task modal so it isn't in a scrollable area.
### Screenshots
<img width="973" alt="image" src="https://github.com/user-attachments/assets/8cc0e668-d089-480f-9a9f-1f0395e36204" />


