### PR TITLE
DEVPROD-18676 Ensure task page does not rely on cedar fields

### DIFF
--- a/apps/spruce/src/analytics/task/useAnnotationAnalytics.ts
+++ b/apps/spruce/src/analytics/task/useAnnotationAnalytics.ts
@@ -8,8 +8,10 @@ import {
   BuildBaronQueryVariables,
   TaskQuery,
   TaskQueryVariables,
+  TaskTestCountQuery,
+  TaskTestCountQueryVariables,
 } from "gql/generated/types";
-import { BUILD_BARON, TASK } from "gql/queries";
+import { BUILD_BARON, TASK, TASK_TEST_COUNT } from "gql/queries";
 import { useQueryParam } from "hooks/useQueryParam";
 import { RequiredQueryParams } from "types/task";
 
@@ -53,12 +55,22 @@ export const useAnnotationAnalytics = () => {
     fetchPolicy: "cache-first",
   });
 
+  const { data: taskTestCountData } = useQuery<
+    TaskTestCountQuery,
+    TaskTestCountQueryVariables
+  >(TASK_TEST_COUNT, {
+    variables: {
+      taskId: taskId || "",
+      execution: execution,
+    },
+    fetchPolicy: "cache-first",
+  });
+  const { failedTestCount } = taskTestCountData?.task || {};
   const { buildBaronConfigured } = bbData?.buildBaron || {};
 
   const {
     displayName,
     displayStatus,
-    failedTestCount,
     latestExecution,
     project,
     requester = "",
@@ -71,7 +83,7 @@ export const useAnnotationAnalytics = () => {
   return useAnalyticsRoot<Action, AnalyticsIdentifier>("Annotations", {
     "task.display_status": displayStatus || "",
     "task.execution": execution,
-    "task.failed_test_count": failedTestCount || "",
+    "task.failed_test_count": failedTestCount ?? 0,
     "task.id": taskId || "",
     "task.is_latest_execution": isLatestExecution,
     "task.name": displayName || "",

--- a/apps/spruce/src/analytics/task/useTaskAnalytics.ts
+++ b/apps/spruce/src/analytics/task/useTaskAnalytics.ts
@@ -7,9 +7,11 @@ import {
   TaskQuery,
   TaskQueryVariables,
   TaskSortCategory,
+  TaskTestCountQuery,
+  TaskTestCountQueryVariables,
   TestSortCategory,
 } from "gql/generated/types";
-import { TASK } from "gql/queries";
+import { TASK, TASK_TEST_COUNT } from "gql/queries";
 import { useQueryParam } from "hooks/useQueryParam";
 import { CommitType } from "pages/task/actionButtons/RelevantCommits/types";
 import { RequiredQueryParams, LogTypes } from "types/task";
@@ -83,11 +85,21 @@ export const useTaskAnalytics = () => {
     errorPolicy: "all",
     fetchPolicy: "cache-first",
   });
+  const { data: taskTestCountData } = useQuery<
+    TaskTestCountQuery,
+    TaskTestCountQueryVariables
+  >(TASK_TEST_COUNT, {
+    variables: {
+      taskId: taskId || "",
+      execution: execution,
+    },
+    fetchPolicy: "cache-first",
+  });
+  const { failedTestCount } = taskTestCountData?.task || {};
 
   const {
     displayName,
     displayStatus,
-    failedTestCount,
     latestExecution,
     project,
     requester = "",

--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -802,6 +802,7 @@ export enum HostAccessLevel {
 export type HostAllocatorSettings = {
   __typename?: "HostAllocatorSettings";
   acceptableHostIdleTime: Scalars["Duration"]["output"];
+  autoTuneMaximumHosts: Scalars["Boolean"]["output"];
   feedbackRule: FeedbackRule;
   futureHostFraction: Scalars["Float"]["output"];
   hostsOverallocatedRule: OverallocatedRule;
@@ -813,6 +814,7 @@ export type HostAllocatorSettings = {
 
 export type HostAllocatorSettingsInput = {
   acceptableHostIdleTime: Scalars["Int"]["input"];
+  autoTuneMaximumHosts?: InputMaybe<Scalars["Boolean"]["input"]>;
   feedbackRule: FeedbackRule;
   futureHostFraction: Scalars["Float"]["input"];
   hostsOverallocatedRule: OverallocatedRule;
@@ -8991,6 +8993,22 @@ export type TaskStatusesQuery = {
   };
 };
 
+export type TaskTestCountQueryVariables = Exact<{
+  taskId: Scalars["String"]["input"];
+  execution?: InputMaybe<Scalars["Int"]["input"]>;
+}>;
+
+export type TaskTestCountQuery = {
+  __typename?: "Query";
+  task?: {
+    __typename?: "Task";
+    id: string;
+    execution: number;
+    failedTestCount: number;
+    totalTestCount: number;
+  } | null;
+};
+
 export type TaskTestSampleQueryVariables = Exact<{
   taskIds: Array<Scalars["String"]["input"]>;
   filters: Array<TestFilter>;
@@ -9101,7 +9119,6 @@ export type TaskQuery = {
     distroId: string;
     estimatedStart?: number | null;
     expectedDuration?: number | null;
-    failedTestCount: number;
     finishTime?: Date | null;
     generatedBy?: string | null;
     generatedByName?: string | null;
@@ -9121,7 +9138,6 @@ export type TaskQuery = {
     status: string;
     tags: Array<string>;
     timeTaken?: number | null;
-    totalTestCount: number;
     id: string;
     buildVariant: string;
     buildVariantDisplayName?: string | null;

--- a/apps/spruce/src/gql/mocks/taskData.ts
+++ b/apps/spruce/src/gql/mocks/taskData.ts
@@ -78,7 +78,6 @@ export const taskQuery: TaskQueryType = {
     pod: null,
     execution: 0,
     expectedDuration: 123,
-    failedTestCount: 0,
     hostId: "i-0e0e62799806e037d",
     isPerfPluginEnabled: false,
     latestExecution: 0,
@@ -112,7 +111,6 @@ export const taskQuery: TaskQueryType = {
       "https://evergreen.mongodb.com/spawn?distro_id=ubuntu1604-small&task_id=spruce_ubuntu1604_e2e_test_patch_e0ece5ad52ad01630bdf29f55b9382a26d6256b3_5f4889313627e0544660c800_20_08_28_04_33_55",
     status: "pending",
     files: { __typename: "TaskFiles", fileCount: 38 },
-    totalTestCount: 0,
     versionMetadata: {
       __typename: "Version",
       id: "spruce_ubuntu1604_e0ece5ad52ad01630bdf29f55b9382a26d6256b3_20_08_26_19_20_41",

--- a/apps/spruce/src/gql/queries/index.ts
+++ b/apps/spruce/src/gql/queries/index.ts
@@ -73,6 +73,7 @@ import TASK_NAMES_FOR_BUILD_VARIANT from "./task-names-for-build-variant.graphql
 import TASK_OWNER_TEAM from "./task-owner-team.graphql";
 import TASK_QUEUE_DISTROS from "./task-queue-distros.graphql";
 import TASK_STATUSES from "./task-statuses.graphql";
+import TASK_TEST_COUNT from "./task-test-count.graphql";
 import TASK_TEST_SAMPLE from "./task-test-sample.graphql";
 import TASK_TESTS_FOR_JOB_LOGS from "./task-tests-for-job-logs.graphql";
 import TASK_TESTS from "./task-tests.graphql";
@@ -174,6 +175,7 @@ export {
   TASK_OWNER_TEAM,
   TASK_QUEUE_DISTROS,
   TASK_STATUSES,
+  TASK_TEST_COUNT,
   TASK_TESTS_FOR_JOB_LOGS,
   TASK_TEST_SAMPLE,
   TASK_TESTS,

--- a/apps/spruce/src/gql/queries/task-test-count.graphql
+++ b/apps/spruce/src/gql/queries/task-test-count.graphql
@@ -1,0 +1,8 @@
+query TaskTestCount($taskId: String!, $execution: Int) {
+  task(taskId: $taskId, execution: $execution) {
+    id
+    execution
+    failedTestCount
+    totalTestCount
+  }
+}

--- a/apps/spruce/src/gql/queries/task.graphql
+++ b/apps/spruce/src/gql/queries/task.graphql
@@ -77,7 +77,6 @@ query Task($taskId: String!, $execution: Int) {
       projectIdentifier
     }
     expectedDuration
-    failedTestCount
     files {
       fileCount
     }
@@ -122,7 +121,6 @@ query Task($taskId: String!, $execution: Int) {
     }
     tags
     timeTaken
-    totalTestCount
     versionMetadata {
       id
       author


### PR DESCRIPTION
DEVPROD-18676
<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
Remove dependency on cedar fields
### Screenshots
<img width="1493" alt="image" src="https://github.com/user-attachments/assets/d0ab9c61-088b-4956-9db5-ddca05b95e95" />

### Testing
<!-- add a description of how you tested it -->

<!-- Have you have updated the analytics documentation if necessary?  
https://docs.google.com/spreadsheets/d/1s4_nq8ZiphXp5Uq_-9HT6GPqz-KOyaq6HuvmXYaSNzg/edit?usp=sharing -->

### Evergreen PR
<!-- link to a corresponding Evergreen PR if applicable -->
