### PR TITLE
DEVPROD-8259: Display ingest and activated time separately in task metadata panel

### DIFF
--- a/apps/spruce/src/pages/task/metadata/index.tsx
+++ b/apps/spruce/src/pages/task/metadata/index.tsx
@@ -89,7 +89,6 @@ export const Metadata: React.FC<Props> = ({ error, loading, task, taskId }) => {
     versionMetadata,
   } = task || {};
 
-  const submittedTime = activatedTime ?? ingestTime;
   const isDisplayTask = executionTasksFull != null;
   const {
     id: baseTaskId,
@@ -156,11 +155,19 @@ export const Metadata: React.FC<Props> = ({ error, loading, task, taskId }) => {
         <MetadataItem>
           <MetadataLabel>Submitted by:</MetadataLabel> {author}
         </MetadataItem>
-        {submittedTime && (
+        {ingestTime && (
           <MetadataItem data-cy="task-metadata-submitted-at">
             <MetadataLabel>Submitted at:</MetadataLabel>{" "}
-            <span title={getDateCopy(submittedTime)}>
-              {getDateCopy(submittedTime, { omitSeconds: true })}
+            <span title={getDateCopy(ingestTime)}>
+              {getDateCopy(ingestTime, { omitSeconds: true })}
+            </span>
+          </MetadataItem>
+        )}
+        {activatedTime && (
+          <MetadataItem data-cy="task-metadata-activated-at">
+            <MetadataLabel>Activated at:</MetadataLabel>{" "}
+            <span title={getDateCopy(activatedTime)}>
+              {getDateCopy(activatedTime, { omitSeconds: true })}
             </span>
           </MetadataItem>
         )}


### PR DESCRIPTION
DEVPROD-8259

### Description
Activated and ingest time are now rendered separately with updated labels. 

