### PR TITLE
DEVPROD-11739 Only run parallel e2e tasks if we have changes in the spruce directory or the lib directory

### DIFF
--- a/.evergreen/scripts/constants.js
+++ b/.evergreen/scripts/constants.js
@@ -46,6 +46,7 @@ const TASK_MAPPING = {
 };
 
 const APPS_DIR = "apps";
+const PACKAGES_DIR = "packages";
 
 const MARKDOWN_EXT = ".md";
 
@@ -56,6 +57,7 @@ const PARALLEL_COUNT = 4;
 export {
   Tasks,
   APPS_DIR,
+  PACKAGES_DIR,
   IGNORED_FILE_EXTENSIONS,
   PARALLEL_COUNT,
   TASK_MAPPING,

--- a/.evergreen/scripts/generate-parallel-e2e-tasks.js
+++ b/.evergreen/scripts/generate-parallel-e2e-tasks.js
@@ -1,6 +1,6 @@
 import { readdirSync, statSync, writeFileSync } from "fs";
 import { join } from "path";
-import { APPS_DIR, PARALLEL_COUNT, Tasks } from "./constants.js"
+import { APPS_DIR, PACKAGES_DIR, PARALLEL_COUNT, Tasks } from "./constants.js"
 import { hasChangesInDirectory } from "./git-utils.js";
 
 /**
@@ -140,9 +140,11 @@ const generateParallelE2ETasks = (bv) => {
 };
 
 const main = () => {
+    const buildVariant = process.env.BUILD_VARIANT;
+
   // Check if there are any changes in the spruce directory
-  if (!hasChangesInDirectory("spruce")) {
-    console.log("No changes detected in spruce directory, skipping e2e task generation");
+  if (!hasChangesInDirectory(`${APPS_DIR}/${buildVariant}`) && !hasChangesInDirectory(PACKAGES_DIR)) {
+    console.log(`No changes detected in ${buildVariant} or packages directory, skipping e2e task generation`);
     // Write an empty task list to maintain the expected file output
     writeFileSync(
       join(process.cwd(), "/.evergreen", "generate-parallel-e2e-tasks.json"),
@@ -151,7 +153,6 @@ const main = () => {
     return;
   }
 
-  const buildVariant = process.env.BUILD_VARIANT;
   if (buildVariant) {
     const evgObj = generateParallelE2ETasks(buildVariant);
     const evgJson = JSON.stringify(evgObj);

--- a/.evergreen/scripts/generate-parallel-e2e-tasks.js
+++ b/.evergreen/scripts/generate-parallel-e2e-tasks.js
@@ -3,6 +3,8 @@ import { join } from "path";
 import { APPS_DIR, PACKAGES_DIR, PARALLEL_COUNT, Tasks } from "./constants.js"
 import { hasChangesInDirectory } from "./git-utils.js";
 
+const EVERGREEN_DIR = join(process.cwd(), "/.evergreen");
+const TASKS_FILE = join(EVERGREEN_DIR, "generate-parallel-e2e-tasks.json");
 /**
  * getDirSize calculates the size of a directory at a given path, optionally including the size of its subdirectories.
  * @param {string} dirPath - string representing the root directory path
@@ -140,14 +142,14 @@ const generateParallelE2ETasks = (bv) => {
 };
 
 const main = () => {
-    const buildVariant = process.env.BUILD_VARIANT;
+  const buildVariant = process.env.BUILD_VARIANT;
 
-  // Check if there are any changes in the spruce directory
+  // Check if there are any changes in the given build variant directory
   if (!hasChangesInDirectory(`${APPS_DIR}/${buildVariant}`) && !hasChangesInDirectory(PACKAGES_DIR)) {
     console.log(`No changes detected in ${buildVariant} or packages directory, skipping e2e task generation`);
     // Write an empty task list to maintain the expected file output
     writeFileSync(
-      join(process.cwd(), "/.evergreen", "generate-parallel-e2e-tasks.json"),
+      TASKS_FILE,
       JSON.stringify({ tasks: [] })
     );
     return;
@@ -159,7 +161,7 @@ const main = () => {
   
     try {
       writeFileSync(
-        join(process.cwd(), "/.evergreen", "generate-parallel-e2e-tasks.json"),
+        TASKS_FILE,
         evgJson
       );
     } catch (e) {

--- a/.evergreen/scripts/generate-tasks.js
+++ b/.evergreen/scripts/generate-tasks.js
@@ -1,4 +1,3 @@
-import { execSync } from "child_process";
 import { writeFileSync } from "fs";
 import { join, parse } from "path";
 import {
@@ -6,42 +5,9 @@ import {
   IGNORED_FILE_EXTENSIONS,
   TASK_MAPPING,
 } from "./constants.js";
+import { whatChanged } from "./git-utils.js";
 
 // This file is written in plain JS because it makes the generator super fast. No need to install TypeScript.
-
-const getMergeBase = () => {
-  try {
-    const mergeBaseCmd = execSync("git merge-base main@{upstream} HEAD")
-      .toString()
-      .trim();
-    return mergeBaseCmd;
-  } catch (e) {
-    throw new Error("getting merge-base", { cause: e });
-  }
-};
-
-/**
- * whatChanged returns a list of files modified in this patch or PR.
- * Prior art from Evergreen:
- * https://github.com/evergreen-ci/evergreen/blob/ab7d4112b352b759acd54c685524177018467c30/cmd/generate-lint/generate-lint.go#L30
- * @returns a string array of modified file names relative to the git root directory
- */
-const whatChanged = () => {
-  const mergeBase = getMergeBase();
-  try {
-    const diffFiles = execSync(`git diff ${mergeBase} --name-only`)
-      .toString()
-      .trim();
-
-    // If there is no diff, this is not a patch build.
-    if (!diffFiles) {
-      return [];
-    }
-    return diffFiles.split("\n").map((file) => file.trim());
-  } catch (e) {
-    throw new Error("getting diff", { cause: e });
-  }
-};
 
 /**
  * targetsFromChangedFiles returns a list of build variants to run based on a list of changed files.
@@ -84,10 +50,12 @@ const generateTasks = () => {
     changes.length === 0
       ? Object.keys(TASK_MAPPING)
       : targetsFromChangedFiles(changes);
+  
   const buildvariants = targets.map((bv) => ({
     name: bv,
     tasks: TASK_MAPPING[bv].map((name) => ({ name })),
   }));
+
   return { buildvariants };
 };
 

--- a/.evergreen/scripts/git-utils.js
+++ b/.evergreen/scripts/git-utils.js
@@ -1,0 +1,49 @@
+import { execSync } from "child_process";
+
+/**
+ * Gets the merge base between the current branch and main
+ * @returns {string} The merge base commit hash
+ */
+export const getMergeBase = () => {
+  try {
+    const mergeBaseCmd = execSync("git merge-base main@{upstream} HEAD")
+      .toString()
+      .trim();
+    return mergeBaseCmd;
+  } catch (e) {
+    throw new Error("getting merge-base", { cause: e });
+  }
+};
+
+/**
+ * whatChanged returns a list of files modified in this patch or PR.
+ * Prior art from Evergreen:
+ * https://github.com/evergreen-ci/evergreen/blob/ab7d4112b352b759acd54c685524177018467c30/cmd/generate-lint/generate-lint.go#L30
+ * @returns {string[]} a string array of modified file names relative to the git root directory
+ */
+export const whatChanged = () => {
+  const mergeBase = getMergeBase();
+  try {
+    const diffFiles = execSync(`git diff ${mergeBase} --name-only`)
+      .toString()
+      .trim();
+
+    // If there is no diff, this is not a patch build.
+    if (!diffFiles) {
+      return [];
+    }
+    return diffFiles.split("\n").map((file) => file.trim());
+  } catch (e) {
+    throw new Error("getting diff", { cause: e });
+  }
+};
+
+/**
+ * Checks if there are any changes in a specific directory
+ * @param {string} directory - The directory to check for changes
+ * @returns {boolean} True if there are changes in the specified directory
+ */
+export const hasChangesInDirectory = (directory) => {
+  const changes = whatChanged();
+  return changes.some(file => file.startsWith(directory));
+}; 

--- a/apps/parsley/src/gql/generated/types.ts
+++ b/apps/parsley/src/gql/generated/types.ts
@@ -3284,14 +3284,10 @@ export type UpstreamProject = {
 
 export type UseSpruceOptions = {
   __typename?: "UseSpruceOptions";
-  hasUsedMainlineCommitsBefore?: Maybe<Scalars["Boolean"]["output"]>;
-  hasUsedSpruceBefore?: Maybe<Scalars["Boolean"]["output"]>;
   spruceV1?: Maybe<Scalars["Boolean"]["output"]>;
 };
 
 export type UseSpruceOptionsInput = {
-  hasUsedMainlineCommitsBefore?: InputMaybe<Scalars["Boolean"]["input"]>;
-  hasUsedSpruceBefore?: InputMaybe<Scalars["Boolean"]["input"]>;
   spruceV1?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 

--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -3284,14 +3284,10 @@ export type UpstreamProject = {
 
 export type UseSpruceOptions = {
   __typename?: "UseSpruceOptions";
-  hasUsedMainlineCommitsBefore?: Maybe<Scalars["Boolean"]["output"]>;
-  hasUsedSpruceBefore?: Maybe<Scalars["Boolean"]["output"]>;
   spruceV1?: Maybe<Scalars["Boolean"]["output"]>;
 };
 
 export type UseSpruceOptionsInput = {
-  hasUsedMainlineCommitsBefore?: InputMaybe<Scalars["Boolean"]["input"]>;
-  hasUsedSpruceBefore?: InputMaybe<Scalars["Boolean"]["input"]>;
   spruceV1?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 


### PR DESCRIPTION
DEVPROD-11739
<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
This PR optimizes our CI pipeline by making E2E tests conditional on relevant code changes. It introduces a check that only runs E2E tests when there are modifications in either the app-specific directory or the shared packages directory.

## Changes
- Created a new `git-utils.js` module to centralize git-related functionality:
  - `getMergeBase()`: Gets the merge base between current branch and main
  - `whatChanged()`: Returns list of modified files in current PR/patch
  - `hasChangesInDirectory()`: Utility to check for changes in specific directories

- Modified `generate-parallel-e2e-tasks.js` to:
  - Check for changes in the relevant app directory (e.g., `apps/spruce`) or shared packages
  - Skip E2E task generation if no relevant changes are detected

### Screenshots
<!-- add screenshots of visible changes -->

### Testing
- Verified that E2E tasks are generated when changes exist in app/spruce directory
- Verified that E2E tasks are generated when changes exist in shared packages
- Verified that E2E tasks are skipped when changes are in unrelated directories
- Confirmed empty task list is written when skipping to maintain file structure


