### PR TITLE
DEVPROD-16173: Unhide Task History tab on production

### DIFF
--- a/apps/spruce/src/components/styles/Layout.tsx
+++ b/apps/spruce/src/components/styles/Layout.tsx
@@ -40,8 +40,11 @@ export const PageLayout = styled.section<{ hasSider?: boolean }>`
   flex-direction: ${({ hasSider }) => (hasSider ? "row" : "column")};
   min-height: 0;
 `;
+
+export const siderCardWidth = 275;
+
 export const PageSider = styled.aside<{ width?: number }>`
-  ${({ width = 275 }) => `
+  ${({ width = siderCardWidth }) => `
    max-width: ${width}px;
    min-width: ${width}px;
    width: ${width}px;
@@ -53,7 +56,7 @@ export const PageContent = styled.main`
   overflow: hidden;
 `;
 
-PageSider.defaultProps = { width: 275 };
+PageSider.defaultProps = { width: siderCardWidth };
 
 export const PageTitle = styled(H2)<H2Props>`
   margin-bottom: ${size.s};

--- a/apps/spruce/src/constants/featureFlags.ts
+++ b/apps/spruce/src/constants/featureFlags.ts
@@ -1,5 +1,1 @@
-import { isProduction } from "utils/environmentVariables";
-
-const showTaskHistoryTab = !isProduction();
-
-export { showTaskHistoryTab };
+// placeholder

--- a/apps/spruce/src/pages/Task.tsx
+++ b/apps/spruce/src/pages/Task.tsx
@@ -151,9 +151,9 @@ export const Task = () => {
             taskId={taskId}
           />
         </PageSider>
-        <PageContent>
+        <StyledPageContent>
           {task && <TaskTabs isDisplayTask={isDisplayTask} task={task} />}
-        </PageContent>
+        </StyledPageContent>
       </PageLayout>
     </PageWrapper>
   );
@@ -163,4 +163,9 @@ const StyledBadgeWrapper = styled.div`
   > :nth-of-type(2) {
     margin-left: 10px;
   }
+`;
+
+const StyledPageContent = styled(PageContent)`
+  // Unset overflow so that sticky header in Task History tab can work properly.
+  overflow: unset;
 `;

--- a/apps/spruce/src/pages/task/TaskTabs.tsx
+++ b/apps/spruce/src/pages/task/TaskTabs.tsx
@@ -5,7 +5,6 @@ import { useTaskAnalytics } from "analytics";
 import { TrendChartsPlugin } from "components/PerfPlugin";
 import { StyledTabs } from "components/styles/StyledTabs";
 import { TabLabelWithBadge } from "components/TabLabelWithBadge";
-import { showTaskHistoryTab } from "constants/featureFlags";
 import { isMainlineRequester, Requester } from "constants/requesters";
 import { getTaskRoute, GetTaskRouteOptions, slugs } from "constants/routes";
 import { TaskQuery } from "gql/generated/types";
@@ -170,8 +169,7 @@ export const TaskTabs: React.FC<TaskTabProps> = ({ isDisplayTask, task }) => {
     [TaskTab.Files]: true,
     [TaskTab.Annotations]: showBuildBaron,
     [TaskTab.TrendCharts]: isPerfPluginEnabled,
-    [TaskTab.History]:
-      showTaskHistoryTab && isMainlineRequester(requester as Requester),
+    [TaskTab.History]: isMainlineRequester(requester as Requester),
   };
 
   const activeTabs = Object.keys(tabMap).filter(

--- a/apps/spruce/src/pages/task/taskTabs/Logs.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/Logs.tsx
@@ -9,6 +9,7 @@ import queryString from "query-string";
 import { useLocation } from "react-router-dom";
 import { size } from "@evg-ui/lib/constants/tokens";
 import { useTaskAnalytics } from "analytics";
+import { siderCardWidth } from "components/styles/Layout";
 import { getParsleyTaskLogLink } from "constants/externalResources";
 import { TaskLogLinks } from "gql/generated/types";
 import { useUpdateURLQueryParams } from "hooks";
@@ -71,7 +72,7 @@ export const Logs: React.FC<Props> = ({ execution, logLinks, taskId }) => {
   const LogComp = options[currentLog];
 
   return (
-    <>
+    <LogContainer>
       <LogHeader>
         <SegmentedControl
           aria-controls="Select a log type"
@@ -154,9 +155,14 @@ export const Logs: React.FC<Props> = ({ execution, logLinks, taskId }) => {
         )}
       </LogHeader>
       {LogComp && <LogComp setNoLogs={setNoLogs} />}
-    </>
+    </LogContainer>
   );
 };
+
+const LogContainer = styled.div`
+  // Subtract sider card width and margins.
+  width: calc(100vw - ${siderCardWidth}px - 80px);
+`;
 
 const LogHeader = styled.div`
   display: flex;

--- a/apps/spruce/src/pages/task/taskTabs/TaskHistory/TaskTimeline/__snapshots__/TaskTimeline_Default.storyshot
+++ b/apps/spruce/src/pages/task/taskTabs/TaskHistory/TaskTimeline/__snapshots__/TaskTimeline_Default.storyshot
@@ -34,17 +34,13 @@
       class="css-1inrmsu-Timeline ezsgi5w1"
       data-cy="task-timeline"
     >
-      <a
+      <div
         class="ezsgi5w0 css-11rp5yh-PolymorphicTaskBox-getTaskBoxStyles-getTaskStatusStyle-TaskBox ehu1qo81"
         data-cy="timeline-box"
-        href="/task/a/history?execution=0"
-        status="success"
       />
-      <a
+      <div
         class="ezsgi5w0 css-qjaf42-PolymorphicTaskBox-getTaskBoxStyles-getTaskStatusStyle-TaskBox ehu1qo81"
         data-cy="timeline-box"
-        href="/task/b/history?execution=0"
-        status="will-run"
       />
       <div
         class="css-dun3rh-CollapsedBox-getTaskBoxStyles-getCollapsedTaskBoxStyles ehu1qo80"
@@ -52,11 +48,9 @@
       >
         1
       </div>
-      <a
+      <div
         class="ezsgi5w0 css-1dyoxl7-PolymorphicTaskBox-getTaskBoxStyles-getTaskStatusStyle-TaskBox ehu1qo81"
         data-cy="timeline-box"
-        href="/task/d/history?execution=0"
-        status="setup-failed"
       />
       <div
         class="css-dun3rh-CollapsedBox-getTaskBoxStyles-getCollapsedTaskBoxStyles ehu1qo80"
@@ -64,11 +58,9 @@
       >
         1
       </div>
-      <a
+      <div
         class="ezsgi5w0 css-1fy6cmy-PolymorphicTaskBox-getTaskBoxStyles-getTaskStatusStyle-TaskBox ehu1qo81"
         data-cy="timeline-box"
-        href="/task/f/history?execution=0"
-        status="failed"
       />
       <div
         class="css-dun3rh-CollapsedBox-getTaskBoxStyles-getCollapsedTaskBoxStyles ehu1qo80"
@@ -76,17 +68,13 @@
       >
         3
       </div>
-      <a
+      <div
         class="ezsgi5w0 css-rbkdys-PolymorphicTaskBox-getTaskBoxStyles-getTaskStatusStyle-TaskBox ehu1qo81"
         data-cy="timeline-box"
-        href="/task/j/history?execution=0"
-        status="known-issue"
       />
-      <a
+      <div
         class="ezsgi5w0 css-12mk7h0-PolymorphicTaskBox-getTaskBoxStyles-getTaskStatusStyle-TaskBox ehu1qo81"
         data-cy="timeline-box"
-        href="/task/k/history?execution=0"
-        status="system-failed"
       />
     </div>
     <button

--- a/apps/spruce/src/pages/task/taskTabs/TaskHistory/TaskTimeline/index.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/TaskHistory/TaskTimeline/index.tsx
@@ -2,15 +2,12 @@ import { forwardRef } from "react";
 import styled from "@emotion/styled";
 import IconButton from "@leafygreen-ui/icon-button";
 import { Skeleton, Size as SkeletonSize } from "@leafygreen-ui/skeleton-loader";
-import { Link } from "react-router-dom";
 import Icon from "@evg-ui/lib/components/Icon";
 import { size } from "@evg-ui/lib/constants/tokens";
 import { TaskStatus } from "@evg-ui/lib/types/task";
 import { TaskBox as BaseTaskBox, CollapsedBox } from "components/TaskBox";
-import { getTaskRoute } from "constants/routes";
 import { TaskHistoryDirection } from "gql/generated/types";
 import { useQueryParams } from "hooks/useQueryParam";
-import { TaskTab } from "types/task";
 import { GroupedTask, TaskHistoryOptions, TaskHistoryTask } from "../types";
 
 type TaskHistoryPagination = {
@@ -70,14 +67,9 @@ const TaskTimeline = forwardRef<HTMLDivElement, TimelineProps>(
                   return (
                     <TaskBox
                       key={task.id}
-                      as={Link}
                       data-cy="timeline-box"
                       rightmost={false}
                       status={task.displayStatus as TaskStatus}
-                      to={getTaskRoute(task.id, {
-                        execution: task.execution,
-                        tab: TaskTab.History,
-                      })}
                     />
                   );
                 } else if (t.inactiveTasks) {

--- a/apps/spruce/src/pages/task/taskTabs/TaskHistory/TaskTimeline/index.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/TaskHistory/TaskTimeline/index.tsx
@@ -2,13 +2,10 @@ import { forwardRef } from "react";
 import styled from "@emotion/styled";
 import IconButton from "@leafygreen-ui/icon-button";
 import { Skeleton, Size as SkeletonSize } from "@leafygreen-ui/skeleton-loader";
-import { Link } from "react-router-dom";
 import Icon from "@evg-ui/lib/components/Icon";
 import { size } from "@evg-ui/lib/constants/tokens";
 import { TaskStatus } from "@evg-ui/lib/types/task";
 import { TaskBox as BaseTaskBox, CollapsedBox } from "components/TaskBox";
-import { getTaskRoute } from "constants/routes";
-import { TaskTab } from "types/task";
 import { GroupedTask } from "../types";
 
 interface TimelineProps {
@@ -33,14 +30,9 @@ const TaskTimeline = forwardRef<HTMLDivElement, TimelineProps>(
                 return (
                   <TaskBox
                     key={task.id}
-                    as={Link}
                     data-cy="timeline-box"
                     rightmost={false}
                     status={task.displayStatus as TaskStatus}
-                    to={getTaskRoute(task.id, {
-                      execution: task.execution,
-                      tab: TaskTab.History,
-                    })}
                   />
                 );
               } else if (t.inactiveTasks) {

--- a/apps/spruce/src/pages/task/taskTabs/TaskHistory/index.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/TaskHistory/index.tsx
@@ -121,64 +121,81 @@ const TaskHistory: React.FC<TaskHistoryProps> = ({ task }) => {
     <Container>
       <Banner variant={BannerVariant.Info}>
         {jiraLinkify(
-          "This page is currently under construction, and may have issues in performance and functionality. See DEVPROD-6584 for project details.",
+          "This page is currently under construction. Performance and functionality bugs may be present. See DEVPROD-6584 for project details.",
           jiraHost,
         )}
       </Banner>
-      <Header>
-        <Subtitle>Task History Overview</Subtitle>
-        <SegmentedControl
-          aria-controls="[data-cy='task-timeline']"
-          onChange={(t) => setViewOption(t as ViewOptions)}
-          size="xsmall"
-          value={viewOption}
-        >
-          <SegmentedControlOption
-            data-cy="collapsed-option"
-            value={ViewOptions.Collapsed}
+      <StickyHeader>
+        <ToggleContainer>
+          <Subtitle>Task History Overview</Subtitle>
+          <SegmentedControl
+            aria-controls="[data-cy='task-timeline']"
+            onChange={(t) => setViewOption(t as ViewOptions)}
+            size="xsmall"
+            value={viewOption}
           >
-            Collapsed
-          </SegmentedControlOption>
-          <SegmentedControlOption
-            data-cy="expanded-option"
-            value={ViewOptions.Expanded}
-          >
-            Expanded
-          </SegmentedControlOption>
-        </SegmentedControl>
-      </Header>
-      <TaskTimeline
-        ref={timelineRef}
-        loading={loading}
-        pagination={{
-          mostRecentTaskOrder,
-          oldestTaskOrder,
-          nextPageCursor,
-          prevPageCursor,
-        }}
-        tasks={visibleTasks}
-      />
-      <Subtitle>Commit Details</Subtitle>
-      <CommitDetailsList
-        currentTask={task}
-        loading={loading}
-        tasks={visibleTasks}
-      />
+            <SegmentedControlOption
+              data-cy="collapsed-option"
+              value={ViewOptions.Collapsed}
+            >
+              Collapsed
+            </SegmentedControlOption>
+            <SegmentedControlOption
+              data-cy="expanded-option"
+              value={ViewOptions.Expanded}
+            >
+              Expanded
+            </SegmentedControlOption>
+          </SegmentedControl>
+        </ToggleContainer>
+        <TaskTimeline
+          ref={timelineRef}
+          loading={loading}
+          pagination={{
+            mostRecentTaskOrder,
+            oldestTaskOrder,
+            nextPageCursor,
+            prevPageCursor,
+          }}
+          tasks={visibleTasks}
+        />
+      </StickyHeader>
+      <ListContent>
+        <Subtitle>Commit Details</Subtitle>
+        <CommitDetailsList
+          currentTask={task}
+          loading={loading}
+          tasks={visibleTasks}
+        />
+      </ListContent>
     </Container>
   );
 };
 
 export default TaskHistory;
 
-const Container = styled.div`
+const Container = styled.div``;
+
+const StickyHeader = styled.div`
+  position: sticky;
+  top: -${size.m};
+  z-index: 1;
+
   display: flex;
   flex-direction: column;
-  gap: ${size.s};
-
-  height: calc(100vh - 100px);
+  gap: ${size.xs};
+  background: white;
+  padding: ${size.xs} 0;
 `;
 
-const Header = styled.div`
+const ListContent = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${size.xs};
+  margin-top: ${size.xxs};
+`;
+
+const ToggleContainer = styled.div`
   display: flex;
   flex-direction: row;
   align-items: center;

--- a/apps/spruce/src/pages/task/taskTabs/TaskHistory/index.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/TaskHistory/index.tsx
@@ -1,6 +1,7 @@
 import { useRef, useState } from "react";
 import { useQuery } from "@apollo/client";
 import styled from "@emotion/styled";
+import Banner, { Variant as BannerVariant } from "@leafygreen-ui/banner";
 import {
   SegmentedControl,
   SegmentedControlOption,
@@ -17,8 +18,10 @@ import {
   TaskQuery,
 } from "gql/generated/types";
 import { TASK_HISTORY } from "gql/queries";
+import { useSpruceConfig } from "hooks";
 import { useDimensions } from "hooks/useDimensions";
 import { useQueryParam } from "hooks/useQueryParam";
+import { jiraLinkify } from "utils/string";
 import CommitDetailsList from "./CommitDetailsList";
 import { ACTIVATED_TASKS_LIMIT } from "./constants";
 import TaskTimeline from "./TaskTimeline";
@@ -34,6 +37,9 @@ const TaskHistory: React.FC<TaskHistoryProps> = ({ task }) => {
   const { width: timelineWidth } = useDimensions<HTMLDivElement>(timelineRef);
 
   const dispatchToast = useToastContext();
+
+  const spruceConfig = useSpruceConfig();
+  const jiraHost = spruceConfig?.jira?.host ?? "";
 
   const [viewOption, setViewOption] = useState(ViewOptions.Collapsed);
   const shouldCollapse = viewOption === ViewOptions.Collapsed;
@@ -86,6 +92,12 @@ const TaskHistory: React.FC<TaskHistoryProps> = ({ task }) => {
 
   return (
     <Container>
+      <Banner variant={BannerVariant.Info}>
+        {jiraLinkify(
+          "This page is currently under construction, and may have issues in performance and functionality. See DEVPROD-6584 for project details.",
+          jiraHost,
+        )}
+      </Banner>
       <Header>
         <Subtitle>Task History Overview</Subtitle>
         <SegmentedControl


### PR DESCRIPTION
DEVPROD-16173
<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
I intend to merge this PR following the pagination PR (evergreen-ci/ui/pull/754).

I removed the task box link because according to the designs, it doesn't work like that. The task link can still be found in the commit details cards. Depending on what the focus group users say we can rework this functionality later.


### Screenshots
<img width="1122" alt="Screenshot 2025-04-15 at 12 50 34 PM" src="https://github.com/user-attachments/assets/b7f1026f-f344-4747-a052-a9f86a9d18be" />

