### PR TITLE
DEVPROD-18245: Add deprecation banner to Task History page

### DIFF
--- a/apps/spruce/src/constants/routes.test.ts
+++ b/apps/spruce/src/constants/routes.test.ts
@@ -166,93 +166,106 @@ describe("getWaterfallRoute", () => {
 });
 describe("getTaskHistoryRoute", () => {
   it("generates a link to the task history page", () => {
-    expect(getTaskHistoryRoute("someProject", "someTaskId")).toBe(
-      "/task-history/someProject/someTaskId",
+    expect(getTaskHistoryRoute("project", "taskName")).toBe(
+      "/task-history/project/taskName",
     );
   });
   it("escapes special characters projectIdentifier", () => {
     expect(
-      getTaskHistoryRoute(identifierWithSpecialCharacters, "someTaskId"),
-    ).toBe(`/task-history/${escapedIdentifier}/someTaskId`);
+      getTaskHistoryRoute(identifierWithSpecialCharacters, "taskName"),
+    ).toBe(`/task-history/${escapedIdentifier}/taskName`);
   });
   it("escapes special characters taskId", () => {
-    expect(
-      getTaskHistoryRoute("someProject", taskIDWithSpecialCharacters),
-    ).toBe(`/task-history/someProject/${escapedTaskID}`);
+    expect(getTaskHistoryRoute("project", taskIDWithSpecialCharacters)).toBe(
+      `/task-history/project/${escapedTaskID}`,
+    );
   });
   it("generates a link with failing or passing tests", () => {
     expect(
-      getTaskHistoryRoute("someProject", "someTaskId", {
+      getTaskHistoryRoute("project", "taskName", {
         filters: {
           failingTests: ["someFailingTest"],
         },
       }),
-    ).toBe("/task-history/someProject/someTaskId?failed=someFailingTest");
+    ).toBe("/task-history/project/taskName?failed=someFailingTest");
     expect(
-      getTaskHistoryRoute("someProject", "someTaskId", {
+      getTaskHistoryRoute("project", "taskName", {
         filters: {
           failingTests: ["someFailingTest", "someOtherFailingTest"],
         },
       }),
     ).toBe(
-      "/task-history/someProject/someTaskId?failed=someFailingTest,someOtherFailingTest",
+      "/task-history/project/taskName?failed=someFailingTest,someOtherFailingTest",
     );
     expect(
-      getTaskHistoryRoute("someProject", "someTaskId", {
+      getTaskHistoryRoute("project", "taskName", {
         filters: {
           passingTests: ["somePassingTests"],
         },
       }),
-    ).toBe("/task-history/someProject/someTaskId?passed=somePassingTests");
+    ).toBe("/task-history/project/taskName?passed=somePassingTests");
     expect(
-      getTaskHistoryRoute("someProject", "someTaskId", {
+      getTaskHistoryRoute("project", "taskName", {
         filters: {
           passingTests: ["somePassingTests", "someOtherPassingTests"],
         },
       }),
     ).toBe(
-      "/task-history/someProject/someTaskId?passed=somePassingTests,someOtherPassingTests",
+      "/task-history/project/taskName?passed=somePassingTests,someOtherPassingTests",
     );
   });
   it("generates a link with failing and passing tests", () => {
     expect(
-      getTaskHistoryRoute("someProject", "someTaskId", {
+      getTaskHistoryRoute("project", "taskName", {
         filters: {
           failingTests: ["someFailingTest"],
           passingTests: ["somePassingTests"],
         },
       }),
     ).toBe(
-      "/task-history/someProject/someTaskId?failed=someFailingTest&passed=somePassingTests",
+      "/task-history/project/taskName?failed=someFailingTest&passed=somePassingTests",
     );
     expect(
-      getTaskHistoryRoute("someProject", "someTaskId", {
+      getTaskHistoryRoute("project", "taskName", {
         filters: {
           failingTests: ["someFailingTest", "someOtherFailingTest"],
           passingTests: ["somePassingTests", "someOtherPassingTests"],
         },
       }),
     ).toBe(
-      "/task-history/someProject/someTaskId?failed=someFailingTest,someOtherFailingTest&passed=somePassingTests,someOtherPassingTests",
+      "/task-history/project/taskName?failed=someFailingTest,someOtherFailingTest&passed=somePassingTests,someOtherPassingTests",
     );
   });
   it("generates a link with a selectedCommit", () => {
     expect(
-      getTaskHistoryRoute("someProject", "someTaskId", {
+      getTaskHistoryRoute("project", "taskName", {
         selectedCommit: 1,
       }),
-    ).toBe("/task-history/someProject/someTaskId?selectedCommit=1");
+    ).toBe("/task-history/project/taskName?selectedCommit=1");
   });
   it("generates a link with a selectedCommit and test filters", () => {
     expect(
-      getTaskHistoryRoute("someProject", "someTaskId", {
+      getTaskHistoryRoute("project", "taskName", {
         filters: {
           failingTests: ["someFailingTest", "someOtherFailingTest"],
         },
         selectedCommit: 1,
       }),
     ).toBe(
-      "/task-history/someProject/someTaskId?failed=someFailingTest,someOtherFailingTest&selectedCommit=1",
+      "/task-history/project/taskName?failed=someFailingTest,someOtherFailingTest&selectedCommit=1",
+    );
+  });
+  it("generates a link with a task ID", () => {
+    expect(
+      getTaskHistoryRoute("project", "taskName", {
+        filters: {
+          failingTests: ["someFailingTest", "someOtherFailingTest"],
+        },
+        selectedCommit: 1,
+        taskId: "12345",
+      }),
+    ).toBe(
+      "/task-history/project/taskName?failed=someFailingTest,someOtherFailingTest&selectedCommit=1&taskId=12345",
     );
   });
 });

--- a/apps/spruce/src/constants/routes.ts
+++ b/apps/spruce/src/constants/routes.ts
@@ -328,6 +328,7 @@ const getHistoryRoute = (
   },
   selectedCommit?: number,
   visibleColumns?: string[],
+  taskId?: string,
 ) => {
   if (filters || selectedCommit) {
     const failingTests = toArray(filters?.failingTests);
@@ -337,6 +338,7 @@ const getHistoryRoute = (
       [TestStatus.Failed]: failingTests,
       [TestStatus.Passed]: passingTests,
       [HistoryQueryParams.SelectedCommit]: selectedCommit,
+      [HistoryQueryParams.TaskID]: taskId,
       [HistoryQueryParams.VisibleColumns]: visibleColumns,
     });
     return `${basePath}?${queryParams}`;
@@ -374,15 +376,17 @@ export const getTaskHistoryRoute = (
     };
     selectedCommit?: number;
     visibleColumns?: string[];
+    taskId?: string;
   },
 ) => {
-  const { filters, selectedCommit, visibleColumns } = options || {};
+  const { filters, selectedCommit, taskId, visibleColumns } = options || {};
 
   return getHistoryRoute(
     `${paths.taskHistory}/${encodeURIComponent(projectIdentifier)}/${encodeURIComponent(taskName)}`,
     filters,
     selectedCommit,
     visibleColumns,
+    taskId,
   );
 };
 

--- a/apps/spruce/src/pages/task/ActionButtons.tsx
+++ b/apps/spruce/src/pages/task/ActionButtons.tsx
@@ -1,14 +1,13 @@
 import { useState } from "react";
 import { useMutation } from "@apollo/client";
 import Button from "@leafygreen-ui/button";
-import { useParams } from "react-router-dom";
 import { useToastContext } from "@evg-ui/lib/context/toast";
 import { useTaskAnalytics } from "analytics";
 import { DropdownItem, ButtonDropdown } from "components/ButtonDropdown";
 import { LoadingButton } from "components/Buttons";
 import SetPriority from "components/SetPriority";
 import { PageButtonRow } from "components/styles";
-import { getTaskHistoryRoute, slugs } from "constants/routes";
+import { getTaskHistoryRoute } from "constants/routes";
 import {
   SetTaskPriorityMutation,
   SetTaskPriorityMutationVariables,
@@ -56,6 +55,7 @@ export const ActionButtons: React.FC<Props> = ({
     canSetPriority,
     canUnschedule,
     displayName,
+    id: taskId,
     project,
     versionMetadata,
   } = task || {};
@@ -66,14 +66,12 @@ export const ActionButtons: React.FC<Props> = ({
   const dispatchToast = useToastContext();
   const [isVisibleModal, setIsVisibleModal] = useState(false);
 
-  const { [slugs.taskId]: taskId } = useParams();
   const taskAnalytics = useTaskAnalytics();
 
   const [scheduleTask, { loading: loadingScheduleTask }] = useMutation<
     ScheduleTasksMutation,
     ScheduleTasksMutationVariables
   >(SCHEDULE_TASKS, {
-    // @ts-expect-error: FIXME. This comment was added by an automated script.
     variables: { taskIds: [taskId], versionId },
     onCompleted: () => {
       dispatchToast.success("Task marked as scheduled");
@@ -87,7 +85,6 @@ export const ActionButtons: React.FC<Props> = ({
     UnscheduleTaskMutation,
     UnscheduleTaskMutationVariables
   >(UNSCHEDULE_TASK, {
-    // @ts-expect-error: FIXME. This comment was added by an automated script.
     variables: { taskId },
     onCompleted: () => {
       dispatchToast.success("Task marked as unscheduled");
@@ -101,10 +98,7 @@ export const ActionButtons: React.FC<Props> = ({
     AbortTaskMutation,
     AbortTaskMutationVariables
   >(ABORT_TASK, {
-    variables: {
-      // @ts-expect-error: FIXME. This comment was added by an automated script.
-      taskId,
-    },
+    variables: { taskId },
     onCompleted: () => {
       dispatchToast.success("Task aborted");
     },
@@ -119,8 +113,7 @@ export const ActionButtons: React.FC<Props> = ({
   >(SET_TASK_PRIORITY, {
     onCompleted: (data) => {
       dispatchToast.success(
-        // @ts-expect-error: FIXME. This comment was added by an automated script.
-        data.setTaskPriority.priority >= 0
+        data?.setTaskPriority?.priority && data.setTaskPriority.priority >= 0
           ? `Priority for task updated to ${data.setTaskPriority.priority}`
           : `Task was successfully disabled`,
       );
@@ -150,6 +143,7 @@ export const ActionButtons: React.FC<Props> = ({
     getTaskHistoryRoute(projectIdentifier, displayName, {
       selectedCommit: !isPatch && order,
       visibleColumns: [buildVariant],
+      taskId: taskId,
     }),
   );
 
@@ -189,7 +183,6 @@ export const ActionButtons: React.FC<Props> = ({
       disabled={disabled || !canDisable}
       onClick={() => {
         setTaskPriority({
-          // @ts-expect-error: FIXME. This comment was added by an automated script.
           variables: { taskId, priority: initialPriority < 0 ? 0 : -1 },
         });
       }}
@@ -201,7 +194,6 @@ export const ActionButtons: React.FC<Props> = ({
     >
       {initialPriority < 0 ? "Enable" : "Disable"}
     </DropdownItem>,
-    // @ts-expect-error: FIXME. This comment was added by an automated script.
     <SetPriority
       key="set-task-priority"
       disabled={disabled || !canSetPriority}
@@ -212,10 +204,7 @@ export const ActionButtons: React.FC<Props> = ({
       key="override-dependencies"
       data-cy="override-dependencies"
       disabled={disabled || !canOverrideDependencies}
-      onClick={() => {
-        // @ts-expect-error: FIXME. This comment was added by an automated script.
-        overrideTaskDependencies({ variables: { taskId } });
-      }}
+      onClick={() => overrideTaskDependencies({ variables: { taskId } })}
     >
       Override Dependencies
     </DropdownItem>,

--- a/apps/spruce/src/pages/task/taskTabs/testsTable/LogsColumn.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/testsTable/LogsColumn.tsx
@@ -17,7 +17,14 @@ interface Props {
 export const LogsColumn: React.FC<Props> = ({ task, testResult }) => {
   const { status, testFile } = testResult;
   const { url: urlHTML, urlParsley, urlRaw } = testResult.logs ?? {};
-  const { buildVariant, displayName, displayTask, order, project } = task ?? {};
+  const {
+    buildVariant,
+    displayName,
+    displayTask,
+    id: taskId,
+    order,
+    project,
+  } = task ?? {};
   const { sendEvent } = useTaskAnalytics();
   const filters =
     status === TestStatus.Fail
@@ -90,6 +97,7 @@ export const LogsColumn: React.FC<Props> = ({ task, testResult }) => {
             filters,
             selectedCommit: order,
             visibleColumns: [buildVariant],
+            taskId,
           })}
         />
       )}

--- a/apps/spruce/src/pages/taskHistory/index.tsx
+++ b/apps/spruce/src/pages/taskHistory/index.tsx
@@ -1,7 +1,9 @@
 import { useQuery } from "@apollo/client";
 import styled from "@emotion/styled";
+import Banner, { Variant as BannerVariant } from "@leafygreen-ui/banner";
 import { H2 } from "@leafygreen-ui/typography";
 import { useParams } from "react-router-dom";
+import { StyledRouterLink } from "@evg-ui/lib/components/styles";
 import { size } from "@evg-ui/lib/constants/tokens";
 import { useToastContext } from "@evg-ui/lib/context/toast";
 import { usePageTitle } from "@evg-ui/lib/hooks/usePageTitle";
@@ -22,12 +24,16 @@ import {
 import HistoryTable from "components/HistoryTable/HistoryTable";
 import { useHistoryTable } from "components/HistoryTable/HistoryTableContext";
 import { PageWrapper } from "components/styles";
-import { slugs } from "constants/routes";
+import { getTaskRoute, slugs } from "constants/routes";
 import {
   MainlineCommitsForHistoryQuery,
   MainlineCommitsForHistoryQueryVariables,
 } from "gql/generated/types";
 import { MAINLINE_COMMITS_FOR_HISTORY } from "gql/queries";
+import { useQueryParam } from "hooks/useQueryParam";
+import { TaskHistoryOptions } from "pages/task/taskTabs/TaskHistory/types";
+import { HistoryQueryParams, TestStatus } from "types/history";
+import { TaskTab } from "types/task";
 import { string } from "utils";
 import BuildVariantSelector from "./BuildVariantSelector";
 import ColumnHeaders from "./ColumnHeaders";
@@ -43,6 +49,10 @@ const TaskHistoryContents: React.FC = () => {
     [slugs.projectIdentifier]: projectIdentifier,
     [slugs.taskName]: taskName,
   } = useParams();
+
+  const [taskId] = useQueryParam<string>(HistoryQueryParams.TaskID, "");
+  const [failedTests] = useQueryParam<string[]>(TestStatus.Failed, []);
+
   // @ts-expect-error: FIXME. This comment was added by an automated script.
   const { ingestNewCommits } = useHistoryTable();
   usePageTitle(`Task History | ${projectIdentifier} | ${taskName}`);
@@ -123,6 +133,24 @@ const TaskHistoryContents: React.FC = () => {
 
   return (
     <PageWrapper>
+      <Banner variant={BannerVariant.Warning}>
+        This page will eventually be deprecated in favor of the Task History tab
+        available on the Task page.{" "}
+        {taskId && (
+          <span>
+            See the corresponding Task History tab for the selected commit{" "}
+            <StyledRouterLink
+              to={getTaskRoute(taskId, {
+                tab: TaskTab.History,
+                [TaskHistoryOptions.FailingTest]: failedTests.join("|"),
+              })}
+            >
+              here
+            </StyledRouterLink>
+            .
+          </span>
+        )}
+      </Banner>
       {/* @ts-expect-error: FIXME. This comment was added by an automated script. */}
       <ProjectBanner projectIdentifier={projectIdentifier} />
       <CenterPage>

--- a/apps/spruce/src/types/history.ts
+++ b/apps/spruce/src/types/history.ts
@@ -7,4 +7,5 @@ export enum TestStatus {
 export enum HistoryQueryParams {
   SelectedCommit = "selectedCommit",
   VisibleColumns = "visibleColumns",
+  TaskID = "taskId",
 }


### PR DESCRIPTION
DEVPROD-18245
<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
Adds a banner to the Task History page. Adds a TaskID parameter for the selected commit so that we can redirect to the Task History tab in that case.

### Screenshots
<!-- add screenshots of visible changes -->
<img width="1344" alt="Screenshot 2025-06-09 at 8 53 35 PM" src="https://github.com/user-attachments/assets/aad2e064-af13-4238-9a76-232c3176a1f7" />

