### PR TITLE
DEVPROD-15569 Fix bug causing page to display a loading screen on poll

### DIFF
--- a/apps/spruce/src/pages/Version.tsx
+++ b/apps/spruce/src/pages/Version.tsx
@@ -28,19 +28,16 @@ import VersionTabs from "./version/Tabs";
 
 export const VersionPage: React.FC = () => {
   const spruceConfig = useSpruceConfig();
-  const { [slugs.versionId]: versionId } = useParams();
+  const { [slugs.versionId]: versionId = "" } = useParams();
   const dispatchToast = useToastContext();
 
-  // This query is used to fetch the version data.
   const {
     data: versionData,
-    error: versionError,
     loading: versionLoading,
     refetch,
     startPolling,
     stopPolling,
   } = useQuery<VersionQuery, VersionQueryVariables>(VERSION, {
-    // @ts-expect-error: FIXME. This comment was added by an automated script.
     variables: { id: versionId },
     fetchPolicy: "cache-and-network",
     onError: (error) => {
@@ -52,11 +49,11 @@ export const VersionPage: React.FC = () => {
 
   usePolling({ startPolling, stopPolling, refetch });
 
-  if (versionLoading) {
+  if (!versionData && versionLoading) {
     return <PatchAndTaskFullPageLoad />;
   }
 
-  if (versionError) {
+  if (!versionData) {
     return (
       <PageWrapper data-cy="version-page">
         <PageDoesNotExist />
@@ -64,7 +61,7 @@ export const VersionPage: React.FC = () => {
     );
   }
 
-  const { version } = versionData || {};
+  const { version } = versionData;
   const {
     errors,
     ignored,
@@ -80,14 +77,12 @@ export const VersionPage: React.FC = () => {
   } = version || {};
   const { patchNumber } = patch || {};
 
-  // @ts-expect-error: FIXME. This comment was added by an automated script.
   const versionText = shortenGithash(revision || versionId);
   const pageTitle = isPatch
     ? `Patch - ${patchNumber}`
     : `Version - ${versionText}`;
 
   const linkifiedMessage = jiraLinkify(
-    // @ts-expect-error: FIXME. This comment was added by an automated script.
     githubPRLinkify(message),
     // @ts-expect-error: FIXME. This comment was added by an automated script.
     spruceConfig?.jira?.host,
@@ -95,7 +90,6 @@ export const VersionPage: React.FC = () => {
 
   return (
     <PageWrapper data-cy="version-page">
-      {/* @ts-expect-error: FIXME. This comment was added by an automated script. */}
       <ProjectBanner projectIdentifier={projectIdentifier} />
       {errors && errors.length > 0 && <ErrorBanner errors={errors} />}
       {warnings && warnings.length > 0 && <WarningBanner warnings={warnings} />}
@@ -107,7 +101,6 @@ export const VersionPage: React.FC = () => {
         />
       )}
       <PageTitle
-        // @ts-expect-error: FIXME. This comment was added by an automated script.
         badge={<PatchStatusBadge status={status} />}
         buttons={
           <ActionButtons
@@ -115,7 +108,6 @@ export const VersionPage: React.FC = () => {
               !!isPatch && requester !== Requester.GitHubMergeQueue
             }
             isPatch={!!isPatch}
-            // @ts-expect-error: FIXME. This comment was added by an automated script.
             versionId={versionId}
           />
         }
@@ -124,22 +116,16 @@ export const VersionPage: React.FC = () => {
         title={linkifiedMessage || `Version ${order}`}
       >
         {isPatch && (
-          // @ts-expect-error: FIXME. This comment was added by an automated script.
           <NameChangeModal originalPatchName={message} patchId={versionId} />
         )}
       </PageTitle>
       <PageLayout hasSider>
         <PageSider>
-          {/* @ts-expect-error: FIXME. This comment was added by an automated script. */}
-          <Metadata loading={false} version={version} />
-          {/* @ts-expect-error: FIXME. This comment was added by an automated script. */}
+          <Metadata version={version} />
           <BuildVariantCard versionId={versionId} />
         </PageSider>
         <PageContent>
-          <VersionTabs
-            // @ts-expect-error: FIXME. This comment was added by an automated script.
-            version={version}
-          />
+          <VersionTabs version={version} />
         </PageContent>
       </PageLayout>
     </PageWrapper>

--- a/apps/spruce/src/pages/version/BuildVariantCard/index.tsx
+++ b/apps/spruce/src/pages/version/BuildVariantCard/index.tsx
@@ -21,6 +21,7 @@ const BuildVariantCard: React.FC<BuildVariantCardProps> = ({ versionId }) => {
     BuildVariantStatsQueryVariables
   >(BUILD_VARIANTS_STATS, {
     fetchPolicy: "cache-and-network",
+
     variables: { id: versionId },
     pollInterval: DEFAULT_POLL_INTERVAL,
   });
@@ -28,7 +29,11 @@ const BuildVariantCard: React.FC<BuildVariantCardProps> = ({ versionId }) => {
   const { version } = data || {};
 
   return (
-    <StickyMetadataCard error={error} loading={loading} title="Build Variants">
+    <StickyMetadataCard
+      error={error}
+      loading={loading && !data}
+      title="Build Variants"
+    >
       <ScrollableBuildVariantStatsContainer data-cy="build-variants">
         {version?.buildVariantStats?.map(
           ({ displayName, statusCounts, variant }) => (

--- a/apps/spruce/src/pages/version/Metadata.tsx
+++ b/apps/spruce/src/pages/version/Metadata.tsx
@@ -26,11 +26,10 @@ import { ParametersModal } from "./ParametersModal";
 const { msToDuration, shortenGithash } = string;
 
 interface Props {
-  loading: boolean;
   version: VersionQuery["version"];
 }
 
-export const Metadata: React.FC<Props> = ({ loading, version }) => {
+export const Metadata: React.FC<Props> = ({ version }) => {
   const getDateCopy = useDateFormat();
   const {
     author,
@@ -61,10 +60,7 @@ export const Metadata: React.FC<Props> = ({ loading, version }) => {
   const isGithubMergePatch = requester === Requester.GitHubMergeQueue;
 
   return (
-    <MetadataCard
-      loading={loading}
-      title={isPatch ? "Patch Metadata" : "Version Metadata"}
-    >
+    <MetadataCard title={isPatch ? "Patch Metadata" : "Version Metadata"}>
       <MetadataItem>
         <MetadataLabel>Project:</MetadataLabel>{" "}
         {projectIdentifier ? (


### PR DESCRIPTION
DEVPROD-15569
<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
A regression was introduced that caused the version page to display a loading screen every time a user would switch tabs and the page would background poll. This fixes it so we only show the loading screen if we don't already have data for the page. I also fixed some ts warnings.

### Testing
Page no longer displays a loading screen when switching tabs

