### PR TITLE
DEVPROD-11739 Add handling if activated_by parent patch

### DIFF
--- a/.evergreen/generate.yml
+++ b/.evergreen/generate.yml
@@ -18,6 +18,7 @@ functions:
         BUILD_VARIANT: ${build_variant}
         REQUESTER: ${requester}
         TRIGGER_ID: ${trigger_event_identifier}
+        ACTIVATED_BY: ${activated_by}
       binary: "node"
       args:
         - ".evergreen/scripts/generate-parallel-e2e-tasks.js"

--- a/.evergreen/scripts/generate-parallel-e2e-tasks.js
+++ b/.evergreen/scripts/generate-parallel-e2e-tasks.js
@@ -4,6 +4,7 @@ import { APPS_DIR, PACKAGES_DIR, PARALLEL_COUNT, Tasks } from "./constants.js"
 import { hasChangesInDirectory } from "./git-utils.js";
 
 const ALWAYS_GENERATE_TASKS_REQUESTERS = ["trigger", "patch", "commit"];
+const PARENT_PATCH_USER = "parent_patch";
 const EVERGREEN_DIR = join(process.cwd(), "/.evergreen");
 const TASKS_FILE = join(EVERGREEN_DIR, "generate-parallel-e2e-tasks.json");
 /**
@@ -150,7 +151,9 @@ const main = () => {
   // If the task is triggered by a upstream task, we should always generate the tasks
   const shouldAlwaysGenerateTasks = ALWAYS_GENERATE_TASKS_REQUESTERS.includes(requester);
   const isDownstreamTask = triggerId !== undefined && triggerId !== "";
-  const mustGenerateTasks = shouldAlwaysGenerateTasks || isDownstreamTask;
+  const activatedBy = process.env.ACTIVATED_BY;
+  const isActivatedByParentPatch = activatedBy === PARENT_PATCH_USER;
+  const mustGenerateTasks = shouldAlwaysGenerateTasks || isDownstreamTask || isActivatedByParentPatch;
 
   // Check if there are any changes in the given build variant directory
   if (!mustGenerateTasks && !hasChangesInDirectory(`${APPS_DIR}/${buildVariant}`) && !hasChangesInDirectory(PACKAGES_DIR) && !isDownstreamTask) {


### PR DESCRIPTION
DEVPROD-11739
<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
@minnakt  pointed out that we are still not generating e2e tasks if the task is generated by a patch. Looking at the task document it looks like the `activated_by` field will have a special value called `parent_patch`  I think this can be used to determine if we should generate tasks for evergreen patches. There doesn't appear to be any other field that signifies if a downstream task was activated by an upstream one for patches. 
![image](https://github.com/user-attachments/assets/308a5571-8619-4e97-bf47-e7b00e581156)


### Screenshots
<!-- add screenshots of visible changes -->

### Testing
Do it live? Since we can't use set module since this relies on a downstream task trigger instead of a module
