### PR TITLE
DEVPROD-15439: Check project setup script option by default

### DIFF
--- a/apps/spruce/cypress/integration/spawn/host.ts
+++ b/apps/spruce/cypress/integration/spawn/host.ts
@@ -205,9 +205,13 @@ describe("Navigating to Spawn Host page", () => {
         `/spawn/host?spawnHost=True&distroId=${distroId}&taskId=${hostTaskId}`,
       );
       cy.dataCy("setup-script-text-area").should("not.exist");
-      cy.contains(
-        "Define setup script to run after host is configured (i.e. task data and artifacts are loaded",
-      ).click();
+      cy.dataCy("project-setup-script-checkbox").uncheck({ force: true });
+      cy.dataCy("setup-script-checkbox").should(
+        "have.attr",
+        "aria-disabled",
+        "false",
+      );
+      cy.dataCy("setup-script-checkbox").check({ force: true });
       cy.dataCy("setup-script-text-area").should("be.visible");
     });
 
@@ -215,6 +219,36 @@ describe("Navigating to Spawn Host page", () => {
       cy.visit(
         `/spawn/host?spawnHost=True&distroId=${distroId}&taskId=${hostTaskId}`,
       );
+      // Project setup script should be checked by default, which should disable setup script.
+      cy.dataCy("project-setup-script-checkbox").should(
+        "have.attr",
+        "aria-checked",
+        "true",
+      );
+      cy.dataCy("project-setup-script-checkbox").should(
+        "have.attr",
+        "aria-disabled",
+        "false",
+      );
+      cy.dataCy("setup-script-checkbox").should(
+        "have.attr",
+        "aria-disabled",
+        "true",
+      );
+
+      // Unchecking project setup script should reenable setup script.
+      cy.dataCy("project-setup-script-checkbox").uncheck({ force: true });
+      cy.dataCy("project-setup-script-checkbox").should(
+        "have.attr",
+        "aria-disabled",
+        "false",
+      );
+      cy.dataCy("setup-script-checkbox").should(
+        "have.attr",
+        "aria-disabled",
+        "false",
+      );
+
       // Checking setup script should disable project setup script.
       cy.dataCy("setup-script-checkbox").check({ force: true });
       cy.dataCy("project-setup-script-checkbox").should(
@@ -222,19 +256,10 @@ describe("Navigating to Spawn Host page", () => {
         "aria-disabled",
         "true",
       );
-      // Unchecking setup script should reenable project setup script.
-      cy.dataCy("setup-script-checkbox").uncheck({ force: true });
-      cy.dataCy("project-setup-script-checkbox").should(
-        "have.attr",
-        "aria-disabled",
-        "false",
-      );
-      // Checking project setup script should disable setup script.
-      cy.dataCy("project-setup-script-checkbox").check({ force: true });
       cy.dataCy("setup-script-checkbox").should(
         "have.attr",
         "aria-disabled",
-        "true",
+        "false",
       );
     });
     const label1 = "Use project-specific setup script defined at /path";

--- a/apps/spruce/src/components/Spawn/spawnHostModal/getFormSchema.tsx
+++ b/apps/spruce/src/components/Spawn/spawnHostModal/getFormSchema.tsx
@@ -70,8 +70,7 @@ export const getFormSchema = ({
     revision,
   } = spawnTaskData || {};
   const hasValidTask = validateTask(spawnTaskData);
-  const hasProjectSetupScript =
-    project?.spawnHostScriptPath && project?.spawnHostScriptPath.length > 0;
+  const hasProjectSetupScript = !!project?.spawnHostScriptPath;
   const shouldRenderVolumeSelection = !isMigration && isVirtualWorkstation;
   const availableVolumes = volumes
     ? volumes.filter((v) => v.homeVolume && !v.hostID)

--- a/apps/spruce/src/components/Spawn/spawnHostModal/getFormSchema.tsx
+++ b/apps/spruce/src/components/Spawn/spawnHostModal/getFormSchema.tsx
@@ -70,6 +70,8 @@ export const getFormSchema = ({
     revision,
   } = spawnTaskData || {};
   const hasValidTask = validateTask(spawnTaskData);
+  const hasProjectSetupScript =
+    project?.spawnHostScriptPath && project?.spawnHostScriptPath.length > 0;
   const shouldRenderVolumeSelection = !isMigration && isVirtualWorkstation;
   const availableVolumes = volumes
     ? volumes.filter((v) => v.homeVolume && !v.hostID)
@@ -222,7 +224,7 @@ export const getFormSchema = ({
                       runProjectSpecificSetupScript: {
                         type: "boolean" as const,
                         title: `Use project-specific setup script defined at ${project?.spawnHostScriptPath}`,
-                        default: true,
+                        default: hasProjectSetupScript,
                       },
                       startHosts: {
                         type: "boolean" as const,
@@ -407,7 +409,7 @@ export const getFormSchema = ({
           },
           runProjectSpecificSetupScript: {
             "ui:widget":
-              hasValidTask && project?.spawnHostScriptPath
+              hasValidTask && hasProjectSetupScript
                 ? widgets.CheckboxWidget
                 : "hidden",
             "ui:disabled": useSetupScript,

--- a/apps/spruce/src/components/Spawn/spawnHostModal/getFormSchema.tsx
+++ b/apps/spruce/src/components/Spawn/spawnHostModal/getFormSchema.tsx
@@ -222,6 +222,7 @@ export const getFormSchema = ({
                       runProjectSpecificSetupScript: {
                         type: "boolean" as const,
                         title: `Use project-specific setup script defined at ${project?.spawnHostScriptPath}`,
+                        default: true,
                       },
                       startHosts: {
                         type: "boolean" as const,

--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -2125,6 +2125,12 @@ export enum ProjectSettingsSection {
   Workstation = "WORKSTATION",
 }
 
+export type ProjectTasksPair = {
+  __typename?: "ProjectTasksPair";
+  allowedTasks: Array<Scalars["String"]["output"]>;
+  projectId: Scalars["String"]["output"];
+};
+
 export type ProjectVars = {
   __typename?: "ProjectVars";
   adminOnlyVars: Array<Scalars["String"]["output"]>;
@@ -2585,6 +2591,11 @@ export type SetLastRevisionPayload = {
   mergeBaseRevision: Scalars["String"]["output"];
 };
 
+export type SingleTaskDistroConfig = {
+  __typename?: "SingleTaskDistroConfig";
+  projectTasksPairs: Array<ProjectTasksPair>;
+};
+
 export type SlackConfig = {
   __typename?: "SlackConfig";
   name?: Maybe<Scalars["String"]["output"]>;
@@ -2693,6 +2704,7 @@ export type SpruceConfig = {
   jira?: Maybe<JiraConfig>;
   providers?: Maybe<CloudProviderConfig>;
   secretFields: Array<Scalars["String"]["output"]>;
+  singleTaskDistro?: Maybe<SingleTaskDistroConfig>;
   slack?: Maybe<SlackConfig>;
   spawnHost: SpawnHostConfig;
   ui: UiConfig;


### PR DESCRIPTION
DEVPROD-15439
<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
This checkbox is hidden if a project doesn't have a setup script defined, so it won't affect other projects.
