### PR TITLE
DEVPROD-16157 Add reason field to log download analytics for better error tracking

### DIFF
--- a/apps/parsley/src/analytics/loadingPage/useLogDownloadAnalytics.ts
+++ b/apps/parsley/src/analytics/loadingPage/useLogDownloadAnalytics.ts
@@ -14,6 +14,7 @@ type Action =
       duration: number;
       "log.type": LogTypes;
       "log.size": number;
+      reason: string;
     }
   | {
       name: "System Event log download incomplete";

--- a/apps/parsley/src/gql/generated/types.ts
+++ b/apps/parsley/src/gql/generated/types.ts
@@ -2129,6 +2129,7 @@ export enum ProjectSettingsSection {
 
 export type ProjectTasksPair = {
   __typename?: "ProjectTasksPair";
+  allowedBVs: Array<Scalars["String"]["output"]>;
   allowedTasks: Array<Scalars["String"]["output"]>;
   projectId: Scalars["String"]["output"];
 };

--- a/apps/parsley/src/hooks/useLogDownloader/index.ts
+++ b/apps/parsley/src/hooks/useLogDownloader/index.ts
@@ -125,6 +125,7 @@ const useLogDownloader = ({
             "log.size": getFileSize(),
             "log.type": logType,
             name: "System Event log download failed",
+            reason: err.message,
           });
         })
         .finally(() => {


### PR DESCRIPTION
DEVPROD-16157
<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
While looking at our analytics, I noticed we weren't logging the reason for failed downloads.

