### PR TITLE
DEVPROD-16014 Fix scripts relying on vite config.

### DIFF
--- a/.evergreen/deploy.yml
+++ b/.evergreen/deploy.yml
@@ -26,7 +26,7 @@ functions:
           - REACT_APP_PARSLEY_SENTRY_DSN
           - REACT_APP_SPRUCE_SENTRY_DSN
           - REACT_APP_SPRUCE_URL
-          - REACT_APP_UI_URL
+          - REACT_APP_EVERGREEN_URL
           - REACT_APP_USER_KEY
           - SPRUCE_SENTRY_AUTH_TOKEN
         env:

--- a/apps/parsley/vite.config.ts
+++ b/apps/parsley/vite.config.ts
@@ -12,114 +12,119 @@ import path from "path";
 import { generateBaseHTTPSViteServerConfig } from "@evg-ui/vite-utils";
 import injectVariablesInHTML from "./config/injectVariablesInHTML";
 
-// Remove when https://github.com/cypress-io/cypress/issues/25397 is resolved.
-dns.setDefaultResultOrder("ipv4first");
+let finalConfig: Record<string, any> = {};
 
-const serverConfig = generateBaseHTTPSViteServerConfig({
-  port: 5173,
-  appURL: process.env.REACT_APP_PARSLEY_URL,
-  httpsPort: 8444,
-  useHTTPS: process.env.REACT_APP_RELEASE_STAGE !== "local",
-});
+// Only run this configuration if we are not in script mode
+if (process.env.VITE_SCRIPT_MODE !== "1") {
+  // Remove when https://github.com/cypress-io/cypress/issues/25397 is resolved.
+  dns.setDefaultResultOrder("ipv4first");
 
-// https://vitejs.dev/config/
-const viteConfig = defineConfig({
-  server: serverConfig,
-  build: {
-    rollupOptions: {
-      plugins: [],
+  const serverConfig = generateBaseHTTPSViteServerConfig({
+    port: 5173,
+    appURL: process.env.REACT_APP_PARSLEY_URL,
+    httpsPort: 8444,
+    useHTTPS: process.env.REACT_APP_RELEASE_STAGE !== "local",
+  });
+
+  // https://vitejs.dev/config/
+  const viteConfig = defineConfig({
+    server: serverConfig,
+    build: {
+      rollupOptions: {
+        plugins: [],
+      },
+      sourcemap: true,
     },
-    sourcemap: true,
-  },
 
-  plugins: [
-    tsconfigPaths(),
-    react({
-      babel: {
-        // @emotion/babel-plugin injects styled component names (e.g. "StyledSelect") into HTML for dev
-        // environments only. It can be toggled for production environments by modifying the parameter
-        // autoLabel. (https://emotion.sh/docs/@emotion/babel-plugin)
-        plugins: ["@emotion/babel-plugin", "import-graphql"],
-      },
-      // Exclude storybook stories from fast refresh.
-      exclude: /\.stories\.tsx?$/,
-      // Only Typescript files should use fast refresh.
-      include: ["**/*.tsx", "**/*.ts"],
+    plugins: [
+      tsconfigPaths(),
+      react({
+        babel: {
+          // @emotion/babel-plugin injects styled component names (e.g. "StyledSelect") into HTML for dev
+          // environments only. It can be toggled for production environments by modifying the parameter
+          // autoLabel. (https://emotion.sh/docs/@emotion/babel-plugin)
+          plugins: ["@emotion/babel-plugin", "import-graphql"],
+        },
+        // Exclude storybook stories from fast refresh.
+        exclude: /\.stories\.tsx?$/,
+        // Only Typescript files should use fast refresh.
+        include: ["**/*.tsx", "**/*.ts"],
 
-      // Enables use of css prop on JSX.
-      jsxImportSource: "@emotion/react",
-    }),
-    envCompatible({
-      prefix: "REACT_APP_",
-    }),
-    injectVariablesInHTML({
-      files: "dist/index.html",
-      variables: [
-        "%REACT_APP_VERSION%",
-        "%GIT_SHA%",
-        "%REACT_APP_RELEASE_STAGE%",
-        "%NODE_ENV%",
-        "%PROFILE_HEAD%",
-      ],
-    }),
-    // Typescript checking
-    checker({ typescript: true }),
-    // Bundle analyzer
-    visualizer({
-      filename: "dist/source_map.html",
-      template: "treemap",
-    }),
-    sentryVitePlugin({
-      authToken: process.env.PARSLEY_SENTRY_AUTH_TOKEN,
-      disable: process.env.NODE_ENV === "development",
-      org: "mongodb-org",
-      project: "parsley",
-      release: {
-        name: process.env.npm_package_version,
-      },
-      sourcemaps: {
-        assets: "dist/assets/*",
-      },
-    }),
-  ],
-
-  // Setting jsxImportSource to @emotion/react raises a warning in the console. This line silences
-  // the warning. (https://github.com/vitejs/vite/issues/8644)
-  esbuild: {
-    logOverride: { "this-is-undefined-in-esm": "silent" },
-  },
-
-  // The resolve field for @leafygreen-ui/emotion is to prevent LG from pulling in SSR dependencies.
-  // It can be potentially removed upon the completion of https://jira.mongodb.org/browse/PD-1543.
-  resolve: {
-    alias: {
-      "@leafygreen-ui/emotion": path.resolve(
-        __dirname,
-        "./config/leafygreen-ui/emotion.ts",
-      ),
-      ...(process.env.PROFILER === "true" && {
-        "react-dom/client": path.resolve(
-          __dirname,
-          "../../node_modules/react-dom/profiling",
-        ),
-        "scheduler/tracing": path.resolve(
-          __dirname,
-          "../../node_modules/scheduler/tracing-profiling",
-        ),
+        // Enables use of css prop on JSX.
+        jsxImportSource: "@emotion/react",
       }),
+      envCompatible({
+        prefix: "REACT_APP_",
+      }),
+      injectVariablesInHTML({
+        files: "dist/index.html",
+        variables: [
+          "%REACT_APP_VERSION%",
+          "%GIT_SHA%",
+          "%REACT_APP_RELEASE_STAGE%",
+          "%NODE_ENV%",
+          "%PROFILE_HEAD%",
+        ],
+      }),
+      // Typescript checking
+      checker({ typescript: true }),
+      // Bundle analyzer
+      visualizer({
+        filename: "dist/source_map.html",
+        template: "treemap",
+      }),
+      sentryVitePlugin({
+        authToken: process.env.PARSLEY_SENTRY_AUTH_TOKEN,
+        disable: process.env.NODE_ENV === "development",
+        org: "mongodb-org",
+        project: "parsley",
+        release: {
+          name: process.env.npm_package_version,
+        },
+        sourcemaps: {
+          assets: "dist/assets/*",
+        },
+      }),
+    ],
+
+    // Setting jsxImportSource to @emotion/react raises a warning in the console. This line silences
+    // the warning. (https://github.com/vitejs/vite/issues/8644)
+    esbuild: {
+      logOverride: { "this-is-undefined-in-esm": "silent" },
     },
-    extensions: [".mjs", ".js", ".ts", ".jsx", ".tsx", ".json"],
-  },
-});
 
-const vitestConfig = defineTestConfig({
-  test: {
-    environment: "jsdom",
-    globals: true,
-    outputFile: { junit: "./bin/vitest/junit.xml" },
-    reporters: ["default", ...(process.env.CI === "true" ? ["junit"] : [])],
-    setupFiles: "./config/vitest/setupTests.ts",
-  },
-});
+    // The resolve field for @leafygreen-ui/emotion is to prevent LG from pulling in SSR dependencies.
+    // It can be potentially removed upon the completion of https://jira.mongodb.org/browse/PD-1543.
+    resolve: {
+      alias: {
+        "@leafygreen-ui/emotion": path.resolve(
+          __dirname,
+          "./config/leafygreen-ui/emotion.ts",
+        ),
+        ...(process.env.PROFILER === "true" && {
+          "react-dom/client": path.resolve(
+            __dirname,
+            "../../node_modules/react-dom/profiling",
+          ),
+          "scheduler/tracing": path.resolve(
+            __dirname,
+            "../../node_modules/scheduler/tracing-profiling",
+          ),
+        }),
+      },
+      extensions: [".mjs", ".js", ".ts", ".jsx", ".tsx", ".json"],
+    },
+  });
 
-export default mergeConfig(viteConfig, vitestConfig);
+  const vitestConfig = defineTestConfig({
+    test: {
+      environment: "jsdom",
+      globals: true,
+      outputFile: { junit: "./bin/vitest/junit.xml" },
+      reporters: ["default", ...(process.env.CI === "true" ? ["junit"] : [])],
+      setupFiles: "./config/vitest/setupTests.ts",
+    },
+  });
+  finalConfig = mergeConfig(viteConfig, vitestConfig);
+}
+export default finalConfig;

--- a/apps/spruce/vite.config.ts
+++ b/apps/spruce/vite.config.ts
@@ -16,152 +16,159 @@ import path from "path";
 import { generateBaseHTTPSViteServerConfig } from "@evg-ui/vite-utils";
 import injectVariablesInHTML from "./config/injectVariablesInHTML";
 
-const require = createRequire(import.meta.url);
+let finalConfig: Record<string, any> = {};
 
-// Remove when https://github.com/cypress-io/cypress/issues/25397 is resolved.
-dns.setDefaultResultOrder("ipv4first");
+// Only run this configuration if we are not in script mode
+if (process.env.VITE_SCRIPT_MODE !== "1") {
+  const require = createRequire(import.meta.url);
 
-// Do not apply Antd's global styles
-fs.writeFileSync(require.resolve("antd/es/style/core/global.less"), "");
-fs.writeFileSync(require.resolve("antd/lib/style/core/global.less"), "");
+  // Remove when https://github.com/cypress-io/cypress/issues/25397 is resolved.
+  dns.setDefaultResultOrder("ipv4first");
 
-const serverConfig = generateBaseHTTPSViteServerConfig({
-  port: 3000,
-  appURL: process.env.REACT_APP_SPRUCE_URL,
-  httpsPort: 8443,
-  useHTTPS: process.env.REACT_APP_RELEASE_STAGE !== "local",
-});
+  // Do not apply Antd's global styles
+  fs.writeFileSync(require.resolve("antd/es/style/core/global.less"), "");
+  fs.writeFileSync(require.resolve("antd/lib/style/core/global.less"), "");
 
-// https://vitejs.dev/config/
-const viteConfig = defineConfig({
-  server: serverConfig,
-  optimizeDeps: {
-    esbuildOptions: {
-      // Node.js global to browser globalThis
-      define: {
-        global: "globalThis",
+  const serverConfig = generateBaseHTTPSViteServerConfig({
+    port: 3000,
+    appURL: process.env.REACT_APP_SPRUCE_URL,
+    httpsPort: 8443,
+    useHTTPS: process.env.REACT_APP_RELEASE_STAGE !== "local",
+  });
+
+  // https://vitejs.dev/config/
+  const viteConfig = defineConfig({
+    server: serverConfig,
+    optimizeDeps: {
+      esbuildOptions: {
+        // Node.js global to browser globalThis
+        define: {
+          global: "globalThis",
+        },
+        // Enable esbuild polyfill plugins
+        plugins: [esbuildCommonjs(["antd"])],
       },
-      // Enable esbuild polyfill plugins
-      plugins: [esbuildCommonjs(["antd"])],
     },
-  },
-  build: {
-    sourcemap: true,
-    rollupOptions: {
-      output: {
-        manualChunks: {
-          vendor: [
-            "react",
-            "react-router-dom",
-            "react-dom",
-            "react-router",
-            "lodash",
-            "antd",
-          ],
+    build: {
+      sourcemap: true,
+      rollupOptions: {
+        output: {
+          manualChunks: {
+            vendor: [
+              "react",
+              "react-router-dom",
+              "react-dom",
+              "react-router",
+              "lodash",
+              "antd",
+            ],
+          },
         },
       },
     },
-  },
-  resolve: {
-    alias: {
-      "@leafygreen-ui/emotion": path.resolve(
-        __dirname,
-        "./config/leafygreen-ui/emotion",
-      ),
-      ...(process.env.PROFILER === "true" && {
-        "react-dom/client": path.resolve(
+    resolve: {
+      alias: {
+        "@leafygreen-ui/emotion": path.resolve(
           __dirname,
-          "../../node_modules/react-dom/profiling",
+          "./config/leafygreen-ui/emotion",
         ),
-        "scheduler/tracing": path.resolve(
-          __dirname,
-          "../../node_modules/scheduler/tracing-profiling",
-        ),
+        ...(process.env.PROFILER === "true" && {
+          "react-dom/client": path.resolve(
+            __dirname,
+            "../../node_modules/react-dom/profiling",
+          ),
+          "scheduler/tracing": path.resolve(
+            __dirname,
+            "../../node_modules/scheduler/tracing-profiling",
+          ),
+        }),
+      },
+      extensions: [".mjs", ".js", ".ts", ".jsx", ".tsx", ".json"],
+    },
+    plugins: [
+      tsconfigPaths(),
+      // Inject env variables
+      envCompatible({
+        prefix: "REACT_APP_",
       }),
-    },
-    extensions: [".mjs", ".js", ".ts", ".jsx", ".tsx", ".json"],
-  },
-  plugins: [
-    tsconfigPaths(),
-    // Inject env variables
-    envCompatible({
-      prefix: "REACT_APP_",
-    }),
-    // Use emotion jsx tag instead of React.JSX
-    react({
-      jsxImportSource: "@emotion/react",
-      babel: {
-        plugins: ["@emotion/babel-plugin", "import-graphql"],
-      },
-      // exclude storybook stories
-      exclude: [/\.stories\.tsx?$/],
-    }),
-    // Replace the variables in our HTML files.
-    injectVariablesInHTML({
-      files: "dist/index.html",
-      variables: [
-        "%REACT_APP_VERSION%",
-        "%GIT_SHA%",
-        "%REACT_APP_RELEASE_STAGE%",
-        "%NODE_ENV%",
-        "%PROFILE_HEAD%",
-      ],
-    }),
-    // Dynamic imports of antd styles
-    vitePluginImp({
-      optimize: true,
-      libList: [
-        {
-          libName: "antd",
-          libDirectory: "es",
-          style: (name) => `antd/es/${name}/style/index.js`,
+      // Use emotion jsx tag instead of React.JSX
+      react({
+        jsxImportSource: "@emotion/react",
+        babel: {
+          plugins: ["@emotion/babel-plugin", "import-graphql"],
         },
-        {
-          libName: "lodash",
-          libDirectory: "",
-          camel2DashComponentName: false,
-          style: (name) => `lodash/${name}`,
+        // exclude storybook stories
+        exclude: [/\.stories\.tsx?$/],
+      }),
+      // Replace the variables in our HTML files.
+      injectVariablesInHTML({
+        files: "dist/index.html",
+        variables: [
+          "%REACT_APP_VERSION%",
+          "%GIT_SHA%",
+          "%REACT_APP_RELEASE_STAGE%",
+          "%NODE_ENV%",
+          "%PROFILE_HEAD%",
+        ],
+      }),
+      // Dynamic imports of antd styles
+      vitePluginImp({
+        optimize: true,
+        libList: [
+          {
+            libName: "antd",
+            libDirectory: "es",
+            style: (name) => `antd/es/${name}/style/index.js`,
+          },
+          {
+            libName: "lodash",
+            libDirectory: "",
+            camel2DashComponentName: false,
+            style: (name) => `lodash/${name}`,
+          },
+        ],
+      }),
+      // Typescript checking
+      checker({ typescript: true }),
+      // Bundle analyzer
+      visualizer({
+        filename: "dist/source_map.html",
+        template: "treemap",
+      }),
+      sentryVitePlugin({
+        org: "mongodb-org",
+        project: "spruce",
+        disable: process.env.NODE_ENV === "development",
+        authToken: process.env.SPRUCE_SENTRY_AUTH_TOKEN,
+        release: {
+          name: process.env.npm_package_version,
         },
-      ],
-    }),
-    // Typescript checking
-    checker({ typescript: true }),
-    // Bundle analyzer
-    visualizer({
-      filename: "dist/source_map.html",
-      template: "treemap",
-    }),
-    sentryVitePlugin({
-      org: "mongodb-org",
-      project: "spruce",
-      disable: process.env.NODE_ENV === "development",
-      authToken: process.env.SPRUCE_SENTRY_AUTH_TOKEN,
-      release: {
-        name: process.env.npm_package_version,
-      },
-      sourcemaps: {
-        assets: "dist/assets/*",
-      },
-    }),
-  ],
-  css: {
-    preprocessorOptions: {
-      less: {
-        javascriptEnabled: true, // enable LESS {@import ...}
+        sourcemaps: {
+          assets: "dist/assets/*",
+        },
+      }),
+    ],
+    css: {
+      preprocessorOptions: {
+        less: {
+          javascriptEnabled: true, // enable LESS {@import ...}
+        },
       },
     },
-  },
-});
+  });
 
-const vitestConfig = defineTestConfig({
-  test: {
-    environment: "jsdom",
-    globals: true,
-    globalSetup: "./config/vitest/global-setup.ts",
-    outputFile: { junit: "./bin/vitest/junit.xml" },
-    reporters: ["default", ...(process.env.CI === "true" ? ["junit"] : [])],
-    setupFiles: "./config/vitest/setupTests.ts",
-  },
-});
+  const vitestConfig = defineTestConfig({
+    test: {
+      environment: "jsdom",
+      globals: true,
+      globalSetup: "./config/vitest/global-setup.ts",
+      outputFile: { junit: "./bin/vitest/junit.xml" },
+      reporters: ["default", ...(process.env.CI === "true" ? ["junit"] : [])],
+      setupFiles: "./config/vitest/setupTests.ts",
+    },
+  });
 
-export default mergeConfig(viteConfig, vitestConfig);
+  finalConfig = mergeConfig(viteConfig, vitestConfig);
+}
+
+export default finalConfig;

--- a/packages/deploy-utils/src/build-and-push/script.ts
+++ b/packages/deploy-utils/src/build-and-push/script.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S vite-node --script
+#!/usr/bin/env -S VITE_SCRIPT_MODE=1 vite-node --script
 
 import { isTargetEnvironment } from "../utils/types";
 import { buildAndPush } from ".";

--- a/packages/deploy-utils/src/deploy.ts
+++ b/packages/deploy-utils/src/deploy.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S vite-node --script
+#!/usr/bin/env -S VITE_SCRIPT_MODE=1 vite-node --script
 
 import { buildAndPush } from "./build-and-push";
 import { prepareProdDeploy } from "./prepare-prod-deploy";

--- a/packages/deploy-utils/src/email/script.ts
+++ b/packages/deploy-utils/src/email/script.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S vite-node --script
+#!/usr/bin/env -S VITE_SCRIPT_MODE=1 vite-node --script
 
 import { sendEmail } from ".";
 

--- a/packages/deploy-utils/src/postversion/script.ts
+++ b/packages/deploy-utils/src/postversion/script.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S vite-node --script
+#!/usr/bin/env -S VITE_SCRIPT_MODE=1 vite-node --script
 
 import { push, pushTags } from "../utils/git";
 import { countdownTimer } from "../utils/shell";

--- a/packages/deploy-utils/src/write-previous-deploy/script.ts
+++ b/packages/deploy-utils/src/write-previous-deploy/script.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S vite-node --script
+#!/usr/bin/env -S VITE_SCRIPT_MODE=1 vite-node --script
 
 import { existsSync, mkdirSync, writeFileSync } from "fs";
 import { getAppToDeploy } from "../utils/environment";


### PR DESCRIPTION
DEVPROD-16014
<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
After merging #642, UI deploys began to fail. Upon investigation, I discovered that the deploy process itself wasn’t broken — [the issue stemmed from the scripts being run during the deploy.](https://parsley.mongodb.com/evergreen/evergreen_ui_spruce_deploy_spruce_prod__spruce_v5.0.1_25_03_21_15_40_28/0/task?bookmarks=0%2C230&selectedLineRange=L136&shareLine=136)
These [scripts](https://github.com/evergreen-ci/ui/blob/9f8705ff08a993962b905fc9fc0fabe0153bd902/packages/deploy-utils/src/write-previous-deploy/script.ts#L1) are written in TypeScript and executed using vite-node as standalone shell scripts. They rely on vite.config.ts from each project to resolve dependencies and settings.
#642 introduced changes that depend on certain environment configurations at runtime. Since the deploy scripts are meant to be self-contained and don’t require the full Vite project config, they began to break due to the now-required env setup in `vite.config.ts`.
This PR introduces a dedicated environment variable that is used to conditionally bypass Vite config logic when running scripts. This allows the scripts to run in isolation without depending on the broader project environment or config, preventing failures during deployment.

### Testing 
Any scripts in deploy-utils are now runnable manually and would fail if ran without these changes