### PR TITLE
DEVPROD-16172: Add test failure table to commit details card

### DIFF
--- a/apps/parsley/src/components/SidePanel/NavGroup/FilterNavGroup/FilterGroup/__snapshots__/FilterGroup_Default.storyshot
+++ b/apps/parsley/src/components/SidePanel/NavGroup/FilterNavGroup/FilterGroup/__snapshots__/FilterGroup_Default.storyshot
@@ -7,7 +7,7 @@
     >
       <button
         aria-disabled="false"
-        aria-labelledby="Accordion icon"
+        aria-label="Accordion icon"
         class="css-7x45r8-AccordionIcon e1omze813 leafygreen-ui-tcjr3n"
         open=""
         style="align-self: start;"
@@ -128,7 +128,7 @@
       data-cy="accordion-collapse-container"
     >
       <div
-        class="css-ma2fau-ContentsContainer e1omze811"
+        class="css-1hezny5-ContentsContainer e1omze811"
       >
         <div
           class="css-2ra843-AccordionContent e12rc5wm5"

--- a/apps/parsley/src/components/SidePanel/__snapshots__/SidePanel_Default.storyshot
+++ b/apps/parsley/src/components/SidePanel/__snapshots__/SidePanel_Default.storyshot
@@ -101,7 +101,7 @@
                         >
                           <button
                             aria-disabled="false"
-                            aria-labelledby="Accordion icon"
+                            aria-label="Accordion icon"
                             class="css-7x45r8-AccordionIcon e1omze813 leafygreen-ui-tcjr3n"
                             open=""
                             style="align-self: start;"
@@ -222,7 +222,7 @@
                           data-cy="accordion-collapse-container"
                         >
                           <div
-                            class="css-ma2fau-ContentsContainer e1omze811"
+                            class="css-1hezny5-ContentsContainer e1omze811"
                           >
                             <div
                               class="css-2ra843-AccordionContent e12rc5wm5"

--- a/apps/spruce/cypress/integration/task/task_history.ts
+++ b/apps/spruce/cypress/integration/task/task_history.ts
@@ -385,4 +385,21 @@ describe("task history", () => {
       cy.get("@firstTaskCard").should("contain", "Order: 12306");
     });
   });
+
+  describe("failing tests table", () => {
+    const failingTestLink =
+      "/task/evg_lint_generate_lint_ecbbf17f49224235d43416ea55566f3b1894bbf7_25_03_21_21_09_20/history?execution=0";
+
+    it("table can be expanded", () => {
+      cy.visit(failingTestLink);
+      cy.dataCy("commit-details-card")
+        .eq(0)
+        .within(() => {
+          cy.dataCy("failing-tests-changes-table").should("not.be.visible");
+          cy.get("[aria-label='Accordion icon']").click();
+          cy.dataCy("failing-tests-changes-table").should("be.visible");
+          cy.dataCy("failing-tests-table-row").should("have.length", 3);
+        });
+    });
+  });
 });

--- a/apps/spruce/src/analytics/index.ts
+++ b/apps/spruce/src/analytics/index.ts
@@ -17,3 +17,4 @@ export { useProjectPatchesAnalytics } from "./patches/useProjectPatchesAnalytics
 export { useVersionAnalytics } from "./version/useVersionAnalytics";
 export { useWaterfallAnalytics } from "./waterfall/useWaterfallAnalytics";
 export { useImageAnalytics } from "./image/useImageAnalytics";
+export { useTaskHistoryAnalytics } from "./task/useTaskHistoryAnalytics";

--- a/apps/spruce/src/analytics/task/useTaskHistoryAnalytics.ts
+++ b/apps/spruce/src/analytics/task/useTaskHistoryAnalytics.ts
@@ -1,0 +1,22 @@
+import { useParams } from "react-router-dom";
+import { useAnalyticsRoot } from "@evg-ui/lib/analytics/hooks";
+import { AnalyticsIdentifier } from "analytics/types";
+import { slugs } from "constants/routes";
+import { useQueryParam } from "hooks/useQueryParam";
+import { RequiredQueryParams } from "types/task";
+
+// TODO: Flesh out with more events in DEVPROD-17669.
+type Action = {
+  name: "Clicked test log link";
+  "test.name": string;
+};
+
+export const useTaskHistoryAnalytics = () => {
+  const { [slugs.taskId]: taskId } = useParams();
+  const [execution] = useQueryParam(RequiredQueryParams.Execution, 0);
+
+  return useAnalyticsRoot<Action, AnalyticsIdentifier>("TaskHistory", {
+    "task.execution": execution,
+    "task.id": taskId || "",
+  });
+};

--- a/apps/spruce/src/analytics/types.ts
+++ b/apps/spruce/src/analytics/types.ts
@@ -17,6 +17,7 @@ export type AnalyticsIdentifier =
   | "Shortcut"
   | "SpawnPages"
   | "Task"
+  | "TaskHistory"
   | "TaskQueue"
   | "UserPatches"
   | "Version"

--- a/apps/spruce/src/components/HistoryTable/HistoryTableRow/BaseRow/FoldedCommit/__snapshots__/FoldedCommit_FoldedCommitStory.storyshot
+++ b/apps/spruce/src/components/HistoryTable/HistoryTableRow/BaseRow/FoldedCommit/__snapshots__/FoldedCommit_FoldedCommitStory.storyshot
@@ -12,7 +12,7 @@
       >
         <button
           aria-disabled="false"
-          aria-labelledby="Accordion icon"
+          aria-label="Accordion icon"
           class="css-lltsma-AccordionIcon e1omze813 leafygreen-ui-tcjr3n"
           style="align-self: center;"
           tabindex="0"

--- a/apps/spruce/src/pages/host/HostEventString/__snapshots__/HostEventString_Default.storyshot
+++ b/apps/spruce/src/pages/host/HostEventString/__snapshots__/HostEventString_Default.storyshot
@@ -141,7 +141,7 @@
           >
             <button
               aria-disabled="false"
-              aria-labelledby="Accordion icon"
+              aria-label="Accordion icon"
               class="css-lltsma-AccordionIcon e1omze813 leafygreen-ui-tcjr3n"
               style="align-self: center;"
               tabindex="0"
@@ -176,7 +176,7 @@
             data-cy="accordion-collapse-container"
           >
             <div
-              class="css-ma2fau-ContentsContainer e1omze811"
+              class="css-1hezny5-ContentsContainer e1omze811"
             >
               <span
                 data-cy="host-event-log-content"
@@ -247,7 +247,7 @@
           >
             <button
               aria-disabled="false"
-              aria-labelledby="Accordion icon"
+              aria-label="Accordion icon"
               class="css-lltsma-AccordionIcon e1omze813 leafygreen-ui-tcjr3n"
               style="align-self: center;"
               tabindex="0"
@@ -282,7 +282,7 @@
             data-cy="accordion-collapse-container"
           >
             <div
-              class="css-ma2fau-ContentsContainer e1omze811"
+              class="css-1hezny5-ContentsContainer e1omze811"
             >
               <span
                 data-cy="host-event-log-content"
@@ -352,7 +352,7 @@
           >
             <button
               aria-disabled="false"
-              aria-labelledby="Accordion icon"
+              aria-label="Accordion icon"
               class="css-lltsma-AccordionIcon e1omze813 leafygreen-ui-tcjr3n"
               style="align-self: center;"
               tabindex="0"
@@ -387,7 +387,7 @@
             data-cy="accordion-collapse-container"
           >
             <div
-              class="css-ma2fau-ContentsContainer e1omze811"
+              class="css-1hezny5-ContentsContainer e1omze811"
             >
               <span
                 data-cy="host-event-log-content"
@@ -548,7 +548,7 @@
           >
             <button
               aria-disabled="false"
-              aria-labelledby="Accordion icon"
+              aria-label="Accordion icon"
               class="css-lltsma-AccordionIcon e1omze813 leafygreen-ui-tcjr3n"
               style="align-self: center;"
               tabindex="0"
@@ -583,7 +583,7 @@
             data-cy="accordion-collapse-container"
           >
             <div
-              class="css-ma2fau-ContentsContainer e1omze811"
+              class="css-1hezny5-ContentsContainer e1omze811"
             >
               <span
                 data-cy="host-event-log-content"
@@ -654,7 +654,7 @@
           >
             <button
               aria-disabled="false"
-              aria-labelledby="Accordion icon"
+              aria-label="Accordion icon"
               class="css-lltsma-AccordionIcon e1omze813 leafygreen-ui-tcjr3n"
               style="align-self: center;"
               tabindex="0"
@@ -689,7 +689,7 @@
             data-cy="accordion-collapse-container"
           >
             <div
-              class="css-ma2fau-ContentsContainer e1omze811"
+              class="css-1hezny5-ContentsContainer e1omze811"
             >
               <span
                 data-cy="host-event-log-content"
@@ -795,7 +795,7 @@
           >
             <button
               aria-disabled="false"
-              aria-labelledby="Accordion icon"
+              aria-label="Accordion icon"
               class="css-lltsma-AccordionIcon e1omze813 leafygreen-ui-tcjr3n"
               style="align-self: center;"
               tabindex="0"
@@ -830,7 +830,7 @@
             data-cy="accordion-collapse-container"
           >
             <div
-              class="css-ma2fau-ContentsContainer e1omze811"
+              class="css-1hezny5-ContentsContainer e1omze811"
             >
               <span
                 data-cy="host-event-log-content"
@@ -956,7 +956,7 @@
           >
             <button
               aria-disabled="false"
-              aria-labelledby="Accordion icon"
+              aria-label="Accordion icon"
               class="css-lltsma-AccordionIcon e1omze813 leafygreen-ui-tcjr3n"
               style="align-self: center;"
               tabindex="0"
@@ -991,7 +991,7 @@
             data-cy="accordion-collapse-container"
           >
             <div
