### PR TITLE
DEVPROD-15061: Clear date and revision filters when jumping to most recent commit

### DIFF
--- a/apps/spruce/src/pages/waterfall/WaterfallMenu/JumpToMostRecent.tsx
+++ b/apps/spruce/src/pages/waterfall/WaterfallMenu/JumpToMostRecent.tsx
@@ -16,6 +16,8 @@ export const JumpToMostRecent: React.FC<Props> = ({ setMenuOpen }) => {
     sendEvent({ name: "Clicked jump to most recent commit button" });
     setQueryParams({
       ...queryParams,
+      [WaterfallFilterOptions.Date]: undefined,
+      [WaterfallFilterOptions.Revision]: undefined,
       [WaterfallFilterOptions.MaxOrder]: undefined,
       [WaterfallFilterOptions.MinOrder]: undefined,
     });


### PR DESCRIPTION
DEVPROD-15061
<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
Also clears date and revision query params when jumping to most recent commit.