### PR TITLE
DEVPROD-822: Include ANSI results in search

### DIFF
--- a/apps/parsley/package.json
+++ b/apps/parsley/package.json
@@ -89,6 +89,7 @@
     "react-dropzone": "14.3.8",
     "react-router-dom": "6.18.0",
     "react-virtuoso": "4.7.12",
+    "strip-ansi": "^7.1.0",
     "vite-node": "3.1.1",
     "xss": "1.0.15"
   },

--- a/apps/parsley/src/utils/searchLogs/index.ts
+++ b/apps/parsley/src/utils/searchLogs/index.ts
@@ -1,3 +1,4 @@
+import stripAnsi from "strip-ansi";
 import { ProcessedLogLines } from "types/logs";
 import {
   isLogRow,
@@ -59,7 +60,7 @@ const searchLogs = (options: searchOptions): number[] => {
       }
     } else if (isLogRow(processedLogLine)) {
       if (processedLogLine >= lowerBound) {
-        if (searchRegex.test(getLine(processedLogLine))) {
+        if (searchRegex.test(stripAnsi(getLine(processedLogLine)))) {
           matchingLogIndices.add(processedLogLine);
         }
       }

--- a/apps/parsley/src/utils/searchLogs/index.ts
+++ b/apps/parsley/src/utils/searchLogs/index.ts
@@ -54,7 +54,7 @@ const searchLogs = (options: searchOptions): number[] => {
         i < processedLogLine.range.end && i <= upperBound;
         i++
       ) {
-        if (i >= lowerBound && searchRegex.test(getLine(i))) {
+        if (i >= lowerBound && searchRegex.test(stripAnsi(getLine(i)))) {
           matchingLogIndices.add(i);
         }
       }

--- a/apps/parsley/src/utils/searchLogs/searchLogs.test.ts
+++ b/apps/parsley/src/utils/searchLogs/searchLogs.test.ts
@@ -259,4 +259,19 @@ describe("searchLogs", () => {
     const matchingIndices = searchLogs(options);
     expect(matchingIndices).toStrictEqual([1, 2, 5, 8, 9]);
   });
+
+  it("should find matches that include ANSI formatting", () => {
+    const lines = [
+      "[2025/06/24 09:28:08.663] [sentry-vite-plugin] Info: Successfully uploaded source maps to Sentry",
+      "[2025/06/24 09:28:08.663] [2mdist/[22m[32mindex.html",
+    ];
+    const options = {
+      getLine: (index: number) => lines[index],
+      lowerBound: 0,
+      processedLogLines: [0, 1],
+      searchRegex: /dist\/i/,
+    };
+    const matchingIndices = searchLogs(options);
+    expect(matchingIndices).toStrictEqual([1]);
+  });
 });

--- a/apps/parsley/src/utils/searchLogs/searchLogs.test.ts
+++ b/apps/parsley/src/utils/searchLogs/searchLogs.test.ts
@@ -274,4 +274,30 @@ describe("searchLogs", () => {
     const matchingIndices = searchLogs(options);
     expect(matchingIndices).toStrictEqual([1]);
   });
+
+  it("should find matches that include ANSI formatting within sections", () => {
+    const lines = [
+      "[2025/06/24 09:28:08.663] [sentry-vite-plugin] Info: Successfully uploaded source maps to Sentry",
+      "Function Name",
+      "[2025/06/24 09:28:08.663] [2mdist/[22m[32mindex.html",
+    ];
+    const processedLogLines: ProcessedLogLines = [
+      0,
+      {
+        functionID: "function-1",
+        functionName: "test",
+        isOpen: false,
+        range: { end: 3, start: 1 },
+        rowType: RowType.SectionHeader,
+      },
+    ];
+    const options = {
+      getLine: (index: number) => lines[index],
+      lowerBound: 0,
+      processedLogLines,
+      searchRegex: /dist\/i/,
+    };
+    const matchingIndices = searchLogs(options);
+    expect(matchingIndices).toStrictEqual([2]);
+  });
 });


### PR DESCRIPTION
DEVPROD-822
<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
<!-- add description, context, thought process, etc -->
Strip ANSI formatting during search so that matches with formatting can be identified.

### Screenshots
<!-- add screenshots of visible changes -->
<img width="1108" alt="image" src="https://github.com/user-attachments/assets/5c7c45e2-0dd9-46af-885b-4d0c1de72636" />

### Testing
<!-- add a description of how you tested it -->
Add unit test