### PR TITLE
DEVPROD-17568 Redirect legacy commits page to waterfall page

### DIFF
--- a/apps/spruce/cypress/integration/waterfall/navigation.ts
+++ b/apps/spruce/cypress/integration/waterfall/navigation.ts
@@ -13,4 +13,12 @@ describe("navigation", () => {
     cy.location("pathname").should("equal", "/project/spruce/waterfall");
     cy.dataCy("waterfall-page").should("be.visible");
   });
+
+  it("is redirected to the waterfall page when a user visits a legacy route", () => {
+    cy.visit("/commits/evergreen");
+    cy.location("pathname").should("equal", "/project/evergreen/waterfall");
+    cy.visit("/commits/evergreen?taskNames=test");
+    cy.location("pathname").should("equal", "/project/evergreen/waterfall");
+    cy.location("search").should("contain", "tasks=test");
+  });
 });

--- a/apps/spruce/src/analytics/waterfall/useWaterfallAnalytics.ts
+++ b/apps/spruce/src/analytics/waterfall/useWaterfallAnalytics.ts
@@ -39,7 +39,7 @@ type Action =
       name: "Viewed waterfall modal";
       navigated_to_waterfall: boolean;
     }
-  | { name: "System Event redirect"; referrer: string };
+  | { name: "Redirected to waterfall page"; referrer: string };
 
 export const useWaterfallAnalytics = () => {
   const { [slugs.projectIdentifier]: projectIdentifier } = useParams();

--- a/apps/spruce/src/analytics/waterfall/useWaterfallAnalytics.ts
+++ b/apps/spruce/src/analytics/waterfall/useWaterfallAnalytics.ts
@@ -38,7 +38,8 @@ type Action =
   | {
       name: "Viewed waterfall modal";
       navigated_to_waterfall: boolean;
-    };
+    }
+  | { name: "System Event redirect"; referrer: string };
 
 export const useWaterfallAnalytics = () => {
   const { [slugs.projectIdentifier]: projectIdentifier } = useParams();

--- a/apps/spruce/src/components/Content/index.tsx
+++ b/apps/spruce/src/components/Content/index.tsx
@@ -88,6 +88,10 @@ export const Content: React.FC = () => (
       />
       <Route element={<VariantHistory />} path={routes.variantHistory} />
       <Route element={<VersionPage />} path={routes.version} />
+      <Route
+        element={<WaterfallCommitsRedirect />}
+        path={redirectRoutes.legacyCommits}
+      />
       <Route element={<Waterfall />} path={routes.waterfall} />
       <Route element={<PageDoesNotExist />} path="*" />
     </Route>

--- a/apps/spruce/src/components/Redirects/WaterfallCommitsRedirect.tsx
+++ b/apps/spruce/src/components/Redirects/WaterfallCommitsRedirect.tsx
@@ -1,8 +1,46 @@
+import { useEffect } from "react";
 import { useParams, Navigate } from "react-router-dom";
+import { useWaterfallAnalytics } from "analytics";
 import { getWaterfallRoute, slugs } from "constants/routes";
+import { useQueryParam } from "hooks/useQueryParam";
+import { WaterfallFilterOptions } from "pages/waterfall/types";
 
 export const WaterfallCommitsRedirect: React.FC = () => {
   const { [slugs.projectIdentifier]: projectIdentifier } = useParams();
+  const [statusFilters] = useQueryParam<string[]>(
+    WaterfallFilterOptions.Statuses,
+    [],
+  );
+  const [taskFilters] = useQueryParam<string[]>(
+    WaterfallFilterOptions.Task,
+    [],
+  );
+  const [requesterFilters] = useQueryParam<string[]>(
+    WaterfallFilterOptions.Requesters,
+    [],
+  );
+  const [variantFilters] = useQueryParam<string[]>(
+    WaterfallFilterOptions.BuildVariant,
+    [],
+  );
+  const { sendEvent } = useWaterfallAnalytics();
+  useEffect(() => {
+    const { referrer } = document;
+    sendEvent({
+      name: "System Event redirect",
+      referrer,
+    });
+    console.log("System Event redirect", referrer);
+  }, []);
 
-  return <Navigate to={getWaterfallRoute(projectIdentifier)} />;
+  return (
+    <Navigate
+      to={getWaterfallRoute(projectIdentifier, {
+        statusFilters,
+        taskFilters,
+        requesterFilters,
+        variantFilters,
+      })}
+    />
+  );
 };

--- a/apps/spruce/src/components/Redirects/WaterfallCommitsRedirect.tsx
+++ b/apps/spruce/src/components/Redirects/WaterfallCommitsRedirect.tsx
@@ -3,34 +3,20 @@ import { useParams, Navigate } from "react-router-dom";
 import { useWaterfallAnalytics } from "analytics";
 import { getWaterfallRoute, slugs } from "constants/routes";
 import { useQueryParam } from "hooks/useQueryParam";
-import { WaterfallFilterOptions } from "pages/waterfall/types";
 
 export const WaterfallCommitsRedirect: React.FC = () => {
   const { [slugs.projectIdentifier]: projectIdentifier } = useParams();
-  const [statusFilters] = useQueryParam<string[]>(
-    WaterfallFilterOptions.Statuses,
-    [],
-  );
-  const [taskFilters] = useQueryParam<string[]>(
-    WaterfallFilterOptions.Task,
-    [],
-  );
-  const [requesterFilters] = useQueryParam<string[]>(
-    WaterfallFilterOptions.Requesters,
-    [],
-  );
-  const [variantFilters] = useQueryParam<string[]>(
-    WaterfallFilterOptions.BuildVariant,
-    [],
-  );
+  const [statusFilters] = useQueryParam<string[]>("statuses", []);
+  const [taskFilters] = useQueryParam<string[]>("taskNames", []);
+  const [requesterFilters] = useQueryParam<string[]>("requester", []);
+  const [variantFilters] = useQueryParam<string[]>("buildVariants", []);
   const { sendEvent } = useWaterfallAnalytics();
   useEffect(() => {
     const { referrer } = document;
     sendEvent({
-      name: "System Event redirect",
+      name: "Redirected to waterfall page",
       referrer,
     });
-    console.log("System Event redirect", referrer);
   }, []);
 
   return (

--- a/apps/spruce/src/constants/routes.test.ts
+++ b/apps/spruce/src/constants/routes.test.ts
@@ -120,17 +120,48 @@ describe("getWaterfallRoute", () => {
       "/project/someProject/waterfall",
     );
   });
-  it("generates a waterfall page link with task filters", () => {
+  it("generates a waterfall page link with status filters", () => {
     expect(
       getWaterfallRoute("someProject", {
-        taskFilters: ["failed"],
+        statusFilters: ["failed"],
       }),
     ).toBe("/project/someProject/waterfall?statuses=failed");
     expect(
       getWaterfallRoute("someProject", {
-        taskFilters: ["failed", "test-timed-out"],
+        statusFilters: ["failed", "test-timed-out"],
       }),
     ).toBe("/project/someProject/waterfall?statuses=failed,test-timed-out");
+  });
+  it("generates a waterfall page link with task filters", () => {
+    expect(
+      getWaterfallRoute("someProject", {
+        taskFilters: ["task1"],
+      }),
+    ).toBe("/project/someProject/waterfall?tasks=task1");
+    expect(
+      getWaterfallRoute("someProject", {
+        taskFilters: ["task1", "task2"],
+      }),
+    ).toBe("/project/someProject/waterfall?tasks=task1,task2");
+  });
+  it("generates a waterfall page link with requester filters", () => {
+    expect(
+      getWaterfallRoute("someProject", {
+        requesterFilters: ["git_tag_requester"],
+      }),
+    ).toBe("/project/someProject/waterfall?requesters=git_tag_requester");
+  });
+  it("generates a waterfall page link with build variant filters", () => {
+    expect(
+      getWaterfallRoute("someProject", {
+        variantFilters: ["variant1"],
+      }),
+    ).toBe("/project/someProject/waterfall?buildVariants=variant1");
+    expect(
+      getWaterfallRoute("someProject", {
+        variantFilters: ["variant1", "variant2"],
+      }),
+    ).toBe("/project/someProject/waterfall?buildVariants=variant1,variant2");
   });
 });
 describe("getTaskHistoryRoute", () => {

--- a/apps/spruce/src/constants/routes.ts
+++ b/apps/spruce/src/constants/routes.ts
@@ -117,6 +117,7 @@ export const redirectRoutes = {
   projectSettings: paths.projects,
   userPatches: `${paths.user}/:${slugs.userId}`,
   waterfall: `${paths.waterfall}/:${slugs.projectIdentifier}`,
+  legacyCommits: `commits/:${slugs.projectIdentifier}`,
 };
 
 export const routes = {
@@ -286,11 +287,20 @@ export const getDistroSettingsRoute = (
 
 export const getWaterfallRoute = (
   projectIdentifier?: string,
-  options?: { taskFilters?: string[] },
+  options?: {
+    statusFilters?: string[];
+    variantFilters?: string[];
+    requesterFilters?: string[];
+    taskFilters?: string[];
+  },
 ) => {
-  const { taskFilters } = options || {};
+  const { requesterFilters, statusFilters, taskFilters, variantFilters } =
+    options || {};
   const queryParams = stringifyQuery({
-    [WaterfallFilterOptions.Statuses]: taskFilters,
+    [WaterfallFilterOptions.Statuses]: statusFilters,
+    [WaterfallFilterOptions.Task]: taskFilters,
+    [WaterfallFilterOptions.Requesters]: requesterFilters,
+    [WaterfallFilterOptions.BuildVariant]: variantFilters,
   });
   return `${paths.project}/${encodeURIComponent(projectIdentifier ?? "")}${paths.waterfall}${queryParams ? `?${queryParams}` : ""}`;
 };

--- a/apps/spruce/src/pages/waterfall/WaterfallFilters.tsx
+++ b/apps/spruce/src/pages/waterfall/WaterfallFilters.tsx
@@ -32,7 +32,7 @@ export const WaterfallFilters: React.FC<WaterfallFiltersProps> = ({
 
   const projectSelectRoute = useCallback(
     (identifier: string) =>
-      getWaterfallRoute(identifier, { taskFilters: statuses }),
+      getWaterfallRoute(identifier, { statusFilters: statuses }),
     [statuses],
   );
 


### PR DESCRIPTION
DEVPROD-17568
<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
Introduce a temporary redirect to redirect links from external facing apps to the new waterfall. While deprecating the page I came to the realization that we still have external apps we do not own sending traffic to the project health page. This  introduces a temporary redirect to preserve links while we identify those apps and make the necessary updates.

=
