### PR TITLE
DEVPROD-16189: Add Search Failure button to failed tests table

### DIFF
--- a/apps/parsley/src/gql/generated/types.ts
+++ b/apps/parsley/src/gql/generated/types.ts
@@ -2816,8 +2816,8 @@ export type Task = {
   details?: Maybe<TaskEndDetail>;
   dispatchTime?: Maybe<Scalars["Time"]["output"]>;
   displayName: Scalars["String"]["output"];
-  displayOnly?: Maybe<Scalars["Boolean"]["output"]>;
   /** This is a task's display status and is what is commonly used on the UI. */
+  displayOnly?: Maybe<Scalars["Boolean"]["output"]>;
   displayStatus: Scalars["String"]["output"];
   displayTask?: Maybe<Task>;
   distroId: Scalars["String"]["output"];
@@ -2857,11 +2857,11 @@ export type Task = {
   startTime?: Maybe<Scalars["Time"]["output"]>;
   /** This is a task's original status. It is the status stored in the database, and is distinct from the displayStatus. */
   status: Scalars["String"]["output"];
+  /** taskLogs returns the tail 100 lines of the task's logs. */
   stepbackInfo?: Maybe<StepbackInfo>;
   tags: Array<Scalars["String"]["output"]>;
   taskGroup?: Maybe<Scalars["String"]["output"]>;
   taskGroupMaxHosts?: Maybe<Scalars["Int"]["output"]>;
-  /** taskLogs returns the tail 100 lines of the task's logs. */
   taskLogs: TaskLogs;
   taskOwnerTeam?: Maybe<TaskOwnerTeam>;
   tests: TaskTestResult;
@@ -2899,6 +2899,7 @@ export type TaskEndDetail = {
   description?: Maybe<Scalars["String"]["output"]>;
   diskDevices: Array<Scalars["String"]["output"]>;
   failingCommand?: Maybe<Scalars["String"]["output"]>;
+  failureMetadataTags: Array<Scalars["String"]["output"]>;
   oomTracker: OomTrackerInfo;
   status: Scalars["String"]["output"];
   timedOut?: Maybe<Scalars["Boolean"]["output"]>;

--- a/apps/spruce/cypress/integration/task/task_history.ts
+++ b/apps/spruce/cypress/integration/task/task_history.ts
@@ -73,32 +73,6 @@ describe("task history", () => {
     });
   });
 
-  describe("test failure search", () => {
-    beforeEach(() => {
-      cy.visit(
-        "task/evergreen_ubuntu1604_test_service_patch_5e823e1f28baeaa22ae00823d83e03082cd148ab_5e4ff3abe3c3317e352062e4_20_02_21_15_13_48/history",
-      );
-    });
-    it("unmatching search results are opaque", () => {
-      cy.dataCy("search-test-failures-input").type("faketest");
-      cy.dataCy("commit-details-card")
-        .first()
-        .should("have.css", "opacity", "1");
-      cy.dataCy("commit-details-card")
-        .eq(1)
-        .should("have.css", "opacity", "0.4");
-      cy.dataCy("commit-details-card")
-        .eq(2)
-        .should("have.css", "opacity", "0.4");
-      cy.dataCy("search-test-failures-input").clear();
-      cy.dataCy("commit-details-card").should("have.css", "opacity", "1");
-    });
-    it("no results found message is shown when no tasks match the search term", () => {
-      cy.dataCy("search-test-failures-input").type("artseinrst");
-      cy.contains("No results on this page").should("be.visible");
-    });
-  });
-
   describe("restarting tasks", () => {
     const successColor = "rgb(0, 163, 92)";
     const willRunColor = "rgb(92, 108, 117)";
@@ -386,12 +360,49 @@ describe("task history", () => {
     });
   });
 
+  describe("test failure search", () => {
+    beforeEach(() => {
+      cy.visit(
+        "task/evergreen_ubuntu1604_test_service_patch_5e823e1f28baeaa22ae00823d83e03082cd148ab_5e4ff3abe3c3317e352062e4_20_02_21_15_13_48/history",
+      );
+      cy.get('input[placeholder="Search failed test"]').as("searchInput");
+    });
+
+    it("should update the URL correctly", () => {
+      cy.get("@searchInput").type("faketest");
+      cy.location("search").should("contain", "failing_test=faketest");
+    });
+
+    it("unmatching search results are opaque", () => {
+      cy.get("@searchInput").type("faketest");
+      cy.dataCy("commit-details-card")
+        .first()
+        .should("have.css", "opacity", "1");
+      cy.dataCy("commit-details-card")
+        .eq(1)
+        .should("have.css", "opacity", "0.4");
+      cy.dataCy("commit-details-card")
+        .eq(2)
+        .should("have.css", "opacity", "0.4");
+      cy.get("@searchInput").clear();
+      cy.dataCy("commit-details-card").should("have.css", "opacity", "1");
+    });
+
+    it("no results found message is shown when no tasks match the search term", () => {
+      cy.get("@searchInput").type("artseinrst");
+      cy.contains("No results on this page").should("be.visible");
+    });
+  });
+
   describe("failing tests table", () => {
     const failingTestLink =
       "/task/evg_lint_generate_lint_ecbbf17f49224235d43416ea55566f3b1894bbf7_25_03_21_21_09_20/history?execution=0";
 
-    it("table can be expanded", () => {
+    beforeEach(() => {
       cy.visit(failingTestLink);
+    });
+
+    it("table can be expanded", () => {
       cy.dataCy("commit-details-card")
         .eq(0)
         .within(() => {
@@ -400,6 +411,27 @@ describe("task history", () => {
           cy.dataCy("failing-tests-changes-table").should("be.visible");
           cy.dataCy("failing-tests-table-row").should("have.length", 3);
         });
+    });
+
+    it("can search for failures", () => {
+      cy.dataCy("commit-details-card")
+        .eq(0)
+        .within(() => {
+          cy.dataCy("failing-tests-changes-table").should("not.be.visible");
+          cy.get("[aria-label='Accordion icon']").click();
+          cy.dataCy("failing-tests-changes-table").should("be.visible");
+          cy.dataCy("failing-tests-table-row").should("have.length", 3);
+          cy.dataCy("failing-tests-table-row")
+            .eq(0)
+            .within(() => {
+              cy.contains("button", "Search Failure").click();
+            });
+        });
+      cy.location("search").should("contain", "failing_test=test_lint_1");
+      cy.get('input[placeholder="Search failed test"]').should(
+        "have.value",
+        "test_lint_1",
+      );
     });
   });
 });

--- a/apps/spruce/package.json
+++ b/apps/spruce/package.json
@@ -92,7 +92,7 @@
     "@leafygreen-ui/popover": "^11.0.17",
     "@leafygreen-ui/radio-box-group": "^13.0.2",
     "@leafygreen-ui/radio-group": "^12.0.11",
-    "@leafygreen-ui/search-input": "^5.0.11",
+    "@leafygreen-ui/search-input": "^5.0.14",
     "@leafygreen-ui/segmented-control": "^8.2.13",
     "@leafygreen-ui/select": "^12.0.0",
     "@leafygreen-ui/side-nav": "^14.1.3",

--- a/apps/spruce/src/analytics/task/useTaskHistoryAnalytics.ts
+++ b/apps/spruce/src/analytics/task/useTaskHistoryAnalytics.ts
@@ -6,10 +6,16 @@ import { useQueryParam } from "hooks/useQueryParam";
 import { RequiredQueryParams } from "types/task";
 
 // TODO: Flesh out with more events in DEVPROD-17669.
-type Action = {
-  name: "Clicked test log link";
-  "test.name": string;
-};
+type Action =
+  | {
+      name: "Clicked test log link";
+      "test.name": string;
+    }
+  | {
+      name: "Filtered to test failure";
+      "test.name": string;
+    }
+  | { name: "Toggled failed tests table"; open: boolean };
 
 export const useTaskHistoryAnalytics = () => {
   const { [slugs.taskId]: taskId } = useParams();

--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -2816,8 +2816,8 @@ export type Task = {
   details?: Maybe<TaskEndDetail>;
   dispatchTime?: Maybe<Scalars["Time"]["output"]>;
   displayName: Scalars["String"]["output"];
-  displayOnly?: Maybe<Scalars["Boolean"]["output"]>;
   /** This is a task's display status and is what is commonly used on the UI. */
+  displayOnly?: Maybe<Scalars["Boolean"]["output"]>;
   displayStatus: Scalars["String"]["output"];
   displayTask?: Maybe<Task>;
   distroId: Scalars["String"]["output"];
@@ -2857,11 +2857,11 @@ export type Task = {
   startTime?: Maybe<Scalars["Time"]["output"]>;
   /** This is a task's original status. It is the status stored in the database, and is distinct from the displayStatus. */
   status: Scalars["String"]["output"];
+  /** taskLogs returns the tail 100 lines of the task's logs. */
   stepbackInfo?: Maybe<StepbackInfo>;
   tags: Array<Scalars["String"]["output"]>;
   taskGroup?: Maybe<Scalars["String"]["output"]>;
   taskGroupMaxHosts?: Maybe<Scalars["Int"]["output"]>;
-  /** taskLogs returns the tail 100 lines of the task's logs. */
   taskLogs: TaskLogs;
   taskOwnerTeam?: Maybe<TaskOwnerTeam>;
   tests: TaskTestResult;
@@ -2899,6 +2899,7 @@ export type TaskEndDetail = {
   description?: Maybe<Scalars["String"]["output"]>;
   diskDevices: Array<Scalars["String"]["output"]>;
   failingCommand?: Maybe<Scalars["String"]["output"]>;
+  failureMetadataTags: Array<Scalars["String"]["output"]>;
   oomTracker: OomTrackerInfo;
   status: Scalars["String"]["output"];
   timedOut?: Maybe<Scalars["Boolean"]["output"]>;

--- a/apps/spruce/src/pages/task/taskTabs/TaskHistory/CommitDetailsCard/FailedTestsTable.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/TaskHistory/CommitDetailsCard/FailedTestsTable.tsx
@@ -14,6 +14,8 @@ import { TestStatus } from "@evg-ui/lib/types/test";
 import { useTaskHistoryAnalytics } from "analytics";
 import { BaseTable } from "components/Table/BaseTable";
 import { TaskTestResult, TestResult } from "gql/generated/types";
+import { useQueryParam } from "hooks/useQueryParam";
+import { TaskHistoryOptions } from "../types";
 
 interface CommitDetailsCardProps {
   tests: Omit<TaskTestResult, "filteredTestCount" | "totalTestCount">;
@@ -23,7 +25,12 @@ const FailedTestsTable: React.FC<CommitDetailsCardProps> = ({ tests }) => {
   const { testResults } = tests;
 
   const { sendEvent } = useTaskHistoryAnalytics();
+
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
+  const [, setFailingTest] = useQueryParam<string>(
+    TaskHistoryOptions.FailingTest,
+    "",
+  );
 
   const columns = useMemo(
     () =>
@@ -33,8 +40,9 @@ const FailedTestsTable: React.FC<CommitDetailsCardProps> = ({ tests }) => {
             name: "Clicked test log link",
             "test.name": testName,
           }),
+        setFailingTest,
       }),
-    [sendEvent],
+    [sendEvent, setFailingTest],
   );
 
   const table = useLeafyGreenTable<TestResult>({
@@ -64,8 +72,10 @@ export default FailedTestsTable;
 
 const getColumns = ({
   onClickLogs,
+  setFailingTest,
 }: {
   onClickLogs: (testName: string) => void;
+  setFailingTest: (testName: string) => void;
 }): LGColumnDef<TestResult>[] => [
   {
     accessorKey: "testFile",
@@ -92,6 +102,12 @@ const getColumns = ({
       },
     }) => (
       <ButtonContainer>
+        <StyledButton
+          onClick={() => setFailingTest(testFile)}
+          size={ButtonSize.XSmall}
+        >
+          Search Failure
+        </StyledButton>
         {urlParsley && (
           <StyledButton
             href={urlParsley}

--- a/apps/spruce/src/pages/task/taskTabs/TaskHistory/CommitDetailsCard/FailedTestsTable.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/TaskHistory/CommitDetailsCard/FailedTestsTable.tsx
@@ -40,7 +40,13 @@ const FailedTestsTable: React.FC<CommitDetailsCardProps> = ({ tests }) => {
             name: "Clicked test log link",
             "test.name": testName,
           }),
-        setFailingTest,
+        onClickSearchFailure: (testName) => {
+          sendEvent({
+            name: "Filtered to test failure",
+            "test.name": testName,
+          });
+          setFailingTest(testName);
+        },
       }),
     [sendEvent, setFailingTest],
   );
@@ -72,10 +78,10 @@ export default FailedTestsTable;
 
 const getColumns = ({
   onClickLogs,
-  setFailingTest,
+  onClickSearchFailure,
 }: {
   onClickLogs: (testName: string) => void;
-  setFailingTest: (testName: string) => void;
+  onClickSearchFailure: (testName: string) => void;
 }): LGColumnDef<TestResult>[] => [
   {
     accessorKey: "testFile",
@@ -103,7 +109,7 @@ const getColumns = ({
     }) => (
       <ButtonContainer>
         <StyledButton
-          onClick={() => setFailingTest(testFile)}
+          onClick={() => onClickSearchFailure(testFile)}
           size={ButtonSize.XSmall}
         >
           Search Failure

--- a/apps/spruce/src/pages/task/taskTabs/TaskHistory/CommitDetailsCard/__snapshots__/CommitDetailsCard_WithFailingTests.storyshot
+++ b/apps/spruce/src/pages/task/taskTabs/TaskHistory/CommitDetailsCard/__snapshots__/CommitDetailsCard_WithFailingTests.storyshot
@@ -278,6 +278,21 @@
                           <div
                             class="css-1gi9ejr-ButtonContainer e1bp1fda1"
                           >
+                            <button
+                              aria-disabled="false"
+                              class="lg-ui-button-0000 leafygreen-ui-168frnw css-11mxq61-StyledButton e1bp1fda0"
+                              data-lgid="lg-button"
+                              type="button"
+                            >
+                              <div
+                                class="leafygreen-ui-v038xi"
+                              />
+                              <div
+                                class="leafygreen-ui-b15bbd"
+                              >
+                                Search Failure
+                              </div>
+                            </button>
                             <a
                               aria-disabled="false"
                               class="lg-ui-button-0000 leafygreen-ui-168frnw css-11mxq61-StyledButton e1bp1fda0"
@@ -396,6 +411,21 @@
                           <div
                             class="css-1gi9ejr-ButtonContainer e1bp1fda1"
                           >
+                            <button
+                              aria-disabled="false"
+                              class="lg-ui-button-0000 leafygreen-ui-168frnw css-11mxq61-StyledButton e1bp1fda0"
+                              data-lgid="lg-button"
+                              type="button"
+                            >
+                              <div
+                                class="leafygreen-ui-v038xi"
+                              />
+                              <div
+                                class="leafygreen-ui-b15bbd"
+                              >
+                                Search Failure
+                              </div>
+                            </button>
                             <a
                               aria-disabled="false"
                               class="lg-ui-button-0000 leafygreen-ui-168frnw css-11mxq61-StyledButton e1bp1fda0"
@@ -514,6 +544,21 @@
                           <div
                             class="css-1gi9ejr-ButtonContainer e1bp1fda1"
                           >
+                            <button
+                              aria-disabled="false"
+                              class="lg-ui-button-0000 leafygreen-ui-168frnw css-11mxq61-StyledButton e1bp1fda0"
+                              data-lgid="lg-button"
+                              type="button"
+                            >
+                              <div
+                                class="leafygreen-ui-v038xi"
+                              />
+                              <div
+                                class="leafygreen-ui-b15bbd"
+                              >
+                                Search Failure
+                              </div>
+                            </button>
                             <a
                               aria-disabled="false"
                               class="lg-ui-button-0000 leafygreen-ui-168frnw css-11mxq61-StyledButton e1bp1fda0"
@@ -632,6 +677,21 @@
                           <div
                             class="css-1gi9ejr-ButtonContainer e1bp1fda1"
                           >
+                            <button
+                              aria-disabled="false"
+                              class="lg-ui-button-0000 leafygreen-ui-168frnw css-11mxq61-StyledButton e1bp1fda0"
+                              data-lgid="lg-button"
+                              type="button"
+                            >
+                              <div
+                                class="leafygreen-ui-v038xi"
+                              />
+                              <div
+                                class="leafygreen-ui-b15bbd"
+                              >
+                                Search Failure
+                              </div>
+                            </button>
                             <a
                               aria-disabled="false"
                               class="lg-ui-button-0000 leafygreen-ui-168frnw css-11mxq61-StyledButton e1bp1fda0"

--- a/apps/spruce/src/pages/task/taskTabs/TaskHistory/CommitDetailsCard/index.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/TaskHistory/CommitDetailsCard/index.tsx
@@ -14,6 +14,7 @@ import { WordBreak } from "@evg-ui/lib/components/styles";
 import { size } from "@evg-ui/lib/constants/tokens";
 import { useToastContext } from "@evg-ui/lib/context/toast";
 import { TaskStatus } from "@evg-ui/lib/types/task";
+import { useTaskHistoryAnalytics } from "analytics";
 import { inactiveElementStyle } from "components/styles";
 import { statusColorMap } from "components/TaskBox";
 import { getGithubCommitUrl } from "constants/externalResources";
@@ -58,6 +59,8 @@ const CommitDetailsCard: React.FC<CommitDetailsCardProps> = ({
     versionMetadata,
   } = task;
   const { author, message } = versionMetadata;
+
+  const { sendEvent } = useTaskHistoryAnalytics();
 
   const spruceConfig = useSpruceConfig();
   const jiraHost = spruceConfig?.jira?.host ?? "";
@@ -151,7 +154,13 @@ const CommitDetailsCard: React.FC<CommitDetailsCardProps> = ({
         {!isProduction() && <OrderLabel>Order: {order}</OrderLabel>}
       </TopLabel>
       {tests.testResults.length > 0 ? (
-        <Accordion caretAlign={AccordionCaretAlign.Start} title={title}>
+        <Accordion
+          caretAlign={AccordionCaretAlign.Start}
+          onToggle={({ isVisible }) =>
+            sendEvent({ name: "Toggled failed tests table", open: isVisible })
+          }
+          title={title}
+        >
           <FailedTestsTable tests={tests} />
         </Accordion>
       ) : (

--- a/apps/spruce/src/pages/task/taskTabs/TaskHistory/CommitDetailsList/__snapshots__/CommitDetailsList_Default.storyshot
+++ b/apps/spruce/src/pages/task/taskTabs/TaskHistory/CommitDetailsList/__snapshots__/CommitDetailsList_Default.storyshot
@@ -655,6 +655,21 @@
                             <div
                               class="css-1gi9ejr-ButtonContainer e1bp1fda1"
                             >
+                              <button
+                                aria-disabled="false"
+                                class="lg-ui-button-0000 leafygreen-ui-168frnw css-11mxq61-StyledButton e1bp1fda0"
+                                data-lgid="lg-button"
+                                type="button"
+                              >
+                                <div
+                                  class="leafygreen-ui-v038xi"
+                                />
+                                <div
+                                  class="leafygreen-ui-b15bbd"
+                                >
+                                  Search Failure
+                                </div>
+                              </button>
                               <a
                                 aria-disabled="false"
                                 class="lg-ui-button-0000 leafygreen-ui-168frnw css-11mxq61-StyledButton e1bp1fda0"

--- a/apps/spruce/src/pages/task/taskTabs/TaskHistory/CommitDetailsList/__snapshots__/CommitDetailsList_WithFilterApplied.storyshot
+++ b/apps/spruce/src/pages/task/taskTabs/TaskHistory/CommitDetailsList/__snapshots__/CommitDetailsList_WithFilterApplied.storyshot
@@ -655,6 +655,21 @@
                             <div
                               class="css-1gi9ejr-ButtonContainer e1bp1fda1"
                             >
+                              <button
+                                aria-disabled="false"
+                                class="lg-ui-button-0000 leafygreen-ui-168frnw css-11mxq61-StyledButton e1bp1fda0"
+                                data-lgid="lg-button"
+                                type="button"
+                              >
+                                <div
+                                  class="leafygreen-ui-v038xi"
+                                />
+                                <div
+                                  class="leafygreen-ui-b15bbd"
+                                >
+                                  Search Failure
+                                </div>
+                              </button>
                               <a
                                 aria-disabled="false"
                                 class="lg-ui-button-0000 leafygreen-ui-168frnw css-11mxq61-StyledButton e1bp1fda0"

--- a/apps/spruce/src/pages/task/taskTabs/TaskHistory/TestFailureSearchInput/index.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/TaskHistory/TestFailureSearchInput/index.tsx
@@ -38,8 +38,8 @@ export const TestFailureSearchInput: React.FC<TestFailureSearchInputProps> = ({
     updateQueryParamWithDebounce(value);
   };
 
-  // If some other component has updated the failingTest param, we need to update the
-  // internal state of searchTerm.
+  // In the case that some other component has updated the failingTest param, we need to update
+  // the internal state of searchTerm.
   useEffect(() => {
     if (failingTest !== searchTerm) {
       setSearchTerm(failingTest);

--- a/apps/spruce/src/pages/task/taskTabs/TaskHistory/TestFailureSearchInput/index.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/TaskHistory/TestFailureSearchInput/index.tsx
@@ -74,6 +74,10 @@ const InputContainer = styled.div`
   flex-direction: column;
   gap: ${size.xxs};
 
+  * {
+    box-sizing: content-box;
+  }
+
   /* Account for chrome blue focus outline */
   margin: 0 ${size.xxs};
 `;

--- a/packages/lib/src/components/styles/globalStyles.ts
+++ b/packages/lib/src/components/styles/globalStyles.ts
@@ -3,10 +3,14 @@ import { fontFamilies, BaseFontSize } from "@leafygreen-ui/tokens";
 
 export const resetStyles = css`
   /* Reset styles, usage recommended by LeafyGreen. */
+  html {
+    box-sizing: border-box;
+  }
+
   *,
   *:before,
   *:after {
-    box-sizing: border-box;
+    box-sizing: inherit;
   }
 `;
 

--- a/packages/lib/src/components/styles/globalStyles.ts
+++ b/packages/lib/src/components/styles/globalStyles.ts
@@ -3,14 +3,10 @@ import { fontFamilies, BaseFontSize } from "@leafygreen-ui/tokens";
 
 export const resetStyles = css`
   /* Reset styles, usage recommended by LeafyGreen. */
-  html {
-    box-sizing: border-box;
-  }
-
   *,
   *:before,
   *:after {
-    box-sizing: inherit;
+    box-sizing: border-box;
   }
 `;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2178,7 +2178,7 @@
     "@leafygreen-ui/hooks" "^8.1.3"
     "@leafygreen-ui/lib" "^13.6.1"
 
-"@leafygreen-ui/a11y@^2.0.4", "@leafygreen-ui/a11y@^2.0.6":
+"@leafygreen-ui/a11y@^2.0.4":
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/@leafygreen-ui/a11y/-/a11y-2.0.6.tgz#3e761d31e1ee8fac1e84dac359127dd5ad133311"
   integrity sha512-DGKOQPiX5KreEsww8NmafPQ2icLgFxPQK/aM3E46lVtlwBpNj/w6vLN+Jkf1SRZ1Z3PrlQ4g/VfX93HC9sBbOw==
@@ -2633,7 +2633,7 @@
     "@leafygreen-ui/tokens" "^2.5.2"
     polished "^4.2.2"
 
-"@leafygreen-ui/icon-button@^16.0.10", "@leafygreen-ui/icon-button@^16.0.11", "@leafygreen-ui/icon-button@^16.0.3", "@leafygreen-ui/icon-button@^16.0.5":
+"@leafygreen-ui/icon-button@^16.0.11", "@leafygreen-ui/icon-button@^16.0.3", "@leafygreen-ui/icon-button@^16.0.5":
   version "16.0.11"
   resolved "https://registry.yarnpkg.com/@leafygreen-ui/icon-button/-/icon-button-16.0.11.tgz#bf573f33d590df424252b865389599354c446f34"
   integrity sha512-N6QilC/Ys5cH8YpBQUXruR9iS7b5oe8hcWkZQhddiwqJ9gNT82gy6ioL1xWxqsQCBfceVmYIj1zrM+PP3Fs8sg==
@@ -2641,6 +2641,20 @@
     "@leafygreen-ui/a11y" "^2.0.7"
     "@leafygreen-ui/emotion" "^4.1.1"
     "@leafygreen-ui/icon" "^13.3.0"
+    "@leafygreen-ui/lib" "^14.2.0"
+    "@leafygreen-ui/palette" "^4.1.4"
+    "@leafygreen-ui/polymorphic" "^2.0.9"
+    "@leafygreen-ui/tokens" "^2.12.2"
+    polished "^4.2.2"
+
+"@leafygreen-ui/icon-button@^16.0.12":
+  version "16.0.12"
+  resolved "https://registry.yarnpkg.com/@leafygreen-ui/icon-button/-/icon-button-16.0.12.tgz#ca0240f7ba373a7d46fdf92ac310e24b0ede8943"
+  integrity sha512-EkuAfWe4J14/VEx0BDRNRXbN6QwaLqAnAYPtf/RUOwEqHzgkQQYkVStpEkAqp50k2OSR1FzopznmWxyPnrW55w==
+  dependencies:
+    "@leafygreen-ui/a11y" "^2.0.7"
+    "@leafygreen-ui/emotion" "^4.1.1"
+    "@leafygreen-ui/icon" "^13.4.0"
     "@leafygreen-ui/lib" "^14.2.0"
     "@leafygreen-ui/palette" "^4.1.4"
     "@leafygreen-ui/polymorphic" "^2.0.9"
@@ -2663,10 +2677,18 @@
     "@leafygreen-ui/emotion" "^4.0.8"
     lodash "^4.17.21"
 
-"@leafygreen-ui/icon@^13.1.2", "@leafygreen-ui/icon@^13.2.0", "@leafygreen-ui/icon@^13.2.2", "@leafygreen-ui/icon@^13.3.0":
+"@leafygreen-ui/icon@^13.1.2", "@leafygreen-ui/icon@^13.2.0", "@leafygreen-ui/icon@^13.3.0":
   version "13.3.0"
   resolved "https://registry.yarnpkg.com/@leafygreen-ui/icon/-/icon-13.3.0.tgz#419e24c199b0574f966890010afd539614a0da61"
   integrity sha512-//vun0KJrtMAN6pTCmQGT3brTFEpSE2LbNnwlJ+l8klG6bwEmcPF9xPCS+XU98/b3UhMhtXHpwbzYN29UteAYg==
+  dependencies:
+    "@leafygreen-ui/emotion" "^4.1.1"
+    lodash "^4.17.21"
+
+"@leafygreen-ui/icon@^13.4.0":
+  version "13.4.0"
+  resolved "https://registry.yarnpkg.com/@leafygreen-ui/icon/-/icon-13.4.0.tgz#d3573393ebd7542fd44436fd46c7c1c5f26e0107"
+  integrity sha512-GtvdkjPPERf8g0+uXGqBRw7Zgzhj1PH4moGQxNqyOc3IHeVkurAxjF1Oq64pKMLeMwuqFGhVGEVfXi3pixTPFg==
   dependencies:
     "@leafygreen-ui/emotion" "^4.1.1"
     lodash "^4.17.21"
@@ -2706,19 +2728,6 @@
     "@leafygreen-ui/tokens" "^2.9.0"
     "@leafygreen-ui/typography" "^19.2.1"
 
-"@leafygreen-ui/input-option@^3.0.10":
-  version "3.0.10"
-  resolved "https://registry.yarnpkg.com/@leafygreen-ui/input-option/-/input-option-3.0.10.tgz#3d2129285fea0d145110ecd2301ac14659e88d36"
-  integrity sha512-P+RY/k0WRRKtBce7SHEajfEGLrXh/VhxDjMlI7JUhf7YVvjwAHUmVSGs0ZtjWgt719QXsgmmawxFM0rJ16JaYA==
-  dependencies:
-    "@leafygreen-ui/a11y" "^2.0.6"
-    "@leafygreen-ui/emotion" "^4.1.1"
-    "@leafygreen-ui/lib" "^14.2.0"
-    "@leafygreen-ui/palette" "^4.1.4"
-    "@leafygreen-ui/polymorphic" "^2.0.9"
-    "@leafygreen-ui/tokens" "^2.12.2"
-    "@leafygreen-ui/typography" "^20.1.7"
-
 "@leafygreen-ui/input-option@^3.0.11":
   version "3.0.11"
   resolved "https://registry.yarnpkg.com/@leafygreen-ui/input-option/-/input-option-3.0.11.tgz#7aa713f5b1f32bbe69f0bd8a4dba779bc7ea842d"
@@ -2731,6 +2740,19 @@
     "@leafygreen-ui/polymorphic" "^2.0.9"
     "@leafygreen-ui/tokens" "^2.12.2"
     "@leafygreen-ui/typography" "^20.1.8"
+
+"@leafygreen-ui/input-option@^3.0.12":
+  version "3.0.12"
+  resolved "https://registry.yarnpkg.com/@leafygreen-ui/input-option/-/input-option-3.0.12.tgz#060e8ae7ac11a1e9c736c14729154889a0f8700c"
+  integrity sha512-p4mC9xZiyTapz2Z7vlgb9c839g2fcpi5ssRogn/Ix7uPaBpg6SAwQU1cqve6/55P1ekXVt0cHBTY1S/n+MtMQA==
+  dependencies:
+    "@leafygreen-ui/a11y" "^2.0.7"
+    "@leafygreen-ui/emotion" "^4.1.1"
+    "@leafygreen-ui/lib" "^14.2.0"
+    "@leafygreen-ui/palette" "^4.1.4"
+    "@leafygreen-ui/polymorphic" "^2.0.9"
+    "@leafygreen-ui/tokens" "^2.12.2"
+    "@leafygreen-ui/typography" "^20.1.9"
 
 "@leafygreen-ui/interaction-ring@^7.0.2":
   version "7.0.2"
@@ -2980,7 +3002,7 @@
     lodash "^4.17.21"
     react-transition-group "^4.4.5"
 
-"@leafygreen-ui/popover@^13.0.5", "@leafygreen-ui/popover@^13.0.9":
+"@leafygreen-ui/popover@^13.0.5":
   version "13.0.9"
   resolved "https://registry.yarnpkg.com/@leafygreen-ui/popover/-/popover-13.0.9.tgz#64766f9b79bdba76391349edd6e8bfd95573ac3c"
   integrity sha512-QL6qBmF+mJPF3oqwEEDqrg7hGXy7vw6Lr9u6G+RD8Mk1d5LGBoFH+3VWCOnJQcRTzN/nuAvhgF8o1chEGk5Jsw==
@@ -3070,23 +3092,23 @@
   dependencies:
     "@leafygreen-ui/tokens" "^2.12.2"
 
-"@leafygreen-ui/search-input@^5.0.11":
-  version "5.0.11"
-  resolved "https://registry.yarnpkg.com/@leafygreen-ui/search-input/-/search-input-5.0.11.tgz#645a5d0cc6fe4bd037d7742fc5cdf0045ad34afc"
-  integrity sha512-91oW4SDff3S4aJ8pr+33NRDFoL9x58Pm2FpTkeGoVGueAb6VLpGFkOYhSC46AcEJjYoHYlRSnumDEAbsrJA0HQ==
+"@leafygreen-ui/search-input@^5.0.14":
+  version "5.0.14"
+  resolved "https://registry.yarnpkg.com/@leafygreen-ui/search-input/-/search-input-5.0.14.tgz#249436eac77a7ffd150f6ad761583e190e3b25f2"
+  integrity sha512-JYds+BtzWjCsmk2mFuDrrq5djBJXNUKR5iKxKIzSaAnAR9asDk0ZDkUjk6jFd5iQUHVv0kX1TbPeS4/f1uaTJg==
   dependencies:
-    "@leafygreen-ui/a11y" "^2.0.6"
+    "@leafygreen-ui/a11y" "^2.0.7"
     "@leafygreen-ui/emotion" "^4.1.1"
-    "@leafygreen-ui/hooks" "^8.4.0"
-    "@leafygreen-ui/icon" "^13.2.2"
-    "@leafygreen-ui/icon-button" "^16.0.10"
-    "@leafygreen-ui/input-option" "^3.0.10"
+    "@leafygreen-ui/hooks" "^8.4.1"
+    "@leafygreen-ui/icon" "^13.4.0"
+    "@leafygreen-ui/icon-button" "^16.0.12"
+    "@leafygreen-ui/input-option" "^3.0.12"
     "@leafygreen-ui/lib" "^14.2.0"
     "@leafygreen-ui/palette" "^4.1.4"
     "@leafygreen-ui/polymorphic" "^2.0.9"
-    "@leafygreen-ui/popover" "^13.0.9"
+    "@leafygreen-ui/popover" "^13.0.11"
     "@leafygreen-ui/tokens" "^2.12.2"
-    "@leafygreen-ui/typography" "^20.1.7"
+    "@leafygreen-ui/typography" "^20.1.9"
     lodash "^4.17.21"
     polished "^4.2.2"
 
@@ -3363,6 +3385,18 @@
   dependencies:
     "@leafygreen-ui/emotion" "^4.1.1"
     "@leafygreen-ui/icon" "^13.3.0"
+    "@leafygreen-ui/lib" "^14.2.0"
+    "@leafygreen-ui/palette" "^4.1.4"
+    "@leafygreen-ui/polymorphic" "^2.0.9"
+    "@leafygreen-ui/tokens" "^2.12.2"
+
+"@leafygreen-ui/typography@^20.1.9":
+  version "20.1.9"
+  resolved "https://registry.yarnpkg.com/@leafygreen-ui/typography/-/typography-20.1.9.tgz#e7b290ea0691238aa5e8f00223b4203f1eb4acc3"
+  integrity sha512-TPnzIRSgu8X/sZY4ASt4a03vVUKrGxLhpBAs//N+kDaf080Z/sMJqfWGaq/zjt3WQx4pVf+ThssHI+ZMOYdHvg==
+  dependencies:
+    "@leafygreen-ui/emotion" "^4.1.1"
+    "@leafygreen-ui/icon" "^13.4.0"
     "@leafygreen-ui/lib" "^14.2.0"
     "@leafygreen-ui/palette" "^4.1.4"
     "@leafygreen-ui/polymorphic" "^2.0.9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2178,7 +2178,7 @@
     "@leafygreen-ui/hooks" "^8.1.3"
     "@leafygreen-ui/lib" "^13.6.1"
 
-"@leafygreen-ui/a11y@^2.0.4", "@leafygreen-ui/a11y@^2.0.6", "@leafygreen-ui/a11y@^2.0.7":
+"@leafygreen-ui/a11y@^2.0.4", "@leafygreen-ui/a11y@^2.0.7":
   version "2.0.7"
   resolved "https://registry.yarnpkg.com/@leafygreen-ui/a11y/-/a11y-2.0.7.tgz#ebdf1310459d873b95eeb9e32b58524f999d1f0e"
   integrity sha512-eIKWOs75WfmobMv1W7tk7nyZzD/NXgC/EnG0PnOYr2PBwtf4MDRyOQnctq/cVy7o6lg6SK0n/P4SbdftWqIDng==
@@ -2588,7 +2588,7 @@
   dependencies:
     lodash "^4.17.21"
 
-"@leafygreen-ui/hooks@^8.0.0", "@leafygreen-ui/hooks@^8.1.3", "@leafygreen-ui/hooks@^8.1.4", "@leafygreen-ui/hooks@^8.2.0", "@leafygreen-ui/hooks@^8.2.1", "@leafygreen-ui/hooks@^8.3.0", "@leafygreen-ui/hooks@^8.3.4", "@leafygreen-ui/hooks@^8.3.6", "@leafygreen-ui/hooks@^8.4.0", "@leafygreen-ui/hooks@^8.4.1":
+"@leafygreen-ui/hooks@^8.0.0", "@leafygreen-ui/hooks@^8.1.3", "@leafygreen-ui/hooks@^8.1.4", "@leafygreen-ui/hooks@^8.2.0", "@leafygreen-ui/hooks@^8.2.1", "@leafygreen-ui/hooks@^8.3.0", "@leafygreen-ui/hooks@^8.3.4", "@leafygreen-ui/hooks@^8.3.6", "@leafygreen-ui/hooks@^8.4.1":
   version "8.4.1"
   resolved "https://registry.yarnpkg.com/@leafygreen-ui/hooks/-/hooks-8.4.1.tgz#709835f1896b447320a583ade7cf17ca05e16249"
   integrity sha512-WZ1p+HeYqqbWVDGTffkRLDE83K/GbjRDYW8jcSYgznba0NAkOkWT9n/+MJp83rd55iyPhBopOKx7270s/sIH4A==
@@ -2610,7 +2610,7 @@
     "@leafygreen-ui/tokens" "^2.5.2"
     polished "^4.2.2"
 
-"@leafygreen-ui/icon-button@^16.0.10", "@leafygreen-ui/icon-button@^16.0.11", "@leafygreen-ui/icon-button@^16.0.3", "@leafygreen-ui/icon-button@^16.0.5":
+"@leafygreen-ui/icon-button@^16.0.11", "@leafygreen-ui/icon-button@^16.0.3", "@leafygreen-ui/icon-button@^16.0.5":
   version "16.0.11"
   resolved "https://registry.yarnpkg.com/@leafygreen-ui/icon-button/-/icon-button-16.0.11.tgz#bf573f33d590df424252b865389599354c446f34"
   integrity sha512-N6QilC/Ys5cH8YpBQUXruR9iS7b5oe8hcWkZQhddiwqJ9gNT82gy6ioL1xWxqsQCBfceVmYIj1zrM+PP3Fs8sg==
@@ -2618,6 +2618,20 @@
     "@leafygreen-ui/a11y" "^2.0.7"
     "@leafygreen-ui/emotion" "^4.1.1"
     "@leafygreen-ui/icon" "^13.3.0"
+    "@leafygreen-ui/lib" "^14.2.0"
+    "@leafygreen-ui/palette" "^4.1.4"
+    "@leafygreen-ui/polymorphic" "^2.0.9"
+    "@leafygreen-ui/tokens" "^2.12.2"
+    polished "^4.2.2"
+
+"@leafygreen-ui/icon-button@^16.0.12":
+  version "16.0.12"
+  resolved "https://registry.yarnpkg.com/@leafygreen-ui/icon-button/-/icon-button-16.0.12.tgz#ca0240f7ba373a7d46fdf92ac310e24b0ede8943"
+  integrity sha512-EkuAfWe4J14/VEx0BDRNRXbN6QwaLqAnAYPtf/RUOwEqHzgkQQYkVStpEkAqp50k2OSR1FzopznmWxyPnrW55w==
+  dependencies:
+    "@leafygreen-ui/a11y" "^2.0.7"
+    "@leafygreen-ui/emotion" "^4.1.1"
+    "@leafygreen-ui/icon" "^13.4.0"
     "@leafygreen-ui/lib" "^14.2.0"
     "@leafygreen-ui/palette" "^4.1.4"
     "@leafygreen-ui/polymorphic" "^2.0.9"
@@ -2640,10 +2654,18 @@
     "@leafygreen-ui/emotion" "^4.0.8"
     lodash "^4.17.21"
 
-"@leafygreen-ui/icon@^13.1.2", "@leafygreen-ui/icon@^13.2.0", "@leafygreen-ui/icon@^13.2.2", "@leafygreen-ui/icon@^13.3.0":
+"@leafygreen-ui/icon@^13.1.2", "@leafygreen-ui/icon@^13.2.0", "@leafygreen-ui/icon@^13.3.0":
   version "13.3.0"
   resolved "https://registry.yarnpkg.com/@leafygreen-ui/icon/-/icon-13.3.0.tgz#419e24c199b0574f966890010afd539614a0da61"
   integrity sha512-//vun0KJrtMAN6pTCmQGT3brTFEpSE2LbNnwlJ+l8klG6bwEmcPF9xPCS+XU98/b3UhMhtXHpwbzYN29UteAYg==
+  dependencies:
+    "@leafygreen-ui/emotion" "^4.1.1"
+    lodash "^4.17.21"
+
+"@leafygreen-ui/icon@^13.4.0":
+  version "13.4.0"
+  resolved "https://registry.yarnpkg.com/@leafygreen-ui/icon/-/icon-13.4.0.tgz#d3573393ebd7542fd44436fd46c7c1c5f26e0107"
+  integrity sha512-GtvdkjPPERf8g0+uXGqBRw7Zgzhj1PH4moGQxNqyOc3IHeVkurAxjF1Oq64pKMLeMwuqFGhVGEVfXi3pixTPFg==
   dependencies:
     "@leafygreen-ui/emotion" "^4.1.1"
     lodash "^4.17.21"
@@ -2683,19 +2705,6 @@
     "@leafygreen-ui/tokens" "^2.9.0"
     "@leafygreen-ui/typography" "^19.2.1"
 
-"@leafygreen-ui/input-option@^3.0.10":
-  version "3.0.10"
-  resolved "https://registry.yarnpkg.com/@leafygreen-ui/input-option/-/input-option-3.0.10.tgz#3d2129285fea0d145110ecd2301ac14659e88d36"
-  integrity sha512-P+RY/k0WRRKtBce7SHEajfEGLrXh/VhxDjMlI7JUhf7YVvjwAHUmVSGs0ZtjWgt719QXsgmmawxFM0rJ16JaYA==
-  dependencies:
-    "@leafygreen-ui/a11y" "^2.0.6"
-    "@leafygreen-ui/emotion" "^4.1.1"
-    "@leafygreen-ui/lib" "^14.2.0"
-    "@leafygreen-ui/palette" "^4.1.4"
-    "@leafygreen-ui/polymorphic" "^2.0.9"
-    "@leafygreen-ui/tokens" "^2.12.2"
-    "@leafygreen-ui/typography" "^20.1.7"
-
 "@leafygreen-ui/input-option@^3.0.11":
   version "3.0.11"
   resolved "https://registry.yarnpkg.com/@leafygreen-ui/input-option/-/input-option-3.0.11.tgz#7aa713f5b1f32bbe69f0bd8a4dba779bc7ea842d"
@@ -2708,6 +2717,19 @@
     "@leafygreen-ui/polymorphic" "^2.0.9"
     "@leafygreen-ui/tokens" "^2.12.2"
     "@leafygreen-ui/typography" "^20.1.8"
+
+"@leafygreen-ui/input-option@^3.0.12":
+  version "3.0.12"
+  resolved "https://registry.yarnpkg.com/@leafygreen-ui/input-option/-/input-option-3.0.12.tgz#060e8ae7ac11a1e9c736c14729154889a0f8700c"
+  integrity sha512-p4mC9xZiyTapz2Z7vlgb9c839g2fcpi5ssRogn/Ix7uPaBpg6SAwQU1cqve6/55P1ekXVt0cHBTY1S/n+MtMQA==
+  dependencies:
+    "@leafygreen-ui/a11y" "^2.0.7"
+    "@leafygreen-ui/emotion" "^4.1.1"
+    "@leafygreen-ui/lib" "^14.2.0"
+    "@leafygreen-ui/palette" "^4.1.4"
+    "@leafygreen-ui/polymorphic" "^2.0.9"
+    "@leafygreen-ui/tokens" "^2.12.2"
+    "@leafygreen-ui/typography" "^20.1.9"
 
 "@leafygreen-ui/interaction-ring@^7.0.2":
   version "7.0.2"
@@ -2956,20 +2978,6 @@
     lodash "^4.17.21"
     react-transition-group "^4.4.5"
 
-"@leafygreen-ui/popover@^13.0.9":
-  version "13.0.9"
-  resolved "https://registry.yarnpkg.com/@leafygreen-ui/popover/-/popover-13.0.9.tgz#64766f9b79bdba76391349edd6e8bfd95573ac3c"
-  integrity sha512-QL6qBmF+mJPF3oqwEEDqrg7hGXy7vw6Lr9u6G+RD8Mk1d5LGBoFH+3VWCOnJQcRTzN/nuAvhgF8o1chEGk5Jsw==
-  dependencies:
-    "@floating-ui/react" "^0.26.28"
-    "@leafygreen-ui/emotion" "^4.1.1"
-    "@leafygreen-ui/hooks" "^8.4.0"
-    "@leafygreen-ui/lib" "^14.2.0"
-    "@leafygreen-ui/portal" "^6.0.5"
-    "@leafygreen-ui/tokens" "^2.12.2"
-    "@types/react-transition-group" "^4.4.5"
-    react-transition-group "^4.4.5"
-
 "@leafygreen-ui/portal@^5.1.1":
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/@leafygreen-ui/portal/-/portal-5.1.1.tgz#7080dd01e03082fbe98f9fbfed424bd9d4e60790"
@@ -2985,14 +2993,6 @@
   dependencies:
     "@leafygreen-ui/hooks" "^8.3.4"
     "@leafygreen-ui/lib" "^14.0.2"
-
-"@leafygreen-ui/portal@^6.0.5":
-  version "6.0.5"
-  resolved "https://registry.yarnpkg.com/@leafygreen-ui/portal/-/portal-6.0.5.tgz#095dd2fa991f59e5d23c1be3e2bc96031633cb97"
-  integrity sha512-heRhQ1GyGVfill0UYkP3MuA+SGZIzxgp07NjpBTI17wXzy25Kply2Nfi8Jt0xYuEKo9Kb+up/WrK/6bFjJmdnw==
-  dependencies:
-    "@leafygreen-ui/hooks" "^8.4.0"
-    "@leafygreen-ui/lib" "^14.2.0"
 
 "@leafygreen-ui/portal@^6.0.6":
   version "6.0.6"
@@ -3046,23 +3046,23 @@
   dependencies:
     "@leafygreen-ui/tokens" "^2.12.2"
 
-"@leafygreen-ui/search-input@^5.0.11":
-  version "5.0.11"
-  resolved "https://registry.yarnpkg.com/@leafygreen-ui/search-input/-/search-input-5.0.11.tgz#645a5d0cc6fe4bd037d7742fc5cdf0045ad34afc"
-  integrity sha512-91oW4SDff3S4aJ8pr+33NRDFoL9x58Pm2FpTkeGoVGueAb6VLpGFkOYhSC46AcEJjYoHYlRSnumDEAbsrJA0HQ==
+"@leafygreen-ui/search-input@^5.0.14":
+  version "5.0.14"
+  resolved "https://registry.yarnpkg.com/@leafygreen-ui/search-input/-/search-input-5.0.14.tgz#249436eac77a7ffd150f6ad761583e190e3b25f2"
+  integrity sha512-JYds+BtzWjCsmk2mFuDrrq5djBJXNUKR5iKxKIzSaAnAR9asDk0ZDkUjk6jFd5iQUHVv0kX1TbPeS4/f1uaTJg==
   dependencies:
-    "@leafygreen-ui/a11y" "^2.0.6"
+    "@leafygreen-ui/a11y" "^2.0.7"
     "@leafygreen-ui/emotion" "^4.1.1"
-    "@leafygreen-ui/hooks" "^8.4.0"
-    "@leafygreen-ui/icon" "^13.2.2"
-    "@leafygreen-ui/icon-button" "^16.0.10"
-    "@leafygreen-ui/input-option" "^3.0.10"
+    "@leafygreen-ui/hooks" "^8.4.1"
+    "@leafygreen-ui/icon" "^13.4.0"
+    "@leafygreen-ui/icon-button" "^16.0.12"
+    "@leafygreen-ui/input-option" "^3.0.12"
     "@leafygreen-ui/lib" "^14.2.0"
     "@leafygreen-ui/palette" "^4.1.4"
     "@leafygreen-ui/polymorphic" "^2.0.9"
-    "@leafygreen-ui/popover" "^13.0.9"
+    "@leafygreen-ui/popover" "^13.0.11"
     "@leafygreen-ui/tokens" "^2.12.2"
-    "@leafygreen-ui/typography" "^20.1.7"
+    "@leafygreen-ui/typography" "^20.1.9"
     lodash "^4.17.21"
     polished "^4.2.2"
 
@@ -3339,6 +3339,18 @@
   dependencies:
     "@leafygreen-ui/emotion" "^4.1.1"
     "@leafygreen-ui/icon" "^13.3.0"
+    "@leafygreen-ui/lib" "^14.2.0"
+    "@leafygreen-ui/palette" "^4.1.4"
+    "@leafygreen-ui/polymorphic" "^2.0.9"
+    "@leafygreen-ui/tokens" "^2.12.2"
+
+"@leafygreen-ui/typography@^20.1.9":
+  version "20.1.9"
+  resolved "https://registry.yarnpkg.com/@leafygreen-ui/typography/-/typography-20.1.9.tgz#e7b290ea0691238aa5e8f00223b4203f1eb4acc3"
+  integrity sha512-TPnzIRSgu8X/sZY4ASt4a03vVUKrGxLhpBAs//N+kDaf080Z/sMJqfWGaq/zjt3WQx4pVf+ThssHI+ZMOYdHvg==
+  dependencies:
+    "@leafygreen-ui/emotion" "^4.1.1"
+    "@leafygreen-ui/icon" "^13.4.0"
     "@leafygreen-ui/lib" "^14.2.0"
     "@leafygreen-ui/palette" "^4.1.4"
     "@leafygreen-ui/polymorphic" "^2.0.9"


### PR DESCRIPTION
DEVPROD-16189
<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
Adds support for searching for failures via table.

### Screenshots
<!-- add screenshots of visible changes -->

https://github.com/user-attachments/assets/ad3598f4-a158-466e-877d-58b7f1747d69


### Testing
* Added Cypress tests 
