### PR TITLE
DEVPROD-12427: Add test to verify that filters with commas are parsed correctly

### DIFF
--- a/apps/parsley/cypress/integration/project_filters.ts
+++ b/apps/parsley/cypress/integration/project_filters.ts
@@ -31,6 +31,21 @@ describe("project filters", () => {
     cy.get("[data-cy^='skipped-lines-row-']").should("exist");
   });
 
+  it("properly processes filters with commas", () => {
+    cy.visit(resmokeLogLink);
+    cy.contains("View project filters").click();
+    cy.dataCy("project-filters-modal").should("be.visible");
+    cy.getInputByLabel('"Connection accepted","attr"').check({
+      force: true,
+    });
+    cy.contains("button", "Apply filters").click();
+    cy.location("search").should(
+      "contain",
+      "110%2522Connection%2520accepted%2522%252C%2522attr%2522",
+    );
+    cy.get("[data-cy^='skipped-lines-row-']").should("exist");
+  });
+
   it("should disable checkbox if filter is already applied", () => {
     cy.visit(`${resmokeLogLink}?filters=100D%255Cd`);
     cy.contains("View project filters").click();


### PR DESCRIPTION
DEVPROD-12427

### Description
This ticket was filed as a bug ticket, but it appears to be functioning correctly.

However, we don't have any tests to verify that it won't break in the future. I have added a test to ensure that this functionality will not break.

### Testing
* [Patch with module](https://spruce.mongodb.com/version/67db8e3101437b0007ccb9cd/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)

### Evergreen PR
* evergreen-ci/evergreen/pull/8852
