### PR TITLE
DEVPROD-1031: Update schedule/unschedule button state on Task page

### DIFF
--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -5543,6 +5543,9 @@ export type ScheduleTasksMutation = {
   __typename?: "Mutation";
   scheduleTasks: Array<{
     __typename?: "Task";
+    status: string;
+    canSchedule: boolean;
+    canUnschedule: boolean;
     buildVariant: string;
     buildVariantDisplayName?: string | null;
     displayName: string;
@@ -5643,7 +5646,15 @@ export type UnscheduleTaskMutationVariables = Exact<{
 
 export type UnscheduleTaskMutation = {
   __typename?: "Mutation";
-  unscheduleTask: { __typename?: "Task"; execution: number; id: string };
+  unscheduleTask: {
+    __typename?: "Task";
+    execution: number;
+    id: string;
+    status: string;
+    displayStatus: string;
+    canSchedule: boolean;
+    canUnschedule: boolean;
+  };
 };
 
 export type UnscheduleVersionTasksMutationVariables = Exact<{

--- a/apps/spruce/src/gql/mutations/schedule-tasks.graphql
+++ b/apps/spruce/src/gql/mutations/schedule-tasks.graphql
@@ -3,5 +3,8 @@
 mutation ScheduleTasks($taskIds: [String!]!, $versionId: String!) {
   scheduleTasks(taskIds: $taskIds, versionId: $versionId) {
     ...BaseTask
+    status
+    canSchedule
+    canUnschedule
   }
 }

--- a/apps/spruce/src/gql/mutations/unschedule-task.graphql
+++ b/apps/spruce/src/gql/mutations/unschedule-task.graphql
@@ -2,5 +2,9 @@ mutation UnscheduleTask($taskId: String!) {
   unscheduleTask(taskId: $taskId) {
     execution
     id
+    status
+    displayStatus
+    canSchedule
+    canUnschedule
   }
 }


### PR DESCRIPTION
DEVPROD-1031

### Description
The schedule and unschedule button disabled states on the Task page were not updating after clicking because the mutations did not fetch canSchedule and canUnschedule. These code changes add those fields so they can get integrated into the gql cache and update the button states.