### PR TITLE
DEVPROD-15374 Add logic to refresh on old bundle errors

### DIFF
--- a/apps/parsley/src/App.tsx
+++ b/apps/parsley/src/App.tsx
@@ -33,25 +33,27 @@ const router = createBrowserRouter([
       },
     ],
     element: (
-      <AuthProvider
-        evergreenAppURL={evergreenURL || ""}
-        localAuthRoute={routes.login}
-        remoteAuthURL={`${evergreenURL}/login`}
-        shouldUseLocalAuth={isLocal()}
-      >
-        <Outlet />
-      </AuthProvider>
+      <ErrorBoundary homeURL={parsleyURL || ""}>
+        <AuthProvider
+          evergreenAppURL={evergreenURL || ""}
+          localAuthRoute={routes.login}
+          remoteAuthURL={`${evergreenURL}/login`}
+          shouldUseLocalAuth={isLocal()}
+        >
+          <Outlet />
+        </AuthProvider>
+      </ErrorBoundary>
     ),
   },
 ]);
 
 const App = () => (
-  <ErrorBoundary homeURL={parsleyURL || ""}>
+  <>
     <GlobalStyles />
     <AppWrapper>
       <RouterProvider router={router} />
     </AppWrapper>
-  </ErrorBoundary>
+  </>
 );
 
 const AppWrapper = styled.div`

--- a/apps/parsley/src/gql/generated/types.ts
+++ b/apps/parsley/src/gql/generated/types.ts
@@ -312,6 +312,12 @@ export type CreateProjectInput = {
   repoRefId?: InputMaybe<Scalars["String"]["input"]>;
 };
 
+export type CursorParams = {
+  cursorId: Scalars["String"]["input"];
+  direction: TaskHistoryDirection;
+  includeCursor: Scalars["Boolean"]["input"];
+};
+
 /** DeactivateStepbackTaskInput is the input to the deactivateStepbackTask mutation. */
 export type DeactivateStepbackTaskInput = {
   buildVariantName: Scalars["String"]["input"];
@@ -2211,6 +2217,7 @@ export type Query = {
   subnetAvailabilityZones: Array<Scalars["String"]["output"]>;
   task?: Maybe<Task>;
   taskAllExecutions: Array<Task>;
+  taskHistory: TaskHistory;
   taskNamesForBuildVariant?: Maybe<Array<Scalars["String"]["output"]>>;
   taskQueueDistros: Array<TaskQueueDistro>;
   taskTestSample?: Maybe<Array<TaskTestResultSample>>;
@@ -2338,6 +2345,10 @@ export type QueryTaskArgs = {
 
 export type QueryTaskAllExecutionsArgs = {
   taskId: Scalars["String"]["input"];
+};
+
+export type QueryTaskHistoryArgs = {
+  options: TaskHistoryOpts;
 };
 
 export type QueryTaskNamesForBuildVariantArgs = {
@@ -2933,6 +2944,32 @@ export type TaskFilterOptions = {
   statuses?: InputMaybe<Array<Scalars["String"]["input"]>>;
   taskName?: InputMaybe<Scalars["String"]["input"]>;
   variant?: InputMaybe<Scalars["String"]["input"]>;
+};
+
+export type TaskHistory = {
+  __typename?: "TaskHistory";
+  pagination: TaskHistoryPagination;
+  tasks: Array<Task>;
+};
+
+export enum TaskHistoryDirection {
+  After = "AFTER",
+  Before = "BEFORE",
+}
+
+export type TaskHistoryOpts = {
+  buildVariant: Scalars["String"]["input"];
+  cursorParams: CursorParams;
+  date?: InputMaybe<Scalars["Time"]["input"]>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  projectIdentifier: Scalars["String"]["input"];
+  taskName: Scalars["String"]["input"];
+};
+
+export type TaskHistoryPagination = {
+  __typename?: "TaskHistoryPagination";
+  mostRecentTaskOrder: Scalars["Int"]["output"];
+  oldestTaskOrder: Scalars["Int"]["output"];
 };
 
 export type TaskInfo = {

--- a/apps/spruce/src/App.tsx
+++ b/apps/spruce/src/App.tsx
@@ -17,14 +17,16 @@ import {
 const router = createBrowserRouter([
   {
     element: (
-      <AuthProvider
-        evergreenAppURL={getEvergreenUrl()}
-        localAuthRoute={routes.login}
-        remoteAuthURL={`${getEvergreenUrl()}/login`}
-        shouldUseLocalAuth={isLocal()}
-      >
-        <Outlet />
-      </AuthProvider>
+      <ErrorBoundary homeURL={getSpruceURL() || ""}>
+        <AuthProvider
+          evergreenAppURL={getEvergreenUrl()}
+          localAuthRoute={routes.login}
+          remoteAuthURL={`${getEvergreenUrl()}/login`}
+          shouldUseLocalAuth={isLocal()}
+        >
+          <Outlet />
+        </AuthProvider>
+      </ErrorBoundary>
     ),
     children: [
       ...(isLocal()
@@ -50,10 +52,10 @@ const router = createBrowserRouter([
 ]);
 
 const App: React.FC = () => (
-  <ErrorBoundary homeURL={getSpruceURL() || ""}>
+  <>
     <GlobalStyles />
     <RouterProvider router={router} />
-  </ErrorBoundary>
+  </>
 );
 
 export default App;

--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -312,6 +312,12 @@ export type CreateProjectInput = {
   repoRefId?: InputMaybe<Scalars["String"]["input"]>;
 };
 
+export type CursorParams = {
+  cursorId: Scalars["String"]["input"];
+  direction: TaskHistoryDirection;
+  includeCursor: Scalars["Boolean"]["input"];
+};
+
 /** DeactivateStepbackTaskInput is the input to the deactivateStepbackTask mutation. */
 export type DeactivateStepbackTaskInput = {
   buildVariantName: Scalars["String"]["input"];
@@ -2129,6 +2135,7 @@ export enum ProjectSettingsSection {
 
 export type ProjectTasksPair = {
   __typename?: "ProjectTasksPair";
+  allowedBVs: Array<Scalars["String"]["output"]>;
   allowedTasks: Array<Scalars["String"]["output"]>;
   projectId: Scalars["String"]["output"];
 };
@@ -2210,6 +2217,7 @@ export type Query = {
   subnetAvailabilityZones: Array<Scalars["String"]["output"]>;
   task?: Maybe<Task>;
   taskAllExecutions: Array<Task>;
+  taskHistory: TaskHistory;
   taskNamesForBuildVariant?: Maybe<Array<Scalars["String"]["output"]>>;
   taskQueueDistros: Array<TaskQueueDistro>;
   taskTestSample?: Maybe<Array<TaskTestResultSample>>;
@@ -2337,6 +2345,10 @@ export type QueryTaskArgs = {
 
 export type QueryTaskAllExecutionsArgs = {
   taskId: Scalars["String"]["input"];
+};
+
+export type QueryTaskHistoryArgs = {
+  options: TaskHistoryOpts;
 };
 
 export type QueryTaskNamesForBuildVariantArgs = {
@@ -2932,6 +2944,32 @@ export type TaskFilterOptions = {
   statuses?: InputMaybe<Array<Scalars["String"]["input"]>>;
   taskName?: InputMaybe<Scalars["String"]["input"]>;
   variant?: InputMaybe<Scalars["String"]["input"]>;
+};
+
+export type TaskHistory = {
+  __typename?: "TaskHistory";
+  pagination: TaskHistoryPagination;
+  tasks: Array<Task>;
+};
+
+export enum TaskHistoryDirection {
+  After = "AFTER",
+  Before = "BEFORE",
+}
+
+export type TaskHistoryOpts = {
+  buildVariant: Scalars["String"]["input"];
+  cursorParams: CursorParams;
+  date?: InputMaybe<Scalars["Time"]["input"]>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  projectIdentifier: Scalars["String"]["input"];
+  taskName: Scalars["String"]["input"];
+};
+
+export type TaskHistoryPagination = {
+  __typename?: "TaskHistoryPagination";
+  mostRecentTaskOrder: Scalars["Int"]["output"];
+  oldestTaskOrder: Scalars["Int"]["output"];
 };
 
 export type TaskInfo = {

--- a/packages/lib/src/components/ErrorBoundary/ErrorBoundary.test.tsx
+++ b/packages/lib/src/components/ErrorBoundary/ErrorBoundary.test.tsx
@@ -1,6 +1,7 @@
 import { isInitialized } from "@sentry/core";
 import { Mock } from "vitest";
 import { render, screen } from "test_utils";
+import { dynamicallyLoadedModuleErrorMessage } from "./utils";
 import ErrorBoundary from ".";
 
 vi.mock("@sentry/react", async (importOriginal) => {
@@ -99,7 +100,7 @@ describe("Error boundary", () => {
       expect(screen.getByDataCy("error-fallback")).toBeInTheDocument();
     });
     it("should refresh the page when an old bundle error occurs", () => {
-      const err = new Error("error loading dynamically imported module");
+      const err = new Error(dynamicallyLoadedModuleErrorMessage);
 
       vi.spyOn(window.location, "reload").mockImplementation(() => {});
 

--- a/packages/lib/src/components/ErrorBoundary/ErrorBoundary.test.tsx
+++ b/packages/lib/src/components/ErrorBoundary/ErrorBoundary.test.tsx
@@ -1,4 +1,5 @@
-import { captureException } from "@sentry/react";
+import { isInitialized } from "@sentry/core";
+import { Mock } from "vitest";
 import { render, screen } from "test_utils";
 import ErrorBoundary from ".";
 
@@ -10,46 +11,110 @@ vi.mock("@sentry/react", async (importOriginal) => {
     captureException: vi.fn(),
   };
 });
-
-describe("default error boundary", () => {
-  beforeEach(() => {
-    vi.spyOn(console, "error").mockImplementation(() => {});
-  });
-
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
-
-  it("should render the passed in component", () => {
-    const TestComponent = () => <div>Hello</div>;
-    const TestErrorBoundary = () => (
-      <ErrorBoundary homeURL="/">
-        <TestComponent />
-      </ErrorBoundary>
-    );
-    render(<TestErrorBoundary />);
-    expect(screen.getByText("Hello")).toBeInTheDocument();
-  });
-
-  it("should display the fallback when an error occurs", () => {
-    const err = new Error("Test error");
-
-    const TestComponent = () => {
-      throw err;
-    };
-    const TestErrorBoundary = () => (
-      <ErrorBoundary homeURL="/">
-        <TestComponent />
-      </ErrorBoundary>
-    );
-    render(<TestErrorBoundary />);
-    expect(screen.getByText("Error")).toBeInTheDocument();
-    expect(console.error).toHaveBeenCalledWith({
-      error: err,
-      errorInfo: expect.objectContaining({
-        componentStack: expect.any(String),
-      }),
+vi.mock("@sentry/core", () => ({
+  isInitialized: vi.fn(),
+}));
+describe("Error boundary", () => {
+  describe("When sentry is not initialized", () => {
+    beforeEach(() => {
+      vi.spyOn(console, "error").mockImplementation(() => {});
     });
-    expect(vi.mocked(captureException)).not.toHaveBeenCalled();
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+    it("should render the passed in component", () => {
+      const TestComponent = () => <div>Hello</div>;
+      const TestErrorBoundary = () => (
+        <ErrorBoundary homeURL="/">
+          <TestComponent />
+        </ErrorBoundary>
+      );
+      render(<TestErrorBoundary />);
+      expect(screen.getByText("Hello")).toBeInTheDocument();
+    });
+
+    it("should display the fallback when an error occurs", () => {
+      const err = new Error("Test error");
+
+      const TestComponent = () => {
+        throw err;
+      };
+      const TestErrorBoundary = () => (
+        <ErrorBoundary homeURL="/">
+          <TestComponent />
+        </ErrorBoundary>
+      );
+      render(<TestErrorBoundary />);
+      expect(screen.getByText("Error")).toBeInTheDocument();
+      expect(console.error).toHaveBeenCalledWith({
+        error: err,
+        errorInfo: expect.objectContaining({
+          componentStack: expect.any(String),
+        }),
+      });
+      expect(screen.getByDataCy("error-fallback")).toBeInTheDocument();
+    });
+  });
+  describe("When sentry is initialized", () => {
+    beforeEach(() => {
+      (isInitialized as unknown as Mock).mockReturnValue(true);
+      vi.spyOn(console, "error").mockImplementation(() => {});
+      Object.defineProperty(window, "location", {
+        value: {
+          ...window.location,
+          reload: vi.fn(),
+        },
+        writable: true,
+      });
+    });
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+    it("should render the passed in component", () => {
+      const TestComponent = () => <div>Hello</div>;
+      const TestErrorBoundary = () => (
+        <ErrorBoundary homeURL="/">
+          <TestComponent />
+        </ErrorBoundary>
+      );
+      render(<TestErrorBoundary />);
+      expect(screen.getByText("Hello")).toBeInTheDocument();
+    });
+
+    it("should display the fallback when a regular error occurs", () => {
+      const err = new Error("Test error");
+
+      const TestComponent = () => {
+        throw err;
+      };
+      const TestErrorBoundary = () => (
+        <ErrorBoundary homeURL="/">
+          <TestComponent />
+        </ErrorBoundary>
+      );
+      render(<TestErrorBoundary />);
+      expect(screen.getByText("Error")).toBeInTheDocument();
+
+      expect(screen.getByDataCy("error-fallback")).toBeInTheDocument();
+    });
+    it("should refresh the page when an old bundle error occurs", () => {
+      const err = new Error("error loading dynamically imported module");
+
+      vi.spyOn(window.location, "reload").mockImplementation(() => {});
+
+      const TestComponent = () => {
+        throw err;
+      };
+      const TestErrorBoundary = () => (
+        <ErrorBoundary homeURL="/">
+          <TestComponent />
+        </ErrorBoundary>
+      );
+      render(<TestErrorBoundary />);
+      expect(screen.getByText("Error")).toBeInTheDocument();
+      expect(screen.getByDataCy("error-fallback")).toBeInTheDocument();
+      expect(window.location.reload).toHaveBeenCalled();
+    });
   });
 });

--- a/packages/lib/src/components/ErrorBoundary/ErrorFallback/ErrorFallback.tsx
+++ b/packages/lib/src/components/ErrorBoundary/ErrorFallback/ErrorFallback.tsx
@@ -11,7 +11,7 @@ interface ErrorFallbackProps {
   homeURL: string;
 }
 const ErrorFallback: React.FC<ErrorFallbackProps> = ({ homeURL }) => (
-  <Center>
+  <Center data-cy="error-fallback">
     <Text>
       <StyledHeader>Error</StyledHeader>
       <StyledSubtitle>

--- a/packages/lib/src/components/ErrorBoundary/ErrorFallback/__snapshots__/ErrorFallback_DefaultError.storyshot
+++ b/packages/lib/src/components/ErrorBoundary/ErrorFallback/__snapshots__/ErrorFallback_DefaultError.storyshot
@@ -4,6 +4,7 @@
   >
     <div
       class="css-157odwz"
+      data-cy="error-fallback"
     >
       <div
         class="css-1xl0rym"

--- a/packages/lib/src/components/ErrorBoundary/SentryErrorBoundary.tsx
+++ b/packages/lib/src/components/ErrorBoundary/SentryErrorBoundary.tsx
@@ -1,7 +1,7 @@
 import { ErrorBoundary } from "@sentry/react";
 import { setScope } from "../../utils/sentry";
 import ErrorFallback from "./ErrorFallback/ErrorFallback";
-
+import { refreshOnOldBundleError } from "./utils";
 /**
  * DO NOT USE THIS COMPONENT DIRECTLY INSTEAD USE `ErrorBoundary`.
  *
@@ -21,6 +21,7 @@ const SentryErrorBoundary: React.FC<{
       setScope(scope);
     }}
     fallback={<ErrorFallback homeURL={homeURL} />}
+    onError={(error) => refreshOnOldBundleError(error as Error)}
   >
     {children}
   </ErrorBoundary>

--- a/packages/lib/src/components/ErrorBoundary/utils.ts
+++ b/packages/lib/src/components/ErrorBoundary/utils.ts
@@ -1,4 +1,7 @@
-import { leaveBreadcrumb, SentryBreadcrumbTypes } from "utils/errorReporting";
+import {
+  leaveBreadcrumb,
+  SentryBreadcrumbTypes,
+} from "../../utils/errorReporting";
 
 /**
  * `refreshOnOldBundleError` is a utility function that refreshes the page if the error is due to an old bundle.

--- a/packages/lib/src/components/ErrorBoundary/utils.ts
+++ b/packages/lib/src/components/ErrorBoundary/utils.ts
@@ -1,0 +1,12 @@
+/**
+ * `refreshOnOldBundleError` is a utility function that refreshes the page if the error is due to an old bundle.
+ * This is useful when the user has an old version of the application and the bundle has changed.
+ * @param error - The error object
+ */
+const refreshOnOldBundleError = (error: Error) => {
+  if (error.message.includes("error loading dynamically imported module")) {
+    window.location.reload();
+  }
+};
+
+export { refreshOnOldBundleError };

--- a/packages/lib/src/components/ErrorBoundary/utils.ts
+++ b/packages/lib/src/components/ErrorBoundary/utils.ts
@@ -9,7 +9,7 @@ import {
  * @param error - The error object
  */
 const refreshOnOldBundleError = (error: Error) => {
-  if (error.message.includes("error loading dynamically imported module")) {
+  if (error.message.includes(dynamicallyLoadedModuleErrorMessage)) {
     leaveBreadcrumb(
       "Encountered an error loading a dynamically imported module, refreshing.",
       { error },
@@ -19,4 +19,5 @@ const refreshOnOldBundleError = (error: Error) => {
   }
 };
 
-export { refreshOnOldBundleError };
+const dynamicallyLoadedModuleErrorMessage = "dynamically imported module";
+export { refreshOnOldBundleError, dynamicallyLoadedModuleErrorMessage };

--- a/packages/lib/src/components/ErrorBoundary/utils.ts
+++ b/packages/lib/src/components/ErrorBoundary/utils.ts
@@ -1,3 +1,5 @@
+import { leaveBreadcrumb, SentryBreadcrumbTypes } from "utils/errorReporting";
+
 /**
  * `refreshOnOldBundleError` is a utility function that refreshes the page if the error is due to an old bundle.
  * This is useful when the user has an old version of the application and the bundle has changed.
@@ -5,6 +7,11 @@
  */
 const refreshOnOldBundleError = (error: Error) => {
   if (error.message.includes("error loading dynamically imported module")) {
+    leaveBreadcrumb(
+      "Encountered an error loading a dynamically imported module, refreshing.",
+      { error },
+      SentryBreadcrumbTypes.Debug,
+    );
     window.location.reload();
   }
 };


### PR DESCRIPTION
DEVPROD-15374 
<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
Error boundary should now automatically refresh the page when a user encounters a bundle error.

