### PR TITLE
DEVPROD-18372 Make vpc subnet prefix optional

### DIFF
--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -68,6 +68,11 @@ export type AdminSettings = {
   bannerTheme?: Maybe<BannerTheme>;
 };
 
+export type AdminSettingsInput = {
+  banner?: InputMaybe<Scalars["String"]["input"]>;
+  bannerTheme?: InputMaybe<BannerTheme>;
+};
+
 /**
  * Annotation models the metadata that a user can add to a task.
  * It is used as a field within the Task type.
@@ -1248,6 +1253,7 @@ export type Mutation = {
   restartJasper: Scalars["Int"]["output"];
   restartTask: Task;
   restartVersions?: Maybe<Array<Version>>;
+  saveAdminSettings: AdminSettings;
   saveDistro: SaveDistroPayload;
   saveProjectSettingsForSection: ProjectSettings;
   saveRepoSettingsForSection: RepoSettings;
@@ -1431,6 +1437,10 @@ export type MutationRestartVersionsArgs = {
   abort: Scalars["Boolean"]["input"];
   versionId: Scalars["String"]["input"];
   versionsToRestart: Array<VersionToRestart>;
+};
+
+export type MutationSaveAdminSettingsArgs = {
+  adminSettings: AdminSettingsInput;
 };
 
 export type MutationSaveDistroArgs = {
@@ -2568,6 +2578,14 @@ export enum RoundingRule {
   Up = "UP",
 }
 
+/**
+ * SpruceConfig defines settings that apply to all users of Evergreen.
+ * For example, if the banner field is populated, then a sitewide banner will be shown to all users.
+ */
+export type SaveAdminSettingsInput = {
+  adminSettings: AdminSettingsInput;
+};
+
 /** SaveDistroInput is the input to the saveDistro mutation. */
 export type SaveDistroInput = {
   distro: DistroInput;
@@ -2714,10 +2732,6 @@ export type SpawnVolumeInput = {
   type: Scalars["String"]["input"];
 };
 
-/**
- * SpruceConfig defines settings that apply to all users of Evergreen.
- * For example, if the banner field is populated, then a sitewide banner will be shown to all users.
- */
 export type SpruceConfig = {
   __typename?: "SpruceConfig";
   banner?: Maybe<Scalars["String"]["output"]>;

--- a/apps/spruce/src/pages/distroSettings/tabs/ProviderTab/schemaFields.ts
+++ b/apps/spruce/src/pages/distroSettings/tabs/ProviderTab/schemaFields.ts
@@ -278,7 +278,6 @@ const vpcOptions = {
                 type: "string" as const,
                 title: "VPC Subnet Prefix",
                 default: "",
-                minLength: 1,
               },
             },
           },
@@ -305,6 +304,7 @@ const vpcOptions = {
       "ui:description":
         "Looks for subnets like <prefix>.subnet_1a, <prefix>.subnet_1b, etc.",
       "ui:elementWrapperCSS": indentCSS,
+      "ui:optional": true,
     },
   },
 };


### PR DESCRIPTION
DEVPROD-18372
<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
The runtime environments team would like to leave this field optional to support single task distros which do not need this field.


