### PR TITLE
DEVPROD-16652 Correctly conditionally render warning banner in spruce form

### DIFF
--- a/apps/spruce/src/components/SpruceForm/Widgets/LeafyGreenWidgets.tsx
+++ b/apps/spruce/src/components/SpruceForm/Widgets/LeafyGreenWidgets.tsx
@@ -145,14 +145,14 @@ export const LeafyGreenCheckBox: React.FC<SpruceWidgetProps> = ({
         }
         onChange={(e) => onChange(e.target.checked)}
       />
-      {warnings?.length && (
+      {warnings?.length ? (
         <StyledBanner
           data-cy={dataCyBanner || "warning-banner"}
           variant="warning"
         >
           {warnings.join(", ")}
         </StyledBanner>
-      )}
+      ) : null}
     </ElementWrapper>
   );
 };

--- a/apps/spruce/src/pages/distroSettings/tabs/GeneralTab/GeneralTab.tsx
+++ b/apps/spruce/src/pages/distroSettings/tabs/GeneralTab/GeneralTab.tsx
@@ -24,16 +24,18 @@ export const GeneralTab: React.FC<TabProps> = ({
   const currentSingleTaskDistroValue =
     state.tabs.general.formData?.distroOptions.singleTaskDistro;
 
-  let singleTaskDistroWarnings: string[] = [];
-  if (!originalSingleTaskDistroValue && currentSingleTaskDistroValue) {
-    singleTaskDistroWarnings = [
-      "This Distro will be converted to a Single Task Distro once saved. Please review before confirming.",
-    ];
-  } else if (originalSingleTaskDistroValue && !currentSingleTaskDistroValue) {
-    singleTaskDistroWarnings = [
-      "This Distro will no longer be a Single Task Distro once saved. Please review before confirming.",
-    ];
-  }
+  const singleTaskDistroWarnings = useMemo(() => {
+    if (!originalSingleTaskDistroValue && currentSingleTaskDistroValue) {
+      return [
+        "This Distro will be converted to a Single Task Distro once saved. Please review before confirming.",
+      ];
+    } else if (originalSingleTaskDistroValue && !currentSingleTaskDistroValue) {
+      return [
+        "This Distro will no longer be a Single Task Distro once saved. Please review before confirming.",
+      ];
+    }
+    return [];
+  }, [originalSingleTaskDistroValue, currentSingleTaskDistroValue]);
   const formSchema = useMemo(
     () =>
       getFormSchema(isContainerDistro, minimumHosts, singleTaskDistroWarnings),

--- a/apps/spruce/src/pages/task/taskTabs/TaskHistory/CommitDetailsList/__snapshots__/CommitDetailsList_WithFilterApplied.storyshot
+++ b/apps/spruce/src/pages/task/taskTabs/TaskHistory/CommitDetailsList/__snapshots__/CommitDetailsList_WithFilterApplied.storyshot
@@ -89,7 +89,9 @@
           Evergreen Admin
            - 
         </b>
-        <span>
+        <span
+          class="css-16elo4e-WordBreak-wordBreakCss e1wygaev0"
+        >
           <a
             class="lg-ui-0001 css-r79zk7-overrideStyles leafygreen-ui-16e7rxl"
             data-cy="jira-link"
@@ -186,7 +188,9 @@
           Evergreen Admin
            - 
         </b>
-        <span>
+        <span
+          class="css-16elo4e-WordBreak-wordBreakCss e1wygaev0"
+        >
           <a
             class="lg-ui-0001 css-r79zk7-overrideStyles leafygreen-ui-16e7rxl"
             data-cy="jira-link"
@@ -321,7 +325,9 @@
           Evergreen Admin
            - 
         </b>
-        <span>
+        <span
+          class="css-16elo4e-WordBreak-wordBreakCss e1wygaev0"
+        >
           <a
             class="lg-ui-0001 css-r79zk7-overrideStyles leafygreen-ui-16e7rxl"
             data-cy="jira-link"
@@ -456,7 +462,9 @@
           Evergreen Admin
            - 
         </b>
-        <span>
+        <span
+          class="css-16elo4e-WordBreak-wordBreakCss e1wygaev0"
+        >
           <a
             class="lg-ui-0001 css-r79zk7-overrideStyles leafygreen-ui-16e7rxl"
             data-cy="jira-link"
@@ -591,7 +599,9 @@
           Evergreen Admin
            - 
         </b>
-        <span>
+        <span
+          class="css-16elo4e-WordBreak-wordBreakCss e1wygaev0"
+        >
           <a
             class="lg-ui-0001 css-r79zk7-overrideStyles leafygreen-ui-16e7rxl"
             data-cy="jira-link"
@@ -688,7 +698,9 @@
           Evergreen Admin
            - 
         </b>
-        <span>
+        <span
+          class="css-16elo4e-WordBreak-wordBreakCss e1wygaev0"
+        >
           <a
             class="lg-ui-0001 css-r79zk7-overrideStyles leafygreen-ui-16e7rxl"
             data-cy="jira-link"


### PR DESCRIPTION
DEVPROD-16652
<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
The 0 in the form was caused by `warnings?.length && (component)` evaluating to false.

### Screenshots
<img width="456" alt="image" src="https://github.com/user-attachments/assets/be583f43-1c3d-45d5-8be8-73a2b570cd5f" />


### Testing
Doesn't show a 0 anymore