### PR TITLE
DEVPROD-17617 Track additional task metadata for annotation analytics

### DIFF
--- a/apps/spruce/src/analytics/task/useAnnotationAnalytics.ts
+++ b/apps/spruce/src/analytics/task/useAnnotationAnalytics.ts
@@ -56,6 +56,8 @@ export const useAnnotationAnalytics = () => {
   const { buildBaronConfigured } = bbData?.buildBaron || {};
 
   const {
+    displayName,
+    displayStatus,
     failedTestCount,
     latestExecution,
     project,
@@ -67,14 +69,16 @@ export const useAnnotationAnalytics = () => {
   const isLatestExecution = latestExecution === execution;
 
   return useAnalyticsRoot<Action, AnalyticsIdentifier>("Annotations", {
-    "task.id": taskId || "",
-    "task.status": taskStatus || "",
+    "task.display_status": displayStatus || "",
     "task.execution": execution,
-    "task.is_latest_execution": isLatestExecution,
     "task.failed_test_count": failedTestCount || "",
+    "task.id": taskId || "",
+    "task.is_latest_execution": isLatestExecution,
+    "task.name": displayName || "",
     "task.project.identifier": identifier || "",
+    "task.status": taskStatus || "",
     "version.is_patch": isPatch,
     "version.requester": requester,
-    buildBaronConfigured: buildBaronConfigured || false,
+    "task.build_baron_configured": buildBaronConfigured || false,
   });
 };

--- a/apps/spruce/src/analytics/task/useTaskAnalytics.ts
+++ b/apps/spruce/src/analytics/task/useTaskAnalytics.ts
@@ -84,23 +84,27 @@ export const useTaskAnalytics = () => {
   });
 
   const {
+    displayName,
+    displayStatus,
     failedTestCount,
     latestExecution,
-    // @ts-expect-error: FIXME. This comment was added by an automated script.
-    project: { identifier } = { identifier: null },
+    project,
     requester = "",
     status: taskStatus,
     versionMetadata: { isPatch } = { isPatch: false },
   } = eventData?.task || {};
+  const { identifier } = project || {};
   const isLatestExecution = latestExecution === execution;
 
   return useAnalyticsRoot<Action, AnalyticsIdentifier>("Task", {
-    "task.status": taskStatus || "",
+    "task.display_status": displayStatus || "",
     "task.execution": execution,
-    "task.is_latest_execution": isLatestExecution,
-    "task.id": taskId || "",
     "task.failed_test_count": failedTestCount || "",
-    "task.project.identifier": identifier,
+    "task.id": taskId || "",
+    "task.is_latest_execution": isLatestExecution,
+    "task.name": displayName || "",
+    "task.project.identifier": identifier || "",
+    "task.status": taskStatus || "",
     "version.is_patch": isPatch,
     "version.requester": requester,
   });


### PR DESCRIPTION
DEVPROD-17617
<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
Add some more information about the task annotation analytic events are associated with.
