### PR TITLE
DEVPROD-16622: Implement onboarding tutorial for Task History tab

### DIFF
--- a/apps/spruce/cypress/integration/task/task_history.ts
+++ b/apps/spruce/cypress/integration/task/task_history.ts
@@ -1,3 +1,5 @@
+import { SEEN_TASK_HISTORY_ONBOARDING_TUTORIAL } from "constants/cookies";
+
 describe("task history", () => {
   const spruceTaskHistoryLink =
     "task/spruce_ubuntu1604_e2e_test_b0c52a750150b4f1f67e501bd3351a808939815c_1f7cf49f4ce587c74212d8997da171c4_22_03_10_15_19_05/history";
@@ -555,6 +557,60 @@ describe("task history", () => {
         "have.value",
         "test_lint_1",
       );
+    });
+  });
+
+  describe("onboarding", () => {
+    it("can go through all steps of the walkthrough", () => {
+      cy.clearCookie(SEEN_TASK_HISTORY_ONBOARDING_TUTORIAL);
+      cy.visit(mciTaskHistoryLink);
+
+      cy.dataCy("walkthrough-backdrop").should("be.visible");
+      cy.dataCy("walkthrough-guide-cue").should("be.visible");
+      cy.contains("Introducing the Task History Tab").should("be.visible");
+      cy.contains("button", "Next").click();
+
+      cy.dataCy("walkthrough-guide-cue").should("be.visible");
+      // Cypress can't handle position:fixed with overlapping elements
+      cy.contains("Task History Overview").should("exist");
+      cy.contains("button", "Next").click();
+
+      cy.dataCy("walkthrough-guide-cue").should("be.visible");
+      cy.contains("Commit Details").should("be.visible");
+      cy.contains("button", "Next").click();
+
+      cy.dataCy("walkthrough-guide-cue").should("be.visible");
+      // Cypress can't handle position:fixed with overlapping elements
+      cy.contains("Search Test Failures").should("exist");
+      cy.contains("button", "Next").click();
+
+      cy.dataCy("walkthrough-guide-cue").should("be.visible");
+      cy.contains("Filter by Date").should("be.visible");
+      cy.contains("button", "Next").click();
+
+      cy.dataCy("walkthrough-guide-cue").should("be.visible");
+      cy.contains("Jump to Current Task").should("be.visible");
+      cy.contains("button", "Next").click();
+
+      cy.dataCy("walkthrough-guide-cue").should("be.visible");
+      cy.contains("View Options").should("be.visible");
+      cy.contains("button", "Get started").click();
+
+      cy.dataCy("walkthrough-guide-cue").should("not.exist");
+      cy.dataCy("walkthrough-backdrop").should("not.exist");
+    });
+
+    it("can end walkthrough early using the dismiss button", () => {
+      cy.clearCookie(SEEN_TASK_HISTORY_ONBOARDING_TUTORIAL);
+      cy.visit(mciTaskHistoryLink);
+
+      cy.dataCy("walkthrough-backdrop").should("be.visible");
+      cy.dataCy("walkthrough-guide-cue").should("be.visible");
+      cy.contains("Introducing the Task History Tab").should("be.visible");
+
+      cy.get("[aria-label='Close Tooltip']").click();
+      cy.dataCy("walkthrough-guide-cue").should("not.exist");
+      cy.dataCy("walkthrough-backdrop").should("not.exist");
     });
   });
 });

--- a/apps/spruce/cypress/support/e2e.ts
+++ b/apps/spruce/cypress/support/e2e.ts
@@ -18,6 +18,7 @@ import "./commands";
 import {
   SLACK_NOTIFICATION_BANNER,
   SEEN_WATERFALL_ONBOARDING_TUTORIAL,
+  SEEN_TASK_HISTORY_ONBOARDING_TUTORIAL,
 } from "constants/cookies";
 import { hasOperationName, isMutation } from "../utils/graphql-test-utils";
 // Alternatively you can use CommonJS syntax:
@@ -160,6 +161,7 @@ const hostMutations = ["ReprovisionToNew", "RestartJasper", "UpdateHostStatus"];
     cy.setCookie(bannerCookie, "true");
     cy.setCookie(SLACK_NOTIFICATION_BANNER, "true");
     cy.setCookie(SEEN_WATERFALL_ONBOARDING_TUTORIAL, "true");
