### PR TITLE
DEVPROD-15343: Replace deprecated `ConfirmationModal` props

### DIFF
--- a/apps/parsley/src/components/NavBar/UploadLink/index.tsx
+++ b/apps/parsley/src/components/NavBar/UploadLink/index.tsx
@@ -41,17 +41,21 @@ const UploadLink: React.FC<UploadLinkProps> = ({ clearLogs, hasLogs }) => {
         Upload
       </StyledRouterLink>
       <ConfirmationModal
-        buttonText="Confirm"
+        cancelButtonProps={{
+          onClick: () => setOpen(false),
+        }}
+        confirmButtonProps={{
+          children: "Confirm",
+          onClick: () => {
+            clearLogs();
+            setOpen(false);
+            navigate(routes.upload);
+          },
+        }}
         css={css`
           z-index: ${zIndex.modal};
         `}
         data-cy="confirmation-modal"
-        onCancel={() => setOpen(false)}
-        onConfirm={() => {
-          clearLogs();
-          setOpen(false);
-          navigate(routes.upload);
-        }}
         open={open}
         title="Navigating away will clear your current logs."
         variant="danger"

--- a/apps/parsley/src/components/ProjectFiltersModal/index.tsx
+++ b/apps/parsley/src/components/ProjectFiltersModal/index.tsx
@@ -73,16 +73,20 @@ const ProjectFiltersModal: React.FC<ProjectFiltersModalProps> = ({
 
   return (
     <ConfirmationModal
-      buttonText="Apply filters"
+      cancelButtonProps={{
+        onClick: onCancel,
+      }}
+      confirmButtonProps={{
+        children: "Apply filters",
+        disabled: state.selectedFilters.length === 0,
+        onClick: onConfirm,
+      }}
       css={css`
         z-index: ${zIndex.modal};
       `}
       data-cy="project-filters-modal"
-      onCancel={onCancel}
-      onConfirm={onConfirm}
       open={open}
       setOpen={setOpen}
-      submitDisabled={state.selectedFilters.length === 0}
       title="Project Filters"
     >
       <Scrollable>

--- a/apps/parsley/src/gql/generated/types.ts
+++ b/apps/parsley/src/gql/generated/types.ts
@@ -2207,7 +2207,6 @@ export type Query = {
   taskTestSample?: Maybe<Array<TaskTestResultSample>>;
   user: User;
   userConfig?: Maybe<UserConfig>;
-  userSettings?: Maybe<UserSettings>;
   version: Version;
   viewableProjectRefs: Array<GroupedProjects>;
   waterfall: Waterfall;

--- a/apps/spruce/src/components/Banners/RepotrackerBanner.tsx
+++ b/apps/spruce/src/components/Banners/RepotrackerBanner.tsx
@@ -74,6 +74,14 @@ export const RepotrackerBanner: React.FC<RepotrackerBannerProps> = ({
     setBaseRevision("");
   };
 
+  const onConfirm = () => {
+    setLastRevision({
+      variables: { projectIdentifier, revision: baseRevision },
+      refetchQueries: ["RepotrackerError"],
+    });
+    resetModal();
+  };
+
   if (!hasRepotrackerError) {
     return null;
   }
@@ -101,19 +109,17 @@ export const RepotrackerBanner: React.FC<RepotrackerBannerProps> = ({
         }
       />
       <ConfirmationModal
-        buttonText="Confirm"
-        data-cy="repotracker-error-modal"
-        onCancel={resetModal}
-        onConfirm={() => {
-          setLastRevision({
-            variables: { projectIdentifier, revision: baseRevision },
-            refetchQueries: ["RepotrackerError"],
-          });
-          resetModal();
+        cancelButtonProps={{
+          onClick: resetModal,
         }}
+        confirmButtonProps={{
+          children: "Confirm",
+          disabled: baseRevision.length < 40,
+          onClick: onConfirm,
+        }}
+        data-cy="repotracker-error-modal"
         open={openModal}
         setOpen={setOpenModal}
-        submitDisabled={baseRevision.length < 40}
         title="Enter New Base Revision"
       >
         <ModalDescription>

--- a/apps/spruce/src/components/Hosts/UpdateStatusModal.tsx
+++ b/apps/spruce/src/components/Hosts/UpdateStatusModal.tsx
@@ -85,12 +85,16 @@ export const UpdateStatusModal: React.FC<Props> = ({
 
   return (
     <ConfirmationModal
-      buttonText="Update"
+      cancelButtonProps={{
+        onClick: onClickCancel,
+      }}
+      confirmButtonProps={{
+        children: "Update",
+        disabled: !status || loadingUpdateHostStatus,
+        onClick: onClickUpdate,
+      }}
       data-cy={dataCy}
-      onCancel={onClickCancel}
-      onConfirm={onClickUpdate}
       open={visible}
-      submitDisabled={!status || loadingUpdateHostStatus}
       title="Update Host Status"
     >
       <StyledSelect

--- a/apps/spruce/src/components/Notifications/index.tsx
+++ b/apps/spruce/src/components/Notifications/index.tsx
@@ -122,12 +122,16 @@ export const NotificationModal: React.FC<NotificationModalProps> = ({
 
   return (
     <ConfirmationModal
-      buttonText="Save"
+      cancelButtonProps={{
+        onClick: onCancel,
+      }}
+      confirmButtonProps={{
+        children: "Save",
+        disabled: hasError,
+        onClick: onClickSave,
+      }}
       data-cy={dataCy}
-      onCancel={onCancel}
-      onConfirm={onClickSave}
       open={visible}
-      submitDisabled={hasError}
       title="Add Subscription"
     >
       <SpruceForm

--- a/apps/spruce/src/components/Settings/NavigationWarningModal.tsx
+++ b/apps/spruce/src/components/Settings/NavigationWarningModal.tsx
@@ -23,10 +23,14 @@ export const NavigationWarningModal: React.FC<NavigationModalProps> = ({
   return (
     blocker.state === "blocked" && (
       <ConfirmationModal
-        buttonText="Leave"
+        cancelButtonProps={{
+          onClick: () => blocker.reset?.(),
+        }}
+        confirmButtonProps={{
+          children: "Leave",
+          onClick: () => blocker.proceed?.(),
+        }}
         data-cy="navigation-warning-modal"
-        onCancel={() => blocker.reset?.()}
-        onConfirm={() => blocker.proceed?.()}
         open
         title="You have unsaved changes that will be discarded. Are you sure you want to leave?"
         variant="danger"

--- a/apps/spruce/src/pages/commits/WaterfallMenu/GitCommitSearch.tsx
+++ b/apps/spruce/src/pages/commits/WaterfallMenu/GitCommitSearch.tsx
@@ -47,13 +47,17 @@ export const GitCommitSearch: React.FC<GitCommitSearchProps> = ({
         Search by Git Hash
       </DropdownItem>
       <ConfirmationModal
-        buttonText="Submit"
+        cancelButtonProps={{
+          onClick: onCancel,
+        }}
+        confirmButtonProps={{
+          children: "Submit",
+          // Force user to input at least 7 characters of the hash.
+          disabled: commitHash.trim().length < 7,
+          onClick: onConfirm,
+        }}
         data-cy="git-commit-search-modal"
-        onCancel={onCancel}
-        onConfirm={onConfirm}
         open={modalOpen}
-        // Force user to input at least 7 characters of the hash.
-        submitDisabled={commitHash.trim().length < 7}
         title="Search by Git Commit Hash"
       >
         <StyledDescription>

--- a/apps/spruce/src/pages/distroSettings/DeleteDistro/index.tsx
+++ b/apps/spruce/src/pages/distroSettings/DeleteDistro/index.tsx
@@ -52,10 +52,14 @@ const Modal: React.FC<ModalProps> = ({ closeModal, distroId, open }) => {
 
   return (
     <ConfirmationModal
-      buttonText="Delete"
+      cancelButtonProps={{
+        onClick: closeModal,
+      }}
+      confirmButtonProps={{
+        children: "Delete",
+        onClick: onConfirm,
+      }}
       data-cy="delete-distro-modal"
-      onCancel={closeModal}
-      onConfirm={onConfirm}
       open={open}
       requiredInputText={distroId}
       title={`Delete “${distroId}”?`}

--- a/apps/spruce/src/pages/distroSettings/NewDistro/CopyModal.tsx
+++ b/apps/spruce/src/pages/distroSettings/NewDistro/CopyModal.tsx
@@ -61,12 +61,16 @@ export const CopyModal: React.FC<Props> = ({ handleClose, open }) => {
 
   return (
     <ConfirmationModal
-      buttonText="Duplicate"
+      cancelButtonProps={{
+        onClick: handleClose,
+      }}
+      confirmButtonProps={{
+        children: "Duplicate",
+        disabled: hasError,
+        onClick: onConfirm,
+      }}
       data-cy="copy-distro-modal"
-      onCancel={handleClose}
-      onConfirm={onConfirm}
       open={open}
-      submitDisabled={hasError}
       title={`Duplicate “${distroId}”`}
     >
       <SpruceForm

--- a/apps/spruce/src/pages/distroSettings/NewDistro/CreateModal.tsx
+++ b/apps/spruce/src/pages/distroSettings/NewDistro/CreateModal.tsx
@@ -58,12 +58,16 @@ export const CreateModal: React.FC<Props> = ({ handleClose, open }) => {
 
   return (
     <ConfirmationModal
-      buttonText="Create"
+      cancelButtonProps={{
+        onClick: handleClose,
+      }}
+      confirmButtonProps={{
+        children: "Create",
+        disabled: hasError,
+        onClick: onConfirm,
+      }}
       data-cy="create-distro-modal"
-      onCancel={handleClose}
-      onConfirm={onConfirm}
       open={open}
-      submitDisabled={hasError}
       title="Create New Distro"
     >
       <SpruceForm

--- a/apps/spruce/src/pages/distroSettings/SaveModal.tsx
+++ b/apps/spruce/src/pages/distroSettings/SaveModal.tsx
@@ -87,15 +87,17 @@ export const SaveModal: React.FC<SaveModalProps> = ({
 
   return (
     <ConfirmationModal
-      buttonText="Save"
+      cancelButtonProps={{
+        onClick: () => onCancel?.(),
+      }}
+      confirmButtonProps={{
+        children: "Save",
+        onClick: () => {
+          onConfirm?.();
+          handleSave();
+        },
+      }}
       data-cy="save-modal"
-      onCancel={() => {
-        onCancel?.();
-      }}
-      onConfirm={() => {
-        onConfirm?.();
-        handleSave();
-      }}
       open={open}
       title="Save page"
     >

--- a/apps/spruce/src/pages/preferences/preferencesTabs/notificationTab/ClearSubscriptions.tsx
+++ b/apps/spruce/src/pages/preferences/preferencesTabs/notificationTab/ClearSubscriptions.tsx
@@ -48,16 +48,20 @@ export const ClearSubscriptions: React.FC = () => {
         Clear all previous subscriptions
       </Button>
       <ConfirmationModal
-        buttonText="Clear All"
-        onCancel={() => setShowModal(false)}
-        onConfirm={() => {
-          clearMySubscriptions();
-          sendEvent({
-            name: "Deleted subscriptions",
-          });
+        cancelButtonProps={{
+          onClick: () => setShowModal(false),
+        }}
+        confirmButtonProps={{
+          children: "Clear all",
+          disabled: loading,
+          onClick: () => {
+            clearMySubscriptions();
+            sendEvent({
+              name: "Deleted subscriptions",
+            });
+          },
         }}
         open={showModal}
-        submitDisabled={loading}
         title="Clear All Subscriptions"
         variant="danger"
       >

--- a/apps/spruce/src/pages/preferences/preferencesTabs/publicKeysTab/EditModal.tsx
+++ b/apps/spruce/src/pages/preferences/preferencesTabs/publicKeysTab/EditModal.tsx
@@ -123,12 +123,16 @@ export const EditModal: React.FC<EditModalProps> = ({
 
   return (
     <ConfirmationModal
-      buttonText="Save"
+      cancelButtonProps={{
+        onClick: closeModal,
+      }}
+      confirmButtonProps={{
+        children: "Save",
+        disabled: errors.length > 0,
+        onClick: onClickSave,
+      }}
       data-cy="key-edit-modal"
-      onCancel={closeModal}
-      onConfirm={onClickSave}
       open={visible}
-      submitDisabled={errors.length > 0}
       title={replaceKeyName ? "Update Public Key" : "Add Public Key"}
     >
       <StyledInput

--- a/apps/spruce/src/pages/projectSettings/CopyProjectModal.tsx
+++ b/apps/spruce/src/pages/projectSettings/CopyProjectModal.tsx
@@ -103,12 +103,16 @@ export const CopyProjectModal: React.FC<Props> = ({
 
   return (
     <ConfirmationModal
-      buttonText="Duplicate"
+      cancelButtonProps={{
+        onClick: handleClose,
+      }}
+      confirmButtonProps={{
+        children: "Duplicate",
+        disabled: hasError,
+        onClick: onConfirm,
+      }}
       data-cy="copy-project-modal"
-      onCancel={handleClose}
-      onConfirm={onConfirm}
       open={open}
-      submitDisabled={hasError}
       title={`Duplicate “${label}”`}
     >
       <SpruceForm

--- a/apps/spruce/src/pages/projectSettings/CreateProjectModal.tsx
+++ b/apps/spruce/src/pages/projectSettings/CreateProjectModal.tsx
@@ -114,12 +114,16 @@ export const CreateProjectModal: React.FC<Props> = ({
 
   return (
     <ConfirmationModal
-      buttonText="Create project"
+      cancelButtonProps={{
+        onClick: handleClose,
+      }}
+      confirmButtonProps={{
+        children: "Create project",
+        disabled: hasError,
+        onClick: onConfirm,
+      }}
       data-cy="create-project-modal"
-      onCancel={handleClose}
-      onConfirm={onConfirm}
       open={open}
-      submitDisabled={hasError}
       title="Create New Project"
     >
       {githubOrgs.length ? (

--- a/apps/spruce/src/pages/projectSettings/DefaultSectionToRepoModal.tsx
+++ b/apps/spruce/src/pages/projectSettings/DefaultSectionToRepoModal.tsx
@@ -46,17 +46,21 @@ export const DefaultSectionToRepoModal = ({
 
   return (
     <ConfirmationModal
-      buttonText="Confirm"
-      data-cy="default-to-repo-modal"
-      onCancel={handleClose}
-      onConfirm={() => {
-        defaultSectionToRepo();
-        sendEvent({
-          name: "Clicked default section to repo button",
-          section,
-        });
-        handleClose();
+      cancelButtonProps={{
+        onClick: handleClose,
       }}
+      confirmButtonProps={{
+        children: "Confirm",
+        onClick: () => {
+          defaultSectionToRepo();
+          sendEvent({
+            name: "Clicked default section to repo button",
+            section,
+          });
+          handleClose();
+        },
+      }}
+      data-cy="default-to-repo-modal"
       open={open}
       requiredInputText="confirm"
       title="Are you sure you want to default all settings in this section to the repo settings?"

--- a/apps/spruce/src/pages/projectSettings/tabs/GeneralTab/Fields/AttachDetachModal.tsx
+++ b/apps/spruce/src/pages/projectSettings/tabs/GeneralTab/Fields/AttachDetachModal.tsx
@@ -70,29 +70,35 @@ export const AttachDetachModal: React.FC<ModalProps> = ({
     refetchQueries: ["ProjectSettings", "RepoSettings", "ViewableProjectRefs"],
   });
 
+  const onConfirm = () => {
+    if (shouldAttach) {
+      attachProjectToRepo();
+      sendEvent({
+        name: "Clicked attach project to repo button",
+        "repo.owner": repoOwner,
+        "repo.name": repoName,
+      });
+    } else {
+      detachProjectFromRepo();
+      sendEvent({
+        name: "Clicked detach project from repo button",
+        "repo.owner": repoOwner,
+        "repo.name": repoName,
+      });
+    }
+    handleClose();
+  };
+
   return (
     <ConfirmationModal
-      buttonText={shouldAttach ? "Attach" : "Detach"}
-      data-cy="attach-repo-modal"
-      onCancel={handleClose}
-      onConfirm={() => {
-        if (shouldAttach) {
-          attachProjectToRepo();
-          sendEvent({
-            name: "Clicked attach project to repo button",
-            "repo.owner": repoOwner,
-            "repo.name": repoName,
-          });
-        } else {
-          detachProjectFromRepo();
-          sendEvent({
-            name: "Clicked detach project from repo button",
-            "repo.owner": repoOwner,
-            "repo.name": repoName,
-          });
-        }
-        handleClose();
+      cancelButtonProps={{
+        onClick: handleClose,
       }}
+      confirmButtonProps={{
+        children: shouldAttach ? "Attach" : "Detach",
+        onClick: onConfirm,
+      }}
+      data-cy="attach-repo-modal"
       open={open}
       title={`Are you sure you want to ${
         shouldAttach ? "attach to" : "detach from"

--- a/apps/spruce/src/pages/projectSettings/tabs/GeneralTab/Fields/DeactivateStepbackTaskField.tsx
+++ b/apps/spruce/src/pages/projectSettings/tabs/GeneralTab/Fields/DeactivateStepbackTaskField.tsx
@@ -54,12 +54,16 @@ const Modal: React.FC<ModalProps> = ({ closeModal, open, projectId }) => {
 
   return (
     <ConfirmationModal
-      buttonText="Confirm"
+      cancelButtonProps={{
+        onClick: closeModal,
+      }}
+      confirmButtonProps={{
+        children: "Confirm",
+        disabled: hasError || loading,
+        onClick: onConfirm,
+      }}
       data-cy="deactivate-stepback-modal"
-      onCancel={closeModal}
-      onConfirm={onConfirm}
       open={open}
-      submitDisabled={hasError || loading}
       title="Deactivate Scheduled Stepback Task"
     >
       <p>

--- a/apps/spruce/src/pages/projectSettings/tabs/GeneralTab/Fields/DeleteProjectField.tsx
+++ b/apps/spruce/src/pages/projectSettings/tabs/GeneralTab/Fields/DeleteProjectField.tsx
@@ -49,12 +49,16 @@ const Modal: React.FC<ModalProps> = ({ closeModal, open, projectId }) => {
 
   return (
     <ConfirmationModal
-      buttonText="Delete"
+      cancelButtonProps={{
+        onClick: closeModal,
+      }}
+      confirmButtonProps={{
+        children: "Delete",
+        disabled: loading,
+        onClick: onConfirm,
+      }}
       data-cy="delete-project-modal"
-      onCancel={closeModal}
-      onConfirm={onConfirm}
       open={open}
-      submitDisabled={loading}
       title={`Delete “${identifier}”?`}
       variant="danger"
     >

--- a/apps/spruce/src/pages/projectSettings/tabs/GeneralTab/Fields/MoveRepoModal.tsx
+++ b/apps/spruce/src/pages/projectSettings/tabs/GeneralTab/Fields/MoveRepoModal.tsx
@@ -59,32 +59,38 @@ export const MoveRepoModal: React.FC<ModalProps> = ({
     ],
   });
 
+  const onConfirm = () => {
+    const newOwner = formState.owner;
+    const newRepo = formState.repo;
+    attachProjectToNewRepo({
+      variables: {
+        project: {
+          projectId,
+          newOwner,
+          newRepo,
+        },
+      },
+    });
+    sendEvent({
+      name: "Clicked move project to new repo button",
+      "repo.owner": newOwner,
+      "repo.name": newRepo,
+    });
+    handleClose();
+  };
+
   return (
     <ConfirmationModal
-      buttonText="Move Project"
-      data-cy="move-repo-modal"
-      onCancel={handleClose}
-      onConfirm={() => {
-        const newOwner = formState.owner;
-        const newRepo = formState.repo;
-        attachProjectToNewRepo({
-          variables: {
-            project: {
-              projectId,
-              newOwner,
-              newRepo,
-            },
-          },
-        });
-        sendEvent({
-          name: "Clicked move project to new repo button",
-          "repo.owner": newOwner,
-          "repo.name": newRepo,
-        });
-        handleClose();
+      cancelButtonProps={{
+        onClick: handleClose,
       }}
+      confirmButtonProps={{
+        children: "Move project",
+        disabled: hasError,
+        onClick: onConfirm,
+      }}
+      data-cy="move-repo-modal"
       open={open}
-      submitDisabled={hasError}
       title="Move to New Repo"
       variant="danger"
     >

--- a/apps/spruce/src/pages/projectSettings/tabs/GeneralTab/Fields/RepoConfigField.test.tsx
+++ b/apps/spruce/src/pages/projectSettings/tabs/GeneralTab/Fields/RepoConfigField.test.tsx
@@ -212,7 +212,7 @@ describe("repoConfigField", () => {
 
       expect(
         screen.getByRole("button", {
-          name: "Move Project",
+          name: "Move project",
         }),
       ).toHaveAttribute("aria-disabled", "true");
     });
@@ -226,7 +226,7 @@ describe("repoConfigField", () => {
       );
       expect(
         screen.getByRole("button", {
-          name: "Move Project",
+          name: "Move project",
         }),
       ).toHaveAttribute("aria-disabled", "true");
     });
@@ -244,7 +244,7 @@ describe("repoConfigField", () => {
       await user.type(screen.queryByDataCy("new-repo-input"), "new-repo-name");
       expect(
         screen.getByRole("button", {
-          name: "Move Project",
+          name: "Move project",
         }),
       ).not.toHaveAttribute("aria-disabled", "true");
     });

--- a/apps/spruce/src/pages/projectSettings/tabs/GeneralTab/Fields/RepotrackerField.tsx
+++ b/apps/spruce/src/pages/projectSettings/tabs/GeneralTab/Fields/RepotrackerField.tsx
@@ -49,11 +49,15 @@ const Modal: React.FC<ModalProps> = ({ closeModal, open, projectId }) => {
 
   return (
     <ConfirmationModal
-      buttonText="Confirm"
-      onCancel={closeModal}
-      onConfirm={onConfirm}
+      cancelButtonProps={{
+        onClick: closeModal,
+      }}
+      confirmButtonProps={{
+        children: "Confirm",
+        disabled: loading,
+        onClick: onConfirm,
+      }}
       open={open}
-      submitDisabled={loading}
       title="Force Repotracker Run"
     >
       Are you sure you would like to force a Repotracker run?

--- a/apps/spruce/src/pages/projectSettings/tabs/GithubAppSettingsTab/Fields/GithubAppActions.tsx
+++ b/apps/spruce/src/pages/projectSettings/tabs/GithubAppSettingsTab/Fields/GithubAppActions.tsx
@@ -44,15 +44,19 @@ const DeleteAppCredentialsButton: React.FC<{
   return (
     <>
       <ConfirmationModal
-        buttonText="Delete"
-        data-cy="delete-github-credentials-modal"
-        onCancel={() => setOpen(false)}
-        onConfirm={() => {
-          deleteGithubAppCredentials({ variables: { projectId } });
-          setOpen(false);
+        cancelButtonProps={{
+          onClick: () => setOpen(false),
         }}
+        confirmButtonProps={{
+          children: "Delete",
+          disabled: loading,
+          onClick: () => {
+            deleteGithubAppCredentials({ variables: { projectId } });
+            setOpen(false);
+          },
+        }}
+        data-cy="delete-github-credentials-modal"
         open={open}
-        submitDisabled={loading}
         title="Delete GitHub app credentials?"
         variant={ModalVariant.Danger}
       >

--- a/apps/spruce/src/pages/projectSettings/tabs/VariablesTab/PromoteVariablesModal.tsx
+++ b/apps/spruce/src/pages/projectSettings/tabs/VariablesTab/PromoteVariablesModal.tsx
@@ -100,12 +100,16 @@ export const PromoteVariablesModal: React.FC<PromoteVariablesModalProps> = ({
 
   return (
     <ConfirmationModal
-      buttonText={getButtonText(selected.size)}
+      cancelButtonProps={{
+        onClick: handleClose,
+      }}
+      confirmButtonProps={{
+        children: getButtonText(selected.size),
+        disabled: selected.size === 0,
+        onClick: onConfirm,
+      }}
       data-cy="promote-vars-modal"
-      onCancel={handleClose}
-      onConfirm={onConfirm}
       open={open}
-      submitDisabled={selected.size === 0}
       title="Move Variables to Repo"
     >
       <Body>

--- a/apps/spruce/src/pages/spawn/spawnHost/EditSpawnHostModal.tsx
+++ b/apps/spruce/src/pages/spawn/spawnHost/EditSpawnHostModal.tsx
@@ -177,9 +177,9 @@ export const EditSpawnHostModal: React.FC<EditSpawnHostModalProps> = ({
         },
       }}
       confirmButtonProps={{
-        onClick: onSubmit,
         children: loadingSpawnHost ? "Saving" : "Save",
         disabled: !hasChanges || hasError || loadingSpawnHost,
+        onClick: onSubmit,
       }}
       data-cy="edit-spawn-host-modal"
       open={visible}

--- a/apps/spruce/src/pages/spawn/spawnHost/PauseSleepScheduleModal.tsx
+++ b/apps/spruce/src/pages/spawn/spawnHost/PauseSleepScheduleModal.tsx
@@ -29,13 +29,17 @@ export const PauseSleepScheduleModal: React.FC<{
 
   return (
     <ConfirmationModal
-      buttonText={pauseButtonText}
-      data-cy="pause-sleep-schedule-modal"
-      onCancel={() => setOpen(false)}
-      onConfirm={() => {
-        handleConfirm(shouldKeepOff);
-        setOpen(false);
+      cancelButtonProps={{
+        onClick: () => setOpen(false),
       }}
+      confirmButtonProps={{
+        children: pauseButtonText,
+        onClick: () => {
+          handleConfirm(shouldKeepOff);
+          setOpen(false);
+        },
+      }}
+      data-cy="pause-sleep-schedule-modal"
       open={open}
       setOpen={setOpen}
       title="Configure Host Pause"

--- a/apps/spruce/src/pages/spawn/spawnVolume/SpawnVolumeModal.tsx
+++ b/apps/spruce/src/pages/spawn/spawnVolume/SpawnVolumeModal.tsx
@@ -101,12 +101,16 @@ export const SpawnVolumeModal: React.FC<SpawnVolumeModalProps> = ({
 
   return (
     <ConfirmationModal
-      buttonText={loadingSpawnVolume ? "Spawning volume" : "Spawn"}
+      cancelButtonProps={{
+        onClick: onCancel,
+      }}
+      confirmButtonProps={{
+        children: loadingSpawnVolume ? "Spawning volume" : "Spawn",
+        disabled: loadingSpawnVolume || !canSubmit,
+        onClick: spawnVolume,
+      }}
       data-cy="spawn-volume-modal"
-      onCancel={onCancel}
-      onConfirm={spawnVolume}
       open={visible}
-      submitDisabled={loadingSpawnVolume || !canSubmit}
       title="Spawn New Volume"
     >
       <SpruceForm

--- a/apps/spruce/src/pages/spawn/spawnVolume/spawnVolumeTableActions/MigrateVolumeModal.tsx
+++ b/apps/spruce/src/pages/spawn/spawnVolume/spawnVolumeTableActions/MigrateVolumeModal.tsx
@@ -159,12 +159,16 @@ export const MigrateVolumeModal: React.FC<MigrateVolumeModalProps> = ({
 
   return (
     <ConfirmationModal
-      buttonText={buttonText}
+      cancelButtonProps={{
+        onClick: onCancel,
+      }}
+      confirmButtonProps={{
+        children: buttonText,
+        disabled: hasError || loadingMigration || volume.migrating,
+        onClick: onConfirm,
+      }}
       data-cy="migrate-modal"
-      onCancel={onCancel}
-      onConfirm={onConfirm}
       open={open}
-      submitDisabled={hasError || loadingMigration || volume.migrating}
       title={title}
     >
       <Body>

--- a/apps/spruce/src/pages/spawn/spawnVolume/spawnVolumeTableActions/MountVolumeModal.tsx
+++ b/apps/spruce/src/pages/spawn/spawnVolume/spawnVolumeTableActions/MountVolumeModal.tsx
@@ -40,29 +40,36 @@ export const MountVolumeModal: React.FC<Props> = ({
   });
   const targetAvailabilityZone = volume.availabilityZone;
   const [selectedHostId, setSelectedHostId] = useState("");
+
+  const onConfirm = () => {
+    spawnAnalytics.sendEvent({
+      name: "Changed mounted volume on host",
+      "volume.id": volume.id,
+      "host.id": selectedHostId,
+    });
+    attachVolume({
+      variables: {
+        volumeAndHost: {
+          volumeId: volume.id,
+          hostId: selectedHostId,
+        },
+      },
+    });
+    onCancel();
+  };
+
   return (
     <ConfirmationModal
-      buttonText="Mount"
-      data-cy="mount-volume-modal"
-      onCancel={onCancel}
-      onConfirm={() => {
-        spawnAnalytics.sendEvent({
-          name: "Changed mounted volume on host",
-          "volume.id": volume.id,
-          "host.id": selectedHostId,
-        });
-        attachVolume({
-          variables: {
-            volumeAndHost: {
-              volumeId: volume.id,
-              hostId: selectedHostId,
-            },
-          },
-        });
-        onCancel();
+      cancelButtonProps={{
+        onClick: onCancel,
       }}
+      confirmButtonProps={{
+        children: "Mount",
+        disabled: !selectedHostId || loadingAttachVolume,
+        onClick: onConfirm,
+      }}
+      data-cy="mount-volume-modal"
       open={visible}
-      submitDisabled={!selectedHostId || loadingAttachVolume}
       title="Attach Volume to Host"
     >
       <ModalContent>

--- a/apps/spruce/src/pages/task/taskTabs/buildBaronAndAnnotations/AddIssueModal/index.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/buildBaronAndAnnotations/AddIssueModal/index.tsx
@@ -93,12 +93,16 @@ export const AddIssueModal: React.FC<Props> = ({
   return (
     <ConfirmationModal
       {...rest}
-      buttonText={`Add ${issueString}`}
+      cancelButtonProps={{
+        onClick: handleCancel,
+      }}
+      confirmButtonProps={{
+        children: `Add ${issueString}`,
+        disabled: !canSubmit,
+        onClick: handleSubmit,
+      }}
       data-cy="add-issue-modal"
-      onCancel={handleCancel}
-      onConfirm={handleSubmit}
       open={visible}
-      submitDisabled={!canSubmit}
       title={title}
     >
       {jiraHost && (

--- a/apps/spruce/src/pages/version/NameChangeModal/index.tsx
+++ b/apps/spruce/src/pages/version/NameChangeModal/index.tsx
@@ -41,7 +41,7 @@ export const NameChangeModal: React.FC<NameChangeModalProps> = ({
     refetchQueries: ["Version"],
   });
 
-  const { newPatchName } = formState;
+  const { newPatchName = "" } = formState;
 
   return (
     <>
@@ -62,7 +62,6 @@ export const NameChangeModal: React.FC<NameChangeModalProps> = ({
             newPatchName === originalPatchName || hasFormError || loading,
           onClick: () => {
             updateDescription({
-              // @ts-expect-error: FIXME. This comment was added by an automated script.
               variables: { patchId, description: newPatchName },
             });
           },

--- a/apps/spruce/src/pages/version/NameChangeModal/index.tsx
+++ b/apps/spruce/src/pages/version/NameChangeModal/index.tsx
@@ -60,11 +60,10 @@ export const NameChangeModal: React.FC<NameChangeModalProps> = ({
           children: "Confirm",
           disabled:
             newPatchName === originalPatchName || hasFormError || loading,
-          onClick: () => {
+          onClick: () =>
             updateDescription({
               variables: { patchId, description: newPatchName },
-            });
-          },
+            }),
         }}
         open={isOpen}
         title="Update Patch Name"

--- a/apps/spruce/src/pages/version/NameChangeModal/index.tsx
+++ b/apps/spruce/src/pages/version/NameChangeModal/index.tsx
@@ -53,18 +53,21 @@ export const NameChangeModal: React.FC<NameChangeModalProps> = ({
         <Icon glyph="Edit" />
       </StyledIconButton>
       <ConfirmationModal
-        buttonText="Confirm"
-        onCancel={() => setIsOpen(false)}
-        onConfirm={() => {
-          updateDescription({
-            // @ts-expect-error: FIXME. This comment was added by an automated script.
-            variables: { patchId, description: newPatchName },
-          });
+        cancelButtonProps={{
+          onClick: () => setIsOpen(false),
+        }}
+        confirmButtonProps={{
+          children: "Confirm",
+          disabled:
+            newPatchName === originalPatchName || hasFormError || loading,
+          onClick: () => {
+            updateDescription({
+              // @ts-expect-error: FIXME. This comment was added by an automated script.
+              variables: { patchId, description: newPatchName },
+            });
+          },
         }}
         open={isOpen}
-        submitDisabled={
-          newPatchName === originalPatchName || hasFormError || loading
-        }
         title="Update Patch Name"
       >
         <SpruceForm


### PR DESCRIPTION
DEVPROD-15343
<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
`buttonText`, `submitDisabled`, `onCancel`, and `onConfirm` are deprecated props. Use updated props to facilitate smoother upgrade when these props are officially removed.

