### PR TITLE
DEVPROD-15848: Add tab for task history

### DIFF
--- a/apps/spruce/cypress/integration/task/task_history.ts
+++ b/apps/spruce/cypress/integration/task/task_history.ts
@@ -1,0 +1,9 @@
+describe("task history", () => {
+  it("can view the task history tab", () => {
+    cy.visit(
+      "task/evergreen_ubuntu1604_js_test_patch_5e823e1f28baeaa22ae00823d83e03082cd148ab_5e4ff3abe3c3317e352062e4_20_02_21_15_13_48/history",
+    );
+    cy.dataCy("task-history-tab").should("have.attr", "aria-selected", "true");
+    cy.dataCy("task-history").should("be.visible");
+  });
+});

--- a/apps/spruce/src/constants/featureFlags.ts
+++ b/apps/spruce/src/constants/featureFlags.ts
@@ -1,1 +1,5 @@
-// Placeholder
+import { isProduction } from "utils/environmentVariables";
+
+const showTaskHistoryTab = !isProduction();
+
+export { showTaskHistoryTab };

--- a/apps/spruce/src/constants/requesters.ts
+++ b/apps/spruce/src/constants/requesters.ts
@@ -10,7 +10,7 @@ enum Requester {
   Trigger = "trigger_request",
 }
 