-              class="css-ma2fau-ContentsContainer e1omze811"
+              class="css-1hezny5-ContentsContainer e1omze811"
             >
               <span
                 data-cy="host-event-log-content"
@@ -1061,7 +1061,7 @@
           >
             <button
               aria-disabled="false"
-              aria-labelledby="Accordion icon"
+              aria-label="Accordion icon"
               class="css-lltsma-AccordionIcon e1omze813 leafygreen-ui-tcjr3n"
               style="align-self: center;"
               tabindex="0"
@@ -1096,7 +1096,7 @@
             data-cy="accordion-collapse-container"
           >
             <div
-              class="css-ma2fau-ContentsContainer e1omze811"
+              class="css-1hezny5-ContentsContainer e1omze811"
             >
               <span
                 data-cy="host-event-log-content"
@@ -1167,7 +1167,7 @@
           >
             <button
               aria-disabled="false"
-              aria-labelledby="Accordion icon"
+              aria-label="Accordion icon"
               class="css-lltsma-AccordionIcon e1omze813 leafygreen-ui-tcjr3n"
               style="align-self: center;"
               tabindex="0"
@@ -1202,7 +1202,7 @@
             data-cy="accordion-collapse-container"
           >
             <div
-              class="css-ma2fau-ContentsContainer e1omze811"
+              class="css-1hezny5-ContentsContainer e1omze811"
             >
               <span
                 data-cy="host-event-log-content"
@@ -1286,7 +1286,7 @@
           >
             <button
               aria-disabled="false"
-              aria-labelledby="Accordion icon"
+              aria-label="Accordion icon"
               class="css-lltsma-AccordionIcon e1omze813 leafygreen-ui-tcjr3n"
               style="align-self: center;"
               tabindex="0"
@@ -1321,7 +1321,7 @@
             data-cy="accordion-collapse-container"
           >
             <div
-              class="css-ma2fau-ContentsContainer e1omze811"
+              class="css-1hezny5-ContentsContainer e1omze811"
             >
               <span
                 data-cy="host-event-log-content"
@@ -1358,7 +1358,7 @@
           >
             <button
               aria-disabled="false"
-              aria-labelledby="Accordion icon"
+              aria-label="Accordion icon"
               class="css-lltsma-AccordionIcon e1omze813 leafygreen-ui-tcjr3n"
               style="align-self: center;"
               tabindex="0"
@@ -1393,7 +1393,7 @@
             data-cy="accordion-collapse-container"
           >
             <div
-              class="css-ma2fau-ContentsContainer e1omze811"
+              class="css-1hezny5-ContentsContainer e1omze811"
             >
               <span
                 data-cy="host-event-log-content"
@@ -1528,7 +1528,7 @@
           >
             <button
               aria-disabled="false"
-              aria-labelledby="Accordion icon"
+              aria-label="Accordion icon"
               class="css-lltsma-AccordionIcon e1omze813 leafygreen-ui-tcjr3n"
               style="align-self: center;"
               tabindex="0"
@@ -1563,7 +1563,7 @@
             data-cy="accordion-collapse-container"
           >
             <div
-              class="css-ma2fau-ContentsContainer e1omze811"
+              class="css-1hezny5-ContentsContainer e1omze811"
             >
               <span
                 data-cy="host-event-log-content"
@@ -1649,7 +1649,7 @@
           >
             <button
               aria-disabled="false"
-              aria-labelledby="Accordion icon"
+              aria-label="Accordion icon"
               class="css-lltsma-AccordionIcon e1omze813 leafygreen-ui-tcjr3n"
               style="align-self: center;"
               tabindex="0"
@@ -1684,7 +1684,7 @@
             data-cy="accordion-collapse-container"
           >
             <div
-              class="css-ma2fau-ContentsContainer e1omze811"
+              class="css-1hezny5-ContentsContainer e1omze811"
             >
               <span
                 data-cy="host-event-log-content"

--- a/apps/spruce/src/pages/host/HostTable/__snapshots__/HostTable_Default.storyshot
+++ b/apps/spruce/src/pages/host/HostTable/__snapshots__/HostTable_Default.storyshot
@@ -639,7 +639,7 @@
                         >
                           <button
                             aria-disabled="false"
-                            aria-labelledby="Accordion icon"
+                            aria-label="Accordion icon"
                             class="css-lltsma-AccordionIcon e1omze813 leafygreen-ui-tcjr3n"
                             style="align-self: center;"
                             tabindex="0"
@@ -674,7 +674,7 @@
                           data-cy="accordion-collapse-container"
                         >
                           <div
-                            class="css-ma2fau-ContentsContainer e1omze811"
+                            class="css-1hezny5-ContentsContainer e1omze811"
                           >
                             <span
                               data-cy="host-event-log-content"
@@ -783,7 +783,7 @@
                         >
                           <button
                             aria-disabled="false"
-                            aria-labelledby="Accordion icon"
+                            aria-label="Accordion icon"
                             class="css-lltsma-AccordionIcon e1omze813 leafygreen-ui-tcjr3n"
                             style="align-self: center;"
                             tabindex="0"
@@ -818,7 +818,7 @@
                           data-cy="accordion-collapse-container"
                         >
                           <div
-                            class="css-ma2fau-ContentsContainer e1omze811"
+                            class="css-1hezny5-ContentsContainer e1omze811"
                           >
                             <span
                               data-cy="host-event-log-content"
@@ -926,7 +926,7 @@
                         >
                           <button
                             aria-disabled="false"
-                            aria-labelledby="Accordion icon"
+                            aria-label="Accordion icon"
                             class="css-lltsma-AccordionIcon e1omze813 leafygreen-ui-tcjr3n"
                             style="align-self: center;"
                             tabindex="0"
@@ -961,7 +961,7 @@
                           data-cy="accordion-collapse-container"
                         >
                           <div
-                            class="css-ma2fau-ContentsContainer e1omze811"
+                            class="css-1hezny5-ContentsContainer e1omze811"
                           >
                             <span
                               data-cy="host-event-log-content"
@@ -1350,7 +1350,7 @@
                         >
                           <button
                             aria-disabled="false"
-                            aria-labelledby="Accordion icon"
+                            aria-label="Accordion icon"
                             class="css-lltsma-AccordionIcon e1omze813 leafygreen-ui-tcjr3n"
                             style="align-self: center;"
                             tabindex="0"
@@ -1385,7 +1385,7 @@
                           data-cy="accordion-collapse-container"
                         >
                           <div
-                            class="css-ma2fau-ContentsContainer e1omze811"
+                            class="css-1hezny5-ContentsContainer e1omze811"
                           >
                             <span
                               data-cy="host-event-log-content"
@@ -1494,7 +1494,7 @@
                         >
                           <button
                             aria-disabled="false"
-                            aria-labelledby="Accordion icon"
+                            aria-label="Accordion icon"
                             class="css-lltsma-AccordionIcon e1omze813 leafygreen-ui-tcjr3n"
                             style="align-self: center;"
                             tabindex="0"
@@ -1529,7 +1529,7 @@
                           data-cy="accordion-collapse-container"
                         >
                           <div
-                            class="css-ma2fau-ContentsContainer e1omze811"
+                            class="css-1hezny5-ContentsContainer e1omze811"
                           >
                             <span
                               data-cy="host-event-log-content"
@@ -1749,7 +1749,7 @@
                         >
                           <button
                             aria-disabled="false"
-                            aria-labelledby="Accordion icon"
+                            aria-label="Accordion icon"
                             class="css-lltsma-AccordionIcon e1omze813 leafygreen-ui-tcjr3n"
                             style="align-self: center;"
                             tabindex="0"
@@ -1784,7 +1784,7 @@
                           data-cy="accordion-collapse-container"
                         >
                           <div
-                            class="css-ma2fau-ContentsContainer e1omze811"
+                            class="css-1hezny5-ContentsContainer e1omze811"
                           >
                             <span
                               data-cy="host-event-log-content"
@@ -2024,7 +2024,7 @@
                         >
                           <button
                             aria-disabled="false"
-                            aria-labelledby="Accordion icon"
+                            aria-label="Accordion icon"
                             class="css-lltsma-AccordionIcon e1omze813 leafygreen-ui-tcjr3n"
                             style="align-self: center;"
                             tabindex="0"
@@ -2059,7 +2059,7 @@
                           data-cy="accordion-collapse-container"
                         >
                           <div
-                            class="css-ma2fau-ContentsContainer e1omze811"
+                            class="css-1hezny5-ContentsContainer e1omze811"
                           >
                             <span
                               data-cy="host-event-log-content"
@@ -2167,7 +2167,7 @@
                         >
                           <button
                             aria-disabled="false"
-                            aria-labelledby="Accordion icon"
+                            aria-label="Accordion icon"
                             class="css-lltsma-AccordionIcon e1omze813 leafygreen-ui-tcjr3n"
                             style="align-self: center;"
                             tabindex="0"
@@ -2202,7 +2202,7 @@
                           data-cy="accordion-collapse-container"
                         >
                           <div
-                            class="css-ma2fau-ContentsContainer e1omze811"
+                            class="css-1hezny5-ContentsContainer e1omze811"
                           >
                             <span
                               data-cy="host-event-log-content"
@@ -2311,7 +2311,7 @@
                         >
                           <button
                             aria-disabled="false"
-                            aria-labelledby="Accordion icon"
+                            aria-label="Accordion icon"
                             class="css-lltsma-AccordionIcon e1omze813 leafygreen-ui-tcjr3n"
                             style="align-self: center;"
                             tabindex="0"
@@ -2346,7 +2346,7 @@
                           data-cy="accordion-collapse-container"
                         >
                           <div
-                            class="css-ma2fau-ContentsContainer e1omze811"
+                            class="css-1hezny5-ContentsContainer e1omze811"
                           >
                             <span
                               data-cy="host-event-log-content"
@@ -2468,7 +2468,7 @@
                         >
                           <button
                             aria-disabled="false"