+    cy.setCookie(SEEN_TASK_HISTORY_ONBOARDING_TUTORIAL, "true");
     mutationDispatched = false;
     clearAmboyDB = false;
     cy.intercept("POST", "/graphql/query", (req) => {

--- a/apps/spruce/src/components/WalkthroughGuideCue/index.tsx
+++ b/apps/spruce/src/components/WalkthroughGuideCue/index.tsx
@@ -1,6 +1,11 @@
 import { useState, useRef, forwardRef, useImperativeHandle } from "react";
 import styled from "@emotion/styled";
-import { GuideCue } from "@leafygreen-ui/guide-cue";
+import {
+  GuideCue,
+  TooltipAlign,
+  TooltipJustify,
+} from "@leafygreen-ui/guide-cue";
+import { Align as BeaconAlign } from "@leafygreen-ui/popover";
 import { zIndex } from "@evg-ui/lib/constants/tokens";
 import { reportError } from "@evg-ui/lib/utils/errorReporting";
 
@@ -9,7 +14,12 @@ export type WalkthroughStep = {
   description: string | React.ReactElement;
   targetId: string;
   shouldClick?: boolean;
+  beaconAlign?: BeaconAlign;
+  tooltipAlign?: TooltipAlign;
+  tooltipJustify?: TooltipJustify;
 };
+
+export { BeaconAlign, TooltipAlign, TooltipJustify };
 
 export type WalkthroughGuideCueProps = {
   dataAttributeName: string;
@@ -68,6 +78,7 @@ export const WalkthroughGuideCue = forwardRef<
           `Cannot find element for the next step in walkthrough: ${nextStep.targetId}`,
         ),
       ).severe();
+      endWalkthrough();
       return;
     }
     if (nextStep.shouldClick) {
@@ -95,6 +106,7 @@ export const WalkthroughGuideCue = forwardRef<
   return (
     <>
       <GuideCue
+        beaconAlign={currentStep.beaconAlign ?? BeaconAlign.CenterHorizontal}
         buttonText={
           currentStepIdx + 1 === walkthroughSteps.length
             ? "Get started"
@@ -113,6 +125,8 @@ export const WalkthroughGuideCue = forwardRef<
         refEl={currentStepRef}
         setOpen={setOpen}
         title={currentStep.title}
+        tooltipAlign={currentStep.tooltipAlign ?? TooltipAlign.Top}
+        tooltipJustify={currentStep.tooltipJustify ?? TooltipJustify.Middle}
       >
         {currentStep.description}
       </GuideCue>
@@ -120,6 +134,8 @@ export const WalkthroughGuideCue = forwardRef<
     </>
   );
 });
