### PR TITLE
DEVPROD-15373 Fix metadata spacing

### DIFF
--- a/apps/spruce/src/components/MetadataCard.tsx
+++ b/apps/spruce/src/components/MetadataCard.tsx
@@ -58,9 +58,7 @@ export const MetadataItem: React.FC<ItemProps> = ({
       {children}
     </Item>
     {tooltipDescription && (
-      <span>
-        <InfoSprinkle align="right">{tooltipDescription}</InfoSprinkle>
-      </span>
+      <InfoSprinkle align="right">{tooltipDescription}</InfoSprinkle>
     )}
   </MetadataItemWrapper>
 );
@@ -80,16 +78,18 @@ const Item = styled(Body)<BodyProps>`
     line-height: 14px;
   }
 
-  :not(:last-child) {
-    margin-bottom: 12px;
-  }
   width: fit-content;
 `;
 
-const MetadataItemWrapper = styled.div`
+const MetadataItemWrapper = styled.span`
   display: flex;
   flex-direction: row;
   gap: 4px;
+  line-height: 14px;
+
+  :not(:last-child) {
+    margin-bottom: 12px;
+  }
 `;
 export const MetadataLabel = styled.b<{ color?: string }>`
   ${({ color }) => color && `color: ${color};`}

--- a/apps/spruce/src/components/MetadataCard/MetadataCard.stories.tsx
+++ b/apps/spruce/src/components/MetadataCard/MetadataCard.stories.tsx
@@ -1,0 +1,34 @@
+import { CustomStoryObj, CustomMeta } from "@evg-ui/lib/test_utils/types";
+import MetadataCard, { MetadataItem, MetadataLabel } from ".";
+
+export default {
+  component: MetadataCard,
+  argTypes: {
+    loading: {
+      control: { type: "boolean" },
+    },
+  },
+  args: {
+    loading: false,
+    title: "Example Metadata Card",
+  },
+} satisfies CustomMeta<typeof MetadataCard>;
+
+export const Default: CustomStoryObj<typeof MetadataCard> = {
+  render: (args) => (
+    <div style={{ width: 300 }}>
+      <MetadataCard {...args}>
+        <MetadataItem>
+          <MetadataLabel>Metadata Label 1:</MetadataLabel> Metadata Value 1
+        </MetadataItem>
+        <MetadataItem tooltipDescription="This is a tooltip description">
+          <MetadataLabel>Metadata Label 2:</MetadataLabel> Metadata Value 2
+        </MetadataItem>
+        <MetadataItem>
+          <MetadataLabel color="red">Metadata Label 3:</MetadataLabel> Metadata
+          Value 3
+        </MetadataItem>
+      </MetadataCard>
+    </div>
+  ),
+};

--- a/apps/spruce/src/components/MetadataCard/__snapshots__/MetadataCard_Default.storyshot
+++ b/apps/spruce/src/components/MetadataCard/__snapshots__/MetadataCard_Default.storyshot
@@ -1,0 +1,88 @@
+<div>
+  <div
+    style="width: 300px;"
+  >
+    <div
+      class="css-1l8tpk-SiderCard e1am38ss0 leafygreen-ui-1ecxdul"
+    >
+      <div>
+        <p
+          class="css-1k03zl5-Title e1130wzj2 leafygreen-ui-1miy0xp"
+        >
+          Example Metadata Card
+        </p>
+        <hr
+          class="css-qqg5h5-Divider eb6szep0"
+        />
+      </div>
+      <span
+        class="css-160t4ez-MetadataItemWrapper e1130wzj0"
+      >
+        <p
+          class="css-1xle18-Item-wordBreakCss e1130wzj1 leafygreen-ui-1tb6tuo"
+        >
+          <b
+            class="css-1xk67r-MetadataLabel e1130wzj3"
+          >
+            Metadata Label 1:
+          </b>
+           Metadata Value 1
+        </p>
+      </span>
+      <span
+        class="css-160t4ez-MetadataItemWrapper e1130wzj0"
+      >
+        <p
+          class="css-1xle18-Item-wordBreakCss e1130wzj1 leafygreen-ui-1tb6tuo"
+        >
+          <b
+            class="css-1xk67r-MetadataLabel e1130wzj3"
+          >
+            Metadata Label 2:
+          </b>
+           Metadata Value 2
+        </p>
+        <span
+          aria-disabled="true"
+          aria-label="more info"
+          class="leafygreen-ui-emw599"
+          data-testid="info-sprinkle-icon"
+          role="button"
+          tabindex="0"
+        >
+          <svg
+            aria-hidden="true"
+            aria-label="Info With Circle Icon"
+            class="leafygreen-ui-1st74h4"
+            height="13"
+            role="img"
+            viewBox="0 0 16 16"
+            width="13"
+          >
+            <path
+              clip-rule="evenodd"
+              d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM9 4C9 4.55228 8.55228 5 8 5C7.44772 5 7 4.55228 7 4C7 3.44772 7.44772 3 8 3C8.55228 3 9 3.44772 9 4ZM8 6C8.55228 6 9 6.44772 9 7V11H9.5C9.77614 11 10 11.2239 10 11.5C10 11.7761 9.77614 12 9.5 12H6.5C6.22386 12 6 11.7761 6 11.5C6 11.2239 6.22386 11 6.5 11H7V7H6.5C6.22386 7 6 6.77614 6 6.5C6 6.22386 6.22386 6 6.5 6H8Z"
+              fill="currentColor"
+              fill-rule="evenodd"
+            />
+          </svg>
+        </span>
+      </span>
+      <span
+        class="css-160t4ez-MetadataItemWrapper e1130wzj0"
+      >
+        <p
+          class="css-1xle18-Item-wordBreakCss e1130wzj1 leafygreen-ui-1tb6tuo"
+        >
+          <b
+            class="css-fern9f-MetadataLabel e1130wzj3"
+            color="red"
+          >
+            Metadata Label 3:
+          </b>
+           Metadata Value 3
+        </p>
+      </span>
+    </div>
+  </div>
+</div>

--- a/apps/spruce/src/components/MetadataCard/index.tsx
+++ b/apps/spruce/src/components/MetadataCard/index.tsx
@@ -2,6 +2,7 @@ import styled from "@emotion/styled";
 import { InfoSprinkle } from "@leafygreen-ui/info-sprinkle";
 import { PolymorphicAs } from "@leafygreen-ui/polymorphic";
 import { ListSkeleton } from "@leafygreen-ui/skeleton-loader";
+import { BaseFontSize } from "@leafygreen-ui/tokens";
 import { Body, BodyProps } from "@leafygreen-ui/typography";
 import { wordBreakCss } from "@evg-ui/lib/components/styles";
 import { ErrorWrapper } from "components/ErrorWrapper";
@@ -55,7 +56,7 @@ export const MetadataItem: React.FC<ItemProps> = ({
       {children}
     </Item>
     {tooltipDescription && (
-      <InfoSprinkle align="right" baseFontSize={13}>
+      <InfoSprinkle align="right" baseFontSize={BaseFontSize.Body1}>
         {tooltipDescription}
       </InfoSprinkle>
     )}

--- a/apps/spruce/src/components/MetadataCard/index.tsx
+++ b/apps/spruce/src/components/MetadataCard/index.tsx
@@ -1,4 +1,3 @@
-import { ApolloError } from "@apollo/client";
 import styled from "@emotion/styled";
 import { InfoSprinkle } from "@leafygreen-ui/info-sprinkle";
 import { PolymorphicAs } from "@leafygreen-ui/polymorphic";
@@ -10,13 +9,13 @@ import { SiderCard } from "components/styles";
 import { Divider } from "components/styles/divider";
 
 interface Props {
-  error?: ApolloError;
+  error?: Error;
   loading?: boolean;
   title?: React.ReactNode;
   children: React.ReactNode;
 }
 
-export const MetadataCard: React.FC<Props> = ({
+const MetadataCard: React.FC<Props> = ({
   children,
   error,
   loading,
@@ -58,11 +57,16 @@ export const MetadataItem: React.FC<ItemProps> = ({
       {children}
     </Item>
     {tooltipDescription && (
-      <InfoSprinkle align="right">{tooltipDescription}</InfoSprinkle>
+      <InfoSprinkle align="right" baseFontSize={13}>
+        {tooltipDescription}
+      </InfoSprinkle>
     )}
   </MetadataItemWrapper>
 );
 
+export const MetadataLabel = styled.b<{ color?: string }>`
+  ${({ color }) => color && `color: ${color};`}
+`;
 const Title = styled(Body)<BodyProps>`
   font-size: 15px;
 `;
@@ -91,6 +95,5 @@ const MetadataItemWrapper = styled.span`
     margin-bottom: 12px;
   }
 `;
-export const MetadataLabel = styled.b<{ color?: string }>`
-  ${({ color }) => color && `color: ${color};`}
-`;
+
+export default MetadataCard;

--- a/apps/spruce/src/components/MetadataCard/index.tsx
+++ b/apps/spruce/src/components/MetadataCard/index.tsx
@@ -1,8 +1,8 @@
 import styled from "@emotion/styled";
 import { InfoSprinkle } from "@leafygreen-ui/info-sprinkle";
 import { PolymorphicAs } from "@leafygreen-ui/polymorphic";
+import { ListSkeleton } from "@leafygreen-ui/skeleton-loader";
 import { Body, BodyProps } from "@leafygreen-ui/typography";
-import { Skeleton } from "antd";
 import { wordBreakCss } from "@evg-ui/lib/components/styles";
 import { ErrorWrapper } from "components/ErrorWrapper";
 import { SiderCard } from "components/styles";
@@ -29,9 +29,7 @@ const MetadataCard: React.FC<Props> = ({
         <Divider />
       </div>
     )}
-    {loading && !error && (
-      <Skeleton active paragraph={{ rows: 4 }} title={false} />
-    )}
+    {loading && !error && <ListSkeleton />}
     {error && !loading && (
       <ErrorWrapper data-cy="metadata-card-error">{error.message}</ErrorWrapper>
     )}

--- a/apps/spruce/src/components/PageSizeSelector/__snapshots__/PageSizeSelector_Default.storyshot
+++ b/apps/spruce/src/components/PageSizeSelector/__snapshots__/PageSizeSelector_Default.storyshot
@@ -4,8 +4,8 @@
     data-lgid="lg-select"
   >
     <button
-      aria-controls="select-240-menu"
-      aria-describedby="select-240-description"
+      aria-controls="select-241-menu"
+      aria-describedby="select-241-description"
       aria-disabled="false"
       aria-expanded="false"
       aria-invalid="false"
@@ -13,7 +13,7 @@
       class="lg-ui-button-0000 leafygreen-ui-c19aul"
       data-lgid="lg-button"
       data-testid="leafygreen-ui-select-menubutton"
-      id="select-241"
+      id="select-242"
       type="button"
       value="10"
     >

--- a/apps/spruce/src/components/SpruceForm/__snapshots__/SpruceForm_Example1.storyshot
+++ b/apps/spruce/src/components/SpruceForm/__snapshots__/SpruceForm_Example1.storyshot
@@ -42,23 +42,23 @@
                     <label
                       class="leafygreen-ui-qj0u2k"
                       data-lgid="lg-label"
-                      for="select-259"
-                      id="select-258-label"
+                      for="select-260"
+                      id="select-259-label"
                     >
                       Project Cloning Method
                     </label>
                   </div>
                   <button
-                    aria-controls="select-258-menu"
-                    aria-describedby="select-258-description"
+                    aria-controls="select-259-menu"
+                    aria-describedby="select-259-description"
                     aria-disabled="false"
                     aria-expanded="false"
                     aria-invalid="false"
-                    aria-labelledby="select-258-label"
+                    aria-labelledby="select-259-label"
                     class="lg-ui-button-0000 leafygreen-ui-1p6i2zy"
                     data-lgid="lg-button"
                     data-testid="leafygreen-ui-select-menubutton"
-                    id="select-259"
+                    id="select-260"
                     type="button"
                     value="legacy-ssh"
                   >
@@ -185,8 +185,8 @@
                                 class="leafygreen-ui-6bdaia"
                                 data-lgid="lg-label"
                                 data-testid="lg-form_field-label"
-                                for="lg-form_field-input-263"
-                                id="lg-form_field-label-260"
+                                for="lg-form_field-input-264"
+                                id="lg-form_field-label-261"
                               >
                                 key
                               </label>
@@ -201,10 +201,10 @@
                                   aria-describedby=""
                                   aria-disabled="false"
                                   aria-invalid="false"
-                                  aria-labelledby="lg-form_field-label-260"
+                                  aria-labelledby="lg-form_field-label-261"
                                   autocomplete="on"
                                   class="lg-ui-form-field-input-0000 leafygreen-ui-1ago99h"
-                                  id="lg-form_field-input-263"
+                                  id="lg-form_field-input-264"
                                   required=""
                                   type="text"
                                   value="Sample Input"
@@ -217,7 +217,7 @@
                               class="leafygreen-ui-11ydt2g"
                               data-lgid="lg-form_field-feedback"
                               data-testid="lg-form_field-feedback"
-                              id="lg-form_field-feedback-262"
+                              id="lg-form_field-feedback-263"
                             />
                           </div>
                         </div>
@@ -240,8 +240,8 @@
                                 class="leafygreen-ui-6bdaia"
                                 data-lgid="lg-label"
                                 data-testid="lg-form_field-label"
-                                for="lg-form_field-input-267"
-                                id="lg-form_field-label-264"
+                                for="lg-form_field-input-268"
+                                id="lg-form_field-label-265"
                               >
                                 value
                               </label>
@@ -256,10 +256,10 @@
                                   aria-describedby=""
                                   aria-disabled="false"
                                   aria-invalid="false"
-                                  aria-labelledby="lg-form_field-label-264"
+                                  aria-labelledby="lg-form_field-label-265"
                                   autocomplete="on"
                                   class="lg-ui-form-field-input-0000 leafygreen-ui-1ago99h"
-                                  id="lg-form_field-input-267"
+                                  id="lg-form_field-input-268"
                                   required=""
                                   type="text"
                                   value="Sample Input"
@@ -272,7 +272,7 @@
                               class="leafygreen-ui-11ydt2g"
                               data-lgid="lg-form_field-feedback"
                               data-testid="lg-form_field-feedback"
-                              id="lg-form_field-feedback-266"
+                              id="lg-form_field-feedback-267"
                             />
                           </div>
                         </div>
@@ -336,8 +336,8 @@
                       class="leafygreen-ui-6bdaia"
                       data-lgid="lg-label"
                       data-testid="lg-form_field-label"
-                      for="textarea-272"
-                      id="lg-form_field-label-268"
+                      for="textarea-273"
+                      id="lg-form_field-label-269"
                     >
                       Valid Projects
                     </label>
@@ -352,9 +352,9 @@
                         aria-describedby=""
                         aria-disabled="false"
                         aria-invalid="false"
-                        aria-labelledby="lg-form_field-label-268"
+                        aria-labelledby="lg-form_field-label-269"
                         class="lg-ui-form-field-input-0000 leafygreen-ui-1hxdgot"
-                        id="textarea-272"
+                        id="textarea-273"
                         rows="5"
                         title="Valid Projects"
                       />
@@ -366,7 +366,7 @@
                     class="leafygreen-ui-11ydt2g"
                     data-lgid="lg-form_field-feedback"
                     data-testid="lg-form_field-feedback"
-                    id="lg-form_field-feedback-270"
+                    id="lg-form_field-feedback-271"
                   />
                 </div>
               </div>

--- a/apps/spruce/src/components/SpruceForm/__snapshots__/SpruceForm_Example2.storyshot
+++ b/apps/spruce/src/components/SpruceForm/__snapshots__/SpruceForm_Example2.storyshot
@@ -39,65 +39,6 @@
                   <label
                     class="leafygreen-ui-1srek1y"
                     data-lgid="lg-label"
-                    for="checkbox-273"
-                    id="checkbox-273-label"
-                  >
-                    <input
-                      aria-checked="false"
-                      aria-disabled="false"
-                      aria-label="checkbox"
-                      aria-labelledby="checkbox-273-label"
-                      class="lg-ui-input-0000 leafygreen-ui-1a1e5kp"
-                      id="checkbox-273"
-                      type="checkbox"
-                    />
-                    <div
-                      class="lg-ui-check-wrapper-0000 leafygreen-ui-nlfut8"
-                    >
-                      <svg
-                        class="leafygreen-ui-6caof5"
-                        fill="none"
-                        height="10"
-                        stroke="#FFFFFF"
-                        viewBox="0 0 10 10"
-                        width="10"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M2 5.5L4.12132 7.62132L8.36396 3.37868"
-                          stroke="#FFFFFF"
-                          stroke-linecap="round"
-                          stroke-linejoin="round"
-                          stroke-width="2"
-                        />
-                      </svg>
-                    </div>
-                    <div
-                      class="lg-ui-ripple-0000 leafygreen-ui-6vh13p"
-                    />
-                    <span
-                      class="leafygreen-ui-187di61"
-                    >
-                      Mark distro as a cluster (jobs are not run on this host, used for special purposes).
-                    </span>
-                  </label>
-                </div>
-              </div>
-            </div>
-            <div
-              class="form-group field field-boolean css-mg3yql-DefaultFieldContainer eny4k1v1"
-              id=" root_disableShallowClone"
-            >
-              <div
-                class="css-17q2u8g-ElementWrapper ee4bs9n0"
-              >
-                <div
-                  class="leafygreen-ui-55kazc"
-                  data-lgid="lg-checkbox"
-                >
-                  <label
-                    class="leafygreen-ui-1srek1y"
-                    data-lgid="lg-label"
                     for="checkbox-274"
                     id="checkbox-274-label"
                   >
@@ -137,7 +78,7 @@
                     <span
                       class="leafygreen-ui-187di61"
                     >
-                      Disable shallow clone for this distro.
+                      Mark distro as a cluster (jobs are not run on this host, used for special purposes).
                     </span>
                   </label>
                 </div>
@@ -145,7 +86,7 @@
             </div>
             <div
               class="form-group field field-boolean css-mg3yql-DefaultFieldContainer eny4k1v1"
-              id=" root_disableQueue"
+              id=" root_disableShallowClone"
             >
               <div
                 class="css-17q2u8g-ElementWrapper ee4bs9n0"
@@ -196,6 +137,65 @@
                     <span
                       class="leafygreen-ui-187di61"
                     >
+                      Disable shallow clone for this distro.
+                    </span>
+                  </label>
+                </div>
+              </div>
+            </div>
+            <div
+              class="form-group field field-boolean css-mg3yql-DefaultFieldContainer eny4k1v1"
+              id=" root_disableQueue"
+            >
+              <div
+                class="css-17q2u8g-ElementWrapper ee4bs9n0"
+              >
+                <div
+                  class="leafygreen-ui-55kazc"
+                  data-lgid="lg-checkbox"
+                >
+                  <label
+                    class="leafygreen-ui-1srek1y"
+                    data-lgid="lg-label"
+                    for="checkbox-276"
+                    id="checkbox-276-label"
+                  >
+                    <input
+                      aria-checked="false"
+                      aria-disabled="false"
+                      aria-label="checkbox"
+                      aria-labelledby="checkbox-276-label"
+                      class="lg-ui-input-0000 leafygreen-ui-1a1e5kp"
+                      id="checkbox-276"
+                      type="checkbox"
+                    />
+                    <div
+                      class="lg-ui-check-wrapper-0000 leafygreen-ui-nlfut8"
+                    >
+                      <svg
+                        class="leafygreen-ui-6caof5"
+                        fill="none"
+                        height="10"
+                        stroke="#FFFFFF"
+                        viewBox="0 0 10 10"
+                        width="10"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M2 5.5L4.12132 7.62132L8.36396 3.37868"
+                          stroke="#FFFFFF"
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                          stroke-width="2"
+                        />
+                      </svg>
+                    </div>
+                    <div
+                      class="lg-ui-ripple-0000 leafygreen-ui-6vh13p"
+                    />
+                    <span
+                      class="leafygreen-ui-187di61"
+                    >
                       Disable queueing this distro. Tasks already in the task queue will be removed.
                     </span>
                   </label>
@@ -216,17 +216,17 @@
                   <label
                     class="leafygreen-ui-1srek1y"
                     data-lgid="lg-label"
-                    for="checkbox-276"
-                    id="checkbox-276-label"
+                    for="checkbox-277"
+                    id="checkbox-277-label"
                   >
                     <input
                       aria-checked="true"
                       aria-disabled="false"
                       aria-label="checkbox"
-                      aria-labelledby="checkbox-276-label"
+                      aria-labelledby="checkbox-277-label"
                       checked=""
                       class="lg-ui-input-0000 leafygreen-ui-1a1e5kp"
-                      id="checkbox-276"
+                      id="checkbox-277"
                       type="checkbox"
                     />
                     <div
@@ -284,7 +284,7 @@
                       for="radio-group--0"
                     >
                       <input
-                        aria-describedby="lg-277"
+                        aria-describedby="lg-278"
                         aria-disabled="false"
                         class="lg-ui-radio-group-0002 leafygreen-ui-1iwed1m"
                         data-label="Restart Jasper service on running hosts of this distro for this update"
@@ -312,7 +312,7 @@
                       for="radio-group--1"
                     >
                       <input
-                        aria-describedby="lg-278"
+                        aria-describedby="lg-279"
                         aria-disabled="false"
                         class="lg-ui-radio-group-0002 leafygreen-ui-1iwed1m"
                         data-label="Reprovision running hosts of this distro for this update"

--- a/apps/spruce/src/components/SpruceForm/__snapshots__/SpruceForm_Example3.storyshot
+++ b/apps/spruce/src/components/SpruceForm/__snapshots__/SpruceForm_Example3.storyshot
@@ -39,17 +39,17 @@
                   <label
                     class="leafygreen-ui-1srek1y"
                     data-lgid="lg-label"
-                    for="checkbox-279"
-                    id="checkbox-279-label"
+                    for="checkbox-280"
+                    id="checkbox-280-label"
                   >
                     <input
                       aria-checked="true"
                       aria-disabled="false"
                       aria-label="checkbox"
-                      aria-labelledby="checkbox-279-label"
+                      aria-labelledby="checkbox-280-label"
                       checked=""
                       class="lg-ui-input-0000 leafygreen-ui-1a1e5kp"
-                      id="checkbox-279"
+                      id="checkbox-280"
                       type="checkbox"
                     />
                     <div

--- a/apps/spruce/src/components/Table/TableControl/__snapshots__/TableControl_Default.storyshot
+++ b/apps/spruce/src/components/Table/TableControl/__snapshots__/TableControl_Default.storyshot
@@ -129,8 +129,8 @@
         data-lgid="lg-select"
       >
         <button
-          aria-controls="select-280-menu"
-          aria-describedby="select-280-description"
+          aria-controls="select-281-menu"
+          aria-describedby="select-281-description"
           aria-disabled="false"
           aria-expanded="false"
           aria-invalid="false"
@@ -139,7 +139,7 @@
           data-cy="tasks-table-page-size-selector"
           data-lgid="lg-button"
           data-testid="leafygreen-ui-select-menubutton"
-          id="select-281"
+          id="select-282"
           type="button"
           value="10"
         >

--- a/apps/spruce/src/components/TextInputWithValidation/__snapshots__/TextInputWithValidation_Default.storyshot
+++ b/apps/spruce/src/components/TextInputWithValidation/__snapshots__/TextInputWithValidation_Default.storyshot
@@ -13,8 +13,8 @@
           class="leafygreen-ui-6bdaia"
           data-lgid="lg-label"
           data-testid="lg-form_field-label"
-          for="lg-form_field-input-285"
-          id="lg-form_field-label-282"
+          for="lg-form_field-input-286"
+          id="lg-form_field-label-283"
         >
           Some search field
         </label>
@@ -29,10 +29,10 @@
             aria-describedby=""
             aria-disabled="false"
             aria-invalid="false"
-            aria-labelledby="lg-form_field-label-282"
+            aria-labelledby="lg-form_field-label-283"
             autocomplete="on"
             class="lg-ui-form-field-input-0000 leafygreen-ui-1ago99h"
-            id="lg-form_field-input-285"
+            id="lg-form_field-input-286"
             required=""
             type="text"
             value=""
@@ -45,7 +45,7 @@
         class="leafygreen-ui-11ydt2g"
         data-lgid="lg-form_field-feedback"
         data-testid="lg-form_field-feedback"
-        id="lg-form_field-feedback-284"
+        id="lg-form_field-feedback-285"
       />
     </div>
     <div

--- a/apps/spruce/src/components/TreeSelect/__snapshots__/TreeSelect_Default.storyshot
+++ b/apps/spruce/src/components/TreeSelect/__snapshots__/TreeSelect_Default.storyshot
@@ -13,61 +13,6 @@
         <label
           class="leafygreen-ui-1srek1y"
           data-lgid="lg-label"
-          for="checkbox-286"
-          id="checkbox-286-label"
-        >
-          <input
-            aria-checked="false"
-            aria-disabled="false"
-            aria-label="checkbox"
-            aria-labelledby="checkbox-286-label"
-            class="lg-ui-input-0000 leafygreen-ui-1a1e5kp"
-            data-cy="checkbox"
-            id="checkbox-286"
-            type="checkbox"
-          />
-          <div
-            class="lg-ui-check-wrapper-0000 leafygreen-ui-nlfut8"
-          >
-            <svg
-              class="leafygreen-ui-6caof5"
-              fill="none"
-              height="10"
-              stroke="#FFFFFF"
-              viewBox="0 0 10 10"
-              width="10"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M2 5.5L4.12132 7.62132L8.36396 3.37868"
-                stroke="#FFFFFF"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </div>
-          <div
-            class="lg-ui-ripple-0000 leafygreen-ui-6vh13p"
-          />
-          <span
-            class="leafygreen-ui-187di61"
-          >
-            All
-          </span>
-        </label>
-      </div>
-    </div>
-    <div
-      class="css-6y9iv7-CheckboxWrapper e1mpj03z3"
-    >
-      <div
-        class="leafygreen-ui-55kazc cy-checkbox"
-        data-lgid="lg-checkbox"
-      >
-        <label
-          class="leafygreen-ui-1srek1y"
-          data-lgid="lg-label"
           for="checkbox-287"
           id="checkbox-287-label"
         >
@@ -108,13 +53,13 @@
           <span
             class="leafygreen-ui-187di61"
           >
-            Shapes
+            All
           </span>
         </label>
       </div>
     </div>
     <div
-      class="css-154o89o-CheckboxWrapper e1mpj03z3"
+      class="css-6y9iv7-CheckboxWrapper e1mpj03z3"
     >
       <div
         class="leafygreen-ui-55kazc cy-checkbox"
@@ -163,7 +108,7 @@
           <span
             class="leafygreen-ui-187di61"
           >
-            rectangle
+            Shapes
           </span>
         </label>
       </div>
@@ -218,7 +163,7 @@
           <span
             class="leafygreen-ui-187di61"
           >
-            circle
+            rectangle
           </span>
         </label>
       </div>
@@ -273,13 +218,13 @@
           <span
             class="leafygreen-ui-187di61"
           >
-            rhombus
+            circle
           </span>
         </label>
       </div>
     </div>
     <div
-      class="css-6y9iv7-CheckboxWrapper e1mpj03z3"
+      class="css-154o89o-CheckboxWrapper e1mpj03z3"
     >
       <div
         class="leafygreen-ui-55kazc cy-checkbox"
@@ -328,7 +273,7 @@
           <span
             class="leafygreen-ui-187di61"
           >
-            Pass
+            rhombus
           </span>
         </label>
       </div>
@@ -383,7 +328,7 @@
           <span
             class="leafygreen-ui-187di61"
           >
-            REALLY LONG TITLE EXAMPLE EXAMPLE EXAMPLE EXAMPLE EXAMPLE!!!!!!!!!!!!!!!!!
+            Pass
           </span>
         </label>
       </div>
@@ -438,7 +383,7 @@
           <span
             class="leafygreen-ui-187di61"
           >
-            Skip
+            REALLY LONG TITLE EXAMPLE EXAMPLE EXAMPLE EXAMPLE EXAMPLE!!!!!!!!!!!!!!!!!
           </span>
         </label>
       </div>
@@ -464,6 +409,61 @@
             class="lg-ui-input-0000 leafygreen-ui-1a1e5kp"
             data-cy="checkbox"
             id="checkbox-294"
+            type="checkbox"
+          />
+          <div
+            class="lg-ui-check-wrapper-0000 leafygreen-ui-nlfut8"
+          >
+            <svg
+              class="leafygreen-ui-6caof5"
+              fill="none"
+              height="10"
+              stroke="#FFFFFF"
+              viewBox="0 0 10 10"
+              width="10"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M2 5.5L4.12132 7.62132L8.36396 3.37868"
+                stroke="#FFFFFF"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+            </svg>
+          </div>
+          <div
+            class="lg-ui-ripple-0000 leafygreen-ui-6vh13p"
+          />
+          <span
+            class="leafygreen-ui-187di61"
+          >
+            Skip
+          </span>
+        </label>
+      </div>
+    </div>
+    <div
+      class="css-6y9iv7-CheckboxWrapper e1mpj03z3"
+    >
+      <div
+        class="leafygreen-ui-55kazc cy-checkbox"
+        data-lgid="lg-checkbox"
+      >
+        <label
+          class="leafygreen-ui-1srek1y"
+          data-lgid="lg-label"
+          for="checkbox-295"
+          id="checkbox-295-label"
+        >
+          <input
+            aria-checked="false"
+            aria-disabled="false"
+            aria-label="checkbox"
+            aria-labelledby="checkbox-295-label"
+            class="lg-ui-input-0000 leafygreen-ui-1a1e5kp"
+            data-cy="checkbox"
+            id="checkbox-295"
             type="checkbox"
           />
           <div

--- a/apps/spruce/src/components/TupleSelect/__snapshots__/TupleSelect_Default.storyshot
+++ b/apps/spruce/src/components/TupleSelect/__snapshots__/TupleSelect_Default.storyshot
@@ -21,8 +21,8 @@
         data-lgid="lg-select"
       >
         <button
-          aria-controls="select-295-menu"
-          aria-describedby="select-295-description"
+          aria-controls="select-296-menu"
+          aria-describedby="select-296-description"
           aria-disabled="false"
           aria-expanded="false"
           aria-invalid="false"
@@ -31,7 +31,7 @@
           data-cy="tuple-select-select"
           data-lgid="lg-button"
           data-testid="leafygreen-ui-select-menubutton"
-          id="select-296"
+          id="select-297"
           type="button"
           value="build_variant"
         >
@@ -114,7 +114,7 @@
             class="leafygreen-ui-11ydt2g"
             data-lgid="lg-form_field-feedback"
             data-testid="lg-form_field-feedback"
-            id="lg-form_field-feedback-299"
+            id="lg-form_field-feedback-300"
           />
         </div>
         <div

--- a/apps/spruce/src/components/TupleSelectWithRegexConditional/__snapshots__/TupleSelectWithRegexConditional_WithConditional.storyshot
+++ b/apps/spruce/src/components/TupleSelectWithRegexConditional/__snapshots__/TupleSelectWithRegexConditional_WithConditional.storyshot
@@ -15,8 +15,8 @@
           class="leafygreen-ui-ozfao7 css-1qa4isu-PaddedSegmentedControl egmqwjk0"
         >
           <div
-            aria-label="segmented-control-301"
-            aria-owns="segmented-control-301-0 segmented-control-301-1"
+            aria-label="segmented-control-302"
+            aria-owns="segmented-control-302-0 segmented-control-302-1"
             class="leafygreen-ui-18en4yf"
             role="tablist"
           >
@@ -33,7 +33,7 @@
                   aria-controls="tuple-select-with-regex"
                   aria-selected="true"
                   class="leafygreen-ui-ypz97o"
-                  id="segmented-control-301-0"
+                  id="segmented-control-302-0"
                   role="tab"
                   tabindex="0"
                   type="button"
@@ -63,7 +63,7 @@
                   aria-controls="tuple-select-with-regex"
                   aria-selected="false"
                   class="leafygreen-ui-ypz97o"
-                  id="segmented-control-301-1"
+                  id="segmented-control-302-1"
                   role="tab"
                   tabindex="-1"
                   type="button"
@@ -98,8 +98,8 @@
         data-lgid="lg-select"
       >
         <button
-          aria-controls="select-302-menu"
-          aria-describedby="select-302-description"
+          aria-controls="select-303-menu"
+          aria-describedby="select-303-description"
           aria-disabled="false"
           aria-expanded="false"
           aria-invalid="false"
@@ -108,7 +108,7 @@
           data-cy="tuple-select-select"
           data-lgid="lg-button"
           data-testid="leafygreen-ui-select-menubutton"
-          id="select-303"
+          id="select-304"
           type="button"
           value="build_variant"
         >
@@ -191,7 +191,7 @@
             class="leafygreen-ui-11ydt2g"
             data-lgid="lg-form_field-feedback"
             data-testid="lg-form_field-feedback"
-            id="lg-form_field-feedback-306"
+            id="lg-form_field-feedback-307"
           />
         </div>
         <div

--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -2207,7 +2207,6 @@ export type Query = {
   taskTestSample?: Maybe<Array<TaskTestResultSample>>;
   user: User;
   userConfig?: Maybe<UserConfig>;
-  userSettings?: Maybe<UserSettings>;
   version: Version;
   viewableProjectRefs: Array<GroupedProjects>;
   waterfall: Waterfall;

--- a/apps/spruce/src/pages/commits/__snapshots__/ProjectHealth_Default.storyshot
+++ b/apps/spruce/src/pages/commits/__snapshots__/ProjectHealth_Default.storyshot
@@ -256,7 +256,7 @@
                             >
                               <input
                                 aria-checked="true"
-                                aria-describedby="lg-324"
+                                aria-describedby="lg-325"
                                 aria-disabled="false"
                                 checked=""
                                 class="lg-ui-radio-group-0002 leafygreen-ui-1iwed1m"
@@ -285,7 +285,7 @@
                               for="chart-radio-percent"
                             >
                               <input
-                                aria-describedby="lg-325"
+                                aria-describedby="lg-326"
                                 aria-disabled="false"
                                 class="lg-ui-radio-group-0002 leafygreen-ui-1iwed1m"
                                 data-cy="cy-chart-percent-radio"

--- a/apps/spruce/src/pages/configurePatch/configurePatchCore/index.tsx
+++ b/apps/spruce/src/pages/configurePatch/configurePatchCore/index.tsx
@@ -12,8 +12,7 @@ import { usePatchAnalytics } from "analytics";
 import { TaskSchedulingWarningBanner } from "components/Banners/TaskSchedulingWarningBanner";
 import { LoadingButton } from "components/Buttons";
 import { CodeChanges } from "components/CodeChanges";
-import {
-  MetadataCard,
+import MetadataCard, {
   MetadataItem,
   MetadataLabel,
 } from "components/MetadataCard";

--- a/apps/spruce/src/pages/container/Metadata/index.tsx
+++ b/apps/spruce/src/pages/container/Metadata/index.tsx
@@ -1,8 +1,7 @@
 import { ApolloError } from "@apollo/client";
 import { InlineCode } from "@leafygreen-ui/typography";
 import { WordBreak, StyledRouterLink } from "@evg-ui/lib/components/styles";
-import {
-  MetadataCard,
+import MetadataCard, {
   MetadataItem,
   MetadataLabel,
 } from "components/MetadataCard";

--- a/apps/spruce/src/pages/host/HostTable/__snapshots__/HostTable_Default.storyshot
+++ b/apps/spruce/src/pages/host/HostTable/__snapshots__/HostTable_Default.storyshot
@@ -98,8 +98,8 @@
           data-lgid="lg-select"
         >
           <button
-            aria-controls="select-349-menu"
-            aria-describedby="select-349-description"
+            aria-controls="select-350-menu"
+            aria-describedby="select-350-description"
             aria-disabled="false"
             aria-expanded="false"
             aria-invalid="false"
@@ -108,7 +108,7 @@
             data-cy="host-event-table-page-size-selector"
             data-lgid="lg-button"
             data-testid="leafygreen-ui-select-menubutton"
-            id="select-350"
+            id="select-351"
             type="button"
             value="10"
           >

--- a/apps/spruce/src/pages/host/Metadata.tsx
+++ b/apps/spruce/src/pages/host/Metadata.tsx
@@ -3,8 +3,7 @@ import styled from "@emotion/styled";
 import { palette } from "@leafygreen-ui/palette";
 import { formatDistanceToNow } from "date-fns";
 import { WordBreak, StyledLink } from "@evg-ui/lib/components/styles";
-import {
-  MetadataCard,
+import MetadataCard, {
   MetadataItem,
   MetadataLabel,
 } from "components/MetadataCard";

--- a/apps/spruce/src/pages/jobLogs/Metadata.tsx
+++ b/apps/spruce/src/pages/jobLogs/Metadata.tsx
@@ -1,7 +1,6 @@
 import { StyledLink } from "@evg-ui/lib/components/styles";
 import { useJobLogsAnalytics } from "analytics";
-import {
-  MetadataCard,
+import MetadataCard, {
   MetadataItem,
   MetadataLabel,
 } from "components/MetadataCard";

--- a/apps/spruce/src/pages/task/metadata/__snapshots__/Metadata_ContainerizedTask.storyshot
+++ b/apps/spruce/src/pages/task/metadata/__snapshots__/Metadata_ContainerizedTask.storyshot
@@ -7,7 +7,7 @@
     >
       <div>
         <p
-          class="css-1k03zl5-Title e1ul56zb3 leafygreen-ui-1miy0xp"
+          class="css-1k03zl5-Title e1130wzj2 leafygreen-ui-1miy0xp"
         >
           Task Metadata
         </p>
@@ -16,14 +16,14 @@
         />
       </div>
       <span
-        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
+        class="css-160t4ez-MetadataItemWrapper e1130wzj0"
       >
         <p
-          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1130wzj1 leafygreen-ui-1tb6tuo"
           data-cy="task-metadata-build-variant"
         >
           <b
-            class="css-1xk67r-MetadataLabel e1ul56zb0"
+            class="css-1xk67r-MetadataLabel e1130wzj3"
           >
             Build Variant:
           </b>
@@ -40,14 +40,14 @@
         </p>
       </span>
       <span
-        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
+        class="css-160t4ez-MetadataItemWrapper e1130wzj0"
       >
         <p
-          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1130wzj1 leafygreen-ui-1tb6tuo"
           data-cy="task-metadata-project"
         >
           <b
-            class="css-1xk67r-MetadataLabel e1ul56zb0"
+            class="css-1xk67r-MetadataLabel e1130wzj3"
           >
             Project:
           </b>
@@ -64,13 +64,13 @@
         </p>
       </span>
       <span
-        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
+        class="css-160t4ez-MetadataItemWrapper e1130wzj0"
       >
         <p
-          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1130wzj1 leafygreen-ui-1tb6tuo"
         >
           <b
-            class="css-1xk67r-MetadataLabel e1ul56zb0"
+            class="css-1xk67r-MetadataLabel e1130wzj3"
           >
             Submitted by:
           </b>
@@ -79,13 +79,13 @@
         </p>
       </span>
       <span
-        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
+        class="css-160t4ez-MetadataItemWrapper e1130wzj0"
       >
         <p
-          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1130wzj1 leafygreen-ui-1tb6tuo"
         >
           <b
-            class="css-1xk67r-MetadataLabel e1ul56zb0"
+            class="css-1xk67r-MetadataLabel e1130wzj3"
           >
             Estimated time to start:
           </b>
@@ -98,13 +98,13 @@
         </p>
       </span>
       <span
-        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
+        class="css-160t4ez-MetadataItemWrapper e1130wzj0"
       >
         <p
-          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1130wzj1 leafygreen-ui-1tb6tuo"
         >
           <b
-            class="css-1xk67r-MetadataLabel e1ul56zb0"
+            class="css-1xk67r-MetadataLabel e1130wzj3"
           >
             Base commit:
           </b>
@@ -123,14 +123,14 @@
         </p>
       </span>
       <span
-        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
+        class="css-160t4ez-MetadataItemWrapper e1130wzj0"
       >
         <p
-          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1130wzj1 leafygreen-ui-1tb6tuo"
           data-cy="task-metadata-description"
         >
           <b
-            class="css-1wckecy-MetadataLabel e1ul56zb0"
+            class="css-1wckecy-MetadataLabel e1130wzj3"
             color="#DB3030"
           >
             Failing Command: 
@@ -155,7 +155,7 @@
     >
       <div>
         <p
-          class="css-1k03zl5-Title e1ul56zb3 leafygreen-ui-1miy0xp"
+          class="css-1k03zl5-Title e1130wzj2 leafygreen-ui-1miy0xp"
         >
           Host Information
         </p>
@@ -164,13 +164,13 @@
         />
       </div>
       <span
-        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
+        class="css-160t4ez-MetadataItemWrapper e1130wzj0"
       >
         <p
-          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1130wzj1 leafygreen-ui-1tb6tuo"
         >
           <b
-            class="css-1xk67r-MetadataLabel e1ul56zb0"
+            class="css-1xk67r-MetadataLabel e1130wzj3"
           >
             Container:
           </b>
@@ -193,7 +193,7 @@
     >
       <div>
         <p
-          class="css-1k03zl5-Title e1ul56zb3 leafygreen-ui-1miy0xp"
+          class="css-1k03zl5-Title e1130wzj2 leafygreen-ui-1miy0xp"
         >
           Tags
         </p>

--- a/apps/spruce/src/pages/task/metadata/__snapshots__/Metadata_ContainerizedTask.storyshot
+++ b/apps/spruce/src/pages/task/metadata/__snapshots__/Metadata_ContainerizedTask.storyshot
@@ -15,11 +15,11 @@
           class="css-qqg5h5-Divider eb6szep0"
         />
       </div>
-      <div
-        class="css-1kc2q0u-MetadataItemWrapper e1ul56zb1"
+      <span
+        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
       >
         <p
-          class="css-1xovdqa-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
           data-cy="task-metadata-build-variant"
         >
           <b
@@ -38,12 +38,12 @@
             </span>
           </a>
         </p>
-      </div>
-      <div
-        class="css-1kc2q0u-MetadataItemWrapper e1ul56zb1"
+      </span>
+      <span
+        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
       >
         <p
-          class="css-1xovdqa-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
           data-cy="task-metadata-project"
         >
           <b
@@ -62,12 +62,12 @@
             </span>
           </a>
         </p>
-      </div>
-      <div
-        class="css-1kc2q0u-MetadataItemWrapper e1ul56zb1"
+      </span>
+      <span
+        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
       >
         <p
-          class="css-1xovdqa-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
         >
           <b
             class="css-1xk67r-MetadataLabel e1ul56zb0"
@@ -77,12 +77,12 @@
            
           mohamed.khelif
         </p>
-      </div>
-      <div
-        class="css-1kc2q0u-MetadataItemWrapper e1ul56zb1"
+      </span>
+      <span
+        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
       >
         <p
-          class="css-1xovdqa-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
         >
           <b
             class="css-1xk67r-MetadataLabel e1ul56zb0"
@@ -96,12 +96,12 @@
             1s
           </span>
         </p>
-      </div>
-      <div
-        class="css-1kc2q0u-MetadataItemWrapper e1ul56zb1"
+      </span>
+      <span
+        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
       >
         <p
-          class="css-1xovdqa-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
         >
           <b
             class="css-1xk67r-MetadataLabel e1ul56zb0"
@@ -121,12 +121,12 @@
             </code>
           </a>
         </p>
-      </div>
-      <div
-        class="css-1kc2q0u-MetadataItemWrapper e1ul56zb1"
+      </span>
+      <span
+        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
       >
         <p
-          class="css-1xovdqa-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
           data-cy="task-metadata-description"
         >
           <b
@@ -148,7 +148,7 @@
             </small>
           </span>
         </p>
-      </div>
+      </span>
     </div>
     <div
       class="css-1l8tpk-SiderCard e1am38ss0 leafygreen-ui-1ecxdul"
@@ -163,11 +163,11 @@
           class="css-qqg5h5-Divider eb6szep0"
         />
       </div>
-      <div
-        class="css-1kc2q0u-MetadataItemWrapper e1ul56zb1"
+      <span
+        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
       >
         <p
-          class="css-1xovdqa-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
         >
           <b
             class="css-1xk67r-MetadataLabel e1ul56zb0"
@@ -186,7 +186,7 @@
             </span>
           </a>
         </p>
-      </div>
+      </span>
     </div>
     <div
       class="css-1l8tpk-SiderCard e1am38ss0 leafygreen-ui-1ecxdul"

--- a/apps/spruce/src/pages/task/metadata/__snapshots__/Metadata_Default.storyshot
+++ b/apps/spruce/src/pages/task/metadata/__snapshots__/Metadata_Default.storyshot
@@ -7,7 +7,7 @@
     >
       <div>
         <p
-          class="css-1k03zl5-Title e1ul56zb3 leafygreen-ui-1miy0xp"
+          class="css-1k03zl5-Title e1130wzj2 leafygreen-ui-1miy0xp"
         >
           Task Metadata
         </p>
@@ -16,14 +16,14 @@
         />
       </div>
       <span
-        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
+        class="css-160t4ez-MetadataItemWrapper e1130wzj0"
       >
         <p
-          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1130wzj1 leafygreen-ui-1tb6tuo"
           data-cy="task-metadata-build-variant"
         >
           <b
-            class="css-1xk67r-MetadataLabel e1ul56zb0"
+            class="css-1xk67r-MetadataLabel e1130wzj3"
           >
             Build Variant:
           </b>
@@ -40,14 +40,14 @@
         </p>
       </span>
       <span
-        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
+        class="css-160t4ez-MetadataItemWrapper e1130wzj0"
       >
         <p
-          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1130wzj1 leafygreen-ui-1tb6tuo"
           data-cy="task-metadata-project"
         >
           <b
-            class="css-1xk67r-MetadataLabel e1ul56zb0"
+            class="css-1xk67r-MetadataLabel e1130wzj3"
           >
             Project:
           </b>
@@ -64,13 +64,13 @@
         </p>
       </span>
       <span
-        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
+        class="css-160t4ez-MetadataItemWrapper e1130wzj0"
       >
         <p
-          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1130wzj1 leafygreen-ui-1tb6tuo"
         >
           <b
-            class="css-1xk67r-MetadataLabel e1ul56zb0"
+            class="css-1xk67r-MetadataLabel e1130wzj3"
           >
             Submitted by:
           </b>
@@ -79,13 +79,13 @@
         </p>
       </span>
       <span
-        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
+        class="css-160t4ez-MetadataItemWrapper e1130wzj0"
       >
         <p
-          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1130wzj1 leafygreen-ui-1tb6tuo"
         >
           <b
-            class="css-1xk67r-MetadataLabel e1ul56zb0"
+            class="css-1xk67r-MetadataLabel e1130wzj3"
           >
             Estimated time to start:
           </b>
@@ -98,13 +98,13 @@
         </p>
       </span>
       <span
-        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
+        class="css-160t4ez-MetadataItemWrapper e1130wzj0"
       >
         <p
-          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1130wzj1 leafygreen-ui-1tb6tuo"
         >
           <b
-            class="css-1xk67r-MetadataLabel e1ul56zb0"
+            class="css-1xk67r-MetadataLabel e1130wzj3"
           >
             Base commit:
           </b>
@@ -123,14 +123,14 @@
         </p>
       </span>
       <span
-        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
+        class="css-160t4ez-MetadataItemWrapper e1130wzj0"
       >
         <p
-          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1130wzj1 leafygreen-ui-1tb6tuo"
           data-cy="task-metadata-description"
         >
           <b
-            class="css-1wckecy-MetadataLabel e1ul56zb0"
+            class="css-1wckecy-MetadataLabel e1130wzj3"
             color="#DB3030"
           >
             Failing Command: 
@@ -155,7 +155,7 @@
     >
       <div>
         <p
-          class="css-1k03zl5-Title e1ul56zb3 leafygreen-ui-1miy0xp"
+          class="css-1k03zl5-Title e1130wzj2 leafygreen-ui-1miy0xp"
         >
           Host Information
         </p>
@@ -164,13 +164,13 @@
         />
       </div>
       <span
-        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
+        class="css-160t4ez-MetadataItemWrapper e1130wzj0"
       >
         <p
-          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1130wzj1 leafygreen-ui-1tb6tuo"
         >
           <b
-            class="css-1xk67r-MetadataLabel e1ul56zb0"
+            class="css-1xk67r-MetadataLabel e1130wzj3"
           >
             ID:
           </b>
@@ -188,13 +188,13 @@
         </p>
       </span>
       <span
-        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
+        class="css-160t4ez-MetadataItemWrapper e1130wzj0"
       >
         <p
-          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1130wzj1 leafygreen-ui-1tb6tuo"
         >
           <b
-            class="css-1xk67r-MetadataLabel e1ul56zb0"
+            class="css-1xk67r-MetadataLabel e1130wzj3"
           >
             Distro:
           </b>
@@ -211,13 +211,13 @@
         </p>
       </span>
       <span
-        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
+        class="css-160t4ez-MetadataItemWrapper e1130wzj0"
       >
         <p
-          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1130wzj1 leafygreen-ui-1tb6tuo"
         >
           <b
-            class="css-1xk67r-MetadataLabel e1ul56zb0"
+            class="css-1xk67r-MetadataLabel e1130wzj3"
           >
             Image:
           </b>
@@ -234,14 +234,14 @@
         </p>
       </span>
       <span
-        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
+        class="css-160t4ez-MetadataItemWrapper e1130wzj0"
       >
         <p
-          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1130wzj1 leafygreen-ui-1tb6tuo"
           data-cy="task-metadata-ami"
         >
           <b
-            class="css-1xk67r-MetadataLabel e1ul56zb0"
+            class="css-1xk67r-MetadataLabel e1130wzj3"
           >
             AMI:
           </b>
@@ -250,10 +250,10 @@
         </p>
       </span>
       <span
-        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
+        class="css-160t4ez-MetadataItemWrapper e1130wzj0"
       >
         <p
-          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1130wzj1 leafygreen-ui-1tb6tuo"
         >
           <a
             class="lg-ui-0001 css-r79zk7-overrideStyles leafygreen-ui-16e7rxl"
@@ -272,7 +272,7 @@
     >
       <div>
         <p
-          class="css-1k03zl5-Title e1ul56zb3 leafygreen-ui-1miy0xp"
+          class="css-1k03zl5-Title e1130wzj2 leafygreen-ui-1miy0xp"
         >
           Tags
         </p>

--- a/apps/spruce/src/pages/task/metadata/__snapshots__/Metadata_Default.storyshot
+++ b/apps/spruce/src/pages/task/metadata/__snapshots__/Metadata_Default.storyshot
@@ -15,11 +15,11 @@
           class="css-qqg5h5-Divider eb6szep0"
         />
       </div>
-      <div
-        class="css-1kc2q0u-MetadataItemWrapper e1ul56zb1"
+      <span
+        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
       >
         <p
-          class="css-1xovdqa-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
           data-cy="task-metadata-build-variant"
         >
           <b
@@ -38,12 +38,12 @@
             </span>
           </a>
         </p>
-      </div>
-      <div
-        class="css-1kc2q0u-MetadataItemWrapper e1ul56zb1"
+      </span>
+      <span
+        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
       >
         <p
-          class="css-1xovdqa-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
           data-cy="task-metadata-project"
         >
           <b
@@ -62,12 +62,12 @@
             </span>
           </a>
         </p>
-      </div>
-      <div
-        class="css-1kc2q0u-MetadataItemWrapper e1ul56zb1"
+      </span>
+      <span
+        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
       >
         <p
-          class="css-1xovdqa-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
         >
           <b
             class="css-1xk67r-MetadataLabel e1ul56zb0"
@@ -77,12 +77,12 @@
            
           mohamed.khelif
         </p>
-      </div>
-      <div
-        class="css-1kc2q0u-MetadataItemWrapper e1ul56zb1"
+      </span>
+      <span
+        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
       >
         <p
-          class="css-1xovdqa-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
         >
           <b
             class="css-1xk67r-MetadataLabel e1ul56zb0"
@@ -96,12 +96,12 @@
             1s
           </span>
         </p>
-      </div>
-      <div
-        class="css-1kc2q0u-MetadataItemWrapper e1ul56zb1"
+      </span>
+      <span
+        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
       >
         <p
-          class="css-1xovdqa-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
         >
           <b
             class="css-1xk67r-MetadataLabel e1ul56zb0"
@@ -121,12 +121,12 @@
             </code>
           </a>
         </p>
-      </div>
-      <div
-        class="css-1kc2q0u-MetadataItemWrapper e1ul56zb1"
+      </span>
+      <span
+        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
       >
         <p
-          class="css-1xovdqa-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
           data-cy="task-metadata-description"
         >
           <b
@@ -148,7 +148,7 @@
             </small>
           </span>
         </p>
-      </div>
+      </span>
     </div>
     <div
       class="css-1l8tpk-SiderCard e1am38ss0 leafygreen-ui-1ecxdul"
@@ -163,11 +163,11 @@
           class="css-qqg5h5-Divider eb6szep0"
         />
       </div>
-      <div
-        class="css-1kc2q0u-MetadataItemWrapper e1ul56zb1"
+      <span
+        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
       >
         <p
-          class="css-1xovdqa-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
         >
           <b
             class="css-1xk67r-MetadataLabel e1ul56zb0"
@@ -186,12 +186,12 @@
             </span>
           </a>
         </p>
-      </div>
-      <div
-        class="css-1kc2q0u-MetadataItemWrapper e1ul56zb1"
+      </span>
+      <span
+        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
       >
         <p
-          class="css-1xovdqa-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
         >
           <b
             class="css-1xk67r-MetadataLabel e1ul56zb0"
@@ -209,12 +209,12 @@
             </span>
           </a>
         </p>
-      </div>
-      <div
-        class="css-1kc2q0u-MetadataItemWrapper e1ul56zb1"
+      </span>
+      <span
+        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
       >
         <p
-          class="css-1xovdqa-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
         >
           <b
             class="css-1xk67r-MetadataLabel e1ul56zb0"
@@ -232,12 +232,12 @@
             </span>
           </a>
         </p>
-      </div>
-      <div
-        class="css-1kc2q0u-MetadataItemWrapper e1ul56zb1"
+      </span>
+      <span
+        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
       >
         <p
-          class="css-1xovdqa-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
           data-cy="task-metadata-ami"
         >
           <b
@@ -248,12 +248,12 @@
            
           ami-0c83bb0a9f48c15bf
         </p>
-      </div>
-      <div
-        class="css-1kc2q0u-MetadataItemWrapper e1ul56zb1"
+      </span>
+      <span
+        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
       >
         <p
-          class="css-1xovdqa-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
         >
           <a
             class="lg-ui-0001 css-r79zk7-overrideStyles leafygreen-ui-16e7rxl"
@@ -265,7 +265,7 @@
             </span>
           </a>
         </p>
-      </div>
+      </span>
     </div>
     <div
       class="css-1l8tpk-SiderCard e1am38ss0 leafygreen-ui-1ecxdul"

--- a/apps/spruce/src/pages/task/metadata/__snapshots__/Metadata_OOMTracker.storyshot
+++ b/apps/spruce/src/pages/task/metadata/__snapshots__/Metadata_OOMTracker.storyshot
@@ -15,11 +15,11 @@
           class="css-qqg5h5-Divider eb6szep0"
         />
       </div>
-      <div
-        class="css-1kc2q0u-MetadataItemWrapper e1ul56zb1"
+      <span
+        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
       >
         <p
-          class="css-1xovdqa-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
           data-cy="task-metadata-build-variant"
         >
           <b
@@ -38,12 +38,12 @@
             </span>
           </a>
         </p>
-      </div>
-      <div
-        class="css-1kc2q0u-MetadataItemWrapper e1ul56zb1"
+      </span>
+      <span
+        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
       >
         <p
-          class="css-1xovdqa-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
           data-cy="task-metadata-project"
         >
           <b
@@ -62,12 +62,12 @@
             </span>
           </a>
         </p>
-      </div>
-      <div
-        class="css-1kc2q0u-MetadataItemWrapper e1ul56zb1"
+      </span>
+      <span
+        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
       >
         <p
-          class="css-1xovdqa-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
         >
           <b
             class="css-1xk67r-MetadataLabel e1ul56zb0"
@@ -77,12 +77,12 @@
            
           mohamed.khelif
         </p>
-      </div>
-      <div
-        class="css-1kc2q0u-MetadataItemWrapper e1ul56zb1"
+      </span>
+      <span
+        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
       >
         <p
-          class="css-1xovdqa-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
         >
           <b
             class="css-1xk67r-MetadataLabel e1ul56zb0"
@@ -96,12 +96,12 @@
             1s
           </span>
         </p>
-      </div>
-      <div
-        class="css-1kc2q0u-MetadataItemWrapper e1ul56zb1"
+      </span>
+      <span
+        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
       >
         <p
-          class="css-1xovdqa-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
         >
           <b
             class="css-1xk67r-MetadataLabel e1ul56zb0"
@@ -121,12 +121,12 @@
             </code>
           </a>
         </p>
-      </div>
-      <div
-        class="css-1kc2q0u-MetadataItemWrapper e1ul56zb1"
+      </span>
+      <span
+        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
       >
         <p
-          class="css-1xovdqa-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
           data-cy="task-metadata-description"
         >
           <b
@@ -137,18 +137,18 @@
           </b>
           'shell.exec' in function 'yarn-test' (step 1 of 1)
         </p>
-      </div>
-      <div
-        class="css-1kc2q0u-MetadataItemWrapper e1ul56zb1"
+      </span>
+      <span
+        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
       >
         <p
-          class="css-1xovdqa-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
         >
           Out of Memory Kill detected
            
           (PIDs: 12345, 67890)
         </p>
-      </div>
+      </span>
     </div>
     <div
       class="css-1l8tpk-SiderCard e1am38ss0 leafygreen-ui-1ecxdul"
@@ -163,11 +163,11 @@
           class="css-qqg5h5-Divider eb6szep0"
         />
       </div>
-      <div
-        class="css-1kc2q0u-MetadataItemWrapper e1ul56zb1"
+      <span
+        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
       >
         <p
-          class="css-1xovdqa-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
         >
           <b
             class="css-1xk67r-MetadataLabel e1ul56zb0"
@@ -186,12 +186,12 @@
             </span>
           </a>
         </p>
-      </div>
-      <div
-        class="css-1kc2q0u-MetadataItemWrapper e1ul56zb1"
+      </span>
+      <span
+        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
       >
         <p
-          class="css-1xovdqa-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
         >
           <b
             class="css-1xk67r-MetadataLabel e1ul56zb0"
@@ -209,12 +209,12 @@
             </span>
           </a>
         </p>
-      </div>
-      <div
-        class="css-1kc2q0u-MetadataItemWrapper e1ul56zb1"
+      </span>
+      <span
+        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
       >
         <p
-          class="css-1xovdqa-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
         >
           <b
             class="css-1xk67r-MetadataLabel e1ul56zb0"
@@ -232,12 +232,12 @@
             </span>
           </a>
         </p>
-      </div>
-      <div
-        class="css-1kc2q0u-MetadataItemWrapper e1ul56zb1"
+      </span>
+      <span
+        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
       >
         <p
-          class="css-1xovdqa-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
           data-cy="task-metadata-ami"
         >
           <b
@@ -248,12 +248,12 @@
            
           ami-0c83bb0a9f48c15bf
         </p>
-      </div>
-      <div
-        class="css-1kc2q0u-MetadataItemWrapper e1ul56zb1"
+      </span>
+      <span
+        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
       >
         <p
-          class="css-1xovdqa-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
         >
           <a
             class="lg-ui-0001 css-r79zk7-overrideStyles leafygreen-ui-16e7rxl"
@@ -265,7 +265,7 @@
             </span>
           </a>
         </p>
-      </div>
+      </span>
     </div>
     <div
       class="css-1l8tpk-SiderCard e1am38ss0 leafygreen-ui-1ecxdul"

--- a/apps/spruce/src/pages/task/metadata/__snapshots__/Metadata_OOMTracker.storyshot
+++ b/apps/spruce/src/pages/task/metadata/__snapshots__/Metadata_OOMTracker.storyshot
@@ -7,7 +7,7 @@
     >
       <div>
         <p
-          class="css-1k03zl5-Title e1ul56zb3 leafygreen-ui-1miy0xp"
+          class="css-1k03zl5-Title e1130wzj2 leafygreen-ui-1miy0xp"
         >
           Task Metadata
         </p>
@@ -16,14 +16,14 @@
         />
       </div>
       <span
-        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
+        class="css-160t4ez-MetadataItemWrapper e1130wzj0"
       >
         <p
-          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1130wzj1 leafygreen-ui-1tb6tuo"
           data-cy="task-metadata-build-variant"
         >
           <b
-            class="css-1xk67r-MetadataLabel e1ul56zb0"
+            class="css-1xk67r-MetadataLabel e1130wzj3"
           >
             Build Variant:
           </b>
@@ -40,14 +40,14 @@
         </p>
       </span>
       <span
-        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
+        class="css-160t4ez-MetadataItemWrapper e1130wzj0"
       >
         <p
-          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1130wzj1 leafygreen-ui-1tb6tuo"
           data-cy="task-metadata-project"
         >
           <b
-            class="css-1xk67r-MetadataLabel e1ul56zb0"
+            class="css-1xk67r-MetadataLabel e1130wzj3"
           >
             Project:
           </b>
@@ -64,13 +64,13 @@
         </p>
       </span>
       <span
-        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
+        class="css-160t4ez-MetadataItemWrapper e1130wzj0"
       >
         <p
-          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1130wzj1 leafygreen-ui-1tb6tuo"
         >
           <b
-            class="css-1xk67r-MetadataLabel e1ul56zb0"
+            class="css-1xk67r-MetadataLabel e1130wzj3"
           >
             Submitted by:
           </b>
@@ -79,13 +79,13 @@
         </p>
       </span>
       <span
-        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
+        class="css-160t4ez-MetadataItemWrapper e1130wzj0"
       >
         <p
-          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1130wzj1 leafygreen-ui-1tb6tuo"
         >
           <b
-            class="css-1xk67r-MetadataLabel e1ul56zb0"
+            class="css-1xk67r-MetadataLabel e1130wzj3"
           >
             Estimated time to start:
           </b>
@@ -98,13 +98,13 @@
         </p>
       </span>
       <span
-        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
+        class="css-160t4ez-MetadataItemWrapper e1130wzj0"
       >
         <p
-          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1130wzj1 leafygreen-ui-1tb6tuo"
         >
           <b
-            class="css-1xk67r-MetadataLabel e1ul56zb0"
+            class="css-1xk67r-MetadataLabel e1130wzj3"
           >
             Base commit:
           </b>
@@ -123,14 +123,14 @@
         </p>
       </span>
       <span
-        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
+        class="css-160t4ez-MetadataItemWrapper e1130wzj0"
       >
         <p
-          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1130wzj1 leafygreen-ui-1tb6tuo"
           data-cy="task-metadata-description"
         >
           <b
-            class="css-1wckecy-MetadataLabel e1ul56zb0"
+            class="css-1wckecy-MetadataLabel e1130wzj3"
             color="#DB3030"
           >
             Failing Command: 
@@ -139,10 +139,10 @@
         </p>
       </span>
       <span
-        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
+        class="css-160t4ez-MetadataItemWrapper e1130wzj0"
       >
         <p
-          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1130wzj1 leafygreen-ui-1tb6tuo"
         >
           Out of Memory Kill detected
            
@@ -155,7 +155,7 @@
     >
       <div>
         <p
-          class="css-1k03zl5-Title e1ul56zb3 leafygreen-ui-1miy0xp"
+          class="css-1k03zl5-Title e1130wzj2 leafygreen-ui-1miy0xp"
         >
           Host Information
         </p>
@@ -164,13 +164,13 @@
         />
       </div>
       <span
-        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
+        class="css-160t4ez-MetadataItemWrapper e1130wzj0"
       >
         <p
-          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1130wzj1 leafygreen-ui-1tb6tuo"
         >
           <b
-            class="css-1xk67r-MetadataLabel e1ul56zb0"
+            class="css-1xk67r-MetadataLabel e1130wzj3"
           >
             ID:
           </b>
@@ -188,13 +188,13 @@
         </p>
       </span>
       <span
-        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
+        class="css-160t4ez-MetadataItemWrapper e1130wzj0"
       >
         <p
-          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1130wzj1 leafygreen-ui-1tb6tuo"
         >
           <b
-            class="css-1xk67r-MetadataLabel e1ul56zb0"
+            class="css-1xk67r-MetadataLabel e1130wzj3"
           >
             Distro:
           </b>
@@ -211,13 +211,13 @@
         </p>
       </span>
       <span
-        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
+        class="css-160t4ez-MetadataItemWrapper e1130wzj0"
       >
         <p
-          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1130wzj1 leafygreen-ui-1tb6tuo"
         >
           <b
-            class="css-1xk67r-MetadataLabel e1ul56zb0"
+            class="css-1xk67r-MetadataLabel e1130wzj3"
           >
             Image:
           </b>
@@ -234,14 +234,14 @@
         </p>
       </span>
       <span
-        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
+        class="css-160t4ez-MetadataItemWrapper e1130wzj0"
       >
         <p
-          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1130wzj1 leafygreen-ui-1tb6tuo"
           data-cy="task-metadata-ami"
         >
           <b
-            class="css-1xk67r-MetadataLabel e1ul56zb0"
+            class="css-1xk67r-MetadataLabel e1130wzj3"
           >
             AMI:
           </b>
@@ -250,10 +250,10 @@
         </p>
       </span>
       <span
-        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
+        class="css-160t4ez-MetadataItemWrapper e1130wzj0"
       >
         <p
-          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1130wzj1 leafygreen-ui-1tb6tuo"
         >
           <a
             class="lg-ui-0001 css-r79zk7-overrideStyles leafygreen-ui-16e7rxl"
@@ -272,7 +272,7 @@
     >
       <div>
         <p
-          class="css-1k03zl5-Title e1ul56zb3 leafygreen-ui-1miy0xp"
+          class="css-1k03zl5-Title e1130wzj2 leafygreen-ui-1miy0xp"
         >
           Tags
         </p>

--- a/apps/spruce/src/pages/task/metadata/__snapshots__/Metadata_WithAbortMessage.storyshot
+++ b/apps/spruce/src/pages/task/metadata/__snapshots__/Metadata_WithAbortMessage.storyshot
@@ -7,7 +7,7 @@
     >
       <div>
         <p
-          class="css-1k03zl5-Title e1ul56zb3 leafygreen-ui-1miy0xp"
+          class="css-1k03zl5-Title e1130wzj2 leafygreen-ui-1miy0xp"
         >
           Task Metadata
         </p>
@@ -16,14 +16,14 @@
         />
       </div>
       <span
-        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
+        class="css-160t4ez-MetadataItemWrapper e1130wzj0"
       >
         <p
-          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1130wzj1 leafygreen-ui-1tb6tuo"
           data-cy="task-metadata-build-variant"
         >
           <b
-            class="css-1xk67r-MetadataLabel e1ul56zb0"
+            class="css-1xk67r-MetadataLabel e1130wzj3"
           >
             Build Variant:
           </b>
@@ -40,14 +40,14 @@
         </p>
       </span>
       <span
-        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
+        class="css-160t4ez-MetadataItemWrapper e1130wzj0"
       >
         <p
-          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1130wzj1 leafygreen-ui-1tb6tuo"
           data-cy="task-metadata-project"
         >
           <b
-            class="css-1xk67r-MetadataLabel e1ul56zb0"
+            class="css-1xk67r-MetadataLabel e1130wzj3"
           >
             Project:
           </b>
@@ -64,13 +64,13 @@
         </p>
       </span>
       <span
-        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
+        class="css-160t4ez-MetadataItemWrapper e1130wzj0"
       >
         <p
-          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1130wzj1 leafygreen-ui-1tb6tuo"
         >
           <b
-            class="css-1xk67r-MetadataLabel e1ul56zb0"
+            class="css-1xk67r-MetadataLabel e1130wzj3"
           >
             Submitted by:
           </b>
@@ -79,13 +79,13 @@
         </p>
       </span>
       <span
-        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
+        class="css-160t4ez-MetadataItemWrapper e1130wzj0"
       >
         <p
-          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1130wzj1 leafygreen-ui-1tb6tuo"
         >
           <b
-            class="css-1xk67r-MetadataLabel e1ul56zb0"
+            class="css-1xk67r-MetadataLabel e1130wzj3"
           >
             Estimated time to start:
           </b>
@@ -98,13 +98,13 @@
         </p>
       </span>
       <span
-        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
+        class="css-160t4ez-MetadataItemWrapper e1130wzj0"
       >
         <p
-          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1130wzj1 leafygreen-ui-1tb6tuo"
         >
           <b
-            class="css-1xk67r-MetadataLabel e1ul56zb0"
+            class="css-1xk67r-MetadataLabel e1130wzj3"
           >
             Base commit:
           </b>
@@ -123,14 +123,14 @@
         </p>
       </span>
       <span
-        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
+        class="css-160t4ez-MetadataItemWrapper e1130wzj0"
       >
         <p
-          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1130wzj1 leafygreen-ui-1tb6tuo"
           data-cy="task-metadata-description"
         >
           <b
-            class="css-1wckecy-MetadataLabel e1ul56zb0"
+            class="css-1wckecy-MetadataLabel e1130wzj3"
             color="#DB3030"
           >
             Failing Command: 
@@ -155,7 +155,7 @@
     >
       <div>
         <p
-          class="css-1k03zl5-Title e1ul56zb3 leafygreen-ui-1miy0xp"
+          class="css-1k03zl5-Title e1130wzj2 leafygreen-ui-1miy0xp"
         >
           Host Information
         </p>
@@ -164,13 +164,13 @@
         />
       </div>
       <span
-        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
+        class="css-160t4ez-MetadataItemWrapper e1130wzj0"
       >
         <p
-          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1130wzj1 leafygreen-ui-1tb6tuo"
         >
           <b
-            class="css-1xk67r-MetadataLabel e1ul56zb0"
+            class="css-1xk67r-MetadataLabel e1130wzj3"
           >
             ID:
           </b>
@@ -188,13 +188,13 @@
         </p>
       </span>
       <span
-        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
+        class="css-160t4ez-MetadataItemWrapper e1130wzj0"
       >
         <p
-          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1130wzj1 leafygreen-ui-1tb6tuo"
         >
           <b
-            class="css-1xk67r-MetadataLabel e1ul56zb0"
+            class="css-1xk67r-MetadataLabel e1130wzj3"
           >
             Distro:
           </b>
@@ -211,13 +211,13 @@
         </p>
       </span>
       <span
-        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
+        class="css-160t4ez-MetadataItemWrapper e1130wzj0"
       >
         <p
-          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1130wzj1 leafygreen-ui-1tb6tuo"
         >
           <b
-            class="css-1xk67r-MetadataLabel e1ul56zb0"
+            class="css-1xk67r-MetadataLabel e1130wzj3"
           >
             Image:
           </b>
@@ -234,14 +234,14 @@
         </p>
       </span>
       <span
-        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
+        class="css-160t4ez-MetadataItemWrapper e1130wzj0"
       >
         <p
-          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1130wzj1 leafygreen-ui-1tb6tuo"
           data-cy="task-metadata-ami"
         >
           <b
-            class="css-1xk67r-MetadataLabel e1ul56zb0"
+            class="css-1xk67r-MetadataLabel e1130wzj3"
           >
             AMI:
           </b>
@@ -250,10 +250,10 @@
         </p>
       </span>
       <span
-        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
+        class="css-160t4ez-MetadataItemWrapper e1130wzj0"
       >
         <p
-          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1130wzj1 leafygreen-ui-1tb6tuo"
         >
           <a
             class="lg-ui-0001 css-r79zk7-overrideStyles leafygreen-ui-16e7rxl"
@@ -272,7 +272,7 @@
     >
       <div>
         <p
-          class="css-1k03zl5-Title e1ul56zb3 leafygreen-ui-1miy0xp"
+          class="css-1k03zl5-Title e1130wzj2 leafygreen-ui-1miy0xp"
         >
           Tags
         </p>

--- a/apps/spruce/src/pages/task/metadata/__snapshots__/Metadata_WithAbortMessage.storyshot
+++ b/apps/spruce/src/pages/task/metadata/__snapshots__/Metadata_WithAbortMessage.storyshot
@@ -15,11 +15,11 @@
           class="css-qqg5h5-Divider eb6szep0"
         />
       </div>
-      <div
-        class="css-1kc2q0u-MetadataItemWrapper e1ul56zb1"
+      <span
+        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
       >
         <p
-          class="css-1xovdqa-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
           data-cy="task-metadata-build-variant"
         >
           <b
@@ -38,12 +38,12 @@
             </span>
           </a>
         </p>
-      </div>
-      <div
-        class="css-1kc2q0u-MetadataItemWrapper e1ul56zb1"
+      </span>
+      <span
+        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
       >
         <p
-          class="css-1xovdqa-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
           data-cy="task-metadata-project"
         >
           <b
@@ -62,12 +62,12 @@
             </span>
           </a>
         </p>
-      </div>
-      <div
-        class="css-1kc2q0u-MetadataItemWrapper e1ul56zb1"
+      </span>
+      <span
+        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
       >
         <p
-          class="css-1xovdqa-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
         >
           <b
             class="css-1xk67r-MetadataLabel e1ul56zb0"
@@ -77,12 +77,12 @@
            
           mohamed.khelif
         </p>
-      </div>
-      <div
-        class="css-1kc2q0u-MetadataItemWrapper e1ul56zb1"
+      </span>
+      <span
+        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
       >
         <p
-          class="css-1xovdqa-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
         >
           <b
             class="css-1xk67r-MetadataLabel e1ul56zb0"
@@ -96,12 +96,12 @@
             1s
           </span>
         </p>
-      </div>
-      <div
-        class="css-1kc2q0u-MetadataItemWrapper e1ul56zb1"
+      </span>
+      <span
+        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
       >
         <p
-          class="css-1xovdqa-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
         >
           <b
             class="css-1xk67r-MetadataLabel e1ul56zb0"
@@ -121,12 +121,12 @@
             </code>
           </a>
         </p>
-      </div>
-      <div
-        class="css-1kc2q0u-MetadataItemWrapper e1ul56zb1"
+      </span>
+      <span
+        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
       >
         <p
-          class="css-1xovdqa-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
           data-cy="task-metadata-description"
         >
           <b
@@ -148,7 +148,7 @@
             </small>
           </span>
         </p>
-      </div>
+      </span>
     </div>
     <div
       class="css-1l8tpk-SiderCard e1am38ss0 leafygreen-ui-1ecxdul"
@@ -163,11 +163,11 @@
           class="css-qqg5h5-Divider eb6szep0"
         />
       </div>
-      <div
-        class="css-1kc2q0u-MetadataItemWrapper e1ul56zb1"
+      <span
+        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
       >
         <p
-          class="css-1xovdqa-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
         >
           <b
             class="css-1xk67r-MetadataLabel e1ul56zb0"
@@ -186,12 +186,12 @@
             </span>
           </a>
         </p>
-      </div>
-      <div
-        class="css-1kc2q0u-MetadataItemWrapper e1ul56zb1"
+      </span>
+      <span
+        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
       >
         <p
-          class="css-1xovdqa-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
         >
           <b
             class="css-1xk67r-MetadataLabel e1ul56zb0"
@@ -209,12 +209,12 @@
             </span>
           </a>
         </p>
-      </div>
-      <div
-        class="css-1kc2q0u-MetadataItemWrapper e1ul56zb1"
+      </span>
+      <span
+        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
       >
         <p
-          class="css-1xovdqa-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
         >
           <b
             class="css-1xk67r-MetadataLabel e1ul56zb0"
@@ -232,12 +232,12 @@
             </span>
           </a>
         </p>
-      </div>
-      <div
-        class="css-1kc2q0u-MetadataItemWrapper e1ul56zb1"
+      </span>
+      <span
+        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
       >
         <p
-          class="css-1xovdqa-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
           data-cy="task-metadata-ami"
         >
           <b
@@ -248,12 +248,12 @@
            
           ami-0c83bb0a9f48c15bf
         </p>
-      </div>
-      <div
-        class="css-1kc2q0u-MetadataItemWrapper e1ul56zb1"
+      </span>
+      <span
+        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
       >
         <p
-          class="css-1xovdqa-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
         >
           <a
             class="lg-ui-0001 css-r79zk7-overrideStyles leafygreen-ui-16e7rxl"
@@ -265,7 +265,7 @@
             </span>
           </a>
         </p>
-      </div>
+      </span>
     </div>
     <div
       class="css-1l8tpk-SiderCard e1am38ss0 leafygreen-ui-1ecxdul"

--- a/apps/spruce/src/pages/task/metadata/__snapshots__/Metadata_WithDependencies.storyshot
+++ b/apps/spruce/src/pages/task/metadata/__snapshots__/Metadata_WithDependencies.storyshot
@@ -7,7 +7,7 @@
     >
       <div>
         <p
-          class="css-1k03zl5-Title e1ul56zb3 leafygreen-ui-1miy0xp"
+          class="css-1k03zl5-Title e1130wzj2 leafygreen-ui-1miy0xp"
         >
           Task Metadata
         </p>
@@ -16,14 +16,14 @@
         />
       </div>
       <span
-        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
+        class="css-160t4ez-MetadataItemWrapper e1130wzj0"
       >
         <p
-          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1130wzj1 leafygreen-ui-1tb6tuo"
           data-cy="task-metadata-build-variant"
         >
           <b
-            class="css-1xk67r-MetadataLabel e1ul56zb0"
+            class="css-1xk67r-MetadataLabel e1130wzj3"
           >
             Build Variant:
           </b>
@@ -40,14 +40,14 @@
         </p>
       </span>
       <span
-        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
+        class="css-160t4ez-MetadataItemWrapper e1130wzj0"
       >
         <p
-          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1130wzj1 leafygreen-ui-1tb6tuo"
           data-cy="task-metadata-project"
         >
           <b
-            class="css-1xk67r-MetadataLabel e1ul56zb0"
+            class="css-1xk67r-MetadataLabel e1130wzj3"
           >
             Project:
           </b>
@@ -64,13 +64,13 @@
         </p>
       </span>
       <span
-        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
+        class="css-160t4ez-MetadataItemWrapper e1130wzj0"
       >
         <p
-          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1130wzj1 leafygreen-ui-1tb6tuo"
         >
           <b
-            class="css-1xk67r-MetadataLabel e1ul56zb0"
+            class="css-1xk67r-MetadataLabel e1130wzj3"
           >
             Submitted by:
           </b>
@@ -79,13 +79,13 @@
         </p>
       </span>
       <span
-        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
+        class="css-160t4ez-MetadataItemWrapper e1130wzj0"
       >
         <p
-          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1130wzj1 leafygreen-ui-1tb6tuo"
         >
           <b
-            class="css-1xk67r-MetadataLabel e1ul56zb0"
+            class="css-1xk67r-MetadataLabel e1130wzj3"
           >
             Estimated time to start:
           </b>
@@ -98,13 +98,13 @@
         </p>
       </span>
       <span
-        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
+        class="css-160t4ez-MetadataItemWrapper e1130wzj0"
       >
         <p
-          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1130wzj1 leafygreen-ui-1tb6tuo"
         >
           <b
-            class="css-1xk67r-MetadataLabel e1ul56zb0"
+            class="css-1xk67r-MetadataLabel e1130wzj3"
           >
             Base commit:
           </b>
@@ -123,14 +123,14 @@
         </p>
       </span>
       <span
-        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
+        class="css-160t4ez-MetadataItemWrapper e1130wzj0"
       >
         <p
-          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1130wzj1 leafygreen-ui-1tb6tuo"
           data-cy="task-metadata-description"
         >
           <b
-            class="css-1wckecy-MetadataLabel e1ul56zb0"
+            class="css-1wckecy-MetadataLabel e1130wzj3"
             color="#DB3030"
           >
             Failing Command: 
@@ -155,7 +155,7 @@
     >
       <div>
         <p
-          class="css-1k03zl5-Title e1ul56zb3 leafygreen-ui-1miy0xp"
+          class="css-1k03zl5-Title e1130wzj2 leafygreen-ui-1miy0xp"
         >
           Host Information
         </p>
@@ -164,13 +164,13 @@
         />
       </div>
       <span
-        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
+        class="css-160t4ez-MetadataItemWrapper e1130wzj0"
       >
         <p
-          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1130wzj1 leafygreen-ui-1tb6tuo"
         >
           <b
-            class="css-1xk67r-MetadataLabel e1ul56zb0"
+            class="css-1xk67r-MetadataLabel e1130wzj3"
           >
             ID:
           </b>
@@ -188,13 +188,13 @@
         </p>
       </span>
       <span
-        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
+        class="css-160t4ez-MetadataItemWrapper e1130wzj0"
       >
         <p
-          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1130wzj1 leafygreen-ui-1tb6tuo"
         >
           <b
-            class="css-1xk67r-MetadataLabel e1ul56zb0"
+            class="css-1xk67r-MetadataLabel e1130wzj3"
           >
             Distro:
           </b>
@@ -211,13 +211,13 @@
         </p>
       </span>
       <span
-        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
+        class="css-160t4ez-MetadataItemWrapper e1130wzj0"
       >
         <p
-          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1130wzj1 leafygreen-ui-1tb6tuo"
         >
           <b
-            class="css-1xk67r-MetadataLabel e1ul56zb0"
+            class="css-1xk67r-MetadataLabel e1130wzj3"
           >
             Image:
           </b>
@@ -234,14 +234,14 @@
         </p>
       </span>
       <span
-        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
+        class="css-160t4ez-MetadataItemWrapper e1130wzj0"
       >
         <p
-          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1130wzj1 leafygreen-ui-1tb6tuo"
           data-cy="task-metadata-ami"
         >
           <b
-            class="css-1xk67r-MetadataLabel e1ul56zb0"
+            class="css-1xk67r-MetadataLabel e1130wzj3"
           >
             AMI:
           </b>
@@ -250,10 +250,10 @@
         </p>
       </span>
       <span
-        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
+        class="css-160t4ez-MetadataItemWrapper e1130wzj0"
       >
         <p
-          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1130wzj1 leafygreen-ui-1tb6tuo"
         >
           <a
             class="lg-ui-0001 css-r79zk7-overrideStyles leafygreen-ui-16e7rxl"
@@ -272,7 +272,7 @@
     >
       <div>
         <p
-          class="css-1k03zl5-Title e1ul56zb3 leafygreen-ui-1miy0xp"
+          class="css-1k03zl5-Title e1130wzj2 leafygreen-ui-1miy0xp"
         >
           Depends On
         </p>
@@ -483,7 +483,7 @@
     >
       <div>
         <p
-          class="css-1k03zl5-Title e1ul56zb3 leafygreen-ui-1miy0xp"
+          class="css-1k03zl5-Title e1130wzj2 leafygreen-ui-1miy0xp"
         >
           Tags
         </p>

--- a/apps/spruce/src/pages/task/metadata/__snapshots__/Metadata_WithDependencies.storyshot
+++ b/apps/spruce/src/pages/task/metadata/__snapshots__/Metadata_WithDependencies.storyshot
@@ -15,11 +15,11 @@
           class="css-qqg5h5-Divider eb6szep0"
         />
       </div>
-      <div
-        class="css-1kc2q0u-MetadataItemWrapper e1ul56zb1"
+      <span
+        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
       >
         <p
-          class="css-1xovdqa-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
           data-cy="task-metadata-build-variant"
         >
           <b
@@ -38,12 +38,12 @@
             </span>
           </a>
         </p>
-      </div>
-      <div
-        class="css-1kc2q0u-MetadataItemWrapper e1ul56zb1"
+      </span>
+      <span
+        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
       >
         <p
-          class="css-1xovdqa-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
           data-cy="task-metadata-project"
         >
           <b
@@ -62,12 +62,12 @@
             </span>
           </a>
         </p>
-      </div>
-      <div
-        class="css-1kc2q0u-MetadataItemWrapper e1ul56zb1"
+      </span>
+      <span
+        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
       >
         <p
-          class="css-1xovdqa-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
         >
           <b
             class="css-1xk67r-MetadataLabel e1ul56zb0"
@@ -77,12 +77,12 @@
            
           mohamed.khelif
         </p>
-      </div>
-      <div
-        class="css-1kc2q0u-MetadataItemWrapper e1ul56zb1"
+      </span>
+      <span
+        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
       >
         <p
-          class="css-1xovdqa-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
         >
           <b
             class="css-1xk67r-MetadataLabel e1ul56zb0"
@@ -96,12 +96,12 @@
             1s
           </span>
         </p>
-      </div>
-      <div
-        class="css-1kc2q0u-MetadataItemWrapper e1ul56zb1"
+      </span>
+      <span
+        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
       >
         <p
-          class="css-1xovdqa-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
         >
           <b
             class="css-1xk67r-MetadataLabel e1ul56zb0"
@@ -121,12 +121,12 @@
             </code>
           </a>
         </p>
-      </div>
-      <div
-        class="css-1kc2q0u-MetadataItemWrapper e1ul56zb1"
+      </span>
+      <span
+        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
       >
         <p
-          class="css-1xovdqa-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
           data-cy="task-metadata-description"
         >
           <b
@@ -148,7 +148,7 @@
             </small>
           </span>
         </p>
-      </div>
+      </span>
     </div>
     <div
       class="css-1l8tpk-SiderCard e1am38ss0 leafygreen-ui-1ecxdul"
@@ -163,11 +163,11 @@
           class="css-qqg5h5-Divider eb6szep0"
         />
       </div>
-      <div
-        class="css-1kc2q0u-MetadataItemWrapper e1ul56zb1"
+      <span
+        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
       >
         <p
-          class="css-1xovdqa-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
         >
           <b
             class="css-1xk67r-MetadataLabel e1ul56zb0"
@@ -186,12 +186,12 @@
             </span>
           </a>
         </p>
-      </div>
-      <div
-        class="css-1kc2q0u-MetadataItemWrapper e1ul56zb1"
+      </span>
+      <span
+        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
       >
         <p
-          class="css-1xovdqa-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
         >
           <b
             class="css-1xk67r-MetadataLabel e1ul56zb0"
@@ -209,12 +209,12 @@
             </span>
           </a>
         </p>
-      </div>
-      <div
-        class="css-1kc2q0u-MetadataItemWrapper e1ul56zb1"
+      </span>
+      <span
+        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
       >
         <p
-          class="css-1xovdqa-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
         >
           <b
             class="css-1xk67r-MetadataLabel e1ul56zb0"
@@ -232,12 +232,12 @@
             </span>
           </a>
         </p>
-      </div>
-      <div
-        class="css-1kc2q0u-MetadataItemWrapper e1ul56zb1"
+      </span>
+      <span
+        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
       >
         <p
-          class="css-1xovdqa-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
           data-cy="task-metadata-ami"
         >
           <b
@@ -248,12 +248,12 @@
            
           ami-0c83bb0a9f48c15bf
         </p>
-      </div>
-      <div
-        class="css-1kc2q0u-MetadataItemWrapper e1ul56zb1"
+      </span>
+      <span
+        class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
       >
         <p
-          class="css-1xovdqa-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+          class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
         >
           <a
             class="lg-ui-0001 css-r79zk7-overrideStyles leafygreen-ui-16e7rxl"
@@ -265,7 +265,7 @@
             </span>
           </a>
         </p>
-      </div>
+      </span>
     </div>
     <div
       class="css-1l8tpk-SiderCard e1am38ss0 leafygreen-ui-1ecxdul"

--- a/apps/spruce/src/pages/task/metadata/index.tsx
+++ b/apps/spruce/src/pages/task/metadata/index.tsx
@@ -13,8 +13,7 @@ import { size, zIndex } from "@evg-ui/lib/constants/tokens";
 import { TaskStatus } from "@evg-ui/lib/types/task";
 import { useTaskAnalytics } from "analytics";
 import ExpandedText from "components/ExpandedText";
-import {
-  MetadataCard,
+import MetadataCard, {
   MetadataItem,
   MetadataLabel,
 } from "components/MetadataCard";

--- a/apps/spruce/src/pages/version/BuildVariantCard/__snapshots__/BuildVariantCard_Default.storyshot
+++ b/apps/spruce/src/pages/version/BuildVariantCard/__snapshots__/BuildVariantCard_Default.storyshot
@@ -4,7 +4,7 @@
   >
     <div>
       <p
-        class="css-1k03zl5-Title e1ul56zb3 leafygreen-ui-1miy0xp"
+        class="css-1k03zl5-Title e1130wzj2 leafygreen-ui-1miy0xp"
       >
         Build Variants
       </p>

--- a/apps/spruce/src/pages/version/BuildVariantCard/index.tsx
+++ b/apps/spruce/src/pages/version/BuildVariantCard/index.tsx
@@ -1,7 +1,7 @@
 import { useQuery } from "@apollo/client";
 import styled from "@emotion/styled";
 import { size } from "@evg-ui/lib/constants/tokens";
-import { MetadataCard } from "components/MetadataCard";
+import MetadataCard from "components/MetadataCard";
 import { navBarHeight } from "components/styles/Layout";
 import { DEFAULT_POLL_INTERVAL } from "constants/index";
 import {

--- a/apps/spruce/src/pages/version/Metadata.tsx
+++ b/apps/spruce/src/pages/version/Metadata.tsx
@@ -2,8 +2,7 @@ import { InlineCode, Disclaimer } from "@leafygreen-ui/typography";
 import { Link } from "react-router-dom";
 import { StyledLink, StyledRouterLink } from "@evg-ui/lib/components/styles";
 import { useVersionAnalytics } from "analytics";
-import {
-  MetadataCard,
+import MetadataCard, {
   MetadataItem,
   MetadataLabel,
 } from "components/MetadataCard";

--- a/apps/spruce/src/pages/version/ParametersModal/__snapshots__/ParametersModal_Default.storyshot
+++ b/apps/spruce/src/pages/version/ParametersModal/__snapshots__/ParametersModal_Default.storyshot
@@ -1,9 +1,9 @@
 <div>
-  <div
-    class="css-1kc2q0u-MetadataItemWrapper e1ul56zb1"
+  <span
+    class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
   >
     <p
-      class="css-1xovdqa-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+      class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
     >
       <span
         class="lg-ui-0001 css-r79zk7-overrideStyles leafygreen-ui-16e7rxl"
@@ -14,5 +14,5 @@
         </span>
       </span>
     </p>
-  </div>
+  </span>
 </div>

--- a/apps/spruce/src/pages/version/ParametersModal/__snapshots__/ParametersModal_Default.storyshot
+++ b/apps/spruce/src/pages/version/ParametersModal/__snapshots__/ParametersModal_Default.storyshot
@@ -1,9 +1,9 @@
 <div>
   <span
-    class="css-160t4ez-MetadataItemWrapper e1ul56zb1"
+    class="css-160t4ez-MetadataItemWrapper e1130wzj0"
   >
     <p
-      class="css-1xle18-Item-wordBreakCss e1ul56zb2 leafygreen-ui-1tb6tuo"
+      class="css-1xle18-Item-wordBreakCss e1130wzj1 leafygreen-ui-1tb6tuo"
     >
       <span
         class="lg-ui-0001 css-r79zk7-overrideStyles leafygreen-ui-16e7rxl"


### PR DESCRIPTION
DEVPROD-15373
<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
My changes in DEVPROD-11546 ended up inadvertently breaking the spacing between metadata items. (I wonder why I didn't notice this).
Also added a storybook story for this to catch it in the future. 
Refactored component to use Leafygreen loading skeleton
### Screenshots
<img width="282" alt="image" src="https://github.com/user-attachments/assets/afc1a417-3944-43cf-b65c-f011e5e434ee" />

### Testing
Add leaf
<!-- Have you have updated the analytics documentation if necessary?  
https://docs.google.com/spreadsheets/d/1s4_nq8ZiphXp5Uq_-9HT6GPqz-KOyaq6HuvmXYaSNzg/edit?usp=sharing -->

### Evergreen PR
<!-- link to a corresponding Evergreen PR if applicable -->
