### PR TITLE
DEVPROD-17610: Show schedule button for inactive tasks on Task History

### DIFF
--- a/apps/spruce/cypress/integration/task/task_history.ts
+++ b/apps/spruce/cypress/integration/task/task_history.ts
@@ -150,6 +150,42 @@ describe("task history", () => {
     });
   });
 
+  describe("scheduling tasks", () => {
+    const willRunColor = "rgb(92, 108, 117)";
+
+    it("scheduling a task should reflect the changes on the UI", () => {
+      cy.visit(spruceTaskHistoryLink);
+
+      cy.dataCy("task-timeline").children().eq(2).as("taskBox");
+      cy.get("@taskBox").should("have.attr", "data-cy", "collapsed-box");
+
+      cy.contains("1 Inactive Commit").click();
+      cy.dataCy("commit-details-card").eq(2).as("taskCard");
+      cy.get("@taskCard").within(() => {
+        cy.dataCy("schedule-button").should(
+          "have.attr",
+          "aria-disabled",
+          "false",
+        );
+        cy.dataCy("schedule-button").click();
+      });
+      cy.validateToast("success", "Task scheduled to run");
+
+      cy.get("@taskBox").should("have.attr", "data-cy", "timeline-box");
+      cy.get("@taskBox").should("have.css", "background-color", willRunColor);
+
+      cy.contains("1 Inactive Commit").should("not.exist");
+      cy.get("@taskCard").within(() => {
+        cy.dataCy("restart-button").should("be.visible");
+        cy.dataCy("restart-button").should(
+          "have.attr",
+          "aria-disabled",
+          "true",
+        );
+      });
+    });
+  });
+
   describe("pagination", () => {
     describe("can paginate forwards and backwards", () => {
       beforeEach(() => {

--- a/apps/spruce/cypress/integration/task/task_history.ts
+++ b/apps/spruce/cypress/integration/task/task_history.ts
@@ -57,7 +57,7 @@ describe("task history", () => {
         .contains("Order: 12380")
         .should("not.exist");
       cy.dataCy("collapsed-card").first().eq(0).as("collapsedCardButton");
-      cy.get("@collapsedCardButton").contains("1 INACTIVE COMMIT");
+      cy.get("@collapsedCardButton").contains("1 Inactive Commit");
       cy.get("@collapsedCardButton").click();
       cy.get("@collapsedCardButton").contains("1 EXPANDED");
       cy.dataCy("commit-details-card").should("have.length", 11);
@@ -65,7 +65,7 @@ describe("task history", () => {
         .contains("Order: 1238")
         .should("be.visible");
       cy.get("@collapsedCardButton").click();
-      cy.get("@collapsedCardButton").contains("1 INACTIVE COMMIT");
+      cy.get("@collapsedCardButton").contains("1 Inactive Commit");
       cy.dataCy("commit-details-card").should("have.length", 10);
       cy.dataCy("commit-details-card")
         .contains("Order: 1238")

--- a/apps/spruce/cypress/integration/task/task_history.ts
+++ b/apps/spruce/cypress/integration/task/task_history.ts
@@ -59,7 +59,7 @@ describe("task history", () => {
       cy.dataCy("collapsed-card").first().eq(0).as("collapsedCardButton");
       cy.get("@collapsedCardButton").contains("1 Inactive Commit");
       cy.get("@collapsedCardButton").click();
-      cy.get("@collapsedCardButton").contains("1 EXPANDED");
+      cy.get("@collapsedCardButton").contains("1 Expanded");
       cy.dataCy("commit-details-card").should("have.length", 11);
       cy.dataCy("commit-details-card")
         .contains("Order: 1238")

--- a/apps/spruce/src/analytics/task/useTaskHistoryAnalytics.ts
+++ b/apps/spruce/src/analytics/task/useTaskHistoryAnalytics.ts
@@ -15,6 +15,14 @@ type Action =
       name: "Filtered to test failure";
       "test.name": string;
     }
+  | {
+      name: "Clicked schedule task button";
+      "task.id": string;
+    }
+  | {
+      name: "Clicked restart task button";
+      "task.id": string;
+    }
   | { name: "Toggled failed tests table"; open: boolean };
 
 export const useTaskHistoryAnalytics = () => {

--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -8846,6 +8846,7 @@ export type TaskHistoryQuery = {
       id: string;
       activated: boolean;
       canRestart: boolean;
+      canSchedule: boolean;
       createTime?: Date | null;
       displayStatus: string;
       execution: number;

--- a/apps/spruce/src/gql/queries/task-history.graphql
+++ b/apps/spruce/src/gql/queries/task-history.graphql
@@ -8,6 +8,7 @@ query TaskHistory($options: TaskHistoryOpts!) {
       id
       activated
       canRestart
+      canSchedule
       createTime
       displayStatus
       execution

--- a/apps/spruce/src/pages/task/taskTabs/TaskHistory/CommitDetailsCard/CommitDetailsCard.stories.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/TaskHistory/CommitDetailsCard/CommitDetailsCard.stories.tsx
@@ -10,29 +10,37 @@ export default {
   component: CommitDetailsCard,
   decorators: [(Story: () => JSX.Element) => WithToastContext(Story)],
   args: {
-    isCurrentTask: true,
-    status: TaskStatus.Succeeded,
+    activated: true,
     canRestart: true,
+    canSchedule: true,
+    isCurrentTask: true,
+    isMatching: true,
     message:
       "DEVPROD-1234: Create Commit Details Card component which will be used in the Commit Details List. It should handle overflow correctly and render different status colors.",
-    isMatching: true,
+    status: TaskStatus.Succeeded,
   },
   argTypes: {
+    activated: {
+      control: { type: "boolean" },
+    },
+    canRestart: {
+      control: { type: "boolean" },
+    },
+    canSchedule: {
+      control: { type: "boolean" },
+    },
     isCurrentTask: {
       control: { type: "boolean" },
     },
-    status: {
-      options: SortedTaskStatus,
-      control: { type: "select" },
-    },
-    canRestart: {
+    isMatching: {
       control: { type: "boolean" },
     },
     message: {
       control: { type: "text" },
     },
-    isMatching: {
-      control: { type: "boolean" },
+    status: {
+      options: SortedTaskStatus,
+      control: { type: "select" },
     },
   },
 } satisfies CustomMeta<TemplateProps>;
@@ -48,12 +56,14 @@ export const WithFailingTests: CustomStoryObj<TemplateProps> = {
 };
 
 type TemplateProps = {
-  isCurrentTask: boolean;
-  status: TaskStatus;
+  activated: boolean;
   canRestart: boolean;
-  message: string;
-  isMatching: boolean;
+  canSchedule: boolean;
   hasFailingTests: boolean;
+  isCurrentTask: boolean;
+  isMatching: boolean;
+  message: string;
+  status: TaskStatus;
 };
 
 const testResults: TestResult[] = [
@@ -93,8 +103,10 @@ const getStoryTask = (args: TemplateProps) => {
 
   return {
     ...task,
+    activated: args.activated,
     displayStatus: args.status,
     canRestart: args.canRestart,
+    canSchedule: args.canSchedule,
     versionMetadata: {
       ...task.versionMetadata,
       message: args.message,

--- a/apps/spruce/src/pages/task/taskTabs/TaskHistory/CommitDetailsCard/CommitDetailsCard.test.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/TaskHistory/CommitDetailsCard/CommitDetailsCard.test.tsx
@@ -1,0 +1,198 @@
+import { RenderFakeToastContext } from "@evg-ui/lib/context/toast/__mocks__";
+import {
+  renderWithRouterMatch,
+  screen,
+  userEvent,
+} from "@evg-ui/lib/src/test_utils";
+import { getSpruceConfigMock } from "gql/mocks/getSpruceConfig";
+import { MockedProvider } from "test_utils/graphql";
+import { tasks } from "../testData";
+import CommitDetailsCard from ".";
+
+describe("CommitDetailsCard component", () => {
+  it("shows 'Restart Task' button if task is activated", () => {
+    const currentTask = {
+      ...tasks[5],
+      activated: true,
+      canRestart: true,
+    };
+    const { Component } = RenderFakeToastContext(
+      <MockedProvider mocks={[getSpruceConfigMock]}>
+        <CommitDetailsCard
+          isCurrentTask={false}
+          isMatching
+          owner="evergreen-ci"
+          repo="evergreen"
+          task={currentTask}
+        />
+      </MockedProvider>,
+    );
+    renderWithRouterMatch(<Component />);
+    const restartButton = screen.getByRole("button", { name: "Restart Task" });
+    expect(restartButton).toBeVisible();
+    expect(restartButton).toHaveAttribute("aria-disabled", "false");
+  });
+
+  it("shows 'Schedule Task' button if task is inactive", () => {
+    const currentTask = {
+      ...tasks[5],
+      activated: false,
+      canSchedule: true,
+    };
+    const { Component } = RenderFakeToastContext(
+      <MockedProvider mocks={[getSpruceConfigMock]}>
+        <CommitDetailsCard
+          isCurrentTask={false}
+          isMatching
+          owner="evergreen-ci"
+          repo="evergreen"
+          task={currentTask}
+        />
+      </MockedProvider>,
+    );
+    renderWithRouterMatch(<Component />);
+    const scheduleButton = screen.getByRole("button", {
+      name: "Schedule Task",
+    });
+    expect(scheduleButton).toBeVisible();
+    expect(scheduleButton).toHaveAttribute("aria-disabled", "false");
+  });
+
+  it("can expand and collapse long description", async () => {
+    const user = userEvent.setup();
+    const longMessage =
+      "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.";
+    const currentTask = {
+      ...tasks[5],
+      versionMetadata: {
+        ...tasks[5].versionMetadata,
+        message: longMessage,
+      },
+    };
+    const { Component } = RenderFakeToastContext(
+      <MockedProvider mocks={[getSpruceConfigMock]}>
+        <CommitDetailsCard
+          isCurrentTask={false}
+          isMatching
+          owner="evergreen-ci"
+          repo="evergreen"
+          task={currentTask}
+        />
+      </MockedProvider>,
+    );
+    renderWithRouterMatch(<Component />);
+    expect(screen.queryByText(longMessage)).toBeNull();
+
+    const showMoreButton = screen.getByRole("button", {
+      name: "Show more",
+    });
+    expect(showMoreButton).toBeVisible();
+    await user.click(showMoreButton);
+    expect(screen.getByText(longMessage)).toBeVisible();
+
+    const showLessButton = screen.getByRole("button", {
+      name: "Show less",
+    });
+    expect(showLessButton).toBeVisible();
+    await user.click(showLessButton);
+    expect(screen.queryByText(longMessage)).toBeNull();
+  });
+
+  it("can expand and collapse failed tests table", async () => {
+    const user = userEvent.setup();
+    const currentTask = {
+      ...tasks[5],
+    };
+    const { Component } = RenderFakeToastContext(
+      <MockedProvider mocks={[getSpruceConfigMock]}>
+        <CommitDetailsCard
+          isCurrentTask={false}
+          isMatching
+          owner="evergreen-ci"
+          repo="evergreen"
+          task={currentTask}
+        />
+      </MockedProvider>,
+    );
+    renderWithRouterMatch(<Component />);
+
+    const accordionContainer = screen.getByDataCy(
+      "accordion-collapse-container",
+    );
+    expect(accordionContainer).toHaveAttribute("aria-expanded", "false");
+
+    const accordionIcon = screen.getByDataCy("accordion-toggle");
+    await user.click(accordionIcon);
+    expect(accordionContainer).toHaveAttribute("aria-expanded", "true");
+
+    expect(screen.getByDataCy("failing-tests-changes-table")).toBeVisible();
+    expect(screen.getAllByDataCy("failing-tests-table-row")).toHaveLength(1);
+  });
+
+  it("shows 'This Task' badge if it's the current task", () => {
+    const currentTask = {
+      ...tasks[5],
+    };
+    const { Component } = RenderFakeToastContext(
+      <MockedProvider mocks={[getSpruceConfigMock]}>
+        <CommitDetailsCard
+          isCurrentTask
+          isMatching
+          owner="evergreen-ci"
+          repo="evergreen"
+          task={currentTask}
+        />
+      </MockedProvider>,
+    );
+    renderWithRouterMatch(<Component />);
+    const thisTaskBadge = screen.getByDataCy("this-task-badge");
+    expect(thisTaskBadge).toBeVisible();
+  });
+
+  it("shows correct links", () => {
+    const currentTask = {
+      ...tasks[5],
+      revision: "abcdef",
+    };
+    const { Component } = RenderFakeToastContext(
+      <MockedProvider mocks={[getSpruceConfigMock]}>
+        <CommitDetailsCard
+          isCurrentTask
+          isMatching
+          owner="evergreen-ci"
+          repo="evergreen"
+          task={currentTask}
+        />
+      </MockedProvider>,
+    );
+    renderWithRouterMatch(<Component />);
+    const githubLink = screen.getByDataCy("github-link");
+    expect(githubLink).toHaveAttribute(
+      "href",
+      `https://github.com/evergreen-ci/evergreen/commit/${currentTask.revision}`,
+    );
+
+    const taskLink = screen.getByDataCy("task-link");
+    expect(taskLink).toHaveAttribute("href", `/task/${currentTask.id}`);
+  });
+
+  it("decreases opacity if isMatching is 'false'", () => {
+    const currentTask = {
+      ...tasks[5],
+    };
+    const { Component } = RenderFakeToastContext(
+      <MockedProvider mocks={[getSpruceConfigMock]}>
+        <CommitDetailsCard
+          isCurrentTask={false}
+          isMatching={false}
+          owner="evergreen-ci"
+          repo="evergreen"
+          task={currentTask}
+        />
+      </MockedProvider>,
+    );
+    renderWithRouterMatch(<Component />);
+    const card = screen.getByDataCy("commit-details-card");
+    expect(card).toHaveStyle("opacity: 0.4");
+  });
+});

--- a/apps/spruce/src/pages/task/taskTabs/TaskHistory/CommitDetailsCard/__snapshots__/CommitDetailsCard_Default.storyshot
+++ b/apps/spruce/src/pages/task/taskTabs/TaskHistory/CommitDetailsCard/__snapshots__/CommitDetailsCard_Default.storyshot
@@ -8,7 +8,7 @@
     >
       <a
         class="lg-ui-0000 leafygreen-ui-hvznge"
-        data-cy="downstream-base-commit"
+        data-cy="task-link"
         href="/task/a"
       >
         <code
@@ -21,6 +21,7 @@
         aria-disabled="false"
         aria-label="GitHub Commit Link"
         class="leafygreen-ui-tcjr3n"
+        data-cy="github-link"
         href="https://github.com/evergreen-ci/evergreen/commit/aef363719d0287e92cd83749a827bae"
         tabindex="0"
         target="__blank"
@@ -63,6 +64,7 @@
       </button>
       <div
         class="leafygreen-ui-h5xdir"
+        data-cy="this-task-badge"
       >
         This Task
       </div>

--- a/apps/spruce/src/pages/task/taskTabs/TaskHistory/CommitDetailsCard/__snapshots__/CommitDetailsCard_WithFailingTests.storyshot
+++ b/apps/spruce/src/pages/task/taskTabs/TaskHistory/CommitDetailsCard/__snapshots__/CommitDetailsCard_WithFailingTests.storyshot
@@ -8,7 +8,7 @@
     >
       <a
         class="lg-ui-0000 leafygreen-ui-hvznge"
-        data-cy="downstream-base-commit"
+        data-cy="task-link"
         href="/task/a"
       >
         <code
@@ -21,6 +21,7 @@
         aria-disabled="false"
         aria-label="GitHub Commit Link"
         class="leafygreen-ui-tcjr3n"
+        data-cy="github-link"
         href="https://github.com/evergreen-ci/evergreen/commit/aef363719d0287e92cd83749a827bae"
         tabindex="0"
         target="__blank"
@@ -63,6 +64,7 @@
       </button>
       <div
         class="leafygreen-ui-h5xdir"
+        data-cy="this-task-badge"
       >
         This Task
       </div>

--- a/apps/spruce/src/pages/task/taskTabs/TaskHistory/CommitDetailsCard/__snapshots__/CommitDetailsCard_WithLongMessage.storyshot
+++ b/apps/spruce/src/pages/task/taskTabs/TaskHistory/CommitDetailsCard/__snapshots__/CommitDetailsCard_WithLongMessage.storyshot
@@ -8,7 +8,7 @@
     >
       <a
         class="lg-ui-0000 leafygreen-ui-hvznge"
-        data-cy="downstream-base-commit"
+        data-cy="task-link"
         href="/task/a"
       >
         <code
@@ -21,6 +21,7 @@
         aria-disabled="false"
         aria-label="GitHub Commit Link"
         class="leafygreen-ui-tcjr3n"
+        data-cy="github-link"
         href="https://github.com/evergreen-ci/evergreen/commit/aef363719d0287e92cd83749a827bae"
         tabindex="0"
         target="__blank"
@@ -63,6 +64,7 @@
       </button>
       <div
         class="leafygreen-ui-h5xdir"
+        data-cy="this-task-badge"
       >
         This Task
       </div>

--- a/apps/spruce/src/pages/task/taskTabs/TaskHistory/CommitDetailsCard/index.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/TaskHistory/CommitDetailsCard/index.tsx
@@ -144,15 +144,12 @@ const CommitDetailsCard: React.FC<CommitDetailsCardProps> = ({
       status={displayStatus as TaskStatus}
     >
       <TopLabel>
-        <InlineCode
-          as={Link}
-          data-cy="downstream-base-commit"
-          to={getTaskRoute(taskId)}
-        >
+        <InlineCode as={Link} data-cy="task-link" to={getTaskRoute(taskId)}>
           {shortenGithash(revision ?? "")}
         </InlineCode>
         <IconButton
           aria-label="GitHub Commit Link"
+          data-cy="github-link"
           href={githubCommitUrl}
           target="__blank"
         >
@@ -189,7 +186,11 @@ const CommitDetailsCard: React.FC<CommitDetailsCardProps> = ({
             Schedule Task
           </Button>
         )}
-        {isCurrentTask && <Badge variant={BadgeVariant.Blue}>This Task</Badge>}
+        {isCurrentTask && (
+          <Badge data-cy="this-task-badge" variant={BadgeVariant.Blue}>
+            This Task
+          </Badge>
+        )}
         <span>{dateCopy}</span>
         {/* Use this to debug issues with pagination. */}
         {!isProduction() && <OrderLabel>Order: {order}</OrderLabel>}

--- a/apps/spruce/src/pages/task/taskTabs/TaskHistory/CommitDetailsList/__snapshots__/CommitDetailsList_Default.storyshot
+++ b/apps/spruce/src/pages/task/taskTabs/TaskHistory/CommitDetailsList/__snapshots__/CommitDetailsList_Default.storyshot
@@ -12,7 +12,7 @@
       >
         <a
           class="lg-ui-0000 leafygreen-ui-hvznge"
-          data-cy="downstream-base-commit"
+          data-cy="task-link"
           href="/task/a"
         >
           <code
@@ -25,6 +25,7 @@
           aria-disabled="false"
           aria-label="GitHub Commit Link"
           class="leafygreen-ui-tcjr3n"
+          data-cy="github-link"
           href="https://github.com/evergreen-ci/spruce/commit/aef363719d0287e92cd83749a827bae"
           tabindex="0"
           target="__blank"
@@ -67,6 +68,7 @@
         </button>
         <div
           class="leafygreen-ui-h5xdir"
+          data-cy="this-task-badge"
         >
           This Task
         </div>
@@ -116,7 +118,7 @@
       >
         <a
           class="lg-ui-0000 leafygreen-ui-hvznge"
-          data-cy="downstream-base-commit"
+          data-cy="task-link"
           href="/task/b"
         >
           <code
@@ -129,6 +131,7 @@
           aria-disabled="false"
           aria-label="GitHub Commit Link"
           class="leafygreen-ui-tcjr3n"
+          data-cy="github-link"
           href="https://github.com/evergreen-ci/spruce/commit/b"
           tabindex="0"
           target="__blank"
@@ -253,7 +256,7 @@
       >
         <a
           class="lg-ui-0000 leafygreen-ui-hvznge"
-          data-cy="downstream-base-commit"
+          data-cy="task-link"
           href="/task/d"
         >
           <code
@@ -266,6 +269,7 @@
           aria-disabled="false"
           aria-label="GitHub Commit Link"
           class="leafygreen-ui-tcjr3n"
+          data-cy="github-link"
           href="https://github.com/evergreen-ci/spruce/commit/d"
           tabindex="0"
           target="__blank"
@@ -390,7 +394,7 @@
       >
         <a
           class="lg-ui-0000 leafygreen-ui-hvznge"
-          data-cy="downstream-base-commit"
+          data-cy="task-link"
           href="/task/f"
         >
           <code
@@ -403,6 +407,7 @@
           aria-disabled="false"
           aria-label="GitHub Commit Link"
           class="leafygreen-ui-tcjr3n"
+          data-cy="github-link"
           href="https://github.com/evergreen-ci/spruce/commit/f"
           tabindex="0"
           target="__blank"
@@ -806,7 +811,7 @@
       >
         <a
           class="lg-ui-0000 leafygreen-ui-hvznge"
-          data-cy="downstream-base-commit"
+          data-cy="task-link"
           href="/task/j"
         >
           <code
@@ -819,6 +824,7 @@
           aria-disabled="false"
           aria-label="GitHub Commit Link"
           class="leafygreen-ui-tcjr3n"
+          data-cy="github-link"
           href="https://github.com/evergreen-ci/spruce/commit/j"
           tabindex="0"
           target="__blank"
@@ -905,7 +911,7 @@
       >
         <a
           class="lg-ui-0000 leafygreen-ui-hvznge"
-          data-cy="downstream-base-commit"
+          data-cy="task-link"
           href="/task/k"
         >
           <code
@@ -918,6 +924,7 @@
           aria-disabled="false"
           aria-label="GitHub Commit Link"
           class="leafygreen-ui-tcjr3n"
+          data-cy="github-link"
           href="https://github.com/evergreen-ci/spruce/commit/k"
           tabindex="0"
           target="__blank"

--- a/apps/spruce/src/pages/task/taskTabs/TaskHistory/CommitDetailsList/__snapshots__/CommitDetailsList_Default.storyshot
+++ b/apps/spruce/src/pages/task/taskTabs/TaskHistory/CommitDetailsList/__snapshots__/CommitDetailsList_Default.storyshot
@@ -240,7 +240,7 @@
           </svg>
           1
            
-          INACTIVE COMMIT
+          Inactive Commit
         </div>
       </button>
     </span>
@@ -377,7 +377,7 @@
           </svg>
           1
            
-          INACTIVE COMMIT
+          Inactive Commit
         </div>
       </button>
     </span>
@@ -754,7 +754,7 @@
           </svg>
           3
            
-          INACTIVE COMMITS
+          Inactive Commits
         </div>
       </button>
     </span>

--- a/apps/spruce/src/pages/task/taskTabs/TaskHistory/CommitDetailsList/__snapshots__/CommitDetailsList_WithFilterApplied.storyshot
+++ b/apps/spruce/src/pages/task/taskTabs/TaskHistory/CommitDetailsList/__snapshots__/CommitDetailsList_WithFilterApplied.storyshot
@@ -12,7 +12,7 @@
       >
         <a
           class="lg-ui-0000 leafygreen-ui-hvznge"
-          data-cy="downstream-base-commit"
+          data-cy="task-link"
           href="/task/a"
         >
           <code
@@ -25,6 +25,7 @@
           aria-disabled="false"
           aria-label="GitHub Commit Link"
           class="leafygreen-ui-tcjr3n"
+          data-cy="github-link"
           href="https://github.com/evergreen-ci/spruce/commit/aef363719d0287e92cd83749a827bae"
           tabindex="0"
           target="__blank"
@@ -67,6 +68,7 @@
         </button>
         <div
           class="leafygreen-ui-h5xdir"
+          data-cy="this-task-badge"
         >
           This Task
         </div>
@@ -116,7 +118,7 @@
       >
         <a
           class="lg-ui-0000 leafygreen-ui-hvznge"
-          data-cy="downstream-base-commit"
+          data-cy="task-link"
           href="/task/b"
         >
           <code
@@ -129,6 +131,7 @@
           aria-disabled="false"
           aria-label="GitHub Commit Link"
           class="leafygreen-ui-tcjr3n"
+          data-cy="github-link"
           href="https://github.com/evergreen-ci/spruce/commit/b"
           tabindex="0"
           target="__blank"
@@ -253,7 +256,7 @@
       >
         <a
           class="lg-ui-0000 leafygreen-ui-hvznge"
-          data-cy="downstream-base-commit"
+          data-cy="task-link"
           href="/task/d"
         >
           <code
@@ -266,6 +269,7 @@
           aria-disabled="false"
           aria-label="GitHub Commit Link"
           class="leafygreen-ui-tcjr3n"
+          data-cy="github-link"
           href="https://github.com/evergreen-ci/spruce/commit/d"
           tabindex="0"
           target="__blank"
@@ -390,7 +394,7 @@
       >
         <a
           class="lg-ui-0000 leafygreen-ui-hvznge"
-          data-cy="downstream-base-commit"
+          data-cy="task-link"
           href="/task/f"
         >
           <code
@@ -403,6 +407,7 @@
           aria-disabled="false"
           aria-label="GitHub Commit Link"
           class="leafygreen-ui-tcjr3n"
+          data-cy="github-link"
           href="https://github.com/evergreen-ci/spruce/commit/f"
           tabindex="0"
           target="__blank"
@@ -806,7 +811,7 @@
       >
         <a
           class="lg-ui-0000 leafygreen-ui-hvznge"
-          data-cy="downstream-base-commit"
+          data-cy="task-link"
           href="/task/j"
         >
           <code
@@ -819,6 +824,7 @@
           aria-disabled="false"
           aria-label="GitHub Commit Link"
           class="leafygreen-ui-tcjr3n"
+          data-cy="github-link"
           href="https://github.com/evergreen-ci/spruce/commit/j"
           tabindex="0"
           target="__blank"
@@ -905,7 +911,7 @@
       >
         <a
           class="lg-ui-0000 leafygreen-ui-hvznge"
-          data-cy="downstream-base-commit"
+          data-cy="task-link"
           href="/task/k"
         >
           <code
@@ -918,6 +924,7 @@
           aria-disabled="false"
           aria-label="GitHub Commit Link"
           class="leafygreen-ui-tcjr3n"
+          data-cy="github-link"
           href="https://github.com/evergreen-ci/spruce/commit/k"
           tabindex="0"
           target="__blank"

--- a/apps/spruce/src/pages/task/taskTabs/TaskHistory/CommitDetailsList/__snapshots__/CommitDetailsList_WithFilterApplied.storyshot
+++ b/apps/spruce/src/pages/task/taskTabs/TaskHistory/CommitDetailsList/__snapshots__/CommitDetailsList_WithFilterApplied.storyshot
@@ -240,7 +240,7 @@
           </svg>
           1
            
-          INACTIVE COMMIT
+          Inactive Commit
         </div>
       </button>
     </span>
@@ -377,7 +377,7 @@
           </svg>
           1
            
-          INACTIVE COMMIT
+          Inactive Commit
         </div>
       </button>
     </span>
@@ -754,7 +754,7 @@
           </svg>
           3
            
-          INACTIVE COMMITS
+          Inactive Commits
         </div>
       </button>
     </span>

--- a/apps/spruce/src/pages/task/taskTabs/TaskHistory/InactiveCommitsButton/InactiveCommitsButton.test.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/TaskHistory/InactiveCommitsButton/InactiveCommitsButton.test.tsx
@@ -32,7 +32,7 @@ describe("InactiveCommitsButton component", () => {
     expect(screen.queryAllByDataCy("commit-details-card")).toHaveLength(0);
     const toggleButton = screen.getByRole("button");
     await user.click(toggleButton);
-    expect(screen.getByText("11 EXPANDED")).toBeInTheDocument();
+    expect(screen.getByText("11 Expanded")).toBeInTheDocument();
     const cards = screen.queryAllByDataCy("commit-details-card");
     for (let i = 0; i < cards.length; i++) {
       expect(cards[i]).toHaveTextContent(tasks[i].versionMetadata.message);

--- a/apps/spruce/src/pages/task/taskTabs/TaskHistory/InactiveCommitsButton/InactiveCommitsButton.test.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/TaskHistory/InactiveCommitsButton/InactiveCommitsButton.test.tsx
@@ -28,7 +28,7 @@ describe("InactiveCommitsButton component", () => {
       </MockedProvider>,
     );
     renderWithRouterMatch(<Component />);
-    expect(screen.getByText("11 INACTIVE COMMITS")).toBeInTheDocument();
+    expect(screen.getByText("11 Inactive Commits")).toBeInTheDocument();
     expect(screen.queryAllByDataCy("commit-details-card")).toHaveLength(0);
     const toggleButton = screen.getByRole("button");
     await user.click(toggleButton);

--- a/apps/spruce/src/pages/task/taskTabs/TaskHistory/InactiveCommitsButton/__snapshots__/InactiveCommitsButton_Default.storyshot
+++ b/apps/spruce/src/pages/task/taskTabs/TaskHistory/InactiveCommitsButton/__snapshots__/InactiveCommitsButton_Default.storyshot
@@ -33,7 +33,7 @@
         </svg>
         11
          
-        INACTIVE COMMITS
+        Inactive Commits
       </div>
     </button>
   </span>

--- a/apps/spruce/src/pages/task/taskTabs/TaskHistory/InactiveCommitsButton/index.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/TaskHistory/InactiveCommitsButton/index.tsx
@@ -38,8 +38,8 @@ const InactiveCommitsButton: React.FC<Props> = ({
         >
           {inactiveTasks.length}{" "}
           {isExpanded
-            ? "EXPANDED"
-            : pluralize("INACTIVE COMMIT", inactiveTasks.length)}
+            ? "Expanded"
+            : pluralize("Inactive Commit", inactiveTasks.length)}
         </Button>
       </span>
       {isExpanded &&

--- a/apps/spruce/src/pages/task/taskTabs/TaskHistory/index.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/TaskHistory/index.tsx
@@ -89,6 +89,7 @@ const TaskHistory: React.FC<TaskHistoryProps> = ({ task }) => {
         date: utcDate,
       },
     },
+    fetchPolicy: "cache-first",
     pollInterval: DEFAULT_POLL_INTERVAL,
     onError: (err) => {
       dispatchToast.error(`Unable to get task history: ${err}`);

--- a/apps/spruce/src/pages/task/taskTabs/TaskHistory/testData.ts
+++ b/apps/spruce/src/pages/task/taskTabs/TaskHistory/testData.ts
@@ -16,6 +16,7 @@ export const tasks: TaskHistoryTask[] = [
     revision: "aef363719d0287e92cd83749a827bae",
     createTime: new Date("2025-04-03T10:22:13Z"),
     canRestart: true,
+    canSchedule: false,
     versionMetadata: {
       id: "version_id",
       author: "Evergreen Admin",
@@ -32,6 +33,7 @@ export const tasks: TaskHistoryTask[] = [
     revision: "b",
     createTime: new Date("2025-04-03T10:22:13Z"),
     canRestart: true,
+    canSchedule: false,
     versionMetadata: {
       id: "version_id",
       author: "Evergreen Admin",
@@ -47,7 +49,8 @@ export const tasks: TaskHistoryTask[] = [
     order: 98,
     revision: "ce135c28ba11e9189cae",
     createTime: new Date("2025-04-03T10:22:13Z"),
-    canRestart: true,
+    canRestart: false,
+    canSchedule: true,
     versionMetadata: {
       id: "version_id",
       author: "Evergreen Admin",
@@ -64,6 +67,7 @@ export const tasks: TaskHistoryTask[] = [
     revision: "d",
     createTime: new Date("2025-04-03T10:22:13Z"),
     canRestart: true,
+    canSchedule: false,
     versionMetadata: {
       id: "version_id",
       author: "Evergreen Admin",
@@ -79,7 +83,8 @@ export const tasks: TaskHistoryTask[] = [
     order: 96,
     revision: "e",
     createTime: new Date("2025-04-03T10:22:13Z"),
-    canRestart: true,
+    canRestart: false,
+    canSchedule: true,
     versionMetadata: {
       id: "version_id",
       author: "Evergreen Admin",
@@ -96,6 +101,7 @@ export const tasks: TaskHistoryTask[] = [
     revision: "f",
     createTime: new Date("2025-04-03T10:22:13Z"),
     canRestart: true,
+    canSchedule: false,
     versionMetadata: {
       id: "version_id",
       author: "Evergreen Admin",
@@ -120,7 +126,8 @@ export const tasks: TaskHistoryTask[] = [
     order: 94,
     revision: "g",
     createTime: new Date("2025-04-03T10:22:13Z"),
-    canRestart: true,
+    canRestart: false,
+    canSchedule: true,
     versionMetadata: {
       id: "version_id",
       author: "Evergreen Admin",
@@ -136,7 +143,8 @@ export const tasks: TaskHistoryTask[] = [
     order: 93,
     revision: "h",
     createTime: new Date("2025-04-03T10:22:13Z"),
-    canRestart: true,
+    canRestart: false,
+    canSchedule: true,
     versionMetadata: {
       id: "version_id",
       author: "Evergreen Admin",
@@ -152,7 +160,8 @@ export const tasks: TaskHistoryTask[] = [
     order: 92,
     revision: "i",
     createTime: new Date("2025-04-03T10:22:13Z"),
-    canRestart: true,
+    canRestart: false,
+    canSchedule: true,
     versionMetadata: {
       id: "version_id",
       author: "Evergreen Admin",
@@ -169,6 +178,7 @@ export const tasks: TaskHistoryTask[] = [
     revision: "j",
     createTime: new Date("2025-04-03T10:22:13Z"),
     canRestart: true,
+    canSchedule: false,
     versionMetadata: {
       id: "version_id",
       author: "Evergreen Admin",
@@ -185,6 +195,7 @@ export const tasks: TaskHistoryTask[] = [
     revision: "k",
     createTime: new Date("2025-04-03T10:22:13Z"),
     canRestart: true,
+    canSchedule: false,
     versionMetadata: {
       id: "version_id",
       author: "Evergreen Admin",


### PR DESCRIPTION
DEVPROD-17610
<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
Shows schedule button for inactive tasks.

### Screenshots
<!-- add screenshots of visible changes -->

https://github.com/user-attachments/assets/2070136c-1d10-4833-8688-059c27414f14

### Testing
* e2e test

<!-- Have you have updated the analytics documentation if necessary?  
https://docs.google.com/spreadsheets/d/1s4_nq8ZiphXp5Uq_-9HT6GPqz-KOyaq6HuvmXYaSNzg/edit?usp=sharing -->