-                            aria-labelledby="Accordion icon"
+                            aria-label="Accordion icon"
                             class="css-lltsma-AccordionIcon e1omze813 leafygreen-ui-tcjr3n"
                             style="align-self: center;"
                             tabindex="0"
@@ -2503,7 +2503,7 @@
                           data-cy="accordion-collapse-container"
                         >
                           <div
-                            class="css-ma2fau-ContentsContainer e1omze811"
+                            class="css-1hezny5-ContentsContainer e1omze811"
                           >
                             <span
                               data-cy="host-event-log-content"
@@ -2578,7 +2578,7 @@
                         >
                           <button
                             aria-disabled="false"
-                            aria-labelledby="Accordion icon"
+                            aria-label="Accordion icon"
                             class="css-lltsma-AccordionIcon e1omze813 leafygreen-ui-tcjr3n"
                             style="align-self: center;"
                             tabindex="0"
@@ -2613,7 +2613,7 @@
                           data-cy="accordion-collapse-container"
                         >
                           <div
-                            class="css-ma2fau-ContentsContainer e1omze811"
+                            class="css-1hezny5-ContentsContainer e1omze811"
                           >
                             <span
                               data-cy="host-event-log-content"
@@ -2900,7 +2900,7 @@
                         >
                           <button
                             aria-disabled="false"
-                            aria-labelledby="Accordion icon"
+                            aria-label="Accordion icon"
                             class="css-lltsma-AccordionIcon e1omze813 leafygreen-ui-tcjr3n"
                             style="align-self: center;"
                             tabindex="0"
@@ -2935,7 +2935,7 @@
                           data-cy="accordion-collapse-container"
                         >
                           <div
-                            class="css-ma2fau-ContentsContainer e1omze811"
+                            class="css-1hezny5-ContentsContainer e1omze811"
                           >
                             <span
                               data-cy="host-event-log-content"
@@ -3097,7 +3097,7 @@
                         >
                           <button
                             aria-disabled="false"
-                            aria-labelledby="Accordion icon"
+                            aria-label="Accordion icon"
                             class="css-lltsma-AccordionIcon e1omze813 leafygreen-ui-tcjr3n"
                             style="align-self: center;"
                             tabindex="0"
@@ -3132,7 +3132,7 @@
                           data-cy="accordion-collapse-container"
                         >
                           <div
-                            class="css-ma2fau-ContentsContainer e1omze811"
+                            class="css-1hezny5-ContentsContainer e1omze811"
                           >
                             <span
                               data-cy="host-event-log-content"

--- a/apps/spruce/src/pages/task/taskTabs/TaskHistory/CommitDetailsCard/CommitDetailsCard.stories.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/TaskHistory/CommitDetailsCard/CommitDetailsCard.stories.tsx
@@ -1,6 +1,8 @@
 import WithToastContext from "@evg-ui/lib/test_utils/toast-decorator";
 import { CustomMeta, CustomStoryObj } from "@evg-ui/lib/test_utils/types";
 import { SortedTaskStatus, TaskStatus } from "@evg-ui/lib/types/task";
+import { TestStatus } from "@evg-ui/lib/types/test";
+import { TestResult } from "gql/generated/types";
 import { tasks } from "../testData";
 import CommitDetailsCard from ".";
 
@@ -39,22 +41,67 @@ export const Default: CustomStoryObj<TemplateProps> = {
   render: (args) => <Template {...args} />,
 };
 
+export const WithFailingTests: CustomStoryObj<TemplateProps> = {
+  render: (args) => (
+    <Template {...args} hasFailingTests status={TaskStatus.Failed} />
+  ),
+};
+
 type TemplateProps = {
   isCurrentTask: boolean;
   status: TaskStatus;
   canRestart: boolean;
   message: string;
   isMatching: boolean;
+  hasFailingTests: boolean;
 };