+
+WalkthroughGuideCue.displayName = "WalkthroughGuideCue";
 
 const Backdrop = styled.div`
   position: fixed;

--- a/apps/spruce/src/constants/cookies.ts
+++ b/apps/spruce/src/constants/cookies.ts
@@ -13,3 +13,5 @@ export const SLACK_NOTIFICATION_BANNER = "has-closed-slack-banner";
 export const SUBSCRIPTION_METHOD = "subscription-method";
 export const SEEN_WATERFALL_ONBOARDING_TUTORIAL =
   "seen-waterfall-onboarding-tutorial";
+export const SEEN_TASK_HISTORY_ONBOARDING_TUTORIAL =
+  "seen-task-history-onboarding-tutorial";

--- a/apps/spruce/src/pages/task/taskTabs/TaskHistory/CommitDetailsCard/index.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/TaskHistory/CommitDetailsCard/index.tsx
@@ -29,6 +29,7 @@ import { RESTART_TASK, SCHEDULE_TASKS } from "gql/mutations";
 import { useDateFormat } from "hooks";
 import { useQueryParam } from "hooks/useQueryParam";
 import { isProduction } from "utils/environmentVariables";
+import { walkthroughCommitCardProps } from "../constants";
 import { TaskHistoryTask } from "../types";
 import CommitDescription from "./CommitDescription";
 import FailedTestsTable from "./FailedTestsTable";
@@ -142,6 +143,7 @@ const CommitDetailsCard: React.FC<CommitDetailsCardProps> = ({
       data-cy="commit-details-card"
       isMatching={isMatching}
       status={displayStatus as TaskStatus}
+      {...walkthroughCommitCardProps}
     >
       <TopLabel>
         <InlineCode as={Link} data-cy="task-link" to={getTaskRoute(taskId)}>

--- a/apps/spruce/src/pages/task/taskTabs/TaskHistory/Controls/index.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/TaskHistory/Controls/index.tsx
@@ -9,6 +9,11 @@ import { Subtitle } from "@leafygreen-ui/typography";
 import { size } from "@evg-ui/lib/constants/tokens";
 import { DateFilter } from "components/DateFilter";
 import { useQueryParams } from "hooks/useQueryParam";
+import {
+  walkthroughDateFilterProps,
+  walkthroughJumpButtonProps,
+  walkthroughInactiveViewProps,
+} from "../constants";
 import { TaskHistoryOptions, ViewOptions } from "../types";
 
 interface ControlsProps {
@@ -29,6 +34,7 @@ export const Controls: React.FC<ControlsProps> = ({
       <LeftContainer>
         <Subtitle>Task History Overview</Subtitle>
         <DateFilter
+          dataCyProps={walkthroughDateFilterProps}
           onChange={(newDate) => {
             setQueryParams({
               ...queryParams,
@@ -53,6 +59,7 @@ export const Controls: React.FC<ControlsProps> = ({
             });
           }}
           size={Size.XSmall}
+          {...walkthroughJumpButtonProps}
         >
           Jump to this task
         </Button>
@@ -62,6 +69,7 @@ export const Controls: React.FC<ControlsProps> = ({
         onChange={(t) => setViewOption(t as ViewOptions)}
         size="xsmall"
         value={viewOption}
+        {...walkthroughInactiveViewProps}
       >
         <SegmentedControlOption
           data-cy="collapsed-option"

--- a/apps/spruce/src/pages/task/taskTabs/TaskHistory/OnboardingTutorial.tsx/index.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/TaskHistory/OnboardingTutorial.tsx/index.tsx
@@ -1,0 +1,29 @@
+import Cookies from "js-cookie";
+import {
+  WalkthroughGuideCue,
+  WalkthroughGuideCueRef,
+} from "components/WalkthroughGuideCue";
+import { SEEN_TASK_HISTORY_ONBOARDING_TUTORIAL } from "constants/cookies";
+import { walkthroughSteps, taskHistoryGuideId } from "../constants";
+
+type OnboardingTutorialProps = {
+  guideCueRef: React.RefObject<WalkthroughGuideCueRef>;
+};
+
+const OnboardingTutorial: React.FC<OnboardingTutorialProps> = ({
+  guideCueRef,
+}) => (
+  <WalkthroughGuideCue
+    ref={guideCueRef}
+    dataAttributeName={taskHistoryGuideId}
+    defaultOpen={Cookies.get(SEEN_TASK_HISTORY_ONBOARDING_TUTORIAL) !== "true"}
+    onClose={() =>
+      Cookies.set(SEEN_TASK_HISTORY_ONBOARDING_TUTORIAL, "true", {
+        expires: 365,
+      })
+    }
+    walkthroughSteps={walkthroughSteps}
+  />
+);
+
+export default OnboardingTutorial;

--- a/apps/spruce/src/pages/task/taskTabs/TaskHistory/TaskTimeline/index.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/TaskHistory/TaskTimeline/index.tsx
@@ -11,10 +11,12 @@ import { TaskBox as BaseTaskBox, CollapsedBox } from "components/TaskBox";
 import { TaskHistoryDirection } from "gql/generated/types";
 import { useUserTimeZone } from "hooks";
 import { useQueryParams } from "hooks/useQueryParam";
+import { walkthroughTimelineProps } from "../constants";
 import { GroupedTask, TaskHistoryOptions, TaskHistoryTask } from "../types";
 import DateSeparator from "./DateSeparator";
 
 const { gray } = palette;
+
 type TaskHistoryPagination = {
   mostRecentTaskOrder: number | undefined;
   oldestTaskOrder: number | undefined;
@@ -63,7 +65,11 @@ const TaskTimeline = forwardRef<HTMLDivElement, TimelineProps>(
         >
           <Icon glyph="ChevronLeft" />
         </IconButton>
-        <Timeline ref={ref} data-cy="task-timeline">
+        <Timeline
+          ref={ref}
+          data-cy="task-timeline"
+          {...walkthroughTimelineProps}
+        >
           {loading ? (
             <Skeleton size={SkeletonSize.Small} />
           ) : (

--- a/apps/spruce/src/pages/task/taskTabs/TaskHistory/TestFailureSearchInput/index.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/TaskHistory/TestFailureSearchInput/index.tsx
@@ -9,6 +9,7 @@ import debounce from "lodash.debounce";
 import { size } from "@evg-ui/lib/constants/tokens";
 import { filterInputDebounceTimeout } from "constants/timeouts";
 import { useQueryParam } from "hooks/useQueryParam";
+import { walkthroughFailureSearchProps } from "../constants";
 import { TaskHistoryOptions } from "../types";
 
 interface TestFailureSearchInputProps {
@@ -58,6 +59,7 @@ export const TestFailureSearchInput: React.FC<TestFailureSearchInputProps> = ({
           placeholder="Search failed test"
           size={SearchInputSize.Small}
           value={searchTerm}
+          {...walkthroughFailureSearchProps}
         />
       </InputContainer>
       {numMatchingResults === 0 && failingTest && (

--- a/apps/spruce/src/pages/task/taskTabs/TaskHistory/constants.ts
+++ b/apps/spruce/src/pages/task/taskTabs/TaskHistory/constants.ts
@@ -1,1 +1,86 @@
+import {
+  BeaconAlign,
+  TooltipAlign,
+  WalkthroughStep,
+} from "components/WalkthroughGuideCue";
+
 export const ACTIVATED_TASKS_LIMIT = 50;
+
+export const taskHistoryGuideId = "data-task-history-guide-id";
+
+export const walkthroughSteps: WalkthroughStep[] = [
+  {
+    title: "Introducing the Task History Tab",
+    description:
+      "An at-a-glance view of task history to help with gauging overall task health and investigating test failures.",
+    targetId: "task-history-tab",
+  },
+  {
+    title: "Task History Overview",
+    description:
+      "A timeline of this task's previous runs. Paginate to view additional history.",
+    targetId: "task-history-overview",
+    beaconAlign: BeaconAlign.Left,
+    tooltipAlign: TooltipAlign.Left,
+  },
+  {
+    title: "Commit Details",
+    description:
+      "Each card is tied to a task in the timeline. Failing tests will be shown here.",
+    targetId: "commit-details",
+    beaconAlign: BeaconAlign.Left,
+    tooltipAlign: TooltipAlign.Left,
+  },
+  {
+    title: "Search Test Failures",
+    description:
+      "Search for specific tests to identify common failures between different tasks.",
+    targetId: "search-test-failures",
+    beaconAlign: BeaconAlign.Left,
+    tooltipAlign: TooltipAlign.Left,
+  },
+  {
+    title: "Filter by Date",
+    description:
+      "Jump directly to any given date in the task history. Tasks are TTL'd after 1 year.",
+    targetId: "search-by-date",
+  },
+  {
+    title: "Jump to Current Task",
+    description: "Use this button to reset the view to the current task.",
+    targetId: "jump-to-task",
+  },
+  {
+    title: "View Options",
+    description: "Choose to collapse or expand inactive commits.",
+    targetId: "inactive-commits",
+  },
+];
+
+export const walkthroughHistoryTabProps = {
+  [taskHistoryGuideId]: walkthroughSteps[0].targetId,
+};
+
+export const walkthroughTimelineProps = {
+  [taskHistoryGuideId]: walkthroughSteps[1].targetId,
+};
+
+export const walkthroughCommitCardProps = {
+  [taskHistoryGuideId]: walkthroughSteps[2].targetId,
+};
+
+export const walkthroughFailureSearchProps = {
+  [taskHistoryGuideId]: walkthroughSteps[3].targetId,
+};
+
+export const walkthroughDateFilterProps = {
+  [taskHistoryGuideId]: walkthroughSteps[4].targetId,
+};
+
+export const walkthroughJumpButtonProps = {
+  [taskHistoryGuideId]: walkthroughSteps[5].targetId,
+};
+
+export const walkthroughInactiveViewProps = {
+  [taskHistoryGuideId]: walkthroughSteps[6].targetId,
+};

--- a/apps/spruce/src/pages/task/taskTabs/TaskHistory/index.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/TaskHistory/index.tsx
@@ -7,6 +7,7 @@ import { size } from "@evg-ui/lib/constants/tokens";
 import { useToastContext } from "@evg-ui/lib/context/toast";
 import { toEscapedRegex } from "@evg-ui/lib/utils/string";
 import { SQUARE_WITH_BORDER } from "components/TaskBox";
+import { WalkthroughGuideCueRef } from "components/WalkthroughGuideCue";
 import { DEFAULT_POLL_INTERVAL } from "constants/index";
 import {
   TaskHistoryDirection,
@@ -18,11 +19,13 @@ import { TASK_HISTORY } from "gql/queries";
 import { useSpruceConfig, useUserTimeZone } from "hooks";
 import { useDimensions } from "hooks/useDimensions";
 import { useQueryParam, useQueryParams } from "hooks/useQueryParam";
+import { isProduction } from "utils/environmentVariables";
 import { jiraLinkify } from "utils/string";
 import { validateRegexp } from "utils/validators";
 import CommitDetailsList from "./CommitDetailsList";
 import { ACTIVATED_TASKS_LIMIT } from "./constants";
 import { Controls } from "./Controls";
+import OnboardingTutorial from "./OnboardingTutorial.tsx";
 import TaskTimeline from "./TaskTimeline";
 import { TestFailureSearchInput } from "./TestFailureSearchInput";
 import { TaskHistoryOptions, ViewOptions } from "./types";
@@ -40,6 +43,8 @@ const MAX_DATES_PER_PAGE = 10; // Maximum number of dates to assume per page in 
 const TaskHistory: React.FC<TaskHistoryProps> = ({ task }) => {
   const timelineRef = useRef<HTMLDivElement>(null);
   const { width: timelineWidth } = useDimensions<HTMLDivElement>(timelineRef);
+
+  const guideCueRef = useRef<WalkthroughGuideCueRef>(null);
 
   const dispatchToast = useToastContext();
 
@@ -151,41 +156,45 @@ const TaskHistory: React.FC<TaskHistoryProps> = ({ task }) => {
   }, [direction, setQueryParams, prevPageCursor, queryParams]);
 
   return (
-    <Container>
-      <Banner variant={BannerVariant.Info}>
-        {jiraLinkify(
-          "This page is currently under construction. Performance and functionality bugs may be present. See DEVPROD-6584 for project details.",
-          jiraHost,
-        )}
-      </Banner>
-      <StickyHeader>
-        <Controls
-          date={date}
-          setViewOption={setViewOption}
-          viewOption={viewOption}
-        />
-        <TaskTimeline
-          ref={timelineRef}
-          loading={loading}
-          pagination={{
-            mostRecentTaskOrder,
-            oldestTaskOrder,
-            nextPageCursor,
-            prevPageCursor,
-          }}
-          tasks={visibleTasks}
-        />
-        <TestFailureSearchInput numMatchingResults={numMatchingResults} />
-      </StickyHeader>
-      <ListContent>
-        <Subtitle>Commit Details</Subtitle>
-        <CommitDetailsList
-          currentTask={task}
-          loading={loading}
-          tasks={visibleTasks}
-        />
-      </ListContent>
-    </Container>
+    <>
+      <Container>
+        <Banner variant={BannerVariant.Info}>
+          {jiraLinkify(
+            "This page is currently under construction. Performance and functionality bugs may be present. See DEVPROD-6584 for project details.",
+            jiraHost,
+          )}
+        </Banner>
+        <StickyHeader>
+          <Controls
+            date={date}
+            setViewOption={setViewOption}
+            viewOption={viewOption}
+          />
+          <TaskTimeline
+            ref={timelineRef}
+            loading={loading}
+            pagination={{
+              mostRecentTaskOrder,
+              oldestTaskOrder,
+              nextPageCursor,
+              prevPageCursor,
+            }}
+            tasks={visibleTasks}
+          />
+          <TestFailureSearchInput numMatchingResults={numMatchingResults} />
+        </StickyHeader>
+        <ListContent>
+          <Subtitle>Commit Details</Subtitle>
+          <CommitDetailsList
+            currentTask={task}
+            loading={loading}
+            tasks={visibleTasks}
+          />
+        </ListContent>
+      </Container>
+      {/* Remove condition in DEVPROD-17669 */}
+      {!isProduction() && <OnboardingTutorial guideCueRef={guideCueRef} />}
+    </>
   );
 };
 

--- a/apps/spruce/src/pages/task/taskTabs/index.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/index.tsx
@@ -17,6 +17,7 @@ import ExecutionTasksTable from "./ExecutionTasksTable";
 import FileTable from "./FileTable";
 import Logs from "./logs";
 import TaskHistory from "./TaskHistory";
+import { walkthroughHistoryTabProps } from "./TaskHistory/constants";
 import TestsTable from "./testsTable/TestsTable";
 import { getDefaultTab } from "./utils/getDefaultTab";
 
@@ -159,6 +160,7 @@ const useTabConfig = (
             tabLabel="Task History"
           />
         }
+        {...walkthroughHistoryTabProps}
       >
         <TaskHistory task={task} />
       </Tab>


### PR DESCRIPTION
DEVPROD-16622
<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
Uses existing `WalkthroughGuideCue` to implement onboarding tutorial for Task History tab.

Mainly want feedback for verbiage and the number of steps (are there too many?)

### Screenshots
<!-- add screenshots of visible changes -->

### Testing
- Cypress tests