### PR TITLE
DEVPROD-18714: Skip Cypress verify step

### DIFF
--- a/.evergreen/shared.yml
+++ b/.evergreen/shared.yml
@@ -188,9 +188,9 @@ functions:
         ${PREPARE_SHELL}
         # Allow spec filtering for an intentional patch.
         if [[ "${cypress_spec}" != "" ]]; then
-          CYPRESS_CI=true yarn cy:run --reporter junit --spec "${cypress_spec}"
+          CYPRESS_CI=true CYPRESS_SKIP_VERIFY=true yarn cy:run --reporter junit --spec "${cypress_spec}"
         else
-          CYPRESS_CI=true yarn cy:run --reporter junit
+          CYPRESS_CI=true CYPRESS_SKIP_VERIFY=true yarn cy:run --reporter junit
         fi
 
   yarn-eslint:


### PR DESCRIPTION
DEVPROD-18714
<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
<!-- add description, context, thought process, etc -->
Add flag to skip [cypress verify](https://docs.cypress.io/app/references/command-line#cypress-verify) step on CI. I believe the verification process timing out was the source of these failures.

### Testing
<!-- add a description of how you tested it -->
[Here](https://spruce.mongodb.com/version/6862bb6dcd604800076120bf/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) is a patch where I was unable to observe the timeout. I'll monitor the task after merging to see if it occurs again.