### PR TITLE
DEVPROD-18287: Improve interaction of scheduling inactive tasks

### DIFF
--- a/apps/spruce/cypress/integration/task/task_history.ts
+++ b/apps/spruce/cypress/integration/task/task_history.ts
@@ -165,17 +165,18 @@ describe("task history", () => {
   describe("scheduling tasks", () => {
     const willRunColor = hexToRGB(gray.dark1);
 
-    it("scheduling a task should reflect the changes on the UI", () => {
+    it("scheduling a task in a group of 1 inactive task", () => {
       cy.visit(spruceTaskHistoryLink);
 
-      // We are targeting the 2nd task element in the task timeline and asserting that it state changes from an inactive collapsed task to an active will-run task
+      // Target the 2nd task element in the task timeline and assert that it
+      // changes from an inactive collapsed task to an active will-run task.
       cy.dataCy("task-timeline")
         .children()
         // Filter out date-separators
         .filter(
           (_idx, el) =>
             !el.hasAttribute("data-cy") ||
-            el.getAttribute("data-cy") !== "date-separator",
+            el.getAttribute("data-cy").includes("date-separator"),
         )
         .eq(2)
         .as("taskBox");
@@ -211,6 +212,28 @@ describe("task history", () => {
           "true",
         );
       });
+    });
+
+    it("scheduling a task in a group of multiple inactive tasks", () => {
+      cy.visit(spruceTaskHistoryLink);
+
+      cy.contains("2 Inactive Commit").click();
+      cy.contains("2 Expanded").should("be.visible");
+
+      cy.dataCy("commit-details-card").eq(7).as("taskCard");
+      cy.get("@taskCard").within(() => {
+        cy.dataCy("schedule-button").should(
+          "have.attr",
+          "aria-disabled",
+          "false",
+        );
+        cy.dataCy("schedule-button").click();
+      });
+      cy.validateToast("success", "Task scheduled to run");
+
+      // The other inactive task in the group should still be visible.
+      cy.contains("1 Expanded").should("be.visible");
+      cy.contains("22ea5d7").should("be.visible");
     });
   });
 

--- a/apps/spruce/cypress/integration/task/task_history.ts
+++ b/apps/spruce/cypress/integration/task/task_history.ts
@@ -176,7 +176,7 @@ describe("task history", () => {
         .filter(
           (_idx, el) =>
             !el.hasAttribute("data-cy") ||
-            el.getAttribute("data-cy").includes("date-separator"),
+            el.getAttribute("data-cy") !== "date-separator",
         )
         .eq(2)
         .as("taskBox");

--- a/apps/spruce/src/analytics/task/useTaskHistoryAnalytics.ts
+++ b/apps/spruce/src/analytics/task/useTaskHistoryAnalytics.ts
@@ -35,6 +35,10 @@ type Action =
       name: "Toggled commit description";
       expanded: boolean;
     }
+  | {
+      name: "Toggled inactive tasks view";
+      expanded: boolean;
+    }
   | { name: "Toggled failed tests table"; open: boolean };
 
 export const useTaskHistoryAnalytics = () => {

--- a/apps/spruce/src/constants/cookies.ts
+++ b/apps/spruce/src/constants/cookies.ts
@@ -15,3 +15,5 @@ export const SEEN_WATERFALL_ONBOARDING_TUTORIAL =
   "seen-waterfall-onboarding-tutorial";
 export const SEEN_TASK_HISTORY_ONBOARDING_TUTORIAL =
   "seen-task-history-onboarding-tutorial";
+export const TASK_HISTORY_INACTIVE_COMMITS_VIEW =
+  "task-history-inactive-commits-view";

--- a/apps/spruce/src/constants/cookies.ts
+++ b/apps/spruce/src/constants/cookies.ts
@@ -1,6 +1,4 @@
 export const ANNOUNCEMENT_TOAST = "announcement-toast";
-export const COMMIT_CHART_TYPE_VIEW_OPTIONS_ACCORDION =
-  "commit-chart-view-options-accordion";
 export const CURRENT_PROJECT = "mci-project-cookie";
 export const DISABLE_QUERY_POLLING = "disable-query-polling";
 export const getNotificationTriggerCookie = (type: string) =>

--- a/apps/spruce/src/pages/task/taskTabs/TaskHistory/CommitDetailsCard/index.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/TaskHistory/CommitDetailsCard/index.tsx
@@ -56,9 +56,9 @@ const CommitDetailsCard = forwardRef<HTMLDivElement, CommitDetailsCardProps>(
 
     const {
       currentTask,
-      expandedMap,
+      expandedTasksMap,
       selectedTask,
-      setExpandedMap,
+      setExpandedTasksMap,
       setHoveredTask,
     } = useTaskHistoryContext();
     const [, setExecution] = useQueryParam(RequiredQueryParams.Execution, 0);
@@ -100,9 +100,9 @@ const CommitDetailsCard = forwardRef<HTMLDivElement, CommitDetailsCardProps>(
     >(SCHEDULE_TASKS, {
       variables: { taskIds: [task.id], versionId },
       onCompleted: () => {
-        const newMap = new Map(expandedMap);
+        const newMap = new Map(expandedTasksMap);
         newMap.delete(task.id);
-        setExpandedMap(newMap);
+        setExpandedTasksMap(newMap);
         dispatchToast.success("Task scheduled to run");
       },
       onError: (err) => {

--- a/apps/spruce/src/pages/task/taskTabs/TaskHistory/CommitDetailsCard/index.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/TaskHistory/CommitDetailsCard/index.tsx
@@ -54,8 +54,13 @@ const CommitDetailsCard = forwardRef<HTMLDivElement, CommitDetailsCardProps>(
     const dispatchToast = useToastContext();
     const getDateCopy = useDateFormat();
 
-    const { currentTask, selectedTask, setHoveredTask } =
-      useTaskHistoryContext();
+    const {
+      currentTask,
+      expandedMap,
+      selectedTask,
+      setExpandedMap,
+      setHoveredTask,
+    } = useTaskHistoryContext();
     const [, setExecution] = useQueryParam(RequiredQueryParams.Execution, 0);
 
     const {
@@ -95,6 +100,9 @@ const CommitDetailsCard = forwardRef<HTMLDivElement, CommitDetailsCardProps>(
     >(SCHEDULE_TASKS, {
       variables: { taskIds: [task.id], versionId },
       onCompleted: () => {
+        const newMap = new Map(expandedMap);
+        newMap.delete(task.id);
+        setExpandedMap(newMap);
         dispatchToast.success("Task scheduled to run");
       },
       onError: (err) => {

--- a/apps/spruce/src/pages/task/taskTabs/TaskHistory/CommitDetailsList/DateSeparator/index.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/TaskHistory/CommitDetailsList/DateSeparator/index.tsx
@@ -5,14 +5,14 @@ import { useDateFormat } from "hooks";
 
 const { gray } = palette;
 interface DateSeparatorProps {
-  date?: Date | null;
+  date: Date;
 }
 const DateSeparator: React.FC<DateSeparatorProps> = ({ date }) => {
   const getDateCopy = useDateFormat();
   return (
     <Container data-cy="horizontal-date-separator">
       <Badge>
-        {getDateCopy(date || "", {
+        {getDateCopy(date, {
           dateOnly: true,
         })}
       </Badge>

--- a/apps/spruce/src/pages/task/taskTabs/TaskHistory/CommitDetailsList/index.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/TaskHistory/CommitDetailsList/index.tsx
@@ -17,7 +17,7 @@ const CommitDetailsList: React.FC<CommitDetailsListProps> = ({
   loading,
   tasks,
 }) => {
-  const { expandedMap } = useTaskHistoryContext();
+  const { expandedTasksMap } = useTaskHistoryContext();
 
   return (
     <CommitList data-cy="commit-details-list">
@@ -47,7 +47,7 @@ const CommitDetailsList: React.FC<CommitDetailsListProps> = ({
               return (
                 <InactiveCommitsButton
                   key={`${inactiveTasks[0].id}-${inactiveTasks[inactiveTasks.length - 1].id}`}
-                  defaultOpen={expandedMap.get(inactiveTasks[0].id)}
+                  defaultOpen={expandedTasksMap.get(inactiveTasks[0].id)}
                   inactiveTasks={inactiveTasks}
                 />
               );

--- a/apps/spruce/src/pages/task/taskTabs/TaskHistory/CommitDetailsList/index.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/TaskHistory/CommitDetailsList/index.tsx
@@ -3,6 +3,7 @@ import { ParagraphSkeleton } from "@leafygreen-ui/skeleton-loader";
 import { size } from "@evg-ui/lib/constants/tokens";
 import CommitDetailsCard from "../CommitDetailsCard";
 import { stickyHeaderScrollOffset } from "../constants";
+import { useTaskHistoryContext } from "../context";
 import InactiveCommitsButton from "../InactiveCommitsButton";
 import { GroupedTask } from "../types";
 import DateSeparator from "./DateSeparator";
@@ -15,41 +16,49 @@ interface CommitDetailsListProps {
 const CommitDetailsList: React.FC<CommitDetailsListProps> = ({
   loading,
   tasks,
-}) => (
-  <CommitList data-cy="commit-details-list">
-    {loading ? (
-      <ParagraphSkeleton />
-    ) : (
-      <>
-        {tasks.map((t) => {
-          const { commitCardRef, date, inactiveTasks, isMatching, task } = t;
-          if (date) {
-            return (
-              <DateSeparator key={`list-date-separator-${date}`} date={date} />
-            );
-          } else if (task) {
-            return (
-              <CommitDetailsCard
-                key={task.id}
-                ref={commitCardRef}
-                isMatching={isMatching}
-                task={task}
-              />
-            );
-          } else if (inactiveTasks) {
-            return (
-              <InactiveCommitsButton
-                key={`${inactiveTasks[0].id}-${inactiveTasks[inactiveTasks.length - 1].id}`}
-                inactiveTasks={inactiveTasks}
-              />
-            );
-          }
-          return null;
-        })}
-      </>
-    )}
-  </CommitList>
-);
+}) => {
+  const { expandedMap } = useTaskHistoryContext();
+
+  return (
+    <CommitList data-cy="commit-details-list">
+      {loading ? (
+        <ParagraphSkeleton />
+      ) : (
+        <>
+          {tasks.map((t) => {
+            const { commitCardRef, date, inactiveTasks, isMatching, task } = t;
+            if (date) {
+              return (
+                <DateSeparator
+                  key={`list-date-separator-${date}`}
+                  date={date}
+                />
+              );
+            } else if (task) {
+              return (
+                <CommitDetailsCard
+                  key={task.id}
+                  ref={commitCardRef}
+                  isMatching={isMatching}
+                  task={task}
+                />
+              );
+            } else if (inactiveTasks) {
+              return (
+                <InactiveCommitsButton
+                  key={`${inactiveTasks[0].id}-${inactiveTasks[inactiveTasks.length - 1].id}`}
+                  defaultOpen={expandedMap.get(inactiveTasks[0].id)}
+                  inactiveTasks={inactiveTasks}
+                />
+              );
+            }
+            return null;
+          })}
+        </>
+      )}
+    </CommitList>
+  );
+};
 
 export default CommitDetailsList;
 

--- a/apps/spruce/src/pages/task/taskTabs/TaskHistory/Controls/index.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/TaskHistory/Controls/index.tsx
@@ -6,8 +6,11 @@ import {
 } from "@leafygreen-ui/segmented-control";
 import { Size } from "@leafygreen-ui/tokens";
 import { Subtitle } from "@leafygreen-ui/typography";
+import Cookies from "js-cookie";
 import { size } from "@evg-ui/lib/constants/tokens";
+import { useTaskHistoryAnalytics } from "analytics";
 import { DateFilter } from "components/DateFilter";
+import { TASK_HISTORY_INACTIVE_COMMITS_VIEW } from "constants/cookies";
 import { useQueryParams } from "hooks/useQueryParam";
 import {
   walkthroughDateFilterProps,
@@ -28,6 +31,7 @@ export const Controls: React.FC<ControlsProps> = ({
   viewOption,
 }) => {
   const [queryParams, setQueryParams] = useQueryParams();
+  const { sendEvent } = useTaskHistoryAnalytics();
 
   return (
     <Container>
@@ -67,7 +71,14 @@ export const Controls: React.FC<ControlsProps> = ({
       <SegmentedControl
         aria-controls="[data-cy='task-timeline']"
         label="Inactive Commits"
-        onChange={(t) => setViewOption(t as ViewOptions)}
+        onChange={(t) => {
+          setViewOption(t as ViewOptions);
+          Cookies.set(TASK_HISTORY_INACTIVE_COMMITS_VIEW, t);
+          sendEvent({
+            name: "Toggled inactive tasks view",
+            expanded: t === ViewOptions.Expanded,
+          });
+        }}
         size="xsmall"
         value={viewOption}
         {...walkthroughInactiveViewProps}

--- a/apps/spruce/src/pages/task/taskTabs/TaskHistory/InactiveCommitsButton/index.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/TaskHistory/InactiveCommitsButton/index.tsx
@@ -16,7 +16,7 @@ const InactiveCommitsButton: React.FC<Props> = ({
   defaultOpen = false,
   inactiveTasks,
 }) => {
-  const { expandedMap, setExpandedMap } = useTaskHistoryContext();
+  const { expandedTasksMap, setExpandedTasksMap } = useTaskHistoryContext();
   const [failingTest] = useQueryParam<string>(
     TaskHistoryOptions.FailingTest,
     "",
@@ -35,7 +35,7 @@ const InactiveCommitsButton: React.FC<Props> = ({
             )
           }
           onClick={() => {
-            const newMap = new Map(expandedMap);
+            const newMap = new Map(expandedTasksMap);
             inactiveTasks.forEach((i) => {
               if (isExpanded) {
                 newMap.delete(i.id);
@@ -43,7 +43,7 @@ const InactiveCommitsButton: React.FC<Props> = ({
                 newMap.set(i.id, true);
               }
             });
-            setExpandedMap(newMap);
+            setExpandedTasksMap(newMap);
             setIsExpanded(!isExpanded);
           }}
           size={Size.XSmall}

--- a/apps/spruce/src/pages/task/taskTabs/TaskHistory/InactiveCommitsButton/index.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/TaskHistory/InactiveCommitsButton/index.tsx
@@ -5,17 +5,23 @@ import { Size } from "@leafygreen-ui/tokens";
 import pluralize from "pluralize";
 import { useQueryParam } from "hooks/useQueryParam";
 import CommitDetailsCard from "../CommitDetailsCard";
+import { useTaskHistoryContext } from "../context";
 import { TaskHistoryOptions, TaskHistoryTask } from "../types";
 
 interface Props {
+  defaultOpen?: boolean;
   inactiveTasks: TaskHistoryTask[];
 }
-const InactiveCommitsButton: React.FC<Props> = ({ inactiveTasks }) => {
+const InactiveCommitsButton: React.FC<Props> = ({
+  defaultOpen = false,
+  inactiveTasks,
+}) => {
+  const { expandedMap, setExpandedMap } = useTaskHistoryContext();
   const [failingTest] = useQueryParam<string>(
     TaskHistoryOptions.FailingTest,
     "",
   );
-  const [isExpanded, setIsExpanded] = useState(false);
+  const [isExpanded, setIsExpanded] = useState(defaultOpen);
   return (
     <>
       <span>
@@ -28,7 +34,18 @@ const InactiveCommitsButton: React.FC<Props> = ({ inactiveTasks }) => {
               <Icon glyph="ChevronRight" />
             )
           }
-          onClick={() => setIsExpanded(!isExpanded)}
+          onClick={() => {
+            const newMap = new Map(expandedMap);
+            inactiveTasks.forEach((i) => {
+              if (isExpanded) {
+                newMap.delete(i.id);
+              } else {
+                newMap.set(i.id, true);
+              }
+            });
+            setExpandedMap(newMap);
+            setIsExpanded(!isExpanded);
+          }}
           size={Size.XSmall}
         >
           {inactiveTasks.length}{" "}

--- a/apps/spruce/src/pages/task/taskTabs/TaskHistory/TaskTimeline/DateSeparator/DateSeparator.test.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/TaskHistory/TaskTimeline/DateSeparator/DateSeparator.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from "@evg-ui/lib/test_utils";
 import DateSeparator from ".";
 
 describe("DateSeparator", () => {
-  const dateObject = new Date("2024-06-01T05:00:00Z");
+  const dateObject = new Date("2024-06-01T15:00:00Z");
 
   it("renders the date in the default timezone (UTC)", () => {
     render(<DateSeparator date={dateObject} />);
@@ -16,16 +16,11 @@ describe("DateSeparator", () => {
 
   it("renders the date in a different timezone (Asia/Tokyo)", () => {
     render(<DateSeparator date={dateObject} timezone="Asia/Tokyo" />);
-    expect(screen.getByText(/5\/31/i)).toBeInTheDocument();
+    expect(screen.getByText(/6\/02/i)).toBeInTheDocument();
   });
 
   it("renders correctly for a date string without timezone info", () => {
     render(<DateSeparator date={dateObject} />);
     expect(screen.getByText(/6\/01/i)).toBeInTheDocument();
-  });
-
-  it("handles invalid date gracefully", () => {
-    render(<DateSeparator date={undefined} />);
-    expect(screen.getByText(/Invalid date/i)).toBeInTheDocument();
   });
 });

--- a/apps/spruce/src/pages/task/taskTabs/TaskHistory/TaskTimeline/DateSeparator/index.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/TaskHistory/TaskTimeline/DateSeparator/index.tsx
@@ -2,20 +2,18 @@ import { css } from "@emotion/react";
 import styled from "@emotion/styled";
 import Badge from "@leafygreen-ui/badge";
 import { palette } from "@leafygreen-ui/palette";
-import { fromZonedTime } from "date-fns-tz";
+import { toZonedTime } from "date-fns-tz";
 import { size } from "@evg-ui/lib/constants/tokens";
 
 const { gray } = palette;
 
 export const DATE_SEPARATOR_WIDTH = 12;
 interface DateSeparatorProps {
-  date?: Date | null;
+  date: Date;
   timezone?: string;
 }
 const DateSeparator: React.FC<DateSeparatorProps> = ({ date, timezone }) => {
-  const zonedTime = timezone
-    ? fromZonedTime(new Date(date || ""), timezone)
-    : new Date(date || "");
+  const zonedTime = timezone ? toZonedTime(date, timezone) : new Date(date);
   const formattedDate = zonedTime.toLocaleDateString("en-US", {
     month: "numeric",
     day: "2-digit",

--- a/apps/spruce/src/pages/task/taskTabs/TaskHistory/context/index.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/TaskHistory/context/index.tsx
@@ -7,8 +7,8 @@ type TaskHistoryContextState = {
   setSelectedTask: (v: string | null) => void;
   setHoveredTask: (v: string | null) => void;
   currentTask: NonNullable<TaskQuery["task"]>;
-  expandedMap: Map<string, boolean>;
-  setExpandedMap: (v: Map<string, boolean>) => void;
+  expandedTasksMap: Map<string, boolean>;
+  setExpandedTasksMap: (v: Map<string, boolean>) => void;
 };
 
 const TaskHistoryContext = createContext<TaskHistoryContextState | null>(null);
@@ -29,7 +29,9 @@ const TaskHistoryContextProvider: React.FC<{
 }> = ({ children, task }) => {
   const [selectedTask, setSelectedTask] = useState<string | null>(null);
   const [hoveredTask, setHoveredTask] = useState<string | null>(null);
-  const [expandedMap, setExpandedMap] = useState(new Map<string, boolean>());
+  const [expandedTasksMap, setExpandedTasksMap] = useState(
+    new Map<string, boolean>(),
+  );
 
   const memoizedContext = useMemo(
     () => ({
@@ -38,8 +40,8 @@ const TaskHistoryContextProvider: React.FC<{
       hoveredTask,
       setHoveredTask,
       currentTask: task,
-      expandedMap,
-      setExpandedMap,
+      expandedTasksMap,
+      setExpandedTasksMap,
     }),
     [
       selectedTask,
@@ -47,8 +49,8 @@ const TaskHistoryContextProvider: React.FC<{
       hoveredTask,
       setHoveredTask,
       task,
-      expandedMap,
-      setExpandedMap,
+      expandedTasksMap,
+      setExpandedTasksMap,
     ],
   );
   return (

--- a/apps/spruce/src/pages/task/taskTabs/TaskHistory/context/index.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/TaskHistory/context/index.tsx
@@ -7,6 +7,8 @@ type TaskHistoryContextState = {
   setSelectedTask: (v: string | null) => void;
   setHoveredTask: (v: string | null) => void;
   currentTask: NonNullable<TaskQuery["task"]>;
+  expandedMap: Map<string, boolean>;
+  setExpandedMap: (v: Map<string, boolean>) => void;
 };
 
 const TaskHistoryContext = createContext<TaskHistoryContextState | null>(null);
@@ -27,6 +29,7 @@ const TaskHistoryContextProvider: React.FC<{
 }> = ({ children, task }) => {
   const [selectedTask, setSelectedTask] = useState<string | null>(null);
   const [hoveredTask, setHoveredTask] = useState<string | null>(null);
+  const [expandedMap, setExpandedMap] = useState(new Map<string, boolean>());
 
   const memoizedContext = useMemo(
     () => ({
@@ -35,8 +38,18 @@ const TaskHistoryContextProvider: React.FC<{
       hoveredTask,
       setHoveredTask,
       currentTask: task,
+      expandedMap,
+      setExpandedMap,
     }),
-    [selectedTask, setSelectedTask, hoveredTask, setHoveredTask, task],
+    [
+      selectedTask,
+      setSelectedTask,
+      hoveredTask,
+      setHoveredTask,
+      task,
+      expandedMap,
+      setExpandedMap,
+    ],
   );
   return (
     <TaskHistoryContext.Provider value={memoizedContext}>

--- a/apps/spruce/src/pages/task/taskTabs/TaskHistory/index.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/TaskHistory/index.tsx
@@ -63,8 +63,8 @@ const TaskHistory: React.FC<TaskHistoryProps> = ({ task }) => {
   const jiraHost = spruceConfig?.jira?.host ?? "";
 
   const [viewOption, setViewOption] = useState(
-    (Cookies.get(TASK_HISTORY_INACTIVE_COMMITS_VIEW) as ViewOptions) ??
-      ViewOptions.Collapsed,
+    (Cookies.get(TASK_HISTORY_INACTIVE_COMMITS_VIEW) ??
+      ViewOptions.Collapsed) as ViewOptions,
   );
   const shouldCollapse = viewOption === ViewOptions.Collapsed;
 

--- a/apps/spruce/src/pages/task/taskTabs/TaskHistory/index.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/TaskHistory/index.tsx
@@ -63,7 +63,8 @@ const TaskHistory: React.FC<TaskHistoryProps> = ({ task }) => {
   const jiraHost = spruceConfig?.jira?.host ?? "";
 
   const [viewOption, setViewOption] = useState(
-    Cookies.get(TASK_HISTORY_INACTIVE_COMMITS_VIEW) as ViewOptions,
+    (Cookies.get(TASK_HISTORY_INACTIVE_COMMITS_VIEW) as ViewOptions) ??
+      ViewOptions.Collapsed,
   );
   const shouldCollapse = viewOption === ViewOptions.Collapsed;
 

--- a/apps/spruce/src/pages/task/taskTabs/TaskHistory/index.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/TaskHistory/index.tsx
@@ -3,11 +3,13 @@ import { useQuery } from "@apollo/client";
 import styled from "@emotion/styled";
 import Banner, { Variant as BannerVariant } from "@leafygreen-ui/banner";
 import { Subtitle } from "@leafygreen-ui/typography";
+import Cookies from "js-cookie";
 import { size, transitionDuration } from "@evg-ui/lib/constants/tokens";
 import { useToastContext } from "@evg-ui/lib/context/toast";
 import { toEscapedRegex } from "@evg-ui/lib/utils/string";
 import { SQUARE_WITH_BORDER } from "components/TaskBox";
 import { WalkthroughGuideCueRef } from "components/WalkthroughGuideCue";
+import { TASK_HISTORY_INACTIVE_COMMITS_VIEW } from "constants/cookies";
 import { DEFAULT_POLL_INTERVAL } from "constants/index";
 import {
   TaskHistoryDirection,
@@ -60,7 +62,9 @@ const TaskHistory: React.FC<TaskHistoryProps> = ({ task }) => {
   const spruceConfig = useSpruceConfig();
   const jiraHost = spruceConfig?.jira?.host ?? "";
 
-  const [viewOption, setViewOption] = useState(ViewOptions.Collapsed);
+  const [viewOption, setViewOption] = useState(
+    Cookies.get(TASK_HISTORY_INACTIVE_COMMITS_VIEW) as ViewOptions,
+  );
   const shouldCollapse = viewOption === ViewOptions.Collapsed;
 
   const { buildVariant, displayName: taskName, project } = task;

--- a/apps/spruce/src/pages/task/taskTabs/TaskHistory/utils/index.ts
+++ b/apps/spruce/src/pages/task/taskTabs/TaskHistory/utils/index.ts
@@ -1,5 +1,5 @@
 import { createRef } from "react";
-import { fromZonedTime } from "date-fns-tz";
+import { fromZonedTime, toZonedTime } from "date-fns-tz";
 import { TaskHistoryTask, GroupedTask } from "../types";
 
 /**
@@ -52,7 +52,7 @@ export const groupTasks = (
 
   const pushDate = (t: TaskHistoryTask) => {
     groupedTasks.push({
-      date: new Date(t.createTime ?? ""),
+      date: t.createTime ?? new Date(),
       inactiveTasks: null,
       task: null,
       isMatching: false,
@@ -141,12 +141,9 @@ export const areDatesOnSameDay = (
   if (!date1 || !date2) {
     return false;
   }
-  const parsedDate1 = timezone
-    ? fromZonedTime(new Date(date1), timezone)
-    : new Date(date1);
-  const parsedDate2 = timezone
-    ? fromZonedTime(new Date(date2), timezone)
-    : new Date(date2);
+  // Use toZonedTime as we want to check for date differences in the target timezone.
+  const parsedDate1 = timezone ? toZonedTime(date1, timezone) : new Date(date1);
+  const parsedDate2 = timezone ? toZonedTime(date2, timezone) : new Date(date2);
   return (
     parsedDate1.getFullYear() === parsedDate2.getFullYear() &&
     parsedDate1.getMonth() === parsedDate2.getMonth() &&


### PR DESCRIPTION
DEVPROD-18287
<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
Dziana gave the following feedback:
* Currently, in collapsed view, when you schedule an inactive task in the middle of a group, the entire group gets collapsed. Sometimes I want to schedule multiple tasks in the group so this is very awkward.

This PR attempts to address this feedback.

### Screenshots
<!-- add screenshots of visible changes -->
Before (opened sections get closed and must be reopened):

https://github.com/user-attachments/assets/7430cd3c-2d7c-4cc6-9e55-74f8243b9b7d

After (opened sections stay open):

https://github.com/user-attachments/assets/94772ac9-8cc3-4cc9-a0b0-3243007d11f1


### Testing
- Added e2e test