### PR TITLE
DEVPROD-17079 Make project banners show up on waterfall

### DIFF
--- a/apps/spruce/src/components/Banners/ProjectBanner.tsx
+++ b/apps/spruce/src/components/Banners/ProjectBanner.tsx
@@ -21,9 +21,8 @@ export const ProjectBanner: React.FC<ProjectBannerProps> = ({
     skip: !projectIdentifier,
   });
   const { text, theme } = projectBannerData?.project.banner || {};
-  if (!text) {
+  if (!text || !theme) {
     return null;
   }
-  // @ts-expect-error: FIXME. This comment was added by an automated script.
   return <PortalBanner banner={<SiteBanner text={text} theme={theme} />} />;
 };

--- a/apps/spruce/src/pages/waterfall/index.tsx
+++ b/apps/spruce/src/pages/waterfall/index.tsx
@@ -5,6 +5,7 @@ import { useParams } from "react-router-dom";
 import { size } from "@evg-ui/lib/constants/tokens";
 import { usePageTitle } from "@evg-ui/lib/hooks/usePageTitle";
 import { useWaterfallAnalytics } from "analytics";
+import { ProjectBanner } from "components/Banners";
 import FilterChips, { useFilterChipQueryParams } from "components/FilterChips";
 import { navBarHeight } from "components/styles/Layout";
 import { WalkthroughGuideCueRef } from "components/WalkthroughGuideCue";
@@ -46,6 +47,7 @@ const Waterfall: React.FC = () => {
         data-cy="waterfall-page"
         id={waterfallPageContainerId}
       >
+        <ProjectBanner projectIdentifier={projectIdentifier ?? ""} />
         <WaterfallFilters
           // Using a key rerenders the filter components so that uncontrolled components can compute a new initial state
           key={projectIdentifier}


### PR DESCRIPTION
DEVPROD-17079
<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
While working on deprecating the mainline commits page and all its associated tests I realized we weren't showing the project banner on the new waterfall page. This PR adds it back
### Screenshots
<img width="1298" alt="image" src="https://github.com/user-attachments/assets/a0a393ef-a943-4179-9302-ebe2a6009f41" />

### Testing
<!-- add a description of how you tested it -->

<!-- Have you have updated the analytics documentation if necessary?  
https://docs.google.com/spreadsheets/d/1s4_nq8ZiphXp5Uq_-9HT6GPqz-KOyaq6HuvmXYaSNzg/edit?usp=sharing -->

### Evergreen PR
<!-- link to a corresponding Evergreen PR if applicable -->