-const commitRequesters = [
+const mainlineRequesters = [
   Requester.AdHoc,
   Requester.GitTag,
   Requester.Gitter,
@@ -18,7 +18,7 @@ const commitRequesters = [
 ];
 
 export const isMainlineRequester = (requester: Requester) =>
-  commitRequesters.includes(requester);
+  mainlineRequesters.includes(requester);
 
 const requesterToTitle: PartialRecord<Requester, string> = {
   [Requester.AdHoc]: "Periodic build",
@@ -39,5 +39,5 @@ export {
   Requester,
   requesterToTitle,
   requesterToDescription,
-  commitRequesters,
+  mainlineRequesters,
 };

--- a/apps/spruce/src/constants/requesters.ts
+++ b/apps/spruce/src/constants/requesters.ts
@@ -10,11 +10,15 @@ enum Requester {
   Trigger = "trigger_request",
 }
 
+const commitRequesters = [
+  Requester.AdHoc,
+  Requester.GitTag,
+  Requester.Gitter,
+  Requester.Trigger,
+];
+
 export const isMainlineRequester = (requester: Requester) =>
-  requester === Requester.AdHoc ||
-  requester === Requester.GitTag ||
-  requester === Requester.Gitter ||
-  requester === Requester.Trigger;
+  commitRequesters.includes(requester);
 
 const requesterToTitle: PartialRecord<Requester, string> = {
   [Requester.AdHoc]: "Periodic build",
@@ -31,4 +35,9 @@ const requesterToDescription: PartialRecord<Requester, string> = {
   [Requester.Trigger]: "Downstream trigger versions",
 };
 
-export { Requester, requesterToTitle, requesterToDescription };
+export {
+  Requester,
+  requesterToTitle,
+  requesterToDescription,
+  commitRequesters,
+};

--- a/apps/spruce/src/constants/requesters.ts
+++ b/apps/spruce/src/constants/requesters.ts
@@ -10,6 +10,12 @@ enum Requester {
   Trigger = "trigger_request",
 }
 
+export const isMainlineRequester = (requester: Requester) =>
+  requester === Requester.AdHoc ||
+  requester === Requester.GitTag ||
+  requester === Requester.Gitter ||
+  requester === Requester.Trigger;
+
 const requesterToTitle: PartialRecord<Requester, string> = {
   [Requester.AdHoc]: "Periodic build",
   [Requester.GitHubMergeQueue]: "GitHub merge request",

--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -1540,8 +1540,6 @@ export type Notifications = {
   __typename?: "Notifications";
   buildBreak?: Maybe<Scalars["String"]["output"]>;
   buildBreakId?: Maybe<Scalars["String"]["output"]>;
-  commitQueue?: Maybe<Scalars["String"]["output"]>;
-  commitQueueId?: Maybe<Scalars["String"]["output"]>;
   patchFinish?: Maybe<Scalars["String"]["output"]>;
   patchFinishId?: Maybe<Scalars["String"]["output"]>;
   patchFirstFailure?: Maybe<Scalars["String"]["output"]>;
@@ -1554,7 +1552,6 @@ export type Notifications = {
 
 export type NotificationsInput = {
   buildBreak?: InputMaybe<Scalars["String"]["input"]>;
-  commitQueue?: InputMaybe<Scalars["String"]["input"]>;
   patchFinish?: InputMaybe<Scalars["String"]["input"]>;
   patchFirstFailure?: InputMaybe<Scalars["String"]["input"]>;
   spawnHostExpiration?: InputMaybe<Scalars["String"]["input"]>;

--- a/apps/spruce/src/pages/task/TaskTabs.tsx
+++ b/apps/spruce/src/pages/task/TaskTabs.tsx
@@ -5,6 +5,8 @@ import { useTaskAnalytics } from "analytics";
 import { TrendChartsPlugin } from "components/PerfPlugin";
 import { StyledTabs } from "components/styles/StyledTabs";
 import { TabLabelWithBadge } from "components/TabLabelWithBadge";
+import { showTaskHistoryTab } from "constants/featureFlags";
+import { isMainlineRequester, Requester } from "constants/requesters";
 import { getTaskRoute, GetTaskRouteOptions, slugs } from "constants/routes";
 import { TaskQuery } from "gql/generated/types";
 import { usePrevious } from "hooks";
@@ -16,6 +18,7 @@ import { useBuildBaronVariables } from "./taskTabs/buildBaronAndAnnotations";
 import { ExecutionTasksTable } from "./taskTabs/ExecutionTasksTable";
 import FileTable from "./taskTabs/FileTable";
 import { Logs } from "./taskTabs/Logs";
+import TaskHistory from "./taskTabs/TaskHistory";
 import { TestsTable } from "./taskTabs/TestsTable";
 
 const { parseQueryString } = queryString;
@@ -40,6 +43,7 @@ export const TaskTabs: React.FC<TaskTabProps> = ({ isDisplayTask, task }) => {
     id,
     isPerfPluginEnabled,
     logs: logLinks,
+    requester,
     totalTestCount,
     versionMetadata,
   } = task ?? {};
@@ -154,6 +158,16 @@ export const TaskTabs: React.FC<TaskTabProps> = ({ isDisplayTask, task }) => {
         <TrendChartsPlugin taskId={id} />
       </Tab>
     ),
+    [TaskTab.History]: (
+      <Tab
+        key="task-history-tab"
+        data-cy="task-history-tab"
+        name="Task History"
+      >
+        {/* @ts-expect-error: FIXME. This comment was added by an automated script. */}
+        <TaskHistory execution={execution} taskId={id} />
+      </Tab>
+    ),
   };
 
   const tabIsActive = {
@@ -163,6 +177,8 @@ export const TaskTabs: React.FC<TaskTabProps> = ({ isDisplayTask, task }) => {
     [TaskTab.Files]: true,
     [TaskTab.Annotations]: showBuildBaron,
     [TaskTab.TrendCharts]: isPerfPluginEnabled,
+    [TaskTab.History]:
+      showTaskHistoryTab && isMainlineRequester(requester as Requester),
   };
 
   const activeTabs = Object.keys(tabMap).filter(

--- a/apps/spruce/src/pages/task/TaskTabs.tsx
+++ b/apps/spruce/src/pages/task/TaskTabs.tsx
@@ -162,7 +162,13 @@ export const TaskTabs: React.FC<TaskTabProps> = ({ isDisplayTask, task }) => {
       <Tab
         key="task-history-tab"
         data-cy="task-history-tab"
-        name="Task History"
+        name={
+          <TabLabelWithBadge
+            badgeText="Beta"
+            badgeVariant="blue"
+            tabLabel="Task History"
+          />
+        }
       >
         {/* @ts-expect-error: FIXME. This comment was added by an automated script. */}
         <TaskHistory execution={execution} taskId={id} />

--- a/apps/spruce/src/pages/task/taskTabs/TaskHistory/index.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/TaskHistory/index.tsx
@@ -1,0 +1,12 @@
+interface TaskHistoryProps {
+  taskId: string;
+  execution: number;
+}
+
+const TaskHistory: React.FC<TaskHistoryProps> = ({ execution, taskId }) => (
+  <div data-cy="task-history">
+    This is the history for task {taskId} and execution {execution}
+  </div>
+);
+
+export default TaskHistory;

--- a/apps/spruce/src/pages/waterfall/RequesterFilter/index.tsx
+++ b/apps/spruce/src/pages/waterfall/RequesterFilter/index.tsx
@@ -2,16 +2,9 @@ import { useTransition } from "react";
 import { Combobox, ComboboxOption } from "@leafygreen-ui/combobox";
 import { zIndex } from "@evg-ui/lib/constants/tokens";
 import { useWaterfallAnalytics } from "analytics";
-import { Requester, requesterToTitle } from "constants/requesters";
+import { requesterToTitle, commitRequesters } from "constants/requesters";
 import { useQueryParam } from "hooks/useQueryParam";
 import { WaterfallFilterOptions } from "../types";
-
-const commitRequesters = [
-  Requester.AdHoc,
-  Requester.GitTag,
-  Requester.Gitter,
-  Requester.Trigger,
-];
 
 export const RequesterFilter = () => {
   const { sendEvent } = useWaterfallAnalytics();

--- a/apps/spruce/src/pages/waterfall/RequesterFilter/index.tsx
+++ b/apps/spruce/src/pages/waterfall/RequesterFilter/index.tsx
@@ -2,7 +2,7 @@ import { useTransition } from "react";
 import { Combobox, ComboboxOption } from "@leafygreen-ui/combobox";
 import { zIndex } from "@evg-ui/lib/constants/tokens";
 import { useWaterfallAnalytics } from "analytics";
-import { requesterToTitle, commitRequesters } from "constants/requesters";
+import { requesterToTitle, mainlineRequesters } from "constants/requesters";
 import { useQueryParam } from "hooks/useQueryParam";
 import { WaterfallFilterOptions } from "../types";
 
@@ -32,7 +32,7 @@ export const RequesterFilter = () => {
       popoverZIndex={zIndex.popover}
       value={requesters}
     >
-      {commitRequesters.map((requester) => (
+      {mainlineRequesters.map((requester) => (
         <ComboboxOption
           key={`${requester}-option`}
           data-cy={`${requester}-option`}

--- a/apps/spruce/src/types/task.ts
+++ b/apps/spruce/src/types/task.ts
@@ -51,6 +51,7 @@ export enum TaskTab {
   ExecutionTasks = "execution-tasks",
   Annotations = "annotations",
   TrendCharts = "trend-charts",
+  History = "history",
 }
 
 export enum LogTypes {


### PR DESCRIPTION
DEVPROD-15848
<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
Adds a tab for task history for mainline commits only.

### Screenshots
<img width="1439" alt="Screenshot 2025-03-20 at 11 47 04 AM" src="https://github.com/user-attachments/assets/05a2c550-9bf8-4c3d-a34c-306838368d64" />


<!-- add screenshots of visible changes -->

### Testing
- Added Cypress test