### PR TITLE
DEVPROD-4167 Start auto refreshing created build baron tickets

### DIFF
--- a/apps/spruce/src/pages/task/taskTabs/TaskHistory/CommitDetailsList/__snapshots__/CommitDetailsList_WithFilterApplied.storyshot
+++ b/apps/spruce/src/pages/task/taskTabs/TaskHistory/CommitDetailsList/__snapshots__/CommitDetailsList_WithFilterApplied.storyshot
@@ -89,7 +89,9 @@
           Evergreen Admin
            - 
         </b>
-        <span>
+        <span
+          class="css-16elo4e-WordBreak-wordBreakCss e1wygaev0"
+        >
           <a
             class="lg-ui-0001 css-r79zk7-overrideStyles leafygreen-ui-16e7rxl"
             data-cy="jira-link"
@@ -186,7 +188,9 @@
           Evergreen Admin
            - 
         </b>
-        <span>
+        <span
+          class="css-16elo4e-WordBreak-wordBreakCss e1wygaev0"
+        >
           <a
             class="lg-ui-0001 css-r79zk7-overrideStyles leafygreen-ui-16e7rxl"
             data-cy="jira-link"
@@ -321,7 +325,9 @@
           Evergreen Admin
            - 
         </b>
-        <span>
+        <span
+          class="css-16elo4e-WordBreak-wordBreakCss e1wygaev0"
+        >
           <a
             class="lg-ui-0001 css-r79zk7-overrideStyles leafygreen-ui-16e7rxl"
             data-cy="jira-link"
@@ -456,7 +462,9 @@
           Evergreen Admin
            - 
         </b>
-        <span>
+        <span
+          class="css-16elo4e-WordBreak-wordBreakCss e1wygaev0"
+        >
           <a
             class="lg-ui-0001 css-r79zk7-overrideStyles leafygreen-ui-16e7rxl"
             data-cy="jira-link"
@@ -591,7 +599,9 @@
           Evergreen Admin
            - 
         </b>
-        <span>
+        <span
+          class="css-16elo4e-WordBreak-wordBreakCss e1wygaev0"
+        >
           <a
             class="lg-ui-0001 css-r79zk7-overrideStyles leafygreen-ui-16e7rxl"
             data-cy="jira-link"
@@ -688,7 +698,9 @@
           Evergreen Admin
            - 
         </b>
-        <span>
+        <span
+          class="css-16elo4e-WordBreak-wordBreakCss e1wygaev0"
+        >
           <a
             class="lg-ui-0001 css-r79zk7-overrideStyles leafygreen-ui-16e7rxl"
             data-cy="jira-link"

--- a/apps/spruce/src/pages/task/taskTabs/buildBaronAndAnnotations/BuildBaron.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/buildBaronAndAnnotations/BuildBaron.tsx
@@ -6,6 +6,7 @@ import {
   BuildBaronQueryVariables,
 } from "gql/generated/types";
 import { BUILD_BARON } from "gql/queries";
+import { usePolling } from "hooks/usePolling";
 import BuildBaronContent from "./BuildBaronContent";
 
 interface Props {
@@ -21,20 +22,22 @@ const BuildBaron: React.FC<Props> = ({
   taskId,
   userCanModify,
 }) => {
-  const { data, loading } = useQuery<BuildBaronQuery, BuildBaronQueryVariables>(
-    BUILD_BARON,
-    {
-      variables: { taskId, execution },
-    },
-  );
-  if (loading) {
+  const { data, loading, refetch, startPolling, stopPolling } = useQuery<
+    BuildBaronQuery,
+    BuildBaronQueryVariables
+  >(BUILD_BARON, {
+    variables: { taskId, execution },
+  });
+  usePolling({ startPolling, stopPolling, refetch });
+
+  const { buildBaron } = data || {};
+  if (loading || !buildBaron) {
     return <ParagraphSkeleton />;
   }
   return (
     <BuildBaronContent
       annotation={annotation}
-      // @ts-expect-error: FIXME. This comment was added by an automated script.
-      bbData={data?.buildBaron}
+      bbData={buildBaron}
       execution={execution}
       loading={loading}
       taskId={taskId}

--- a/apps/spruce/src/pages/task/taskTabs/buildBaronAndAnnotations/FileTicketButton.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/buildBaronAndAnnotations/FileTicketButton.tsx
@@ -34,7 +34,7 @@ const FileTicketButton: React.FC<FileTicketProps> = ({ execution, taskId }) => {
         `There was an error filing the ticket: ${error.message}`,
       );
     },
-    refetchQueries: ["CreatedTickets", "CustomCreatedIssues"],
+    refetchQueries: ["CreatedTickets", "CustomCreatedIssues", "BuildBaron"],
   });
 
   const [buttonText, setButtonText] = useState<string>("File ticket");


### PR DESCRIPTION
DEVPROD-4167
<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
We weren't refreshing or polling build baron created jira tickets this adds support for that.

### Screenshots


https://github.com/user-attachments/assets/eafe4a32-3dbc-4a5e-9ffa-b99964307ca2