-const getStoryTask = (args: TemplateProps) => ({
-  ...tasks[0],
-  displayStatus: args.status,
-  canRestart: args.canRestart,
-  versionMetadata: {
-    ...tasks[0].versionMetadata,
-    message: args.message,
+
+const testResults: TestResult[] = [
+  {
+    id: "e2e_test_1",
+    testFile: "e2e_test",
+    status: TestStatus.Fail,
+    logs: { urlParsley: "a-parsley-url.mongodb.com" },
   },
-});
+  {
+    id: "e2e_test_2",
+    testFile: "e2e_test",
+    status: TestStatus.Fail,
+    logs: { urlParsley: "b-parsley-url.mongodb.com" },
+  },
+  {
+    id: "e2e_test_3",
+    testFile: "e2e_test",
+    status: TestStatus.SilentFail,
+    logs: { urlParsley: "c-parsley-url.mongodb.com" },
+  },
+  {
+    id: "e2e_test_4",
+    testFile: "e2e_test",
+    status: TestStatus.Fail,
+    logs: { urlParsley: "s-parsley-url.mongodb.com" },
+  },
+];
+
+const getStoryTask = (args: TemplateProps) => {
+  const task = args.hasFailingTests
+    ? {
+        ...tasks[0],
+        tests: { testResults },
+      }
+    : tasks[0];
+
+  return {
+    ...task,
+    displayStatus: args.status,
+    canRestart: args.canRestart,
+    versionMetadata: {
+      ...task.versionMetadata,
+      message: args.message,
+    },
+  };
+};
+
 const Template = (args: TemplateProps) => {
   const storyTask = getStoryTask(args);
   return (

--- a/apps/spruce/src/pages/task/taskTabs/TaskHistory/CommitDetailsCard/CommitDetailsCard.stories.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/TaskHistory/CommitDetailsCard/CommitDetailsCard.stories.tsx
@@ -59,25 +59,25 @@ type TemplateProps = {
 const testResults: TestResult[] = [
   {
     id: "e2e_test_1",
-    testFile: "e2e_test",
+    testFile: "e2e_test_1",
     status: TestStatus.Fail,
     logs: { urlParsley: "a-parsley-url.mongodb.com" },
   },
   {
     id: "e2e_test_2",
-    testFile: "e2e_test",
+    testFile: "e2e_test_2",
     status: TestStatus.Fail,
     logs: { urlParsley: "b-parsley-url.mongodb.com" },
   },
   {
     id: "e2e_test_3",
-    testFile: "e2e_test",
+    testFile: "e2e_test_3",
     status: TestStatus.SilentFail,
     logs: { urlParsley: "c-parsley-url.mongodb.com" },
   },
   {
     id: "e2e_test_4",
-    testFile: "e2e_test",
+    testFile: "e2e_test_4",
     status: TestStatus.Fail,
     logs: { urlParsley: "s-parsley-url.mongodb.com" },
   },

--- a/apps/spruce/src/pages/task/taskTabs/TaskHistory/CommitDetailsCard/FailedTestsTable.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/TaskHistory/CommitDetailsCard/FailedTestsTable.tsx
@@ -1,0 +1,99 @@
+import { useState } from "react";
+import styled from "@emotion/styled";
+import Button, { Size as ButtonSize } from "@leafygreen-ui/button";
+import {
+  ColumnFiltersState,
+  LGColumnDef,
+  useLeafyGreenTable,
+} from "@leafygreen-ui/table";
+import TestStatusBadge from "@evg-ui/lib/components/Badge/TestStatusBadge";
+import Icon from "@evg-ui/lib/components/Icon";
+import { WordBreak } from "@evg-ui/lib/components/styles";
+import { size } from "@evg-ui/lib/constants/tokens";
+import { TestStatus } from "@evg-ui/lib/types/test";
+import { BaseTable } from "components/Table/BaseTable";
+import { TaskTestResult, TestResult } from "gql/generated/types";
+
+interface CommitDetailsCardProps {
+  tests: Omit<TaskTestResult, "filteredTestCount" | "totalTestCount">;
+}
+
+const FailedTestsTable: React.FC<CommitDetailsCardProps> = ({ tests }) => {
+  const { testResults } = tests;
+
+  const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
+
+  const table = useLeafyGreenTable<TestResult>({
+    columns,
+    data: testResults ?? [],
+    defaultColumn: {
+      enableColumnFilter: false,
+      enableSorting: false,
+    },
+    onColumnFiltersChange: setColumnFilters,
+    state: {
+      columnFilters,
+    },
+  });
+
+  return (
+    <BaseTable
+      data-cy="failing-tests-changes-table"
+      data-cy-row="failing-tests-table-row"
+      shouldAlternateRowColor
+      table={table}
+    />
+  );
+};
+
+export default FailedTestsTable;
+
+const columns: LGColumnDef<TestResult>[] = [
+  {
+    accessorKey: "testFile",
+    header: "Test Failure Name",
+    meta: { width: "60%" },
+    cell: ({ getValue }) => <WordBreak>{getValue() as string}</WordBreak>,
+  },
+  {
+    accessorKey: "status",
+    header: "Failure Type",
+    meta: { width: "80px" },
+    cell: ({ getValue }) => (
+      <TestStatusBadge status={getValue() as TestStatus} />
+    ),
+  },
+  {
+    header: "Actions",
+    cell: ({
+      row: {
+        original: {
+          logs: { urlParsley },
+        },
+      },
+    }) => (
+      <ButtonContainer>
+        {urlParsley && (
+          <StyledButton
+            href={urlParsley}
+            rightGlyph={<Icon glyph="OpenNewTab" />}
+            size={ButtonSize.XSmall}
+            target="__blank"
+            title="Parsley logs"
+          >
+            Logs
+          </StyledButton>
+        )}
+      </ButtonContainer>
+    ),
+  },
+];
+
+const ButtonContainer = styled.div`
+  display: flex;
+  gap: ${size.xs};
+`;
+
+const StyledButton = styled(Button)`
+  flex-shrink: 0;
+`;

--- a/apps/spruce/src/pages/task/taskTabs/TaskHistory/CommitDetailsCard/__snapshots__/CommitDetailsCard_WithFailingTests.storyshot
+++ b/apps/spruce/src/pages/task/taskTabs/TaskHistory/CommitDetailsCard/__snapshots__/CommitDetailsCard_WithFailingTests.storyshot
@@ -1,0 +1,685 @@
+<div>
+  <div
+    class="css-173zci2-CommitCard e1a625uv4"
+    data-cy="commit-details-card"
+  >
+    <div
+      class="css-12rnwxt-TopLabel e1a625uv3"
+    >
+      <a
+        class="lg-ui-0000 leafygreen-ui-hvznge"
+        data-cy="downstream-base-commit"
+        href="/task/a"
+      >
+        <code
+          class="leafygreen-ui-i6ovbf"
+        >
+          aef3637
+        </code>
+      </a>
+      <a
+        aria-disabled="false"
+        aria-label="GitHub Commit Link"
+        class="leafygreen-ui-tcjr3n"
+        href="https://github.com/evergreen-ci/evergreen/commit/aef363719d0287e92cd83749a827bae"
+        tabindex="0"
+        target="__blank"
+      >
+        <div
+          class="leafygreen-ui-xhlipt"
+        >
+          <svg
+            aria-label="GitHub Icon"
+            fill="none"
+            height="16"
+            viewBox="0 0 98 96"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              clip-rule="evenodd"
+              d="M48.854 0C21.839 0 0 22 0 49.217c0 21.756 13.993 40.172 33.405 46.69 2.427.49 3.316-1.059 3.316-2.362 0-1.141-.08-5.052-.08-9.127-13.59 2.934-16.42-5.867-16.42-5.867-2.184-5.704-5.42-7.17-5.42-7.17-4.448-3.015.324-3.015.324-3.015 4.934.326 7.523 5.052 7.523 5.052 4.367 7.496 11.404 5.378 14.235 4.074.404-3.178 1.699-5.378 3.074-6.6-10.839-1.141-22.243-5.378-22.243-24.283 0-5.378 1.94-9.778 5.014-13.2-.485-1.222-2.184-6.275.486-13.038 0 0 4.125-1.304 13.426 5.052a46.97 46.97 0 0 1 12.214-1.63c4.125 0 8.33.571 12.213 1.63 9.302-6.356 13.427-5.052 13.427-5.052 2.67 6.763.97 11.816.485 13.038 3.155 3.422 5.015 7.822 5.015 13.2 0 18.905-11.404 23.06-22.324 24.283 1.78 1.548 3.316 4.481 3.316 9.126 0 6.6-.08 11.897-.08 13.526 0 1.304.89 2.853 3.316 2.364 19.412-6.52 33.405-24.935 33.405-46.691C97.707 22 75.788 0 48.854 0z"
+              fill="#001E2B"
+              fill-rule="evenodd"
+            />
+          </svg>
+        </div>
+      </a>
+      <button
+        aria-disabled="false"
+        class="lg-ui-button-0000 leafygreen-ui-168frnw"
+        data-cy="restart-button"
+        data-lgid="lg-button"
+        type="button"
+      >
+        <div
+          class="leafygreen-ui-v038xi"
+        />
+        <div
+          class="leafygreen-ui-b15bbd"
+        >
+          Restart Task
+        </div>
+      </button>
+      <div
+        class="leafygreen-ui-h5xdir"
+      >
+        This Task
+      </div>
+      <span>
+        Apr 3, 2025, 10:22 AM
+      </span>
+      <div
+        class="css-1pa0taf-OrderLabel e1a625uv2"
+      >
+        Order: 
+        100
+      </div>
+    </div>
+    <div>
+      <div
+        class="css-16i4gmg-AccordionToggle e1omze814"
+        data-cy="accordion-toggle"
+        role="button"
+      >
+        <button
+          aria-disabled="false"
+          aria-label="Accordion icon"
+          class="css-lltsma-AccordionIcon e1omze813 leafygreen-ui-tcjr3n"
+          style="align-self: start;"
+          tabindex="0"
+        >
+          <div
+            class="leafygreen-ui-xhlipt"
+          >
+            <svg
+              aria-label="Chevron Right Icon"
+              class="leafygreen-ui-jc2z8v"
+              fill="none"
+              height="16"
+              role="img"
+              viewBox="0 0 16 16"
+              width="16"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                clip-rule="evenodd"
+                d="M5.364 14.364a1 1 0 0 0 1.414 0l4.95-4.95.707-.707a1 1 0 0 0 0-1.414l-.707-.707-4.95-4.95a1 1 0 0 0-1.414 0l-.707.707a1 1 0 0 0 0 1.414L8.899 8l-4.242 4.243a1 1 0 0 0 0 1.414l.707.707Z"
+                fill="currentColor"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </div>
+        </button>
+        <span>
+          <div
+            class="css-1qgx25j-BottomLabel e1a625uv0"
+          >
+            <b
+              class="css-1nvsyyh-AuthorLabel e1a625uv1"
+            >
+              Evergreen Admin
+               - 
+            </b>
+            <span
+              class="css-16elo4e-WordBreak-wordBreakCss e1wygaev0"
+            >
+              <a
+                class="lg-ui-0001 css-r79zk7-overrideStyles leafygreen-ui-16e7rxl"
+                data-cy="jira-link"
+                href="https:///browse/DEVPROD-1234"
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                <span>
+                  DEVPROD-1234
+                </span>
+              </a>
+              : Create Commit Details Card component which will be used in the Commit Details List. It should handle overflow correctly and render different status colors.
+            </span>
+          </div>
+        </span>
+      </div>
+      <div
+        aria-expanded="false"
+        class="css-sstoka-AnimatedAccordion e1omze812"
+        data-cy="accordion-collapse-container"
+      >
+        <div
+          class="css-1hezny5-ContentsContainer e1omze811"
+        >
+          <div
+            class="leafygreen-ui-1si66qn"
+            tabindex="0"
+          >
+            <div />
+            <table
+              class="lg-ui-lg-table-0000 leafygreen-ui-1soynca"
+              data-cy="failing-tests-changes-table"
+              data-is-sticky="false"
+              data-lgid="lg-table"
+            >
+              <thead
+                class="leafygreen-ui-181p7kg"
+              >
+                <tr
+                  class="leafygreen-ui-5fo1n0"
+                >
+                  <th
+                    class="leafygreen-ui-1it7wsd"
+                    data-lgid="lg-table-header"
+                    scope="col"
+                    style="width: 60%;"
+                  >
+                    <div
+                      class="leafygreen-ui-11hl1ow"
+                    >
+                      Test Failure Name
+                    </div>
+                  </th>
+                  <th
+                    class="leafygreen-ui-1it7wsd"
+                    data-lgid="lg-table-header"
+                    scope="col"
+                    style="width: 80px;"
+                  >
+                    <div
+                      class="leafygreen-ui-11hl1ow"
+                    >
+                      Failure Type
+                    </div>
+                  </th>
+                  <th
+                    class="leafygreen-ui-1it7wsd"
+                    data-lgid="lg-table-header"
+                    scope="col"
+                  >
+                    <div
+                      class="leafygreen-ui-11hl1ow"
+                    >
+                      Actions
+                    </div>
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr
+                  aria-disabled="false"
+                  class="leafygreen-ui-1j40m9a leafygreen-ui-5svxsn"
+                  data-cy="failing-tests-table-row"
+                  data-depth="0"
+                  data-expanded="false"
+                  data-index="0"
+                  data-lgid="lg-table-row"
+                  data-selected="false"
+                  id="lg-table-row-0"
+                >
+                  <td
+                    class="leafygreen-ui-6m4hlf leafygreen-ui-1qv2n80"
+                    data-lgid="lg-table-cell"
+                    style="padding-bottom: 4px; padding-top: 4px;"
+                  >
+                    <div
+                      class="leafygreen-ui-18w181u"
+                    >
+                      <div
+                        class="leafygreen-ui-mjg5qs"
+                      >
+                        <div
+                          class=""
+                        >
+                          <span
+                            class="css-16elo4e-WordBreak-wordBreakCss e1wygaev0"
+                          >
+                            e2e_test
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    class="leafygreen-ui-6m4hlf leafygreen-ui-1qv2n80"
+                    data-lgid="lg-table-cell"
+                    style="padding-bottom: 4px; padding-top: 4px;"
+                  >
+                    <div
+                      class="leafygreen-ui-18w181u"
+                    >
+                      <div
+                        class="leafygreen-ui-mjg5qs"
+                      >
+                        <div
+                          class=""
+                        >
+                          <div
+                            class="leafygreen-ui-dhdzha"
+                            data-cy="test-status-badge"
+                          >
+                            Fail
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    class="leafygreen-ui-6m4hlf leafygreen-ui-1qv2n80"
+                    data-lgid="lg-table-cell"
+                    style="padding-bottom: 4px; padding-top: 4px;"
+                  >
+                    <div
+                      class="leafygreen-ui-18w181u"
+                    >
+                      <div
+                        class="leafygreen-ui-mjg5qs"
+                      >
+                        <div
+                          class=""
+                        >
+                          <div
+                            class="css-1gi9ejr-ButtonContainer e1bp1fda1"
+                          >
+                            <a
+                              aria-disabled="false"
+                              class="lg-ui-button-0000 leafygreen-ui-168frnw css-11mxq61-StyledButton e1bp1fda0"
+                              data-lgid="lg-button"
+                              href="a-parsley-url.mongodb.com"
+                              target="__blank"
+                              title="Parsley logs"
+                            >
+                              <div
+                                class="leafygreen-ui-v038xi"
+                              />
+                              <div
+                                class="leafygreen-ui-b15bbd"
+                              >
+                                Logs
+                                <svg
+                                  alt=""
+                                  aria-hidden="true"
+                                  class="leafygreen-ui-1q35ofk"
+                                  fill="none"
+                                  height="16"
+                                  role="presentation"
+                                  viewBox="0 0 16 16"
+                                  width="16"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M13.823 2.45a.278.278 0 0 0-.272-.273l-4.045-.079a.277.277 0 0 0-.201.474l1.08 1.08-2.45 2.452a1.395 1.395 0 0 0-.148.174L5.999 8.065a1.369 1.369 0 1 0 1.936 1.936l1.787-1.788c.061-.043.12-.093.174-.147l2.451-2.452 1.081 1.081a.277.277 0 0 0 .474-.201l-.079-4.045Z"
+                                    fill="currentColor"
+                                  />
+                                  <path
+                                    d="M7.25 3.129a.75.75 0 0 1 0 1.5H4a.5.5 0 0 0-.5.5v6.864a.5.5 0 0 0 .5.5h6.864a.5.5 0 0 0 .5-.5V8.75a.75.75 0 0 1 1.5 0v3.243a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5.129a2 2 0 0 1 2-2h3.25Z"
+                                    fill="currentColor"
+                                  />
+                                </svg>
+                              </div>
+                            </a>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                </tr>
+                <tr
+                  aria-disabled="false"
+                  class="leafygreen-ui-1j40m9a leafygreen-ui-5svxsn"
+                  data-cy="failing-tests-table-row"
+                  data-depth="0"
+                  data-expanded="false"
+                  data-index="1"
+                  data-lgid="lg-table-row"
+                  data-selected="false"
+                  id="lg-table-row-1"
+                >
+                  <td
+                    class="leafygreen-ui-6m4hlf leafygreen-ui-1qv2n80"
+                    data-lgid="lg-table-cell"
+                    style="padding-bottom: 4px; padding-top: 4px;"
+                  >
+                    <div
+                      class="leafygreen-ui-18w181u"
+                    >
+                      <div
+                        class="leafygreen-ui-mjg5qs"
+                      >
+                        <div
+                          class=""
+                        >
+                          <span
+                            class="css-16elo4e-WordBreak-wordBreakCss e1wygaev0"
+                          >
+                            e2e_test
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    class="leafygreen-ui-6m4hlf leafygreen-ui-1qv2n80"
+                    data-lgid="lg-table-cell"
+                    style="padding-bottom: 4px; padding-top: 4px;"
+                  >
+                    <div
+                      class="leafygreen-ui-18w181u"
+                    >
+                      <div
+                        class="leafygreen-ui-mjg5qs"
+                      >
+                        <div
+                          class=""
+                        >
+                          <div
+                            class="leafygreen-ui-dhdzha"
+                            data-cy="test-status-badge"
+                          >
+                            Fail
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    class="leafygreen-ui-6m4hlf leafygreen-ui-1qv2n80"
+                    data-lgid="lg-table-cell"
+                    style="padding-bottom: 4px; padding-top: 4px;"
+                  >
+                    <div
+                      class="leafygreen-ui-18w181u"
+                    >
+                      <div
+                        class="leafygreen-ui-mjg5qs"
+                      >
+                        <div
+                          class=""
+                        >
+                          <div
+                            class="css-1gi9ejr-ButtonContainer e1bp1fda1"
+                          >
+                            <a
+                              aria-disabled="false"
+                              class="lg-ui-button-0000 leafygreen-ui-168frnw css-11mxq61-StyledButton e1bp1fda0"
+                              data-lgid="lg-button"
+                              href="b-parsley-url.mongodb.com"
+                              target="__blank"
+                              title="Parsley logs"
+                            >
+                              <div
+                                class="leafygreen-ui-v038xi"
+                              />
+                              <div
+                                class="leafygreen-ui-b15bbd"
+                              >
+                                Logs
+                                <svg
+                                  alt=""
+                                  aria-hidden="true"
+                                  class="leafygreen-ui-1q35ofk"
+                                  fill="none"
+                                  height="16"
+                                  role="presentation"
+                                  viewBox="0 0 16 16"
+                                  width="16"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M13.823 2.45a.278.278 0 0 0-.272-.273l-4.045-.079a.277.277 0 0 0-.201.474l1.08 1.08-2.45 2.452a1.395 1.395 0 0 0-.148.174L5.999 8.065a1.369 1.369 0 1 0 1.936 1.936l1.787-1.788c.061-.043.12-.093.174-.147l2.451-2.452 1.081 1.081a.277.277 0 0 0 .474-.201l-.079-4.045Z"
+                                    fill="currentColor"
+                                  />
+                                  <path
+                                    d="M7.25 3.129a.75.75 0 0 1 0 1.5H4a.5.5 0 0 0-.5.5v6.864a.5.5 0 0 0 .5.5h6.864a.5.5 0 0 0 .5-.5V8.75a.75.75 0 0 1 1.5 0v3.243a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5.129a2 2 0 0 1 2-2h3.25Z"
+                                    fill="currentColor"
+                                  />
+                                </svg>
+                              </div>
+                            </a>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                </tr>
+                <tr
+                  aria-disabled="false"
+                  class="leafygreen-ui-1j40m9a leafygreen-ui-5svxsn"
+                  data-cy="failing-tests-table-row"
+                  data-depth="0"
+                  data-expanded="false"
+                  data-index="2"
+                  data-lgid="lg-table-row"
+                  data-selected="false"
+                  id="lg-table-row-2"
+                >
+                  <td
+                    class="leafygreen-ui-6m4hlf leafygreen-ui-1qv2n80"
+                    data-lgid="lg-table-cell"
+                    style="padding-bottom: 4px; padding-top: 4px;"
+                  >
+                    <div
+                      class="leafygreen-ui-18w181u"
+                    >
+                      <div
+                        class="leafygreen-ui-mjg5qs"
+                      >
+                        <div
+                          class=""
+                        >
+                          <span
+                            class="css-16elo4e-WordBreak-wordBreakCss e1wygaev0"
+                          >
+                            e2e_test
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    class="leafygreen-ui-6m4hlf leafygreen-ui-1qv2n80"
+                    data-lgid="lg-table-cell"
+                    style="padding-bottom: 4px; padding-top: 4px;"
+                  >
+                    <div
+                      class="leafygreen-ui-18w181u"
+                    >
+                      <div
+                        class="leafygreen-ui-mjg5qs"
+                      >
+                        <div
+                          class=""
+                        >
+                          <div
+                            class="leafygreen-ui-h5xdir"
+                            data-cy="test-status-badge"
+                          >
+                            Silent Fail
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    class="leafygreen-ui-6m4hlf leafygreen-ui-1qv2n80"
+                    data-lgid="lg-table-cell"
+                    style="padding-bottom: 4px; padding-top: 4px;"
+                  >
+                    <div
+                      class="leafygreen-ui-18w181u"
+                    >
+                      <div
+                        class="leafygreen-ui-mjg5qs"
+                      >
+                        <div
+                          class=""
+                        >
+                          <div
+                            class="css-1gi9ejr-ButtonContainer e1bp1fda1"
+                          >
+                            <a
+                              aria-disabled="false"
+                              class="lg-ui-button-0000 leafygreen-ui-168frnw css-11mxq61-StyledButton e1bp1fda0"
+                              data-lgid="lg-button"
+                              href="c-parsley-url.mongodb.com"
+                              target="__blank"
+                              title="Parsley logs"
+                            >
+                              <div
+                                class="leafygreen-ui-v038xi"
+                              />
+                              <div
+                                class="leafygreen-ui-b15bbd"
+                              >
+                                Logs
+                                <svg
+                                  alt=""
+                                  aria-hidden="true"
+                                  class="leafygreen-ui-1q35ofk"
+                                  fill="none"
+                                  height="16"
+                                  role="presentation"
+                                  viewBox="0 0 16 16"
+                                  width="16"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M13.823 2.45a.278.278 0 0 0-.272-.273l-4.045-.079a.277.277 0 0 0-.201.474l1.08 1.08-2.45 2.452a1.395 1.395 0 0 0-.148.174L5.999 8.065a1.369 1.369 0 1 0 1.936 1.936l1.787-1.788c.061-.043.12-.093.174-.147l2.451-2.452 1.081 1.081a.277.277 0 0 0 .474-.201l-.079-4.045Z"
+                                    fill="currentColor"
+                                  />
+                                  <path
+                                    d="M7.25 3.129a.75.75 0 0 1 0 1.5H4a.5.5 0 0 0-.5.5v6.864a.5.5 0 0 0 .5.5h6.864a.5.5 0 0 0 .5-.5V8.75a.75.75 0 0 1 1.5 0v3.243a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5.129a2 2 0 0 1 2-2h3.25Z"
+                                    fill="currentColor"
+                                  />
+                                </svg>
+                              </div>
+                            </a>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                </tr>
+                <tr
+                  aria-disabled="false"
+                  class="leafygreen-ui-1j40m9a leafygreen-ui-5svxsn"
+                  data-cy="failing-tests-table-row"
+                  data-depth="0"
+                  data-expanded="false"
+                  data-index="3"
+                  data-lgid="lg-table-row"
+                  data-selected="false"
+                  id="lg-table-row-3"
+                >
+                  <td
+                    class="leafygreen-ui-6m4hlf leafygreen-ui-1qv2n80"
+                    data-lgid="lg-table-cell"
+                    style="padding-bottom: 4px; padding-top: 4px;"
+                  >
+                    <div
+                      class="leafygreen-ui-18w181u"
+                    >
+                      <div
+                        class="leafygreen-ui-mjg5qs"
+                      >
+                        <div
+                          class=""
+                        >
+                          <span
+                            class="css-16elo4e-WordBreak-wordBreakCss e1wygaev0"
+                          >
+                            e2e_test
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    class="leafygreen-ui-6m4hlf leafygreen-ui-1qv2n80"
+                    data-lgid="lg-table-cell"
+                    style="padding-bottom: 4px; padding-top: 4px;"
+                  >
+                    <div
+                      class="leafygreen-ui-18w181u"
+                    >
+                      <div
+                        class="leafygreen-ui-mjg5qs"
+                      >
+                        <div
+                          class=""
+                        >
+                          <div
+                            class="leafygreen-ui-dhdzha"
+                            data-cy="test-status-badge"
+                          >
+                            Fail
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    class="leafygreen-ui-6m4hlf leafygreen-ui-1qv2n80"
+                    data-lgid="lg-table-cell"
+                    style="padding-bottom: 4px; padding-top: 4px;"
+                  >
+                    <div
+                      class="leafygreen-ui-18w181u"
+                    >
+                      <div
+                        class="leafygreen-ui-mjg5qs"
+                      >
+                        <div
+                          class=""
+                        >
+                          <div
+                            class="css-1gi9ejr-ButtonContainer e1bp1fda1"
+                          >
+                            <a
+                              aria-disabled="false"
+                              class="lg-ui-button-0000 leafygreen-ui-168frnw css-11mxq61-StyledButton e1bp1fda0"
+                              data-lgid="lg-button"
+                              href="s-parsley-url.mongodb.com"
+                              target="__blank"
+                              title="Parsley logs"
+                            >
+                              <div
+                                class="leafygreen-ui-v038xi"
+                              />
+                              <div
+                                class="leafygreen-ui-b15bbd"
+                              >
+                                Logs
+                                <svg
+                                  alt=""
+                                  aria-hidden="true"
+                                  class="leafygreen-ui-1q35ofk"
+                                  fill="none"
+                                  height="16"
+                                  role="presentation"
+                                  viewBox="0 0 16 16"
+                                  width="16"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M13.823 2.45a.278.278 0 0 0-.272-.273l-4.045-.079a.277.277 0 0 0-.201.474l1.08 1.08-2.45 2.452a1.395 1.395 0 0 0-.148.174L5.999 8.065a1.369 1.369 0 1 0 1.936 1.936l1.787-1.788c.061-.043.12-.093.174-.147l2.451-2.452 1.081 1.081a.277.277 0 0 0 .474-.201l-.079-4.045Z"
+                                    fill="currentColor"
+                                  />
+                                  <path
+                                    d="M7.25 3.129a.75.75 0 0 1 0 1.5H4a.5.5 0 0 0-.5.5v6.864a.5.5 0 0 0 .5.5h6.864a.5.5 0 0 0 .5-.5V8.75a.75.75 0 0 1 1.5 0v3.243a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5.129a2 2 0 0 1 2-2h3.25Z"
+                                    fill="currentColor"
+                                  />
+                                </svg>
+                              </div>
+                            </a>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/apps/spruce/src/pages/task/taskTabs/TaskHistory/CommitDetailsCard/__snapshots__/CommitDetailsCard_WithFailingTests.storyshot
+++ b/apps/spruce/src/pages/task/taskTabs/TaskHistory/CommitDetailsCard/__snapshots__/CommitDetailsCard_WithFailingTests.storyshot
@@ -231,7 +231,7 @@
                           <span
                             class="css-16elo4e-WordBreak-wordBreakCss e1wygaev0"
                           >
-                            e2e_test
+                            e2e_test_1
                           </span>
                         </div>
                       </div>
@@ -349,7 +349,7 @@
                           <span
                             class="css-16elo4e-WordBreak-wordBreakCss e1wygaev0"
                           >
-                            e2e_test
+                            e2e_test_2
                           </span>
                         </div>
                       </div>
@@ -467,7 +467,7 @@
                           <span
                             class="css-16elo4e-WordBreak-wordBreakCss e1wygaev0"
                           >
-                            e2e_test
+                            e2e_test_3
                           </span>
                         </div>
                       </div>
@@ -585,7 +585,7 @@
                           <span
                             class="css-16elo4e-WordBreak-wordBreakCss e1wygaev0"
                           >
-                            e2e_test
+                            e2e_test_4
                           </span>
                         </div>
                       </div>

--- a/apps/spruce/src/pages/task/taskTabs/TaskHistory/CommitDetailsCard/index.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/TaskHistory/CommitDetailsCard/index.tsx
@@ -6,6 +6,9 @@ import IconButton from "@leafygreen-ui/icon-button";
 import { palette } from "@leafygreen-ui/palette";
 import { InlineCode } from "@leafygreen-ui/typography";
 import { Link } from "react-router-dom";
+import Accordion, {
+  AccordionCaretAlign,
+} from "@evg-ui/lib/components/Accordion";
 import Icon from "@evg-ui/lib/components/Icon";
 import { WordBreak } from "@evg-ui/lib/components/styles";
 import { size } from "@evg-ui/lib/constants/tokens";
@@ -25,6 +28,7 @@ import { useQueryParam } from "hooks/useQueryParam";
 import { isProduction } from "utils/environmentVariables";
 import { jiraLinkify, shortenGithash } from "utils/string";
 import { TaskHistoryTask } from "../types";
+import FailedTestsTable from "./FailedTestsTable";
 
 const { gray } = palette;
 
@@ -50,6 +54,7 @@ const CommitDetailsCard: React.FC<CommitDetailsCardProps> = ({
     id: taskId,
     order,
     revision,
+    tests,
     versionMetadata,
   } = task;
   const { author, message } = versionMetadata;
@@ -103,6 +108,13 @@ const CommitDetailsCard: React.FC<CommitDetailsCardProps> = ({
     refetchQueries: [isCurrentTask ? "TaskHistory" : ""],
   });
 
+  const title = (
+    <BottomLabel>
+      <AuthorLabel>{author} - </AuthorLabel>
+      <WordBreak>{jiraLinkify(message, jiraHost)}</WordBreak>
+    </BottomLabel>
+  );
+
   return (
     <CommitCard
       key={taskId}
@@ -138,10 +150,13 @@ const CommitDetailsCard: React.FC<CommitDetailsCardProps> = ({
         {/* Use this to debug issues with pagination. */}
         {!isProduction() && <OrderLabel>Order: {order}</OrderLabel>}
       </TopLabel>
-      <BottomLabel>
-        <AuthorLabel>{author} - </AuthorLabel>
-        <WordBreak>{jiraLinkify(message, jiraHost)}</WordBreak>
-      </BottomLabel>
+      {tests.testResults.length > 0 ? (
+        <Accordion caretAlign={AccordionCaretAlign.Start} title={title}>
+          <FailedTestsTable tests={tests} />
+        </Accordion>
+      ) : (
+        title
+      )}
     </CommitCard>
   );
 };

--- a/apps/spruce/src/pages/task/taskTabs/TaskHistory/CommitDetailsList/__snapshots__/CommitDetailsList_Default.storyshot
+++ b/apps/spruce/src/pages/task/taskTabs/TaskHistory/CommitDetailsList/__snapshots__/CommitDetailsList_Default.storyshot
@@ -453,31 +453,256 @@
           95
         </div>
       </div>
-      <div
-        class="css-1qgx25j-BottomLabel e1a625uv0"
-      >
-        <b
-          class="css-1nvsyyh-AuthorLabel e1a625uv1"
+      <div>
+        <div
+          class="css-16i4gmg-AccordionToggle e1omze814"
+          data-cy="accordion-toggle"
+          role="button"
         >
-          Evergreen Admin
-           - 
-        </b>
-        <span
-          class="css-16elo4e-WordBreak-wordBreakCss e1wygaev0"
-        >
-          <a
-            class="lg-ui-0001 css-r79zk7-overrideStyles leafygreen-ui-16e7rxl"
-            data-cy="jira-link"
-            href="https:///browse/DEVPROD-1234"
-            rel="noopener noreferrer"
-            target="_blank"
+          <button
+            aria-disabled="false"
+            aria-label="Accordion icon"
+            class="css-lltsma-AccordionIcon e1omze813 leafygreen-ui-tcjr3n"
+            style="align-self: start;"
+            tabindex="0"
           >
-            <span>
-              DEVPROD-1234
-            </span>
-          </a>
-          : F
-        </span>
+            <div
+              class="leafygreen-ui-xhlipt"
+            >
+              <svg
+                aria-label="Chevron Right Icon"
+                class="leafygreen-ui-jc2z8v"
+                fill="none"
+                height="16"
+                role="img"
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  clip-rule="evenodd"
+                  d="M5.364 14.364a1 1 0 0 0 1.414 0l4.95-4.95.707-.707a1 1 0 0 0 0-1.414l-.707-.707-4.95-4.95a1 1 0 0 0-1.414 0l-.707.707a1 1 0 0 0 0 1.414L8.899 8l-4.242 4.243a1 1 0 0 0 0 1.414l.707.707Z"
+                  fill="currentColor"
+                  fill-rule="evenodd"
+                />
+              </svg>
+            </div>
+          </button>
+          <span>
+            <div
+              class="css-1qgx25j-BottomLabel e1a625uv0"
+            >
+              <b
+                class="css-1nvsyyh-AuthorLabel e1a625uv1"
+              >
+                Evergreen Admin
+                 - 
+              </b>
+              <span
+                class="css-16elo4e-WordBreak-wordBreakCss e1wygaev0"
+              >
+                <a
+                  class="lg-ui-0001 css-r79zk7-overrideStyles leafygreen-ui-16e7rxl"
+                  data-cy="jira-link"
+                  href="https:///browse/DEVPROD-1234"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  <span>
+                    DEVPROD-1234
+                  </span>
+                </a>
+                : F
+              </span>
+            </div>
+          </span>
+        </div>
+        <div
+          aria-expanded="false"
+          class="css-sstoka-AnimatedAccordion e1omze812"
+          data-cy="accordion-collapse-container"
+        >
+          <div
+            class="css-1hezny5-ContentsContainer e1omze811"
+          >
+            <div
+              class="leafygreen-ui-1si66qn"
+              tabindex="0"
+            >
+              <div />
+              <table
+                class="lg-ui-lg-table-0000 leafygreen-ui-1soynca"
+                data-cy="failing-tests-changes-table"
+                data-is-sticky="false"
+                data-lgid="lg-table"
+              >
+                <thead
+                  class="leafygreen-ui-181p7kg"
+                >
+                  <tr
+                    class="leafygreen-ui-5fo1n0"
+                  >
+                    <th
+                      class="leafygreen-ui-1it7wsd"
+                      data-lgid="lg-table-header"
+                      scope="col"
+                      style="width: 60%;"
+                    >
+                      <div
+                        class="leafygreen-ui-11hl1ow"
+                      >
+                        Test Failure Name
+                      </div>
+                    </th>
+                    <th
+                      class="leafygreen-ui-1it7wsd"
+                      data-lgid="lg-table-header"
+                      scope="col"
+                      style="width: 80px;"
+                    >
+                      <div
+                        class="leafygreen-ui-11hl1ow"
+                      >
+                        Failure Type
+                      </div>
+                    </th>
+                    <th
+                      class="leafygreen-ui-1it7wsd"
+                      data-lgid="lg-table-header"
+                      scope="col"
+                    >
+                      <div
+                        class="leafygreen-ui-11hl1ow"
+                      >
+                        Actions
+                      </div>
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr
+                    aria-disabled="false"
+                    class="leafygreen-ui-1j40m9a leafygreen-ui-5svxsn"
+                    data-cy="failing-tests-table-row"
+                    data-depth="0"
+                    data-expanded="false"
+                    data-index="0"
+                    data-lgid="lg-table-row"
+                    data-selected="false"
+                    id="lg-table-row-0"
+                  >
+                    <td
+                      class="leafygreen-ui-6m4hlf leafygreen-ui-1qv2n80"
+                      data-lgid="lg-table-cell"
+                      style="padding-bottom: 4px; padding-top: 4px;"
+                    >
+                      <div
+                        class="leafygreen-ui-18w181u"
+                      >
+                        <div
+                          class="leafygreen-ui-mjg5qs"
+                        >
+                          <div
+                            class=""
+                          >
+                            <span
+                              class="css-16elo4e-WordBreak-wordBreakCss e1wygaev0"
+                            >
+                              e2e_test
+                            </span>
+                          </div>
+                        </div>
+                      </div>
+                    </td>
+                    <td
+                      class="leafygreen-ui-6m4hlf leafygreen-ui-1qv2n80"
+                      data-lgid="lg-table-cell"
+                      style="padding-bottom: 4px; padding-top: 4px;"
+                    >
+                      <div
+                        class="leafygreen-ui-18w181u"
+                      >
+                        <div
+                          class="leafygreen-ui-mjg5qs"
+                        >
+                          <div
+                            class=""
+                          >
+                            <div
+                              class="leafygreen-ui-dhdzha"
+                              data-cy="test-status-badge"
+                            >
+                              Fail
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </td>
+                    <td
+                      class="leafygreen-ui-6m4hlf leafygreen-ui-1qv2n80"
+                      data-lgid="lg-table-cell"
+                      style="padding-bottom: 4px; padding-top: 4px;"
+                    >
+                      <div
+                        class="leafygreen-ui-18w181u"
+                      >
+                        <div
+                          class="leafygreen-ui-mjg5qs"
+                        >
+                          <div
+                            class=""
+                          >
+                            <div
+                              class="css-1gi9ejr-ButtonContainer e1bp1fda1"
+                            >
+                              <a
+                                aria-disabled="false"
+                                class="lg-ui-button-0000 leafygreen-ui-168frnw css-11mxq61-StyledButton e1bp1fda0"
+                                data-lgid="lg-button"
+                                href="a-parsley-url.mongodb.com"
+                                target="__blank"
+                                title="Parsley logs"
+                              >
+                                <div
+                                  class="leafygreen-ui-v038xi"
+                                />
+                                <div
+                                  class="leafygreen-ui-b15bbd"
+                                >
+                                  Logs
+                                  <svg
+                                    alt=""
+                                    aria-hidden="true"
+                                    class="leafygreen-ui-1q35ofk"
+                                    fill="none"
+                                    height="16"
+                                    role="presentation"
+                                    viewBox="0 0 16 16"
+                                    width="16"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="M13.823 2.45a.278.278 0 0 0-.272-.273l-4.045-.079a.277.277 0 0 0-.201.474l1.08 1.08-2.45 2.452a1.395 1.395 0 0 0-.148.174L5.999 8.065a1.369 1.369 0 1 0 1.936 1.936l1.787-1.788c.061-.043.12-.093.174-.147l2.451-2.452 1.081 1.081a.277.277 0 0 0 .474-.201l-.079-4.045Z"
+                                      fill="currentColor"
+                                    />
+                                    <path
+                                      d="M7.25 3.129a.75.75 0 0 1 0 1.5H4a.5.5 0 0 0-.5.5v6.864a.5.5 0 0 0 .5.5h6.864a.5.5 0 0 0 .5-.5V8.75a.75.75 0 0 1 1.5 0v3.243a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5.129a2 2 0 0 1 2-2h3.25Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </div>
+                              </a>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
     <span>

--- a/apps/spruce/src/pages/task/taskTabs/TaskHistory/CommitDetailsList/__snapshots__/CommitDetailsList_WithFilterApplied.storyshot
+++ b/apps/spruce/src/pages/task/taskTabs/TaskHistory/CommitDetailsList/__snapshots__/CommitDetailsList_WithFilterApplied.storyshot
@@ -453,31 +453,256 @@
           95
         </div>
       </div>
-      <div
-        class="css-1qgx25j-BottomLabel e1a625uv0"
-      >
-        <b
-          class="css-1nvsyyh-AuthorLabel e1a625uv1"
+      <div>
+        <div
+          class="css-16i4gmg-AccordionToggle e1omze814"
+          data-cy="accordion-toggle"
+          role="button"
         >
-          Evergreen Admin
-           - 
-        </b>
-        <span
-          class="css-16elo4e-WordBreak-wordBreakCss e1wygaev0"
-        >
-          <a
-            class="lg-ui-0001 css-r79zk7-overrideStyles leafygreen-ui-16e7rxl"
-            data-cy="jira-link"
-            href="https:///browse/DEVPROD-1234"
-            rel="noopener noreferrer"
-            target="_blank"
+          <button
+            aria-disabled="false"
+            aria-label="Accordion icon"
+            class="css-lltsma-AccordionIcon e1omze813 leafygreen-ui-tcjr3n"
+            style="align-self: start;"
+            tabindex="0"
           >
-            <span>
-              DEVPROD-1234
-            </span>
-          </a>
-          : F
-        </span>
+            <div
+              class="leafygreen-ui-xhlipt"
+            >
+              <svg
+                aria-label="Chevron Right Icon"
+                class="leafygreen-ui-jc2z8v"
+                fill="none"
+                height="16"
+                role="img"
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  clip-rule="evenodd"
+                  d="M5.364 14.364a1 1 0 0 0 1.414 0l4.95-4.95.707-.707a1 1 0 0 0 0-1.414l-.707-.707-4.95-4.95a1 1 0 0 0-1.414 0l-.707.707a1 1 0 0 0 0 1.414L8.899 8l-4.242 4.243a1 1 0 0 0 0 1.414l.707.707Z"
+                  fill="currentColor"
+                  fill-rule="evenodd"
+                />
+              </svg>
+            </div>
+          </button>
+          <span>
+            <div
+              class="css-1qgx25j-BottomLabel e1a625uv0"
+            >
+              <b
+                class="css-1nvsyyh-AuthorLabel e1a625uv1"
+              >
+                Evergreen Admin
+                 - 
+              </b>
+              <span
+                class="css-16elo4e-WordBreak-wordBreakCss e1wygaev0"
+              >
+                <a
+                  class="lg-ui-0001 css-r79zk7-overrideStyles leafygreen-ui-16e7rxl"
+                  data-cy="jira-link"
+                  href="https:///browse/DEVPROD-1234"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  <span>
+                    DEVPROD-1234
+                  </span>
+                </a>
+                : F
+              </span>
+            </div>
+          </span>
+        </div>
+        <div
+          aria-expanded="false"
+          class="css-sstoka-AnimatedAccordion e1omze812"
+          data-cy="accordion-collapse-container"
+        >
+          <div
+            class="css-1hezny5-ContentsContainer e1omze811"
+          >
+            <div
+              class="leafygreen-ui-1si66qn"
+              tabindex="0"
+            >
+              <div />
+              <table
+                class="lg-ui-lg-table-0000 leafygreen-ui-1soynca"
+                data-cy="failing-tests-changes-table"
+                data-is-sticky="false"
+                data-lgid="lg-table"
+              >
+                <thead
+                  class="leafygreen-ui-181p7kg"
+                >
+                  <tr
+                    class="leafygreen-ui-5fo1n0"
+                  >
+                    <th
+                      class="leafygreen-ui-1it7wsd"
+                      data-lgid="lg-table-header"
+                      scope="col"
+                      style="width: 60%;"
+                    >
+                      <div
+                        class="leafygreen-ui-11hl1ow"
+                      >
+                        Test Failure Name
+                      </div>
+                    </th>
+                    <th
+                      class="leafygreen-ui-1it7wsd"
+                      data-lgid="lg-table-header"
+                      scope="col"
+                      style="width: 80px;"
+                    >
+                      <div
+                        class="leafygreen-ui-11hl1ow"
+                      >
+                        Failure Type
+                      </div>
+                    </th>
+                    <th
+                      class="leafygreen-ui-1it7wsd"
+                      data-lgid="lg-table-header"
+                      scope="col"
+                    >
+                      <div
+                        class="leafygreen-ui-11hl1ow"
+                      >
+                        Actions
+                      </div>
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr
+                    aria-disabled="false"
+                    class="leafygreen-ui-1j40m9a leafygreen-ui-5svxsn"
+                    data-cy="failing-tests-table-row"
+                    data-depth="0"
+                    data-expanded="false"
+                    data-index="0"
+                    data-lgid="lg-table-row"
+                    data-selected="false"
+                    id="lg-table-row-0"
+                  >
+                    <td
+                      class="leafygreen-ui-6m4hlf leafygreen-ui-1qv2n80"
+                      data-lgid="lg-table-cell"
+                      style="padding-bottom: 4px; padding-top: 4px;"
+                    >
+                      <div
+                        class="leafygreen-ui-18w181u"
+                      >
+                        <div
+                          class="leafygreen-ui-mjg5qs"
+                        >
+                          <div
+                            class=""
+                          >
+                            <span
+                              class="css-16elo4e-WordBreak-wordBreakCss e1wygaev0"
+                            >
+                              e2e_test
+                            </span>
+                          </div>
+                        </div>
+                      </div>
+                    </td>
+                    <td
+                      class="leafygreen-ui-6m4hlf leafygreen-ui-1qv2n80"
+                      data-lgid="lg-table-cell"
+                      style="padding-bottom: 4px; padding-top: 4px;"
+                    >
+                      <div
+                        class="leafygreen-ui-18w181u"
+                      >
+                        <div
+                          class="leafygreen-ui-mjg5qs"
+                        >
+                          <div
+                            class=""
+                          >
+                            <div
+                              class="leafygreen-ui-dhdzha"
+                              data-cy="test-status-badge"
+                            >
+                              Fail
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </td>
+                    <td
+                      class="leafygreen-ui-6m4hlf leafygreen-ui-1qv2n80"
+                      data-lgid="lg-table-cell"
+                      style="padding-bottom: 4px; padding-top: 4px;"
+                    >
+                      <div
+                        class="leafygreen-ui-18w181u"
+                      >
+                        <div
+                          class="leafygreen-ui-mjg5qs"
+                        >
+                          <div
+                            class=""
+                          >
+                            <div
+                              class="css-1gi9ejr-ButtonContainer e1bp1fda1"
+                            >
+                              <a
+                                aria-disabled="false"
+                                class="lg-ui-button-0000 leafygreen-ui-168frnw css-11mxq61-StyledButton e1bp1fda0"
+                                data-lgid="lg-button"
+                                href="a-parsley-url.mongodb.com"
+                                target="__blank"
+                                title="Parsley logs"
+                              >
+                                <div
+                                  class="leafygreen-ui-v038xi"
+                                />
+                                <div
+                                  class="leafygreen-ui-b15bbd"
+                                >
+                                  Logs
+                                  <svg
+                                    alt=""
+                                    aria-hidden="true"
+                                    class="leafygreen-ui-1q35ofk"
+                                    fill="none"
+                                    height="16"
+                                    role="presentation"
+                                    viewBox="0 0 16 16"
+                                    width="16"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="M13.823 2.45a.278.278 0 0 0-.272-.273l-4.045-.079a.277.277 0 0 0-.201.474l1.08 1.08-2.45 2.452a1.395 1.395 0 0 0-.148.174L5.999 8.065a1.369 1.369 0 1 0 1.936 1.936l1.787-1.788c.061-.043.12-.093.174-.147l2.451-2.452 1.081 1.081a.277.277 0 0 0 .474-.201l-.079-4.045Z"
+                                      fill="currentColor"
+                                    />
+                                    <path
+                                      d="M7.25 3.129a.75.75 0 0 1 0 1.5H4a.5.5 0 0 0-.5.5v6.864a.5.5 0 0 0 .5.5h6.864a.5.5 0 0 0 .5-.5V8.75a.75.75 0 0 1 1.5 0v3.243a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5.129a2 2 0 0 1 2-2h3.25Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </div>
+                              </a>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
     <span>

--- a/apps/spruce/src/pages/task/taskTabs/TaskHistory/testData.ts
+++ b/apps/spruce/src/pages/task/taskTabs/TaskHistory/testData.ts
@@ -1,4 +1,5 @@
 import { TaskStatus } from "@evg-ui/lib/types/task";
+import { TestStatus } from "@evg-ui/lib/types/test";
 import { GroupedTask, TaskHistoryTask } from "./types";
 
 const emptyTests = {
@@ -105,7 +106,7 @@ export const tasks: TaskHistoryTask[] = [
         {
           id: "e2e_test_id",
           testFile: "e2e_test",
-          status: "failed",
+          status: TestStatus.Fail,
           logs: { urlParsley: "a-parsley-url.mongodb.com" },
         },
       ],

--- a/apps/spruce/src/pages/version/Tabs/TestAnalysis/GroupedTestMapList/FailedTestGroup/__snapshots__/FailedTestGroup_Default.storyshot
+++ b/apps/spruce/src/pages/version/Tabs/TestAnalysis/GroupedTestMapList/FailedTestGroup/__snapshots__/FailedTestGroup_Default.storyshot
@@ -7,7 +7,7 @@
     >
       <button
         aria-disabled="false"
-        aria-labelledby="Accordion icon"
+        aria-label="Accordion icon"
         class="css-lltsma-AccordionIcon e1omze813 leafygreen-ui-tcjr3n"
         style="align-self: start;"
         tabindex="0"
@@ -58,7 +58,7 @@
       data-cy="accordion-collapse-container"
     >
       <div
-        class="css-ma2fau-ContentsContainer e1omze811"
+        class="css-1hezny5-ContentsContainer e1omze811"
       >
         <div
           class="css-12mjh8o-StyledCard eea2d851 leafygreen-ui-1ecxdul"

--- a/apps/spruce/src/pages/version/Tabs/TestAnalysis/GroupedTestMapList/FailedTestGroup/__snapshots__/FailedTestGroup_LongTestName.storyshot
+++ b/apps/spruce/src/pages/version/Tabs/TestAnalysis/GroupedTestMapList/FailedTestGroup/__snapshots__/FailedTestGroup_LongTestName.storyshot
@@ -7,7 +7,7 @@
     >
       <button
         aria-disabled="false"
-        aria-labelledby="Accordion icon"
+        aria-label="Accordion icon"
         class="css-lltsma-AccordionIcon e1omze813 leafygreen-ui-tcjr3n"
         style="align-self: start;"
         tabindex="0"
@@ -58,7 +58,7 @@
       data-cy="accordion-collapse-container"
     >
       <div
-        class="css-ma2fau-ContentsContainer e1omze811"
+        class="css-1hezny5-ContentsContainer e1omze811"
       >
         <div
           class="css-12mjh8o-StyledCard eea2d851 leafygreen-ui-1ecxdul"

--- a/packages/lib/src/components/Accordion/__snapshots__/Accordion_Default.storyshot
+++ b/packages/lib/src/components/Accordion/__snapshots__/Accordion_Default.storyshot
@@ -7,7 +7,7 @@
     >
       <button
         aria-disabled="false"
-        aria-labelledby="Accordion icon"
+        aria-label="Accordion icon"
         class="css-tgrklh leafygreen-ui-tcjr3n"
         style="align-self: center;"
         tabindex="0"
@@ -44,7 +44,7 @@
       data-cy="accordion-collapse-container"
     >
       <div
-        class="css-1o2r8wi"
+        class="css-1njzqz8"
       >
         Accordion content
       </div>

--- a/packages/lib/src/components/Accordion/__snapshots__/Accordion_WithSubtitle.storyshot
+++ b/packages/lib/src/components/Accordion/__snapshots__/Accordion_WithSubtitle.storyshot
@@ -7,7 +7,7 @@
     >
       <button
         aria-disabled="false"
-        aria-labelledby="Accordion icon"
+        aria-label="Accordion icon"
         class="css-tgrklh leafygreen-ui-tcjr3n"
         style="align-self: center;"
         tabindex="0"
@@ -49,7 +49,7 @@
       data-cy="accordion-collapse-container"
     >
       <div
-        class="css-1o2r8wi"
+        class="css-1njzqz8"
       >
         Accordion content
       </div>

--- a/packages/lib/src/components/Accordion/__snapshots__/Accordion_WithToggledTitle.storyshot
+++ b/packages/lib/src/components/Accordion/__snapshots__/Accordion_WithToggledTitle.storyshot
@@ -7,7 +7,7 @@
     >
       <button
         aria-disabled="false"
-        aria-labelledby="Accordion icon"
+        aria-label="Accordion icon"
         class="css-tgrklh leafygreen-ui-tcjr3n"
         style="align-self: center;"
         tabindex="0"
@@ -44,7 +44,7 @@
       data-cy="accordion-collapse-container"
     >
       <div
-        class="css-1o2r8wi"
+        class="css-1njzqz8"
       >
         Accordion content
       </div>

--- a/packages/lib/src/components/Accordion/index.tsx
+++ b/packages/lib/src/components/Accordion/index.tsx
@@ -79,7 +79,7 @@ const Accordion: React.FC<AccordionProps> = ({
         role="button"
       >
         <AccordionIcon
-          aria-labelledby="Accordion icon"
+          aria-label="Accordion icon"
           open={accordionOpen}
           style={{ alignSelf: caretAlign }}
         >
@@ -134,9 +134,8 @@ const ContentsContainer = styled.div<{ useIndent: boolean }>`
     `
       margin-left: 26px;
 
-      /* Styles below handle input focus borders which get cut off due to overflow: hidden */
+      /* Handle input focus borders which get cut off due to overflow: hidden */
       padding: 0 ${size.xxs};
-      margin-right: -${size.s}
     `}
 `;
 


### PR DESCRIPTION
DEVPROD-16172
<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
Adds test failure table to commit details card. Also, I messed up some `Accordion` styles so I fixed them.

Search failures and follow-up improvements will be made in [DEVPROD-16189](https://jira.mongodb.org/browse/DEVPROD-16189).

### Screenshots
<!-- add screenshots of visible changes -->
<img width="1125" alt="Screenshot 2025-05-20 at 3 31 22 PM" src="https://github.com/user-attachments/assets/3fbdaf42-64fa-43c2-8230-491588a53031" />


### Testing
* Cypress test
* Update stories
