### PR TITLE
DEVPROD-16397: Add back GraphQL alphabetize rule

### DIFF
--- a/apps/parsley/src/gql/fragments/base-task.graphql
+++ b/apps/parsley/src/gql/fragments/base-task.graphql
@@ -1,8 +1,8 @@
 fragment BaseTask on Task {
+  id
   displayName
   displayStatus
   execution
-  id
   patchNumber
   versionMetadata {
     id

--- a/apps/parsley/src/gql/generated/types.ts
+++ b/apps/parsley/src/gql/generated/types.ts
@@ -3601,10 +3601,10 @@ export type WorkstationSetupCommandInput = {
 
 export type BaseTaskFragment = {
   __typename?: "Task";
+  id: string;
   displayName: string;
   displayStatus: string;
   execution: number;
-  id: string;
   patchNumber?: number | null;
   versionMetadata: {
     __typename?: "Version";
@@ -3644,10 +3644,10 @@ export type LogkeeperTaskQuery = {
     id: string;
     task: {
       __typename?: "Task";
+      id: string;
       displayName: string;
       displayStatus: string;
       execution: number;
-      id: string;
       patchNumber?: number | null;
       tests: {
         __typename?: "TaskTestResult";
@@ -3681,10 +3681,10 @@ export type TaskQuery = {
   __typename?: "Query";
   task?: {
     __typename?: "Task";
+    id: string;
     displayName: string;
     displayStatus: string;
     execution: number;
-    id: string;
     patchNumber?: number | null;
     details?: {
       __typename?: "TaskEndDetail";
@@ -3726,8 +3726,8 @@ export type TestLogUrlAndRenderingTypeQuery = {
       __typename?: "TaskTestResult";
       testResults: Array<{
         __typename?: "TestResult";
-        groupID?: string | null;
         id: string;
+        groupID?: string | null;
         status: string;
         testFile: string;
         logs: {
@@ -3800,8 +3800,8 @@ export type TaskFilesQuery = {
   __typename?: "Query";
   task?: {
     __typename?: "Task";
-    execution: number;
     id: string;
+    execution: number;
     files: {
       __typename?: "TaskFiles";
       groupedFiles: Array<{

--- a/apps/parsley/src/gql/queries/get-test-log-url-and-rendering-type.graphql
+++ b/apps/parsley/src/gql/queries/get-test-log-url-and-rendering-type.graphql
@@ -7,8 +7,8 @@ query TestLogURLAndRenderingType(
     id
     tests(opts: { testName: $testName, excludeDisplayNames: true }) {
       testResults {
-        groupID
         id
+        groupID
         logs {
           renderingType
           url

--- a/apps/parsley/src/gql/queries/task-files.graphql
+++ b/apps/parsley/src/gql/queries/task-files.graphql
@@ -1,5 +1,6 @@
 query TaskFiles($taskId: String!, $execution: Int) {
   task(taskId: $taskId, execution: $execution) {
+    id
     execution
     files {
       groupedFiles {
@@ -12,6 +13,5 @@ query TaskFiles($taskId: String!, $execution: Int) {
         taskName
       }
     }
-    id
   }
 }

--- a/apps/spruce/src/gql/fragments/annotation.graphql
+++ b/apps/spruce/src/gql/fragments/annotation.graphql
@@ -1,4 +1,5 @@
 fragment Annotation on Annotation {
+  id
   createdIssues {
     issueKey
     source {
@@ -8,7 +9,6 @@ fragment Annotation on Annotation {
     }
     url
   }
-  id
   issues {
     issueKey
     source {

--- a/apps/spruce/src/gql/fragments/baseHost.graphql
+++ b/apps/spruce/src/gql/fragments/baseHost.graphql
@@ -1,6 +1,6 @@
 fragment BaseHost on Host {
-  hostUrl
   id
+  hostUrl
   persistentDnsName
   provider
   startedBy

--- a/apps/spruce/src/gql/fragments/basePatch.graphql
+++ b/apps/spruce/src/gql/fragments/basePatch.graphql
@@ -1,9 +1,9 @@
 fragment BasePatch on Patch {
+  id
   activated
   alias
   author
   description
-  id
   parameters {
     key
     value

--- a/apps/spruce/src/gql/fragments/baseSpawnHost.graphql
+++ b/apps/spruce/src/gql/fragments/baseSpawnHost.graphql
@@ -1,8 +1,8 @@
 #import "./baseHost.graphql"
 
 fragment BaseSpawnHost on Host {
-  availabilityZone
   ...BaseHost
+  availabilityZone
   displayName
   distro {
     id
@@ -13,8 +13,8 @@ fragment BaseSpawnHost on Host {
   }
   expiration
   homeVolume {
-    displayName
     id
+    displayName
   }
   homeVolumeID
   instanceTags {
@@ -25,8 +25,8 @@ fragment BaseSpawnHost on Host {
   instanceType
   noExpiration
   volumes {
-    displayName
     id
+    displayName
     migrating
   }
 }

--- a/apps/spruce/src/gql/fragments/baseTask.graphql
+++ b/apps/spruce/src/gql/fragments/baseTask.graphql
@@ -1,9 +1,9 @@
 fragment BaseTask on Task {
+  id
   buildVariant
   buildVariantDisplayName
   displayName
   displayStatus
   execution
-  id
   revision
 }

--- a/apps/spruce/src/gql/fragments/patchesPage.graphql
+++ b/apps/spruce/src/gql/fragments/patchesPage.graphql
@@ -1,6 +1,7 @@
 fragment PatchesPagePatches on Patches {
   filteredPatchCount
   patches {
+    id
     activated
     alias
     author
@@ -8,7 +9,6 @@ fragment PatchesPagePatches on Patches {
     createTime
     description
     hidden
-    id
     projectIdentifier
     projectMetadata {
       id

--- a/apps/spruce/src/gql/fragments/projectSettings/access.graphql
+++ b/apps/spruce/src/gql/fragments/projectSettings/access.graphql
@@ -1,11 +1,11 @@
 fragment ProjectAccessSettings on Project {
-  admins
   id
+  admins
   restricted
 }
 
 fragment RepoAccessSettings on RepoRef {
-  admins
   id
+  admins
   restricted
 }

--- a/apps/spruce/src/gql/fragments/projectSettings/aliases.graphql
+++ b/apps/spruce/src/gql/fragments/projectSettings/aliases.graphql
@@ -1,8 +1,8 @@
 fragment Alias on ProjectAlias {
+  id
   alias
   description
   gitTag
-  id
   parameters {
     key
     value

--- a/apps/spruce/src/gql/fragments/projectSettings/appSettings.graphql
+++ b/apps/spruce/src/gql/fragments/projectSettings/appSettings.graphql
@@ -4,8 +4,8 @@ fragment ProjectAppSettings on ProjectSettings {
     privateKey
   }
   projectRef {
-    githubPermissionGroupByRequester
     id
+    githubPermissionGroupByRequester
   }
 }
 
@@ -15,8 +15,8 @@ fragment ProjectEventAppSettings on ProjectEventSettings {
     privateKey
   }
   projectRef {
-    githubPermissionGroupByRequester
     id
+    githubPermissionGroupByRequester
   }
 }
 
@@ -26,7 +26,7 @@ fragment RepoAppSettings on RepoSettings {
     privateKey
   }
   projectRef {
-    githubPermissionGroupByRequester
     id
+    githubPermissionGroupByRequester
   }
 }

--- a/apps/spruce/src/gql/fragments/projectSettings/containers.graphql
+++ b/apps/spruce/src/gql/fragments/projectSettings/containers.graphql
@@ -1,17 +1,17 @@
 fragment ProjectContainerSettings on Project {
+  id
   containerSizeDefinitions {
     cpu
     memoryMb
     name
   }
-  id
 }
 
 fragment RepoContainerSettings on RepoRef {
+  id
   containerSizeDefinitions {
     cpu
     memoryMb
     name
   }
-  id
 }

--- a/apps/spruce/src/gql/fragments/projectSettings/general.graphql
+++ b/apps/spruce/src/gql/fragments/projectSettings/general.graphql
@@ -1,4 +1,5 @@
 fragment ProjectGeneralSettings on Project {
+  id
   batchTime
   branch
   deactivatePrevious
@@ -6,7 +7,6 @@ fragment ProjectGeneralSettings on Project {
   dispatchingDisabled
   displayName
   enabled
-  id
   owner
   patchingDisabled
   remotePath
@@ -19,12 +19,12 @@ fragment ProjectGeneralSettings on Project {
 }
 
 fragment RepoGeneralSettings on RepoRef {
+  id
   batchTime
   deactivatePrevious
   disabledStatsCache
   dispatchingDisabled
   displayName
-  id
   owner
   patchingDisabled
   remotePath

--- a/apps/spruce/src/gql/fragments/projectSettings/githubCommitQueue.graphql
+++ b/apps/spruce/src/gql/fragments/projectSettings/githubCommitQueue.graphql
@@ -1,4 +1,5 @@
 fragment ProjectGithubSettings on Project {
+  id
   commitQueue {
     enabled
   }
@@ -7,13 +8,13 @@ fragment ProjectGithubSettings on Project {
   gitTagAuthorizedTeams
   gitTagAuthorizedUsers
   gitTagVersionsEnabled
-  id
   manualPrTestingEnabled
   oldestAllowedMergeBase
   prTestingEnabled
 }
 
 fragment RepoGithubSettings on RepoRef {
+  id
   commitQueue {
     enabled
   }
@@ -22,7 +23,6 @@ fragment RepoGithubSettings on RepoRef {
   gitTagAuthorizedTeams
   gitTagAuthorizedUsers
   gitTagVersionsEnabled
-  id
   manualPrTestingEnabled
   oldestAllowedMergeBase
   prTestingEnabled

--- a/apps/spruce/src/gql/fragments/projectSettings/index.graphql
+++ b/apps/spruce/src/gql/fragments/projectSettings/index.graphql
@@ -15,15 +15,13 @@
 #import "./appSettings.graphql"
 
 fragment ProjectSettingsFields on ProjectSettings {
-  aliases {
-    ...Alias
-  }
   ...ProjectAppSettings
   ...ProjectGithubCommitQueue
   ...ProjectPermissionGroupSettings
+  aliases {
+    ...Alias
+  }
   projectRef {
-    id
-    identifier
     ...ProjectAccessSettings
     ...ProjectContainerSettings
     ...ProjectGeneralSettings
@@ -33,7 +31,9 @@ fragment ProjectSettingsFields on ProjectSettings {
     ...ProjectPluginsSettings
     ...ProjectTriggersSettings
     ...ProjectViewsAndFiltersSettings
+    id
     ...ProjectVirtualWorkstationSettings
+    identifier
     repoRefId
   }
   subscriptions {
@@ -45,26 +45,26 @@ fragment ProjectSettingsFields on ProjectSettings {
 }
 
 fragment RepoSettingsFields on RepoSettings {
+  ...RepoAppSettings
+  ...RepoGithubCommitQueue
+  ...RepoPermissionGroupSettings
   aliases {
     ...Alias
   }
   projectRef {
-    displayName
-    id
     ...RepoAccessSettings
     ...RepoContainerSettings
     ...RepoGeneralSettings
     ...RepoNotificationSettings
     ...RepoPatchAliasSettings
+    id
     ...RepoPeriodicBuildsSettings
+    displayName
     ...RepoPluginsSettings
     ...RepoTriggersSettings
     ...RepoViewsAndFiltersSettings
     ...RepoVirtualWorkstationSettings
   }
-  ...RepoAppSettings
-  ...RepoGithubCommitQueue
-  ...RepoPermissionGroupSettings
   subscriptions {
     ...Subscriptions
   }

--- a/apps/spruce/src/gql/fragments/projectSettings/index.graphql
+++ b/apps/spruce/src/gql/fragments/projectSettings/index.graphql
@@ -31,8 +31,8 @@ fragment ProjectSettingsFields on ProjectSettings {
     ...ProjectPluginsSettings
     ...ProjectTriggersSettings
     ...ProjectViewsAndFiltersSettings
-    id
     ...ProjectVirtualWorkstationSettings
+    id
     identifier
     repoRefId
   }
@@ -57,13 +57,13 @@ fragment RepoSettingsFields on RepoSettings {
     ...RepoGeneralSettings
     ...RepoNotificationSettings
     ...RepoPatchAliasSettings
-    id
     ...RepoPeriodicBuildsSettings
-    displayName
     ...RepoPluginsSettings
     ...RepoTriggersSettings
     ...RepoViewsAndFiltersSettings
     ...RepoVirtualWorkstationSettings
+    id
+    displayName
   }
   subscriptions {
     ...Subscriptions

--- a/apps/spruce/src/gql/fragments/projectSettings/notifications.graphql
+++ b/apps/spruce/src/gql/fragments/projectSettings/notifications.graphql
@@ -1,9 +1,9 @@
 fragment ProjectNotificationSettings on Project {
+  id
   banner {
     text
     theme
   }
-  id
   notifyOnBuildFailure
 }
 

--- a/apps/spruce/src/gql/fragments/projectSettings/patchAliases.graphql
+++ b/apps/spruce/src/gql/fragments/projectSettings/patchAliases.graphql
@@ -1,6 +1,6 @@
 fragment ProjectPatchAliasSettings on Project {
-  githubTriggerAliases
   id
+  githubTriggerAliases
   patchTriggerAliases {
     alias
     childProjectIdentifier
@@ -16,8 +16,8 @@ fragment ProjectPatchAliasSettings on Project {
 }
 
 fragment RepoPatchAliasSettings on RepoRef {
-  githubTriggerAliases
   id
+  githubTriggerAliases
   patchTriggerAliases {
     alias
     childProjectIdentifier

--- a/apps/spruce/src/gql/fragments/projectSettings/periodicBuilds.graphql
+++ b/apps/spruce/src/gql/fragments/projectSettings/periodicBuilds.graphql
@@ -1,10 +1,10 @@
 fragment ProjectPeriodicBuildsSettings on Project {
   id
   periodicBuilds {
+    id
     alias
     configFile
     cron
-    id
     intervalHours
     message
     nextRunTime
@@ -14,10 +14,10 @@ fragment ProjectPeriodicBuildsSettings on Project {
 fragment RepoPeriodicBuildsSettings on RepoRef {
   id
   periodicBuilds {
+    id
     alias
     configFile
     cron
-    id
     intervalHours
     message
     nextRunTime

--- a/apps/spruce/src/gql/fragments/projectSettings/permissionGroups.graphql
+++ b/apps/spruce/src/gql/fragments/projectSettings/permissionGroups.graphql
@@ -3,12 +3,12 @@ fragment ProjectPermissionGroupSettings on ProjectSettings {
     appId
   }
   projectRef {
+    id
     githubDynamicTokenPermissionGroups {
       name
       permissions
     }
     githubPermissionGroupByRequester
-    id
   }
 }
 fragment ProjectEventPermissionGroupSettings on ProjectEventSettings {
@@ -16,12 +16,12 @@ fragment ProjectEventPermissionGroupSettings on ProjectEventSettings {
     appId
   }
   projectRef {
+    id
     githubDynamicTokenPermissionGroups {
       name
       permissions
     }
     githubPermissionGroupByRequester
-    id
   }
 }
 
@@ -30,11 +30,11 @@ fragment RepoPermissionGroupSettings on RepoSettings {
     appId
   }
   projectRef {
+    id
     githubDynamicTokenPermissionGroups {
       name
       permissions
     }
     githubPermissionGroupByRequester
-    id
   }
 }

--- a/apps/spruce/src/gql/fragments/projectSettings/plugins.graphql
+++ b/apps/spruce/src/gql/fragments/projectSettings/plugins.graphql
@@ -1,4 +1,5 @@
 fragment ProjectPluginsSettings on Project {
+  id
   buildBaronSettings {
     ticketCreateIssueType
     ticketCreateProject
@@ -9,7 +10,6 @@ fragment ProjectPluginsSettings on Project {
     requesters
     urlTemplate
   }
-  id
   perfEnabled
   taskAnnotationSettings {
     fileTicketWebhook {
@@ -20,6 +20,7 @@ fragment ProjectPluginsSettings on Project {
 }
 
 fragment RepoPluginsSettings on RepoRef {
+  id
   buildBaronSettings {
     ticketCreateIssueType
     ticketCreateProject
@@ -30,7 +31,6 @@ fragment RepoPluginsSettings on RepoRef {
     requesters
     urlTemplate
   }
-  id
   perfEnabled
   taskAnnotationSettings {
     fileTicketWebhook {

--- a/apps/spruce/src/gql/fragments/projectSettings/projectEventSettings.graphql
+++ b/apps/spruce/src/gql/fragments/projectSettings/projectEventSettings.graphql
@@ -14,15 +14,13 @@
 #import "./appSettings.graphql"
 
 fragment ProjectEventSettings on ProjectEventSettings {
-  aliases {
-    ...Alias
-  }
   ...ProjectEventAppSettings
   ...ProjectEventGithubCommitQueue
   ...ProjectEventPermissionGroupSettings
+  aliases {
+    ...Alias
+  }
   projectRef {
-    hidden
-    identifier
     ...ProjectAccessSettings
     ...ProjectGeneralSettings
     ...ProjectNotificationSettings
@@ -32,6 +30,8 @@ fragment ProjectEventSettings on ProjectEventSettings {
     ...ProjectTriggersSettings
     ...ProjectViewsAndFiltersSettings
     ...ProjectVirtualWorkstationSettings
+    hidden
+    identifier
     repoRefId
     tracksPushEvents
     versionControlEnabled

--- a/apps/spruce/src/gql/fragments/upstreamProject.graphql
+++ b/apps/spruce/src/gql/fragments/upstreamProject.graphql
@@ -6,8 +6,8 @@ fragment UpstreamProject on Version {
     repo
     revision
     task {
-      execution
       id
+      execution
     }
     triggerID
     triggerType

--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -3699,8 +3699,8 @@ export type JiraTicketFragment = {
 
 export type BaseHostFragment = {
   __typename?: "Host";
-  hostUrl: string;
   id: string;
+  hostUrl: string;
   persistentDnsName: string;
   provider: string;
   startedBy: string;
@@ -3712,11 +3712,11 @@ export type BaseHostFragment = {
 
 export type BasePatchFragment = {
   __typename?: "Patch";
+  id: string;
   activated: boolean;
   alias?: string | null;
   author: string;
   description: string;
-  id: string;
   status: string;
   parameters: Array<{ __typename?: "Parameter"; key: string; value: string }>;
   variantsTasks: Array<{
@@ -3734,8 +3734,8 @@ export type BaseSpawnHostFragment = {
   homeVolumeID?: string | null;
   instanceType?: string | null;
   noExpiration: boolean;
-  hostUrl: string;
   id: string;
+  hostUrl: string;
   persistentDnsName: string;
   provider: string;
   startedBy: string;
@@ -3753,8 +3753,8 @@ export type BaseSpawnHostFragment = {
   } | null;
   homeVolume?: {
     __typename?: "Volume";
-    displayName: string;
     id: string;
+    displayName: string;
   } | null;
   instanceTags: Array<{
     __typename?: "InstanceTag";
@@ -3764,20 +3764,20 @@ export type BaseSpawnHostFragment = {
   }>;
   volumes: Array<{
     __typename?: "Volume";
-    displayName: string;
     id: string;
+    displayName: string;
     migrating: boolean;
   }>;
 };
 
 export type BaseTaskFragment = {
   __typename?: "Task";
+  id: string;
   buildVariant: string;
   buildVariantDisplayName?: string | null;
   displayName: string;
   displayStatus: string;
   execution: number;
-  id: string;
   revision?: string | null;
 };
 
@@ -3817,6 +3817,7 @@ export type PatchesPagePatchesFragment = {
   filteredPatchCount: number;
   patches: Array<{
     __typename?: "Patch";
+    id: string;
     activated: boolean;
     alias?: string | null;
     author: string;
@@ -3824,7 +3825,6 @@ export type PatchesPagePatchesFragment = {
     createTime?: Date | null;
     description: string;
     hidden: boolean;
-    id: string;
     projectIdentifier: string;
     status: string;
     projectMetadata?: {
@@ -3852,24 +3852,24 @@ export type PatchesPagePatchesFragment = {
 
 export type ProjectAccessSettingsFragment = {
   __typename?: "Project";
-  admins?: Array<string> | null;
   id: string;
+  admins?: Array<string> | null;
   restricted?: boolean | null;
 };
 
 export type RepoAccessSettingsFragment = {
   __typename?: "RepoRef";
-  admins: Array<string>;
   id: string;
+  admins: Array<string>;
   restricted: boolean;
 };
 
 export type AliasFragment = {
   __typename?: "ProjectAlias";
+  id: string;
   alias: string;
   description?: string | null;
   gitTag: string;
-  id: string;
   remotePath: string;
   task: string;
   taskTags: Array<string>;
@@ -3887,8 +3887,8 @@ export type ProjectAppSettingsFragment = {
   } | null;
   projectRef?: {
     __typename?: "Project";
-    githubPermissionGroupByRequester?: { [key: string]: any } | null;
     id: string;
+    githubPermissionGroupByRequester?: { [key: string]: any } | null;
   } | null;
 };
 
@@ -3901,8 +3901,8 @@ export type ProjectEventAppSettingsFragment = {
   } | null;
   projectRef?: {
     __typename?: "Project";
-    githubPermissionGroupByRequester?: { [key: string]: any } | null;
     id: string;
+    githubPermissionGroupByRequester?: { [key: string]: any } | null;
   } | null;
 };
 
@@ -3915,8 +3915,8 @@ export type RepoAppSettingsFragment = {
   } | null;
   projectRef?: {
     __typename?: "RepoRef";
-    githubPermissionGroupByRequester?: { [key: string]: any } | null;
     id: string;
+    githubPermissionGroupByRequester?: { [key: string]: any } | null;
   } | null;
 };
 
@@ -3944,6 +3944,7 @@ export type RepoContainerSettingsFragment = {
 
 export type ProjectGeneralSettingsFragment = {
   __typename?: "Project";
+  id: string;
   batchTime: number;
   branch: string;
   deactivatePrevious?: boolean | null;
@@ -3951,7 +3952,6 @@ export type ProjectGeneralSettingsFragment = {
   dispatchingDisabled?: boolean | null;
   displayName: string;
   enabled?: boolean | null;
-  id: string;
   owner: string;
   patchingDisabled?: boolean | null;
   remotePath: string;
@@ -3965,12 +3965,12 @@ export type ProjectGeneralSettingsFragment = {
 
 export type RepoGeneralSettingsFragment = {
   __typename?: "RepoRef";
+  id: string;
   batchTime: number;
   deactivatePrevious: boolean;
   disabledStatsCache: boolean;
   dispatchingDisabled: boolean;
   displayName: string;
-  id: string;
   owner: string;
   patchingDisabled: boolean;
   remotePath: string;
@@ -3984,12 +3984,12 @@ export type RepoGeneralSettingsFragment = {
 
 export type ProjectGithubSettingsFragment = {
   __typename?: "Project";
+  id: string;
   githubChecksEnabled?: boolean | null;
   githubTriggerAliases?: Array<string> | null;
   gitTagAuthorizedTeams?: Array<string> | null;
   gitTagAuthorizedUsers?: Array<string> | null;
   gitTagVersionsEnabled?: boolean | null;
-  id: string;
   manualPrTestingEnabled?: boolean | null;
   oldestAllowedMergeBase: string;
   prTestingEnabled?: boolean | null;
@@ -3998,12 +3998,12 @@ export type ProjectGithubSettingsFragment = {
 
 export type RepoGithubSettingsFragment = {
   __typename?: "RepoRef";
+  id: string;
   githubChecksEnabled: boolean;
   githubTriggerAliases?: Array<string> | null;
   gitTagAuthorizedTeams?: Array<string> | null;
   gitTagAuthorizedUsers?: Array<string> | null;
   gitTagVersionsEnabled: boolean;
-  id: string;
   manualPrTestingEnabled: boolean;
   oldestAllowedMergeBase: string;
   prTestingEnabled: boolean;
@@ -4015,12 +4015,12 @@ export type ProjectGithubCommitQueueFragment = {
   githubWebhooksEnabled: boolean;
   projectRef?: {
     __typename?: "Project";
+    id: string;
     githubChecksEnabled?: boolean | null;
     githubTriggerAliases?: Array<string> | null;
     gitTagAuthorizedTeams?: Array<string> | null;
     gitTagAuthorizedUsers?: Array<string> | null;
     gitTagVersionsEnabled?: boolean | null;
-    id: string;
     manualPrTestingEnabled?: boolean | null;
     oldestAllowedMergeBase: string;
     prTestingEnabled?: boolean | null;
@@ -4033,12 +4033,12 @@ export type RepoGithubCommitQueueFragment = {
   githubWebhooksEnabled: boolean;
   projectRef?: {
     __typename?: "RepoRef";
+    id: string;
     githubChecksEnabled: boolean;
     githubTriggerAliases?: Array<string> | null;
     gitTagAuthorizedTeams?: Array<string> | null;
     gitTagAuthorizedUsers?: Array<string> | null;
     gitTagVersionsEnabled: boolean;
-    id: string;
     manualPrTestingEnabled: boolean;
     oldestAllowedMergeBase: string;
     prTestingEnabled: boolean;
@@ -4051,12 +4051,12 @@ export type ProjectEventGithubCommitQueueFragment = {
   githubWebhooksEnabled: boolean;
   projectRef?: {
     __typename?: "Project";
+    id: string;
     githubChecksEnabled?: boolean | null;
     githubTriggerAliases?: Array<string> | null;
     gitTagAuthorizedTeams?: Array<string> | null;
     gitTagAuthorizedUsers?: Array<string> | null;
     gitTagVersionsEnabled?: boolean | null;
-    id: string;
     manualPrTestingEnabled?: boolean | null;
     oldestAllowedMergeBase: string;
     prTestingEnabled?: boolean | null;
@@ -4069,10 +4069,10 @@ export type ProjectSettingsFieldsFragment = {
   githubWebhooksEnabled: boolean;
   aliases?: Array<{
     __typename?: "ProjectAlias";
+    id: string;
     alias: string;
     description?: string | null;
     gitTag: string;
-    id: string;
     remotePath: string;
     task: string;
     taskTags: Array<string>;
@@ -4147,10 +4147,10 @@ export type ProjectSettingsFieldsFragment = {
     }> | null;
     periodicBuilds?: Array<{
       __typename?: "PeriodicBuild";
+      id: string;
       alias: string;
       configFile: string;
       cron: string;
-      id: string;
       intervalHours: number;
       message: string;
       nextRunTime: Date;
@@ -4277,10 +4277,10 @@ export type RepoSettingsFieldsFragment = {
   githubWebhooksEnabled: boolean;
   aliases?: Array<{
     __typename?: "ProjectAlias";
+    id: string;
     alias: string;
     description?: string | null;
     gitTag: string;
-    id: string;
     remotePath: string;
     task: string;
     taskTags: Array<string>;
@@ -4290,8 +4290,8 @@ export type RepoSettingsFieldsFragment = {
   }> | null;
   projectRef?: {
     __typename?: "RepoRef";
-    displayName: string;
     id: string;
+    displayName: string;
     githubPermissionGroupByRequester?: { [key: string]: any } | null;
     admins: Array<string>;
     restricted: boolean;
@@ -4345,10 +4345,10 @@ export type RepoSettingsFieldsFragment = {
     }> | null;
     periodicBuilds?: Array<{
       __typename?: "PeriodicBuild";
+      id: string;
       alias: string;
       configFile: string;
       cron: string;
-      id: string;
       intervalHours: number;
       message: string;
       nextRunTime: Date;
@@ -4545,8 +4545,8 @@ export type SubscriptionsFragment = {
 
 export type ProjectPatchAliasSettingsFragment = {
   __typename?: "Project";
-  githubTriggerAliases?: Array<string> | null;
   id: string;
+  githubTriggerAliases?: Array<string> | null;
   patchTriggerAliases?: Array<{
     __typename?: "PatchTriggerAlias";
     alias: string;
@@ -4565,8 +4565,8 @@ export type ProjectPatchAliasSettingsFragment = {
 
 export type RepoPatchAliasSettingsFragment = {
   __typename?: "RepoRef";
-  githubTriggerAliases?: Array<string> | null;
   id: string;
+  githubTriggerAliases?: Array<string> | null;
   patchTriggerAliases?: Array<{
     __typename?: "PatchTriggerAlias";
     alias: string;
@@ -4588,10 +4588,10 @@ export type ProjectPeriodicBuildsSettingsFragment = {
   id: string;
   periodicBuilds?: Array<{
     __typename?: "PeriodicBuild";
+    id: string;
     alias: string;
     configFile: string;
     cron: string;
-    id: string;
     intervalHours: number;
     message: string;
     nextRunTime: Date;
@@ -4603,10 +4603,10 @@ export type RepoPeriodicBuildsSettingsFragment = {
   id: string;
   periodicBuilds?: Array<{
     __typename?: "PeriodicBuild";
+    id: string;
     alias: string;
     configFile: string;
     cron: string;
-    id: string;
     intervalHours: number;
     message: string;
     nextRunTime: Date;
@@ -4621,8 +4621,8 @@ export type ProjectPermissionGroupSettingsFragment = {
   } | null;
   projectRef?: {
     __typename?: "Project";
-    githubPermissionGroupByRequester?: { [key: string]: any } | null;
     id: string;
+    githubPermissionGroupByRequester?: { [key: string]: any } | null;
     githubDynamicTokenPermissionGroups: Array<{
       __typename?: "GitHubDynamicTokenPermissionGroup";
       name: string;
@@ -4639,8 +4639,8 @@ export type ProjectEventPermissionGroupSettingsFragment = {
   } | null;
   projectRef?: {
     __typename?: "Project";
-    githubPermissionGroupByRequester?: { [key: string]: any } | null;
     id: string;
+    githubPermissionGroupByRequester?: { [key: string]: any } | null;
     githubDynamicTokenPermissionGroups: Array<{
       __typename?: "GitHubDynamicTokenPermissionGroup";
       name: string;
@@ -4657,8 +4657,8 @@ export type RepoPermissionGroupSettingsFragment = {
   } | null;
   projectRef?: {
     __typename?: "RepoRef";
-    githubPermissionGroupByRequester?: { [key: string]: any } | null;
     id: string;
+    githubPermissionGroupByRequester?: { [key: string]: any } | null;
     githubDynamicTokenPermissionGroups: Array<{
       __typename?: "GitHubDynamicTokenPermissionGroup";
       name: string;
@@ -4724,10 +4724,10 @@ export type ProjectEventSettingsFragment = {
   githubWebhooksEnabled: boolean;
   aliases?: Array<{
     __typename?: "ProjectAlias";
+    id: string;
     alias: string;
     description?: string | null;
     gitTag: string;
-    id: string;
     remotePath: string;
     task: string;
     taskTags: Array<string>;
@@ -4742,8 +4742,8 @@ export type ProjectEventSettingsFragment = {
     repoRefId: string;
     tracksPushEvents?: boolean | null;
     versionControlEnabled?: boolean | null;
-    githubPermissionGroupByRequester?: { [key: string]: any } | null;
     id: string;
+    githubPermissionGroupByRequester?: { [key: string]: any } | null;
     admins?: Array<string> | null;
     restricted?: boolean | null;
     batchTime: number;
@@ -4798,10 +4798,10 @@ export type ProjectEventSettingsFragment = {
     }> | null;
     periodicBuilds?: Array<{
       __typename?: "PeriodicBuild";
+      id: string;
       alias: string;
       configFile: string;
       cron: string;
-      id: string;
       intervalHours: number;
       message: string;
       nextRunTime: Date;
@@ -5026,7 +5026,7 @@ export type UpstreamProjectFragment = {
     revision: string;
     triggerID: string;
     triggerType: string;
-    task?: { __typename?: "Task"; execution: number; id: string } | null;
+    task?: { __typename?: "Task"; id: string; execution: number } | null;
     version?: { __typename?: "Version"; id: string } | null;
   } | null;
 };
@@ -5040,12 +5040,12 @@ export type AbortTaskMutation = {
   abortTask: {
     __typename?: "Task";
     priority?: number | null;
+    id: string;
     buildVariant: string;
     buildVariantDisplayName?: string | null;
     displayName: string;
     displayStatus: string;
     execution: number;
-    id: string;
     revision?: string | null;
   };
 };
@@ -5070,8 +5070,8 @@ export type AddFavoriteProjectMutation = {
   __typename?: "Mutation";
   addFavoriteProject: {
     __typename?: "Project";
-    displayName: string;
     id: string;
+    displayName: string;
     identifier: string;
     isFavorite: boolean;
     owner: string;
@@ -5285,8 +5285,8 @@ export type EditSpawnHostMutation = {
     homeVolumeID?: string | null;
     instanceType?: string | null;
     noExpiration: boolean;
-    hostUrl: string;
     id: string;
+    hostUrl: string;
     persistentDnsName: string;
     provider: string;
     startedBy: string;
@@ -5304,8 +5304,8 @@ export type EditSpawnHostMutation = {
     } | null;
     homeVolume?: {
       __typename?: "Volume";
-      displayName: string;
       id: string;
+      displayName: string;
     } | null;
     instanceTags: Array<{
       __typename?: "InstanceTag";
@@ -5315,8 +5315,8 @@ export type EditSpawnHostMutation = {
     }>;
     volumes: Array<{
       __typename?: "Volume";
-      displayName: string;
       id: string;
+      displayName: string;
       migrating: boolean;
     }>;
   };
@@ -5371,9 +5371,9 @@ export type OverrideTaskDependenciesMutation = {
   __typename?: "Mutation";
   overrideTaskDependencies: {
     __typename?: "Task";
+    id: string;
     displayStatus: string;
     execution: number;
-    id: string;
   };
 };
 
@@ -5407,8 +5407,8 @@ export type RemoveFavoriteProjectMutation = {
   __typename?: "Mutation";
   removeFavoriteProject: {
     __typename?: "Project";
-    displayName: string;
     id: string;
+    displayName: string;
     identifier: string;
     isFavorite: boolean;
     owner: string;
@@ -5468,11 +5468,11 @@ export type RestartTaskMutation = {
     execution: number;
     latestExecution: number;
     priority?: number | null;
+    id: string;
     buildVariant: string;
     buildVariantDisplayName?: string | null;
     displayName: string;
     displayStatus: string;
-    id: string;
     revision?: string | null;
   };
 };
@@ -5567,11 +5567,11 @@ export type SchedulePatchMutation = {
     __typename?: "Patch";
     tasks: Array<string>;
     variants: Array<string>;
+    id: string;
     activated: boolean;
     alias?: string | null;
     author: string;
     description: string;
-    id: string;
     status: string;
     versionFull?: {
       __typename?: "Version";
@@ -5596,15 +5596,15 @@ export type ScheduleTasksMutation = {
   __typename?: "Mutation";
   scheduleTasks: Array<{
     __typename?: "Task";
-    status: string;
     canSchedule: boolean;
     canUnschedule: boolean;
+    status: string;
+    id: string;
     buildVariant: string;
     buildVariantDisplayName?: string | null;
     displayName: string;
     displayStatus: string;
     execution: number;
-    id: string;
     revision?: string | null;
   }>;
 };
@@ -5617,9 +5617,9 @@ export type ScheduleUndispatchedBaseTasksMutation = {
   __typename?: "Mutation";
   scheduleUndispatchedBaseTasks?: Array<{
     __typename?: "Task";
+    id: string;
     displayStatus: string;
     execution: number;
-    id: string;
   }> | null;
 };
 
@@ -5645,8 +5645,8 @@ export type SetPatchVisibilityMutation = {
   __typename?: "Mutation";
   setPatchVisibility: Array<{
     __typename?: "Patch";
-    hidden: boolean;
     id: string;
+    hidden: boolean;
   }>;
 };
 
@@ -5659,8 +5659,8 @@ export type SetTaskPriorityMutation = {
   __typename?: "Mutation";
   setTaskPriority: {
     __typename?: "Task";
-    execution: number;
     id: string;
+    execution: number;
     priority?: number | null;
   };
 };
@@ -5701,12 +5701,12 @@ export type UnscheduleTaskMutation = {
   __typename?: "Mutation";
   unscheduleTask: {
     __typename?: "Task";
-    execution: number;
     id: string;
-    status: string;
-    displayStatus: string;
     canSchedule: boolean;
     canUnschedule: boolean;
+    displayStatus: string;
+    execution: number;
+    status: string;
   };
 };
 
@@ -5740,11 +5740,11 @@ export type UpdatePatchDescriptionMutation = {
   __typename?: "Mutation";
   schedulePatch: {
     __typename?: "Patch";
+    id: string;
     activated: boolean;
     alias?: string | null;
     author: string;
     description: string;
-    id: string;
     status: string;
     parameters: Array<{ __typename?: "Parameter"; key: string; value: string }>;
     variantsTasks: Array<{
@@ -5836,8 +5836,8 @@ export type AgentLogsQuery = {
   __typename?: "Query";
   task?: {
     __typename?: "Task";
-    execution: number;
     id: string;
+    execution: number;
     taskLogs: {
       __typename?: "TaskLogs";
       agentLogs: Array<{
@@ -5859,8 +5859,8 @@ export type AllLogsQuery = {
   __typename?: "Query";
   task?: {
     __typename?: "Task";
-    execution: number;
     id: string;
+    execution: number;
     taskLogs: {
       __typename?: "TaskLogs";
       allLogs: Array<{
@@ -5888,17 +5888,17 @@ export type BaseVersionAndTaskQuery = {
   __typename?: "Query";
   task?: {
     __typename?: "Task";
+    id: string;
     buildVariant: string;
     displayName: string;
     displayStatus: string;
     execution: number;
-    id: string;
     projectIdentifier?: string | null;
     baseTask?: {
       __typename?: "Task";
+      id: string;
       displayStatus: string;
       execution: number;
-      id: string;
     } | null;
     versionMetadata: {
       __typename?: "Version";
@@ -6008,11 +6008,11 @@ export type BuildVariantsWithChildrenQuery = {
       variant: string;
       tasks?: Array<{
         __typename?: "Task";
+        id: string;
         baseStatus?: string | null;
         displayName: string;
         displayStatus: string;
         execution: number;
-        id: string;
       }> | null;
     }> | null;
     childVersions?: Array<{
@@ -6026,11 +6026,11 @@ export type BuildVariantsWithChildrenQuery = {
         variant: string;
         tasks?: Array<{
           __typename?: "Task";
+          id: string;
           baseStatus?: string | null;
           displayName: string;
           displayStatus: string;
           execution: number;
-          id: string;
         }> | null;
       }> | null;
       generatedTaskCounts: Array<{
@@ -6120,11 +6120,11 @@ export type DisplayTaskQuery = {
   __typename?: "Query";
   task?: {
     __typename?: "Task";
+    id: string;
     displayName: string;
     execution: number;
     executionTasks?: Array<string> | null;
-    id: string;
-    displayTask?: { __typename?: "Task"; execution: number; id: string } | null;
+    displayTask?: { __typename?: "Task"; id: string; execution: number } | null;
   } | null;
 };
 
@@ -6158,11 +6158,11 @@ export type DistroTaskQueueQuery = {
   __typename?: "Query";
   distroTaskQueue: Array<{
     __typename?: "TaskQueueItem";
+    id: string;
     activatedBy: string;
     buildVariant: string;
     displayName: string;
     expectedDuration: number;
-    id: string;
     priority: number;
     project: string;
     projectIdentifier?: string | null;
@@ -6293,8 +6293,8 @@ export type FailedTaskStatusIconTooltipQuery = {
   __typename?: "Query";
   task?: {
     __typename?: "Task";
-    execution: number;
     id: string;
+    execution: number;
     tests: {
       __typename?: "TaskTestResult";
       filteredTestCount: number;
@@ -6346,15 +6346,15 @@ export type HostEventsQuery = {
   __typename?: "Query";
   host?: {
     __typename?: "Host";
-    eventTypes: Array<HostEventType>;
     id: string;
+    eventTypes: Array<HostEventType>;
     events: {
       __typename?: "HostEvents";
       count: number;
       eventLogEntries: Array<{
         __typename?: "HostEventLogEntry";
-        eventType?: HostEventType | null;
         id: string;
+        eventType?: HostEventType | null;
         processedAt: Date;
         resourceId: string;
         resourceType: string;
@@ -6394,8 +6394,8 @@ export type HostQuery = {
     ami?: string | null;
     distroId?: string | null;
     lastCommunicationTime?: Date | null;
-    hostUrl: string;
     id: string;
+    hostUrl: string;
     persistentDnsName: string;
     provider: string;
     startedBy: string;
@@ -6405,8 +6405,8 @@ export type HostQuery = {
     user?: string | null;
     distro?: {
       __typename?: "DistroInfo";
-      bootstrapMethod?: string | null;
       id?: string | null;
+      bootstrapMethod?: string | null;
     } | null;
     runningTask?: {
       __typename?: "TaskInfo";
@@ -6436,10 +6436,10 @@ export type HostsQuery = {
     totalHostsCount: number;
     hosts: Array<{
       __typename?: "Host";
+      id: string;
       distroId?: string | null;
       elapsed?: Date | null;
       hostUrl: string;
-      id: string;
       noExpiration: boolean;
       provider: string;
       startedBy: string;
@@ -6449,8 +6449,8 @@ export type HostsQuery = {
       uptime?: Date | null;
       distro?: {
         __typename?: "DistroInfo";
-        bootstrapMethod?: string | null;
         id?: string | null;
+        bootstrapMethod?: string | null;
       } | null;
       runningTask?: {
         __typename?: "TaskInfo";
@@ -6523,14 +6523,14 @@ export type ImageGeneralQuery = {
   __typename?: "Query";
   image?: {
     __typename?: "Image";
-    ami: string;
     id: string;
+    ami: string;
     lastDeployed: Date;
     latestTask?: {
       __typename?: "Task";
+      id: string;
       execution: number;
       finishTime?: Date | null;
-      id: string;
     } | null;
   } | null;
 };
@@ -6628,8 +6628,8 @@ export type CustomCreatedIssuesQuery = {
   __typename?: "Query";
   task?: {
     __typename?: "Task";
-    execution: number;
     id: string;
+    execution: number;
     annotation?: {
       __typename?: "Annotation";
       id: string;
@@ -6672,8 +6672,8 @@ export type IssuesQuery = {
   __typename?: "Query";
   task?: {
     __typename?: "Task";
-    execution: number;
     id: string;
+    execution: number;
     annotation?: {
       __typename?: "Annotation";
       id: string;
@@ -6716,8 +6716,8 @@ export type SuspectedIssuesQuery = {
   __typename?: "Query";
   task?: {
     __typename?: "Task";
-    execution: number;
     id: string;
+    execution: number;
     annotation?: {
       __typename?: "Annotation";
       id: string;
@@ -6770,9 +6770,9 @@ export type LastMainlineCommitQuery = {
           __typename?: "GroupedBuildVariant";
           tasks?: Array<{
             __typename?: "Task";
+            id: string;
             displayStatus: string;
             execution: number;
-            id: string;
             order: number;
           }> | null;
         }> | null;
@@ -6789,9 +6789,9 @@ export type LogkeeperBuildMetadataQuery = {
   __typename?: "Query";
   logkeeperBuildMetadata: {
     __typename?: "LogkeeperBuild";
+    id: string;
     builder: string;
     buildNum: number;
-    id: string;
     taskExecution: number;
     taskId: string;
     tests: Array<{ __typename?: "LogkeeperTest"; id: string; name: string }>;
@@ -6813,9 +6813,9 @@ export type MainlineCommitsForHistoryQuery = {
       __typename?: "MainlineCommitVersion";
       rolledUpVersions?: Array<{
         __typename?: "Version";
+        id: string;
         author: string;
         createTime: Date;
-        id: string;
         message: string;
         order: number;
         revision: string;
@@ -6827,9 +6827,9 @@ export type MainlineCommitsForHistoryQuery = {
       }> | null;
       version?: {
         __typename?: "Version";
+        id: string;
         author: string;
         createTime: Date;
-        id: string;
         message: string;
         order: number;
         revision: string;
@@ -6839,10 +6839,10 @@ export type MainlineCommitsForHistoryQuery = {
           variant: string;
           tasks?: Array<{
             __typename?: "Task";
+            id: string;
             displayName: string;
             displayStatus: string;
             execution: number;
-            id: string;
           }> | null;
         }> | null;
         gitTags?: Array<{
@@ -6858,7 +6858,7 @@ export type MainlineCommitsForHistoryQuery = {
           revision: string;
           triggerID: string;
           triggerType: string;
-          task?: { __typename?: "Task"; execution: number; id: string } | null;
+          task?: { __typename?: "Task"; id: string; execution: number } | null;
           version?: { __typename?: "Version"; id: string } | null;
         } | null;
       } | null;
@@ -6884,9 +6884,9 @@ export type MainlineCommitsQuery = {
       __typename?: "MainlineCommitVersion";
       rolledUpVersions?: Array<{
         __typename?: "Version";
+        id: string;
         author: string;
         createTime: Date;
-        id: string;
         ignored: boolean;
         message: string;
         order: number;
@@ -6894,9 +6894,9 @@ export type MainlineCommitsQuery = {
       }> | null;
       version?: {
         __typename?: "Version";
+        id: string;
         author: string;
         createTime: Date;
-        id: string;
         message: string;
         order: number;
         projectIdentifier: string;
@@ -6907,11 +6907,11 @@ export type MainlineCommitsQuery = {
           variant: string;
           tasks?: Array<{
             __typename?: "Task";
+            id: string;
             displayName: string;
             displayStatus: string;
             execution: number;
             hasCedarResults: boolean;
-            id: string;
             timeTaken?: number | null;
           }> | null;
         }> | null;
@@ -6947,7 +6947,7 @@ export type MainlineCommitsQuery = {
           revision: string;
           triggerID: string;
           triggerType: string;
-          task?: { __typename?: "Task"; execution: number; id: string } | null;
+          task?: { __typename?: "Task"; id: string; execution: number } | null;
           version?: { __typename?: "Version"; id: string } | null;
         } | null;
       } | null;
@@ -6967,8 +6967,8 @@ export type MyHostsQuery = {
     homeVolumeID?: string | null;
     instanceType?: string | null;
     noExpiration: boolean;
-    hostUrl: string;
     id: string;
+    hostUrl: string;
     persistentDnsName: string;
     provider: string;
     startedBy: string;
@@ -6997,8 +6997,8 @@ export type MyHostsQuery = {
     } | null;
     homeVolume?: {
       __typename?: "Volume";
-      displayName: string;
       id: string;
+      displayName: string;
     } | null;
     instanceTags: Array<{
       __typename?: "InstanceTag";
@@ -7008,8 +7008,8 @@ export type MyHostsQuery = {
     }>;
     volumes: Array<{
       __typename?: "Volume";
-      displayName: string;
       id: string;
+      displayName: string;
       migrating: boolean;
     }>;
   }>;
@@ -7021,6 +7021,7 @@ export type MyVolumesQuery = {
   __typename?: "Query";
   myVolumes: Array<{
     __typename?: "Volume";
+    id: string;
     availabilityZone: string;
     createdBy: string;
     creationTime?: Date | null;
@@ -7029,15 +7030,14 @@ export type MyVolumesQuery = {
     expiration?: Date | null;
     homeVolume: boolean;
     hostID: string;
-    id: string;
     migrating: boolean;
     noExpiration: boolean;
     size: number;
     type: string;
     host?: {
       __typename?: "Host";
-      displayName?: string | null;
       id: string;
+      displayName?: string | null;
       noExpiration: boolean;
     } | null;
   }>;
@@ -7062,11 +7062,11 @@ export type ConfigurePatchQuery = {
   patch: {
     __typename?: "Patch";
     projectIdentifier: string;
+    id: string;
     activated: boolean;
     alias?: string | null;
     author: string;
     description: string;
-    id: string;
     status: string;
     childPatchAliases?: Array<{
       __typename?: "ChildPatchAlias";
@@ -7127,8 +7127,8 @@ export type PatchTaskStatusesQuery = {
   __typename?: "Query";
   patch: {
     __typename?: "Patch";
-    baseTaskStatuses: Array<string>;
     id: string;
+    baseTaskStatuses: Array<string>;
     taskStatuses: Array<string>;
   };
 };
@@ -7145,11 +7145,11 @@ export type PatchQuery = {
     patchNumber: number;
     projectID: string;
     projectIdentifier: string;
+    id: string;
     activated: boolean;
     alias?: string | null;
     author: string;
     description: string;
-    id: string;
     status: string;
     versionFull?: { __typename?: "Version"; id: string } | null;
     parameters: Array<{ __typename?: "Parameter"; key: string; value: string }>;
@@ -7177,8 +7177,8 @@ export type PodEventsQuery = {
       count: number;
       eventLogEntries: Array<{
         __typename?: "PodEventLogEntry";
-        eventType?: string | null;
         id: string;
+        eventType?: string | null;
         processedAt: Date;
         resourceId: string;
         resourceType: string;
@@ -7193,9 +7193,9 @@ export type PodEventsQuery = {
           taskStatus?: string | null;
           task?: {
             __typename?: "Task";
+            id: string;
             displayName: string;
             execution: number;
-            id: string;
           } | null;
         };
       }>;
@@ -7216,9 +7216,9 @@ export type PodQuery = {
     type: string;
     task?: {
       __typename?: "Task";
+      id: string;
       displayName: string;
       execution: number;
-      id: string;
     } | null;
     taskContainerCreationOpts: {
       __typename?: "TaskContainerCreationOpts";
@@ -7269,10 +7269,10 @@ export type ProjectEventLogsQuery = {
         githubWebhooksEnabled: boolean;
         aliases?: Array<{
           __typename?: "ProjectAlias";
+          id: string;
           alias: string;
           description?: string | null;
           gitTag: string;
-          id: string;
           remotePath: string;
           task: string;
           taskTags: Array<string>;
@@ -7291,8 +7291,8 @@ export type ProjectEventLogsQuery = {
           repoRefId: string;
           tracksPushEvents?: boolean | null;
           versionControlEnabled?: boolean | null;
-          githubPermissionGroupByRequester?: { [key: string]: any } | null;
           id: string;
+          githubPermissionGroupByRequester?: { [key: string]: any } | null;
           admins?: Array<string> | null;
           restricted?: boolean | null;
           batchTime: number;
@@ -7347,10 +7347,10 @@ export type ProjectEventLogsQuery = {
           }> | null;
           periodicBuilds?: Array<{
             __typename?: "PeriodicBuild";
+            id: string;
             alias: string;
             configFile: string;
             cron: string;
-            id: string;
             intervalHours: number;
             message: string;
             nextRunTime: Date;
@@ -7483,10 +7483,10 @@ export type ProjectEventLogsQuery = {
         githubWebhooksEnabled: boolean;
         aliases?: Array<{
           __typename?: "ProjectAlias";
+          id: string;
           alias: string;
           description?: string | null;
           gitTag: string;
-          id: string;
           remotePath: string;
           task: string;
           taskTags: Array<string>;
@@ -7505,8 +7505,8 @@ export type ProjectEventLogsQuery = {
           repoRefId: string;
           tracksPushEvents?: boolean | null;
           versionControlEnabled?: boolean | null;
-          githubPermissionGroupByRequester?: { [key: string]: any } | null;
           id: string;
+          githubPermissionGroupByRequester?: { [key: string]: any } | null;
           admins?: Array<string> | null;
           restricted?: boolean | null;
           batchTime: number;
@@ -7561,10 +7561,10 @@ export type ProjectEventLogsQuery = {
           }> | null;
           periodicBuilds?: Array<{
             __typename?: "PeriodicBuild";
+            id: string;
             alias: string;
             configFile: string;
             cron: string;
-            id: string;
             intervalHours: number;
             message: string;
             nextRunTime: Date;
@@ -7718,13 +7718,14 @@ export type ProjectPatchesQuery = {
   __typename?: "Query";
   project: {
     __typename?: "Project";
-    displayName: string;
     id: string;
+    displayName: string;
     patches: {
       __typename?: "Patches";
       filteredPatchCount: number;
       patches: Array<{
         __typename?: "Patch";
+        id: string;
         activated: boolean;
         alias?: string | null;
         author: string;
@@ -7732,7 +7733,6 @@ export type ProjectPatchesQuery = {
         createTime?: Date | null;
         description: string;
         hidden: boolean;
-        id: string;
         projectIdentifier: string;
         status: string;
         projectMetadata?: {
@@ -7771,10 +7771,10 @@ export type ProjectSettingsQuery = {
     githubWebhooksEnabled: boolean;
     aliases?: Array<{
       __typename?: "ProjectAlias";
+      id: string;
       alias: string;
       description?: string | null;
       gitTag: string;
-      id: string;
       remotePath: string;
       task: string;
       taskTags: Array<string>;
@@ -7853,10 +7853,10 @@ export type ProjectSettingsQuery = {
       }> | null;
       periodicBuilds?: Array<{
         __typename?: "PeriodicBuild";
+        id: string;
         alias: string;
         configFile: string;
         cron: string;
-        id: string;
         intervalHours: number;
         message: string;
         nextRunTime: Date;
@@ -8000,8 +8000,8 @@ export type ProjectsQuery = {
     groupDisplayName: string;
     projects: Array<{
       __typename?: "Project";
-      displayName: string;
       id: string;
+      displayName: string;
       identifier: string;
       isFavorite: boolean;
       owner: string;
@@ -8037,10 +8037,10 @@ export type RepoEventLogsQuery = {
         githubWebhooksEnabled: boolean;
         aliases?: Array<{
           __typename?: "ProjectAlias";
+          id: string;
           alias: string;
           description?: string | null;
           gitTag: string;
-          id: string;
           remotePath: string;
           task: string;
           taskTags: Array<string>;
@@ -8059,8 +8059,8 @@ export type RepoEventLogsQuery = {
           repoRefId: string;
           tracksPushEvents?: boolean | null;
           versionControlEnabled?: boolean | null;
-          githubPermissionGroupByRequester?: { [key: string]: any } | null;
           id: string;
+          githubPermissionGroupByRequester?: { [key: string]: any } | null;
           admins?: Array<string> | null;
           restricted?: boolean | null;
           batchTime: number;
@@ -8115,10 +8115,10 @@ export type RepoEventLogsQuery = {
           }> | null;
           periodicBuilds?: Array<{
             __typename?: "PeriodicBuild";
+            id: string;
             alias: string;
             configFile: string;
             cron: string;
-            id: string;
             intervalHours: number;
             message: string;
             nextRunTime: Date;
@@ -8251,10 +8251,10 @@ export type RepoEventLogsQuery = {
         githubWebhooksEnabled: boolean;
         aliases?: Array<{
           __typename?: "ProjectAlias";
+          id: string;
           alias: string;
           description?: string | null;
           gitTag: string;
-          id: string;
           remotePath: string;
           task: string;
           taskTags: Array<string>;
@@ -8273,8 +8273,8 @@ export type RepoEventLogsQuery = {
           repoRefId: string;
           tracksPushEvents?: boolean | null;
           versionControlEnabled?: boolean | null;
-          githubPermissionGroupByRequester?: { [key: string]: any } | null;
           id: string;
+          githubPermissionGroupByRequester?: { [key: string]: any } | null;
           admins?: Array<string> | null;
           restricted?: boolean | null;
           batchTime: number;
@@ -8329,10 +8329,10 @@ export type RepoEventLogsQuery = {
           }> | null;
           periodicBuilds?: Array<{
             __typename?: "PeriodicBuild";
+            id: string;
             alias: string;
             configFile: string;
             cron: string;
-            id: string;
             intervalHours: number;
             message: string;
             nextRunTime: Date;
@@ -8475,10 +8475,10 @@ export type RepoSettingsQuery = {
     githubWebhooksEnabled: boolean;
     aliases?: Array<{
       __typename?: "ProjectAlias";
+      id: string;
       alias: string;
       description?: string | null;
       gitTag: string;
-      id: string;
       remotePath: string;
       task: string;
       taskTags: Array<string>;
@@ -8492,8 +8492,8 @@ export type RepoSettingsQuery = {
     }> | null;
     projectRef?: {
       __typename?: "RepoRef";
-      displayName: string;
       id: string;
+      displayName: string;
       githubPermissionGroupByRequester?: { [key: string]: any } | null;
       admins: Array<string>;
       restricted: boolean;
@@ -8547,10 +8547,10 @@ export type RepoSettingsQuery = {
       }> | null;
       periodicBuilds?: Array<{
         __typename?: "PeriodicBuild";
+        id: string;
         alias: string;
         configFile: string;
         cron: string;
-        id: string;
         intervalHours: number;
         message: string;
         nextRunTime: Date;
@@ -8681,8 +8681,8 @@ export type RepotrackerErrorQuery = {
   __typename?: "Query";
   project: {
     __typename?: "Project";
-    branch: string;
     id: string;
+    branch: string;
     repotrackerError?: {
       __typename?: "RepotrackerError";
       exists: boolean;
@@ -8711,9 +8711,9 @@ export type SingleTaskDistroQuery = {
       __typename?: "SingleTaskDistroConfig";
       projectTasksPairs: Array<{
         __typename?: "ProjectTasksPair";
-        projectId: string;
-        allowedTasks: Array<string>;
         allowedBVs: Array<string>;
+        allowedTasks: Array<string>;
+        projectId: string;
       }>;
     } | null;
   } | null;
@@ -8739,12 +8739,12 @@ export type SpawnTaskQuery = {
   __typename?: "Query";
   task?: {
     __typename?: "Task";
+    id: string;
     buildVariant: string;
     buildVariantDisplayName?: string | null;
     displayName: string;
     displayStatus: string;
     execution: number;
-    id: string;
     revision?: string | null;
     project?: {
       __typename?: "Project";
@@ -8766,8 +8766,8 @@ export type SpruceConfigQuery = {
       __typename?: "ContainerPoolsConfig";
       pools: Array<{
         __typename?: "ContainerPool";
-        distro: string;
         id: string;
+        distro: string;
         maxContainers: number;
         port: number;
       }>;
@@ -8821,8 +8821,8 @@ export type SystemLogsQuery = {
   __typename?: "Query";
   task?: {
     __typename?: "Task";
-    execution: number;
     id: string;
+    execution: number;
     taskLogs: {
       __typename?: "TaskLogs";
       systemLogs: Array<{
@@ -8843,10 +8843,10 @@ export type TaskAllExecutionsQuery = {
   __typename?: "Query";
   taskAllExecutions: Array<{
     __typename?: "Task";
+    id: string;
     activatedTime?: Date | null;
     displayStatus: string;
     execution: number;
-    id: string;
     ingestTime?: Date | null;
   }>;
 };
@@ -8860,14 +8860,14 @@ export type TaskEventLogsQuery = {
   __typename?: "Query";
   task?: {
     __typename?: "Task";
-    execution: number;
     id: string;
+    execution: number;
     taskLogs: {
       __typename?: "TaskLogs";
       eventLogs: Array<{
         __typename?: "TaskEventLogEntry";
-        eventType?: string | null;
         id: string;
+        eventType?: string | null;
         timestamp?: Date | null;
         data: {
           __typename?: "TaskEventLogData";
@@ -8895,8 +8895,8 @@ export type TaskFilesQuery = {
   __typename?: "Query";
   task?: {
     __typename?: "Task";
-    execution: number;
     id: string;
+    execution: number;
     files: {
       __typename?: "TaskFiles";
       fileCount: number;
@@ -8925,10 +8925,10 @@ export type TaskHistoryQuery = {
     tasks: Array<{
       __typename?: "Task";
       id: string;
-      order: number;
+      activated: boolean;
       displayStatus: string;
       execution: number;
-      activated: boolean;
+      order: number;
     }>;
   };
 };
@@ -8942,8 +8942,8 @@ export type TaskLogsQuery = {
   __typename?: "Query";
   task?: {
     __typename?: "Task";
-    execution: number;
     id: string;
+    execution: number;
     taskLogs: {
       __typename?: "TaskLogs";
       taskLogs: Array<{
@@ -8972,8 +8972,8 @@ export type TaskQueueDistrosQuery = {
   __typename?: "Query";
   taskQueueDistros: Array<{
     __typename?: "TaskQueueDistro";
-    hostCount: number;
     id: string;
+    hostCount: number;
     taskCount: number;
   }>;
 };
@@ -8986,8 +8986,8 @@ export type TaskStatusesQuery = {
   __typename?: "Query";
   version: {
     __typename?: "Version";
-    baseTaskStatuses: Array<string>;
     id: string;
+    baseTaskStatuses: Array<string>;
     taskStatuses: Array<string>;
   };
 };
@@ -9018,19 +9018,19 @@ export type TaskTestsForJobLogsQuery = {
   __typename?: "Query";
   task?: {
     __typename?: "Task";
+    id: string;
     buildVariant: string;
     buildVariantDisplayName?: string | null;
     displayName: string;
     displayStatus: string;
     execution: number;
-    id: string;
     revision?: string | null;
     tests: {
       __typename?: "TaskTestResult";
       testResults: Array<{
         __typename?: "TestResult";
-        groupID?: string | null;
         id: string;
+        groupID?: string | null;
         status: string;
         testFile: string;
         logs: { __typename?: "TestLog"; urlParsley?: string | null };
@@ -9053,17 +9053,17 @@ export type TaskTestsQuery = {
   __typename?: "Query";
   task?: {
     __typename?: "Task";
-    execution: number;
     id: string;
+    execution: number;
     tests: {
       __typename?: "TaskTestResult";
       filteredTestCount: number;
       totalTestCount: number;
       testResults: Array<{
         __typename?: "TestResult";
+        id: string;
         baseStatus?: string | null;
         duration?: number | null;
-        id: string;
         status: string;
         testFile: string;
         logs: {
@@ -9123,12 +9123,12 @@ export type TaskQuery = {
     tags: Array<string>;
     timeTaken?: number | null;
     totalTestCount: number;
+    id: string;
     buildVariant: string;
     buildVariantDisplayName?: string | null;
     displayName: string;
     displayStatus: string;
     execution: number;
-    id: string;
     revision?: string | null;
     abortInfo?: {
       __typename?: "AbortInfo";
@@ -9196,8 +9196,8 @@ export type TaskQuery = {
     } | null;
     baseTask?: {
       __typename?: "Task";
-      execution: number;
       id: string;
+      execution: number;
       timeTaken?: number | null;
       versionMetadata: { __typename?: "Version"; id: string; revision: string };
     } | null;
@@ -9227,18 +9227,18 @@ export type TaskQuery = {
     } | null;
     displayTask?: {
       __typename?: "Task";
+      id: string;
       displayName: string;
       execution: number;
-      id: string;
     } | null;
     executionTasksFull?: Array<{
       __typename?: "Task";
+      id: string;
       buildVariant: string;
       buildVariantDisplayName?: string | null;
       displayName: string;
       displayStatus: string;
       execution: number;
-      id: string;
       projectIdentifier?: string | null;
       revision?: string | null;
     }> | null;
@@ -9262,8 +9262,8 @@ export type TaskQuery = {
     } | null;
     versionMetadata: {
       __typename?: "Version";
-      author: string;
       id: string;
+      author: string;
       isPatch: boolean;
       message: string;
       order: number;
@@ -9290,12 +9290,12 @@ export type TestAnalysisQuery = {
       count: number;
       data: Array<{
         __typename?: "Task";
+        id: string;
         buildVariant: string;
         buildVariantDisplayName?: string | null;
         displayName: string;
         displayStatus: string;
         execution: number;
-        id: string;
         tests: {
           __typename?: "TaskTestResult";
           filteredTestCount: number;
@@ -9330,11 +9330,11 @@ export type UndispatchedTasksQuery = {
       __typename?: "VersionTasks";
       data: Array<{
         __typename?: "Task";
+        id: string;
         buildVariant: string;
         buildVariantDisplayName?: string | null;
         displayName: string;
         execution: number;
-        id: string;
       }>;
     };
   };
@@ -9403,6 +9403,7 @@ export type UserPatchesQuery = {
       filteredPatchCount: number;
       patches: Array<{
         __typename?: "Patch";
+        id: string;
         activated: boolean;
         alias?: string | null;
         author: string;
@@ -9410,7 +9411,6 @@ export type UserPatchesQuery = {
         createTime?: Date | null;
         description: string;
         hidden: boolean;
-        id: string;
         projectIdentifier: string;
         status: string;
         projectMetadata?: {
@@ -9515,6 +9515,17 @@ export type UserSubscriptionsQuery = {
   user: {
     __typename?: "User";
     userId: string;
+    settings: {
+      __typename?: "UserSettings";
+      notifications?: {
+        __typename?: "Notifications";
+        buildBreakId?: string | null;
+        patchFinishId?: string | null;
+        patchFirstFailureId?: string | null;
+        spawnHostExpirationId?: string | null;
+        spawnHostOutcomeId?: string | null;
+      } | null;
+    };
     subscriptions?: Array<{
       __typename?: "GeneralSubscription";
       id: string;
@@ -9539,17 +9550,6 @@ export type UserSubscriptionsQuery = {
         };
       } | null;
     }> | null;
-    settings: {
-      __typename?: "UserSettings";
-      notifications?: {
-        __typename?: "Notifications";
-        buildBreakId?: string | null;
-        patchFinishId?: string | null;
-        patchFirstFailureId?: string | null;
-        spawnHostExpirationId?: string | null;
-        spawnHostOutcomeId?: string | null;
-      } | null;
-    };
   };
 };
 
@@ -9581,20 +9581,20 @@ export type VersionTaskDurationsQuery = {
       count: number;
       data: Array<{
         __typename?: "Task";
+        id: string;
         buildVariantDisplayName?: string | null;
         displayName: string;
         displayStatus: string;
         execution: number;
-        id: string;
         startTime?: Date | null;
         timeTaken?: number | null;
         subRows?: Array<{
           __typename?: "Task";
+          id: string;
           buildVariantDisplayName?: string | null;
           displayName: string;
           displayStatus: string;
           execution: number;
-          id: string;
           startTime?: Date | null;
           timeTaken?: number | null;
         }> | null;
@@ -9619,6 +9619,7 @@ export type VersionTasksQuery = {
       count: number;
       data: Array<{
         __typename?: "Task";
+        id: string;
         aborted: boolean;
         blocked: boolean;
         buildVariant: string;
@@ -9626,29 +9627,28 @@ export type VersionTasksQuery = {
         displayName: string;
         displayStatus: string;
         execution: number;
-        id: string;
         projectIdentifier?: string | null;
         baseTask?: {
           __typename?: "Task";
+          id: string;
           displayStatus: string;
           execution: number;
-          id: string;
         } | null;
         dependsOn?: Array<{ __typename?: "Dependency"; name: string }> | null;
         executionTasksFull?: Array<{
           __typename?: "Task";
+          id: string;
           buildVariant: string;
           buildVariantDisplayName?: string | null;
           displayName: string;
           displayStatus: string;
           execution: number;
-          id: string;
           projectIdentifier?: string | null;
           baseTask?: {
             __typename?: "Task";
+            id: string;
             displayStatus: string;
             execution: number;
-            id: string;
           } | null;
         }> | null;
       }>;
@@ -9673,7 +9673,7 @@ export type VersionUpstreamProjectQuery = {
       revision: string;
       triggerID: string;
       triggerType: string;
-      task?: { __typename?: "Task"; execution: number; id: string } | null;
+      task?: { __typename?: "Task"; id: string; execution: number } | null;
       version?: { __typename?: "Version"; id: string } | null;
     } | null;
   };
@@ -9687,13 +9687,13 @@ export type VersionQuery = {
   __typename?: "Query";
   version: {
     __typename?: "Version";
+    id: string;
     activated?: boolean | null;
     author: string;
     authorEmail: string;
     createTime: Date;
     errors: Array<string>;
     finishTime?: Date | null;
-    id: string;
     ignored: boolean;
     isPatch: boolean;
     message: string;
@@ -9720,8 +9720,8 @@ export type VersionQuery = {
     }> | null;
     manifest?: {
       __typename?: "Manifest";
-      branch: string;
       id: string;
+      branch: string;
       isBase: boolean;
       moduleOverrides?: { [key: string]: any } | null;
       modules?: any | null;
@@ -9731,13 +9731,13 @@ export type VersionQuery = {
     parameters: Array<{ __typename?: "Parameter"; key: string; value: string }>;
     patch?: {
       __typename?: "Patch";
-      alias?: string | null;
       id: string;
+      alias?: string | null;
       patchNumber: number;
       childPatches?: Array<{
         __typename?: "Patch";
-        githash: string;
         id: string;
+        githash: string;
         projectIdentifier: string;
         status: string;
         taskCount?: number | null;
@@ -9761,8 +9761,8 @@ export type VersionQuery = {
     } | null;
     projectMetadata?: {
       __typename?: "Project";
-      branch: string;
       id: string;
+      branch: string;
       owner: string;
       repo: string;
     } | null;
@@ -9779,7 +9779,7 @@ export type VersionQuery = {
       revision: string;
       triggerID: string;
       triggerType: string;
-      task?: { __typename?: "Task"; execution: number; id: string } | null;
+      task?: { __typename?: "Task"; id: string; execution: number } | null;
       version?: { __typename?: "Version"; id: string } | null;
     } | null;
   };
@@ -9794,9 +9794,9 @@ export type ViewableProjectRefsQuery = {
     groupDisplayName: string;
     projects: Array<{
       __typename?: "Project";
+      id: string;
       displayName: string;
       enabled?: boolean | null;
-      id: string;
       identifier: string;
       isFavorite: boolean;
       owner: string;
@@ -9836,11 +9836,11 @@ export type WaterfallQuery = {
     __typename?: "Waterfall";
     flattenedVersions: Array<{
       __typename?: "Version";
+      id: string;
       activated?: boolean | null;
       author: string;
       createTime: Date;
       errors: Array<string>;
-      id: string;
       message: string;
       order: number;
       requester: string;
@@ -9848,16 +9848,16 @@ export type WaterfallQuery = {
       gitTags?: Array<{ __typename?: "GitTag"; tag: string }> | null;
       waterfallBuilds?: Array<{
         __typename?: "WaterfallBuild";
+        id: string;
         activated: boolean;
         buildVariant: string;
         displayName: string;
-        id: string;
         tasks: Array<{
           __typename?: "WaterfallTask";
+          id: string;
           displayName: string;
           displayStatusCache: string;
           execution: number;
-          id: string;
           status: string;
         }>;
       }> | null;

--- a/apps/spruce/src/gql/mutations/add-favorite-project.graphql
+++ b/apps/spruce/src/gql/mutations/add-favorite-project.graphql
@@ -1,7 +1,7 @@
 mutation AddFavoriteProject($projectIdentifier: String!) {
   addFavoriteProject(opts: { projectIdentifier: $projectIdentifier }) {
-    displayName
     id
+    displayName
     identifier
     isFavorite
     owner

--- a/apps/spruce/src/gql/mutations/override-task-dependencies.graphql
+++ b/apps/spruce/src/gql/mutations/override-task-dependencies.graphql
@@ -1,7 +1,7 @@
 mutation OverrideTaskDependencies($taskId: String!) {
   overrideTaskDependencies(taskId: $taskId) {
+    id
     displayStatus
     execution
-    id
   }
 }

--- a/apps/spruce/src/gql/mutations/remove-favorite-project.graphql
+++ b/apps/spruce/src/gql/mutations/remove-favorite-project.graphql
@@ -1,7 +1,7 @@
 mutation RemoveFavoriteProject($projectIdentifier: String!) {
   removeFavoriteProject(opts: { projectIdentifier: $projectIdentifier }) {
-    displayName
     id
+    displayName
     identifier
     isFavorite
     owner

--- a/apps/spruce/src/gql/mutations/restart-versions.graphql
+++ b/apps/spruce/src/gql/mutations/restart-versions.graphql
@@ -10,11 +10,11 @@ mutation RestartVersions(
   ) {
     id
     patch {
+      id
       childPatches {
         id
         status
       }
-      id
       status
     }
     status

--- a/apps/spruce/src/gql/mutations/schedule-patch.graphql
+++ b/apps/spruce/src/gql/mutations/schedule-patch.graphql
@@ -6,10 +6,10 @@ mutation SchedulePatch($patchId: String!, $configure: PatchConfigure!) {
     tasks
     variants
     versionFull {
+      id
       childVersions {
         id
       }
-      id
     }
   }
 }

--- a/apps/spruce/src/gql/mutations/schedule-tasks.graphql
+++ b/apps/spruce/src/gql/mutations/schedule-tasks.graphql
@@ -3,8 +3,8 @@
 mutation ScheduleTasks($taskIds: [String!]!, $versionId: String!) {
   scheduleTasks(taskIds: $taskIds, versionId: $versionId) {
     ...BaseTask
-    status
     canSchedule
     canUnschedule
+    status
   }
 }

--- a/apps/spruce/src/gql/mutations/schedule-undispatched-base-tasks.graphql
+++ b/apps/spruce/src/gql/mutations/schedule-undispatched-base-tasks.graphql
@@ -1,7 +1,7 @@
 mutation ScheduleUndispatchedBaseTasks($versionId: String!) {
   scheduleUndispatchedBaseTasks(versionId: $versionId) {
+    id
     displayStatus
     execution
-    id
   }
 }

--- a/apps/spruce/src/gql/mutations/set-patch-visibility.graphql
+++ b/apps/spruce/src/gql/mutations/set-patch-visibility.graphql
@@ -1,6 +1,6 @@
 mutation SetPatchVisibility($patchIds: [String!]!, $hidden: Boolean!) {
   setPatchVisibility(patchIds: $patchIds, hidden: $hidden) {
-    hidden
     id
+    hidden
   }
 }

--- a/apps/spruce/src/gql/mutations/set-task-priority.graphql
+++ b/apps/spruce/src/gql/mutations/set-task-priority.graphql
@@ -1,7 +1,7 @@
 mutation SetTaskPriority($taskId: String!, $priority: Int!) {
   setTaskPriority(taskId: $taskId, priority: $priority) {
-    execution
     id
+    execution
     priority
   }
 }

--- a/apps/spruce/src/gql/mutations/unschedule-task.graphql
+++ b/apps/spruce/src/gql/mutations/unschedule-task.graphql
@@ -1,10 +1,10 @@
 mutation UnscheduleTask($taskId: String!) {
   unscheduleTask(taskId: $taskId) {
-    execution
     id
-    status
-    displayStatus
     canSchedule
     canUnschedule
+    displayStatus
+    execution
+    status
   }
 }

--- a/apps/spruce/src/gql/queries/agent-logs.graphql
+++ b/apps/spruce/src/gql/queries/agent-logs.graphql
@@ -2,8 +2,8 @@
 
 query AgentLogs($id: String!, $execution: Int) {
   task(taskId: $id, execution: $execution) {
-    execution
     id
+    execution
     taskLogs {
       agentLogs {
         ...LogMessage

--- a/apps/spruce/src/gql/queries/all-logs.graphql
+++ b/apps/spruce/src/gql/queries/all-logs.graphql
@@ -2,8 +2,8 @@
 
 query AllLogs($id: String!, $execution: Int) {
   task(taskId: $id, execution: $execution) {
-    execution
     id
+    execution
     taskLogs {
       allLogs {
         ...LogMessage

--- a/apps/spruce/src/gql/queries/base-version-and-task.graphql
+++ b/apps/spruce/src/gql/queries/base-version-and-task.graphql
@@ -1,22 +1,22 @@
 query BaseVersionAndTask($taskId: String!) {
   task(taskId: $taskId) {
+    id
     baseTask {
+      id
       displayStatus
       execution
-      id
     }
     buildVariant
     displayName
     displayStatus
     execution
-    id
     projectIdentifier
     versionMetadata {
+      id
       baseVersion {
         id
         order
       }
-      id
       isPatch
     }
   }

--- a/apps/spruce/src/gql/queries/build-variant-stats.graphql
+++ b/apps/spruce/src/gql/queries/build-variant-stats.graphql
@@ -1,5 +1,6 @@
 query BuildVariantStats($id: String!) {
   version(versionId: $id) {
+    id
     buildVariantStats(options: {}) {
       displayName
       statusCounts {
@@ -8,6 +9,5 @@ query BuildVariantStats($id: String!) {
       }
       variant
     }
-    id
   }
 }

--- a/apps/spruce/src/gql/queries/build-variants-with-children.graphql
+++ b/apps/spruce/src/gql/queries/build-variants-with-children.graphql
@@ -1,25 +1,27 @@
 query BuildVariantsWithChildren($id: String!, $statuses: [String!]!) {
   version(versionId: $id) {
+    id
     buildVariants(options: { statuses: $statuses }) {
       displayName
       tasks {
+        id
         baseStatus
         displayName
         displayStatus
         execution
-        id
       }
       variant
     }
     childVersions {
+      id
       buildVariants(options: { statuses: $statuses }) {
         displayName
         tasks {
+          id
           baseStatus
           displayName
           displayStatus
           execution
-          id
         }
         variant
       }
@@ -27,7 +29,6 @@ query BuildVariantsWithChildren($id: String!, $statuses: [String!]!) {
         estimatedTasks
         taskId
       }
-      id
       project
       projectIdentifier
     }
@@ -35,6 +36,5 @@ query BuildVariantsWithChildren($id: String!, $statuses: [String!]!) {
       estimatedTasks
       taskId
     }
-    id
   }
 }

--- a/apps/spruce/src/gql/queries/display-task.graphql
+++ b/apps/spruce/src/gql/queries/display-task.graphql
@@ -1,12 +1,12 @@
 query DisplayTask($taskId: String!, $execution: Int) {
   task(taskId: $taskId, execution: $execution) {
+    id
     displayName
     displayTask {
-      execution
       id
+      execution
     }
     execution
     executionTasks
-    id
   }
 }

--- a/apps/spruce/src/gql/queries/distro-task-queue.graphql
+++ b/apps/spruce/src/gql/queries/distro-task-queue.graphql
@@ -1,10 +1,10 @@
 query DistroTaskQueue($distroId: String!) {
   distroTaskQueue(distroId: $distroId) {
+    id
     activatedBy
     buildVariant
     displayName
     expectedDuration
-    id
     priority
     project
     projectIdentifier

--- a/apps/spruce/src/gql/queries/failed-task-status-icon-tooltip.graphql
+++ b/apps/spruce/src/gql/queries/failed-task-status-icon-tooltip.graphql
@@ -1,7 +1,7 @@
 query FailedTaskStatusIconTooltip($taskId: String!) {
   task(taskId: $taskId) {
-    execution
     id
+    execution
     tests(opts: { statuses: ["fail"], limit: 5 }) {
       filteredTestCount
       testResults {

--- a/apps/spruce/src/gql/queries/host-events.graphql
+++ b/apps/spruce/src/gql/queries/host-events.graphql
@@ -1,8 +1,10 @@
 query HostEvents($id: String!, $opts: HostEventsInput!) {
   host(hostId: $id) {
+    id
     events(opts: $opts) {
       count
       eventLogEntries {
+        id
         data {
           agentBuild
           agentRevision
@@ -22,7 +24,6 @@ query HostEvents($id: String!, $opts: HostEventsInput!) {
           user
         }
         eventType
-        id
         processedAt
         resourceId
         resourceType
@@ -30,6 +31,5 @@ query HostEvents($id: String!, $opts: HostEventsInput!) {
       }
     }
     eventTypes
-    id
   }
 }

--- a/apps/spruce/src/gql/queries/host.graphql
+++ b/apps/spruce/src/gql/queries/host.graphql
@@ -2,11 +2,11 @@
 
 query Host($id: String!) {
   host(hostId: $id) {
-    ami
     ...BaseHost
+    ami
     distro {
-      bootstrapMethod
       id
+      bootstrapMethod
     }
     distroId
     lastCommunicationTime

--- a/apps/spruce/src/gql/queries/hosts.graphql
+++ b/apps/spruce/src/gql/queries/hosts.graphql
@@ -22,14 +22,14 @@ query Hosts(
   ) {
     filteredHostsCount
     hosts {
+      id
       distro {
-        bootstrapMethod
         id
+        bootstrapMethod
       }
       distroId
       elapsed
       hostUrl
-      id
       noExpiration
       provider
       runningTask {

--- a/apps/spruce/src/gql/queries/image-distros.graphql
+++ b/apps/spruce/src/gql/queries/image-distros.graphql
@@ -1,5 +1,6 @@
 query ImageDistros($imageId: String!) {
   image(imageId: $imageId) {
+    id
     distros {
       hostAllocatorSettings {
         maximumHosts
@@ -8,6 +9,5 @@ query ImageDistros($imageId: String!) {
       provider
       providerSettingsList
     }
-    id
   }
 }

--- a/apps/spruce/src/gql/queries/image-events.graphql
+++ b/apps/spruce/src/gql/queries/image-events.graphql
@@ -1,5 +1,6 @@
 query ImageEvents($imageId: String!, $limit: Int!, $page: Int!) {
   image(imageId: $imageId) {
+    id
     events(limit: $limit, page: $page) {
       count
       eventLogEntries {
@@ -15,6 +16,5 @@ query ImageEvents($imageId: String!, $limit: Int!, $page: Int!) {
         timestamp
       }
     }
-    id
   }
 }

--- a/apps/spruce/src/gql/queries/image-general.graphql
+++ b/apps/spruce/src/gql/queries/image-general.graphql
@@ -1,12 +1,12 @@
 query ImageGeneral($imageId: String!) {
   image(imageId: $imageId) {
-    ami
     id
+    ami
     lastDeployed
     latestTask {
+      id
       execution
       finishTime
-      id
     }
   }
 }

--- a/apps/spruce/src/gql/queries/jira-custom-created-issues.graphql
+++ b/apps/spruce/src/gql/queries/jira-custom-created-issues.graphql
@@ -2,13 +2,13 @@
 
 query CustomCreatedIssues($taskId: String!, $execution: Int) {
   task(taskId: $taskId, execution: $execution) {
+    id
     annotation {
+      id
       createdIssues {
         ...IssueLink
       }
-      id
     }
     execution
-    id
   }
 }

--- a/apps/spruce/src/gql/queries/jira-issues.graphql
+++ b/apps/spruce/src/gql/queries/jira-issues.graphql
@@ -2,6 +2,7 @@
 
 query Issues($taskId: String!, $execution: Int) {
   task(taskId: $taskId, execution: $execution) {
+    id
     annotation {
       id
       issues {
@@ -9,6 +10,5 @@ query Issues($taskId: String!, $execution: Int) {
       }
     }
     execution
-    id
   }
 }

--- a/apps/spruce/src/gql/queries/jira-suspected-issues.graphql
+++ b/apps/spruce/src/gql/queries/jira-suspected-issues.graphql
@@ -2,6 +2,7 @@
 
 query SuspectedIssues($taskId: String!, $execution: Int) {
   task(taskId: $taskId, execution: $execution) {
+    id
     annotation {
       id
       suspectedIssues {
@@ -9,6 +10,5 @@ query SuspectedIssues($taskId: String!, $execution: Int) {
       }
     }
     execution
-    id
   }
 }

--- a/apps/spruce/src/gql/queries/last-mainline-commit.graphql
+++ b/apps/spruce/src/gql/queries/last-mainline-commit.graphql
@@ -14,15 +14,15 @@ query LastMainlineCommit(
   ) {
     versions {
       version {
+        id
         buildVariants(options: $buildVariantOptions) {
           tasks {
+            id
             displayStatus
             execution
-            id
             order
           }
         }
-        id
       }
     }
   }

--- a/apps/spruce/src/gql/queries/logkeeper-build-metadata.graphql
+++ b/apps/spruce/src/gql/queries/logkeeper-build-metadata.graphql
@@ -1,8 +1,8 @@
 query LogkeeperBuildMetadata($buildId: String!) {
   logkeeperBuildMetadata(buildId: $buildId) {
+    id
     builder
     buildNum
-    id
     taskExecution
     taskId
     tests {

--- a/apps/spruce/src/gql/queries/mainline-commits-for-history.graphql
+++ b/apps/spruce/src/gql/queries/mainline-commits-for-history.graphql
@@ -12,26 +12,28 @@ query MainlineCommitsForHistory(
     prevPageOrderNumber
     versions {
       rolledUpVersions {
+        id
         author
         createTime
         gitTags {
           pusher
           tag
         }
-        id
         message
         order
         revision
       }
       version {
+        ...UpstreamProject
+        id
         author
         buildVariants(options: $buildVariantOptions) {
           displayName
           tasks {
+            id
             displayName
             displayStatus
             execution
-            id
           }
           variant
         }
@@ -40,11 +42,9 @@ query MainlineCommitsForHistory(
           pusher
           tag
         }
-        id
         message
         order
         revision
-        ...UpstreamProject
       }
     }
   }

--- a/apps/spruce/src/gql/queries/mainline-commits.graphql
+++ b/apps/spruce/src/gql/queries/mainline-commits.graphql
@@ -15,24 +15,26 @@ query MainlineCommits(
     prevPageOrderNumber
     versions {
       rolledUpVersions {
+        id
         author
         createTime
-        id
         ignored
         message
         order
         revision
       }
       version {
+        id
+        ...UpstreamProject
         author
         buildVariants(options: $buildVariantOptionsForTaskIcons) {
           displayName
           tasks {
+            id
             displayName
             displayStatus
             execution
             hasCedarResults
-            id
             timeTaken
           }
           variant
@@ -50,7 +52,6 @@ query MainlineCommits(
           pusher
           tag
         }
-        id
         message
         order
         projectIdentifier
@@ -62,7 +63,6 @@ query MainlineCommits(
           }
           eta
         }
-        ...UpstreamProject
       }
     }
   }

--- a/apps/spruce/src/gql/queries/mainline-commits.graphql
+++ b/apps/spruce/src/gql/queries/mainline-commits.graphql
@@ -24,8 +24,8 @@ query MainlineCommits(
         revision
       }
       version {
-        id
         ...UpstreamProject
+        id
         author
         buildVariants(options: $buildVariantOptionsForTaskIcons) {
           displayName

--- a/apps/spruce/src/gql/queries/my-volumes.graphql
+++ b/apps/spruce/src/gql/queries/my-volumes.graphql
@@ -1,5 +1,6 @@
 query MyVolumes {
   myVolumes {
+    id
     availabilityZone
     createdBy
     creationTime
@@ -8,12 +9,11 @@ query MyVolumes {
     expiration
     homeVolume
     host {
-      displayName
       id
+      displayName
       noExpiration
     }
     hostID
-    id
     migrating
     noExpiration
     size

--- a/apps/spruce/src/gql/queries/patch-task-statuses.graphql
+++ b/apps/spruce/src/gql/queries/patch-task-statuses.graphql
@@ -1,7 +1,7 @@
 query PatchTaskStatuses($id: String!) {
   patch(patchId: $id) {
-    baseTaskStatuses
     id
+    baseTaskStatuses
     taskStatuses
   }
 }

--- a/apps/spruce/src/gql/queries/pod-events.graphql
+++ b/apps/spruce/src/gql/queries/pod-events.graphql
@@ -1,29 +1,29 @@
 query PodEvents($id: String!, $limit: Int, $page: Int) {
   pod(podId: $id) {
+    id
     events(page: $page, limit: $limit) {
       count
       eventLogEntries {
+        id
         data {
           newStatus
           oldStatus
           reason
           task {
+            id
             displayName
             execution
-            id
           }
           taskExecution
           taskID
           taskStatus
         }
         eventType
-        id
         processedAt
         resourceId
         resourceType
         timestamp
       }
     }
-    id
   }
 }

--- a/apps/spruce/src/gql/queries/pod.graphql
+++ b/apps/spruce/src/gql/queries/pod.graphql
@@ -3,9 +3,9 @@ query Pod($podId: String!) {
     id
     status
     task {
+      id
       displayName
       execution
-      id
     }
     taskContainerCreationOpts {
       arch

--- a/apps/spruce/src/gql/queries/project-banner.graphql
+++ b/apps/spruce/src/gql/queries/project-banner.graphql
@@ -1,9 +1,9 @@
 query ProjectBanner($identifier: String!) {
   project(projectIdentifier: $identifier) {
+    id
     banner {
       text
       theme
     }
-    id
   }
 }

--- a/apps/spruce/src/gql/queries/project-patches.graphql
+++ b/apps/spruce/src/gql/queries/project-patches.graphql
@@ -5,8 +5,8 @@ query ProjectPatches(
   $patchesInput: PatchesInput!
 ) {
   project(projectIdentifier: $projectIdentifier) {
-    displayName
     id
+    displayName
     patches(patchesInput: $patchesInput) {
       ...PatchesPagePatches
     }

--- a/apps/spruce/src/gql/queries/projects.graphql
+++ b/apps/spruce/src/gql/queries/projects.graphql
@@ -2,8 +2,8 @@ query Projects {
   projects {
     groupDisplayName
     projects {
-      displayName
       id
+      displayName
       identifier
       isFavorite
       owner

--- a/apps/spruce/src/gql/queries/repotracker-error.graphql
+++ b/apps/spruce/src/gql/queries/repotracker-error.graphql
@@ -1,7 +1,7 @@
 query RepotrackerError($projectIdentifier: String!) {
   project(projectIdentifier: $projectIdentifier) {
-    branch
     id
+    branch
     repotrackerError {
       exists
       invalidRevision

--- a/apps/spruce/src/gql/queries/single-task-distro.graphql
+++ b/apps/spruce/src/gql/queries/single-task-distro.graphql
@@ -2,9 +2,9 @@ query SingleTaskDistro {
   spruceConfig {
     singleTaskDistro {
       projectTasksPairs {
-        projectId
-        allowedTasks
         allowedBVs
+        allowedTasks
+        projectId
       }
     }
   }

--- a/apps/spruce/src/gql/queries/spruce-config.graphql
+++ b/apps/spruce/src/gql/queries/spruce-config.graphql
@@ -4,8 +4,8 @@ query SpruceConfig {
     bannerTheme
     containerPools {
       pools {
-        distro
         id
+        distro
         maxContainers
         port
       }

--- a/apps/spruce/src/gql/queries/system-logs.graphql
+++ b/apps/spruce/src/gql/queries/system-logs.graphql
@@ -2,8 +2,8 @@
 
 query SystemLogs($id: String!, $execution: Int) {
   task(taskId: $id, execution: $execution) {
-    execution
     id
+    execution
     taskLogs {
       systemLogs {
         ...LogMessage

--- a/apps/spruce/src/gql/queries/task-all-executions.graphql
+++ b/apps/spruce/src/gql/queries/task-all-executions.graphql
@@ -1,9 +1,9 @@
 query TaskAllExecutions($taskId: String!) {
   taskAllExecutions(taskId: $taskId) {
+    id
     activatedTime
     displayStatus
     execution
-    id
     ingestTime
   }
 }

--- a/apps/spruce/src/gql/queries/task-event-logs.graphql
+++ b/apps/spruce/src/gql/queries/task-event-logs.graphql
@@ -1,9 +1,10 @@
 query TaskEventLogs($id: String!, $execution: Int) {
   task(taskId: $id, execution: $execution) {
-    execution
     id
+    execution
     taskLogs {
       eventLogs {
+        id
         data {
           blockedOn
           hostId
@@ -16,7 +17,6 @@ query TaskEventLogs($id: String!, $execution: Int) {
           userId
         }
         eventType
-        id
         timestamp
       }
     }

--- a/apps/spruce/src/gql/queries/task-files.graphql
+++ b/apps/spruce/src/gql/queries/task-files.graphql
@@ -1,5 +1,6 @@
 query TaskFiles($taskId: String!, $execution: Int) {
   task(taskId: $taskId, execution: $execution) {
+    id
     execution
     files {
       fileCount
@@ -12,6 +13,5 @@ query TaskFiles($taskId: String!, $execution: Int) {
         taskName
       }
     }
-    id
   }
 }

--- a/apps/spruce/src/gql/queries/task-history.graphql
+++ b/apps/spruce/src/gql/queries/task-history.graphql
@@ -2,10 +2,10 @@ query TaskHistory($options: TaskHistoryOpts!) {
   taskHistory(options: $options) {
     tasks {
       id
-      order
+      activated
       displayStatus
       execution
-      activated
+      order
     }
   }
 }

--- a/apps/spruce/src/gql/queries/task-logs.graphql
+++ b/apps/spruce/src/gql/queries/task-logs.graphql
@@ -2,8 +2,8 @@
 
 query TaskLogs($id: String!, $execution: Int) {
   task(taskId: $id, execution: $execution) {
-    execution
     id
+    execution
     taskLogs {
       taskLogs {
         ...LogMessage

--- a/apps/spruce/src/gql/queries/task-queue-distros.graphql
+++ b/apps/spruce/src/gql/queries/task-queue-distros.graphql
@@ -1,7 +1,7 @@
 query TaskQueueDistros {
   taskQueueDistros {
-    hostCount
     id
+    hostCount
     taskCount
   }
 }

--- a/apps/spruce/src/gql/queries/task-statuses.graphql
+++ b/apps/spruce/src/gql/queries/task-statuses.graphql
@@ -1,7 +1,7 @@
 query TaskStatuses($id: String!) {
   version(versionId: $id) {
-    baseTaskStatuses
     id
+    baseTaskStatuses
     taskStatuses
   }
 }

--- a/apps/spruce/src/gql/queries/task-tests-for-job-logs.graphql
+++ b/apps/spruce/src/gql/queries/task-tests-for-job-logs.graphql
@@ -5,8 +5,8 @@ query TaskTestsForJobLogs($id: String!, $execution: Int) {
     ...BaseTask
     tests(opts: {}) {
       testResults {
-        groupID
         id
+        groupID
         logs {
           urlParsley
         }

--- a/apps/spruce/src/gql/queries/task-tests.graphql
+++ b/apps/spruce/src/gql/queries/task-tests.graphql
@@ -8,8 +8,8 @@ query TaskTests(
   $testName: String!
 ) {
   task(taskId: $id, execution: $execution) {
-    execution
     id
+    execution
     tests(
       opts: {
         sort: $sort
@@ -21,9 +21,9 @@ query TaskTests(
     ) {
       filteredTestCount
       testResults {
+        id
         baseStatus
         duration
-        id
         logs {
           url
           urlParsley

--- a/apps/spruce/src/gql/queries/task.graphql
+++ b/apps/spruce/src/gql/queries/task.graphql
@@ -3,6 +3,7 @@
 
 query Task($taskId: String!, $execution: Int) {
   task(taskId: $taskId, execution: $execution) {
+    ...BaseTask
     aborted
     abortInfo {
       buildVariantDisplayName
@@ -19,15 +20,14 @@ query Task($taskId: String!, $execution: Int) {
       ...Annotation
     }
     baseTask {
-      execution
       id
+      execution
       timeTaken
       versionMetadata {
         id
         revision
       }
     }
-    ...BaseTask
     blocked
     canAbort
     canDisable
@@ -59,20 +59,20 @@ query Task($taskId: String!, $execution: Int) {
       type
     }
     displayTask {
+      id
       displayName
       execution
-      id
     }
     distroId
     estimatedStart
     executionTasksFull {
       ...BaseTask
+      id
       buildVariant
       buildVariantDisplayName
       displayName
       displayStatus
       execution
-      id
       projectIdentifier
     }
     expectedDuration
@@ -121,8 +121,8 @@ query Task($taskId: String!, $execution: Int) {
     timeTaken
     totalTestCount
     versionMetadata {
-      author
       id
+      author
       isPatch
       message
       order

--- a/apps/spruce/src/gql/queries/test-analysis.graphql
+++ b/apps/spruce/src/gql/queries/test-analysis.graphql
@@ -8,12 +8,12 @@ query TestAnalysis(
     tasks(options: $options) {
       count
       data {
+        id
         buildVariant
         buildVariantDisplayName
         displayName
         displayStatus
         execution
-        id
         tests(opts: $opts) {
           filteredTestCount
           testResults {

--- a/apps/spruce/src/gql/queries/undispatched-tasks.graphql
+++ b/apps/spruce/src/gql/queries/undispatched-tasks.graphql
@@ -1,19 +1,19 @@
 query UndispatchedTasks($versionId: String!) {
   version(versionId: $versionId) {
+    id
     generatedTaskCounts {
       estimatedTasks
       taskId
     }
-    id
     tasks(
       options: { statuses: ["unscheduled"], includeNeverActivatedTasks: true }
     ) {
       data {
+        id
         buildVariant
         buildVariantDisplayName
         displayName
         execution
-        id
       }
     }
   }

--- a/apps/spruce/src/gql/queries/user-subscriptions.graphql
+++ b/apps/spruce/src/gql/queries/user-subscriptions.graphql
@@ -1,5 +1,14 @@
 query UserSubscriptions {
   user {
+    settings {
+      notifications {
+        buildBreakId
+        patchFinishId
+        patchFirstFailureId
+        spawnHostExpirationId
+        spawnHostOutcomeId
+      }
+    }
     subscriptions {
       id
       ownerType
@@ -24,14 +33,5 @@ query UserSubscriptions {
       triggerData
     }
     userId
-    settings {
-      notifications {
-        buildBreakId
-        patchFinishId
-        patchFirstFailureId
-        spawnHostExpirationId
-        spawnHostOutcomeId
-      }
-    }
   }
 }

--- a/apps/spruce/src/gql/queries/version-task-durations.graphql
+++ b/apps/spruce/src/gql/queries/version-task-durations.graphql
@@ -7,18 +7,18 @@ query VersionTaskDurations(
     tasks(options: $taskFilterOptions) {
       count
       data {
+        id
         buildVariantDisplayName
         displayName
         displayStatus
         execution
-        id
         startTime
         subRows: executionTasksFull {
+          id
           buildVariantDisplayName
           displayName
           displayStatus
           execution
-          id
           startTime
           timeTaken
         }

--- a/apps/spruce/src/gql/queries/version-tasks.graphql
+++ b/apps/spruce/src/gql/queries/version-tasks.graphql
@@ -8,11 +8,12 @@ query VersionTasks(
     tasks(options: $taskFilterOptions) {
       count
       data {
+        id
         aborted
         baseTask {
+          id
           displayStatus
           execution
-          id
         }
         blocked
         buildVariant
@@ -24,20 +25,19 @@ query VersionTasks(
         displayStatus
         execution
         executionTasksFull {
+          id
           baseTask {
+            id
             displayStatus
             execution
-            id
           }
           buildVariant
           buildVariantDisplayName
           displayName
           displayStatus
           execution
-          id
           projectIdentifier
         }
-        id
         projectIdentifier
       }
     }

--- a/apps/spruce/src/gql/queries/version-upstream-project.graphql
+++ b/apps/spruce/src/gql/queries/version-upstream-project.graphql
@@ -2,7 +2,7 @@
 
 query VersionUpstreamProject($versionId: String!) {
   version(versionId: $versionId) {
-    id
     ...UpstreamProject
+    id
   }
 }

--- a/apps/spruce/src/gql/queries/version.graphql
+++ b/apps/spruce/src/gql/queries/version.graphql
@@ -2,6 +2,7 @@
 
 query Version($id: String!) {
   version(versionId: $id) {
+    id
     activated
     author
     authorEmail
@@ -19,12 +20,11 @@ query Version($id: String!) {
       pusher
       tag
     }
-    id
     ignored
     isPatch
     manifest {
-      branch
       id
+      branch
       isBase
       moduleOverrides
       modules
@@ -38,10 +38,11 @@ query Version($id: String!) {
       value
     }
     patch {
+      id
       alias
       childPatches {
-        githash
         id
+        githash
         parameters {
           key
           value
@@ -50,16 +51,16 @@ query Version($id: String!) {
         status
         taskCount
         versionFull {
+          id
           baseVersion {
             id
           }
-          id
           status
         }
       }
-      id
       patchNumber
     }
+    ...UpstreamProject
     previousVersion {
       id
       revision
@@ -67,8 +68,8 @@ query Version($id: String!) {
     project
     projectIdentifier
     projectMetadata {
-      branch
       id
+      branch
       owner
       repo
     }
@@ -78,7 +79,6 @@ query Version($id: String!) {
     startTime
     status
     taskCount
-    ...UpstreamProject
     versionTiming {
       makespan
       timeTaken

--- a/apps/spruce/src/gql/queries/version.graphql
+++ b/apps/spruce/src/gql/queries/version.graphql
@@ -2,6 +2,7 @@
 
 query Version($id: String!) {
   version(versionId: $id) {
+    ...UpstreamProject
     id
     activated
     author
@@ -60,7 +61,6 @@ query Version($id: String!) {
       }
       patchNumber
     }
-    ...UpstreamProject
     previousVersion {
       id
       revision

--- a/apps/spruce/src/gql/queries/viewable-projects.graphql
+++ b/apps/spruce/src/gql/queries/viewable-projects.graphql
@@ -2,9 +2,9 @@ query ViewableProjectRefs {
   viewableProjectRefs {
     groupDisplayName
     projects {
+      id
       displayName
       enabled
-      id
       identifier
       isFavorite
       owner

--- a/apps/spruce/src/gql/queries/waterfall.graphql
+++ b/apps/spruce/src/gql/queries/waterfall.graphql
@@ -3,6 +3,7 @@
 query Waterfall($options: WaterfallOptions!) {
   waterfall(options: $options) {
     flattenedVersions {
+      id
       activated
       author
       createTime
@@ -10,21 +11,20 @@ query Waterfall($options: WaterfallOptions!) {
       gitTags {
         tag
       }
-      id
       message
       order
       requester
       revision
       waterfallBuilds {
+        id
         activated
         buildVariant
         displayName
-        id
         tasks {
+          id
           displayName
           displayStatusCache
           execution
-          id
           status
         }
       }

--- a/packages/eslint-config/eslint.config.js
+++ b/packages/eslint-config/eslint.config.js
@@ -322,6 +322,10 @@ const graphQLConfig = {
   },
   rules: {
     ...graphqlPlugin.configs["flat/operations-recommended"].rules,
+    "@graphql-eslint/alphabetize": [
+      WARN,
+      { selections: ["OperationDefinition"], groups: ["...", "id", "*"] },
+    ],
     "@graphql-eslint/no-deprecated": WARN,
     "@graphql-eslint/selection-set-depth": [WARN, { maxDepth: 8 }],
     "spaced-comment": OFF,

--- a/packages/eslint-config/eslint.config.js
+++ b/packages/eslint-config/eslint.config.js
@@ -324,7 +324,10 @@ const graphQLConfig = {
     ...graphqlPlugin.configs["flat/operations-recommended"].rules,
     "@graphql-eslint/alphabetize": [
       WARN,
-      { selections: ["OperationDefinition"], groups: ["...", "id", "*"] },
+      {
+        selections: ["OperationDefinition", "FragmentDefinition"],
+        groups: ["...", "id", "*"],
+      },
     ],
     "@graphql-eslint/no-deprecated": WARN,
     "@graphql-eslint/selection-set-depth": [WARN, { maxDepth: 8 }],

--- a/packages/eslint-config/eslint.config.js
+++ b/packages/eslint-config/eslint.config.js
@@ -323,7 +323,7 @@ const graphQLConfig = {
   rules: {
     ...graphqlPlugin.configs["flat/operations-recommended"].rules,
     "@graphql-eslint/alphabetize": [
-      WARN,
+      errorIfStrict,
       {
         selections: ["OperationDefinition", "FragmentDefinition"],
         groups: ["...", "id", "*"],


### PR DESCRIPTION
DEVPROD-16397
<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
We used to have this rule but I think I lost it when migrating the repo to ESLint 9.

Also added some rules to enforce that fragments and `id` field is always put first.


