### PR TITLE
DEVPROD-943: Allow Parsley filters to have descriptions

### DIFF
--- a/apps/parsley/src/components/ProjectFiltersModal/ProjectFilter.tsx
+++ b/apps/parsley/src/components/ProjectFiltersModal/ProjectFilter.tsx
@@ -13,7 +13,7 @@ interface ProjectFilterProps {
   removeFilter: (filterToRemove: string) => void;
   active: boolean;
   selected: boolean;
-  filter: Omit<ParsleyFilter, "description">;
+  filter: ParsleyFilter;
 }
 
 const ProjectFilter: React.FC<ProjectFilterProps> = ({
@@ -41,7 +41,9 @@ const ProjectFilter: React.FC<ProjectFilterProps> = ({
   return (
     <ProjectFilterContainer data-cy="project-filter">
       <Checkbox
+        bold={false}
         checked={active || selected}
+        description={filter.description}
         disabled={active}
         label={
           <>

--- a/apps/parsley/src/components/ProjectFiltersModal/ProjectFiltersModal.test.tsx
+++ b/apps/parsley/src/components/ProjectFiltersModal/ProjectFiltersModal.test.tsx
@@ -169,18 +169,21 @@ const projectFiltersMock: ApolloMock<
           {
             __typename: "ParsleyFilter",
             caseSensitive: true,
+            description: "",
             exactMatch: true,
             expression: "my_filter_1",
           },
           {
             __typename: "ParsleyFilter",
             caseSensitive: true,
+            description: "Filter Two",
             exactMatch: false,
             expression: "my_filter_2",
           },
           {
             __typename: "ParsleyFilter",
             caseSensitive: false,
+            description: "",
             exactMatch: false,
             expression: "my_filter_3",
           },

--- a/apps/parsley/src/gql/generated/types.ts
+++ b/apps/parsley/src/gql/generated/types.ts
@@ -2945,7 +2945,7 @@ export type Task = {
   generateTask?: Maybe<Scalars["Boolean"]["output"]>;
   generatedBy?: Maybe<Scalars["String"]["output"]>;
   generatedByName?: Maybe<Scalars["String"]["output"]>;
-  hasCedarResults: Scalars["Boolean"]["output"];
+  hasTestResults: Scalars["Boolean"]["output"];
   hostId?: Maybe<Scalars["String"]["output"]>;
   id: Scalars["String"]["output"];
   imageId: Scalars["String"]["output"];
@@ -3921,6 +3921,7 @@ export type ProjectFiltersQuery = {
     parsleyFilters?: Array<{
       __typename?: "ParsleyFilter";
       caseSensitive: boolean;
+      description: string;
       exactMatch: boolean;
       expression: string;
     }> | null;

--- a/apps/parsley/src/gql/queries/project-filters.graphql
+++ b/apps/parsley/src/gql/queries/project-filters.graphql
@@ -3,6 +3,7 @@ query ProjectFilters($projectId: String!) {
     id
     parsleyFilters {
       caseSensitive
+      description
       exactMatch
       expression
     }

--- a/apps/parsley/src/test_data/projectFilters.ts
+++ b/apps/parsley/src/test_data/projectFilters.ts
@@ -24,6 +24,7 @@ export const projectFiltersMock: ApolloMock<
           {
             __typename: "ParsleyFilter",
             caseSensitive: true,
+            description: "",
             exactMatch: true,
             expression:
               "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
@@ -31,12 +32,14 @@ export const projectFiltersMock: ApolloMock<
           {
             __typename: "ParsleyFilter",
             caseSensitive: true,
+            description: "",
             exactMatch: false,
             expression: "active filter",
           },
           {
             __typename: "ParsleyFilter",
             caseSensitive: false,
+            description: "Smiley",
             exactMatch: false,
             expression: ":D",
           },

--- a/apps/spruce/src/gql/fragments/projectSettings/viewsAndFilters.graphql
+++ b/apps/spruce/src/gql/fragments/projectSettings/viewsAndFilters.graphql
@@ -2,6 +2,7 @@ fragment ProjectViewsAndFiltersSettings on Project {
   id
   parsleyFilters {
     caseSensitive
+    description
     exactMatch
     expression
   }
@@ -11,6 +12,7 @@ fragment RepoViewsAndFiltersSettings on RepoRef {
   id
   parsleyFilters {
     caseSensitive
+    description
     exactMatch
     expression
   }

--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -4336,6 +4336,7 @@ export type ProjectSettingsFieldsFragment = {
     parsleyFilters?: Array<{
       __typename?: "ParsleyFilter";
       caseSensitive: boolean;
+      description: string;
       exactMatch: boolean;
       expression: string;
     }> | null;
@@ -4534,6 +4535,7 @@ export type RepoSettingsFieldsFragment = {
     parsleyFilters?: Array<{
       __typename?: "ParsleyFilter";
       caseSensitive: boolean;
+      description: string;
       exactMatch: boolean;
       expression: string;
     }> | null;
@@ -4986,6 +4988,7 @@ export type ProjectEventSettingsFragment = {
     parsleyFilters?: Array<{
       __typename?: "ParsleyFilter";
       caseSensitive: boolean;
+      description: string;
       exactMatch: boolean;
       expression: string;
     }> | null;
@@ -5115,6 +5118,7 @@ export type ProjectViewsAndFiltersSettingsFragment = {
   parsleyFilters?: Array<{
     __typename?: "ParsleyFilter";
     caseSensitive: boolean;
+    description: string;
     exactMatch: boolean;
     expression: string;
   }> | null;
@@ -5126,6 +5130,7 @@ export type RepoViewsAndFiltersSettingsFragment = {
   parsleyFilters?: Array<{
     __typename?: "ParsleyFilter";
     caseSensitive: boolean;
+    description: string;
     exactMatch: boolean;
     expression: string;
   }> | null;
@@ -7473,6 +7478,7 @@ export type ProjectEventLogsQuery = {
           parsleyFilters?: Array<{
             __typename?: "ParsleyFilter";
             caseSensitive: boolean;
+            description: string;
             exactMatch: boolean;
             expression: string;
           }> | null;
@@ -7686,6 +7692,7 @@ export type ProjectEventLogsQuery = {
           parsleyFilters?: Array<{
             __typename?: "ParsleyFilter";
             caseSensitive: boolean;
+            description: string;
             exactMatch: boolean;
             expression: string;
           }> | null;
@@ -7964,6 +7971,7 @@ export type ProjectSettingsQuery = {
       parsleyFilters?: Array<{
         __typename?: "ParsleyFilter";
         caseSensitive: boolean;
+        description: string;
         exactMatch: boolean;
         expression: string;
       }> | null;
@@ -8225,6 +8233,7 @@ export type RepoEventLogsQuery = {
           parsleyFilters?: Array<{
             __typename?: "ParsleyFilter";
             caseSensitive: boolean;
+            description: string;
             exactMatch: boolean;
             expression: string;
           }> | null;
@@ -8438,6 +8447,7 @@ export type RepoEventLogsQuery = {
           parsleyFilters?: Array<{
             __typename?: "ParsleyFilter";
             caseSensitive: boolean;
+            description: string;
             exactMatch: boolean;
             expression: string;
           }> | null;
@@ -8656,6 +8666,7 @@ export type RepoSettingsQuery = {
       parsleyFilters?: Array<{
         __typename?: "ParsleyFilter";
         caseSensitive: boolean;
+        description: string;
         exactMatch: boolean;
         expression: string;
       }> | null;

--- a/apps/spruce/src/pages/projectSettings/tabs/ViewsAndFiltersTab/getFormSchema.ts
+++ b/apps/spruce/src/pages/projectSettings/tabs/ViewsAndFiltersTab/getFormSchema.ts
@@ -22,6 +22,11 @@ export const getFormSchema = (
               minLength: 1,
               format: "validRegex",
             },
+            description: {
+              type: "string" as const,
+              title: "Description",
+              default: "",
+            },
             caseSensitive: {
               type: "boolean" as const,
               title: "Case",

--- a/apps/spruce/src/pages/projectSettings/tabs/ViewsAndFiltersTab/transformers.test.ts
+++ b/apps/spruce/src/pages/projectSettings/tabs/ViewsAndFiltersTab/transformers.test.ts
@@ -31,6 +31,7 @@ const repoForm: ViewsFormState = {
   parsleyFilters: [
     {
       displayTitle: "repo-filter",
+      description: "Repo Filter",
       expression: "repo-filter",
       caseSensitive: false,
       exactMatch: false,
@@ -44,6 +45,7 @@ const repoResult: Pick<RepoSettingsInput, "repoId" | "projectRef"> = {
     id: "repo",
     parsleyFilters: [
       {
+        description: "Repo Filter",
         expression: "repo-filter",
         caseSensitive: false,
         exactMatch: false,
@@ -56,12 +58,14 @@ const projectForm: ViewsFormState = {
   parsleyFilters: [
     {
       displayTitle: "filter_1",
+      description: "Filter One",
       expression: "filter_1",
       caseSensitive: true,
       exactMatch: true,
     },
     {
       displayTitle: "filter_2",
+      description: "Filter Two",
       expression: "filter_2",
       caseSensitive: false,
       exactMatch: false,
@@ -75,14 +79,16 @@ const projectResult: Pick<ProjectSettingsInput, "projectId" | "projectRef"> = {
     id: "project",
     parsleyFilters: [
       {
-        expression: "filter_1",
         caseSensitive: true,
+        description: "Filter One",
         exactMatch: true,
+        expression: "filter_1",
       },
       {
-        expression: "filter_2",
         caseSensitive: false,
+        description: "Filter Two",
         exactMatch: false,
+        expression: "filter_2",
       },
     ],
   },

--- a/apps/spruce/src/pages/projectSettings/tabs/ViewsAndFiltersTab/transformers.ts
+++ b/apps/spruce/src/pages/projectSettings/tabs/ViewsAndFiltersTab/transformers.ts
@@ -10,11 +10,11 @@ export const gqlToForm = ((data) => {
 
   return {
     parsleyFilters:
-      // @ts-expect-error: FIXME. This comment was added by an automated script.
-      projectRef.parsleyFilters?.map(
-        ({ caseSensitive, exactMatch, expression }) => ({
+      projectRef?.parsleyFilters?.map(
+        ({ caseSensitive, description, exactMatch, expression }) => ({
           displayTitle: expression,
           expression,
+          description,
           caseSensitive,
           exactMatch,
         }),
@@ -29,8 +29,9 @@ export const formToGql = (({ parsleyFilters }, isRepo, id) => ({
     // @ts-expect-error: FIXME. This comment was added by an automated script.
     id,
     parsleyFilters: parsleyFilters.map(
-      ({ caseSensitive, exactMatch, expression }) => ({
+      ({ caseSensitive, description, exactMatch, expression }) => ({
         expression,
+        description,
         caseSensitive,
         exactMatch,
       }),

--- a/apps/spruce/src/pages/projectSettings/tabs/ViewsAndFiltersTab/types.ts
+++ b/apps/spruce/src/pages/projectSettings/tabs/ViewsAndFiltersTab/types.ts
@@ -2,6 +2,7 @@ import { ProjectType } from "../utils";
 
 type ParsleyFilter = {
   caseSensitive: boolean;
+  description: string;
   displayTitle?: string;
   exactMatch: boolean;
   expression: string;

--- a/apps/spruce/src/pages/projectSettings/tabs/testData.ts
+++ b/apps/spruce/src/pages/projectSettings/tabs/testData.ts
@@ -101,11 +101,13 @@ const projectBase: ProjectSettingsQuery["projectSettings"] = {
     periodicBuilds: [],
     parsleyFilters: [
       {
+        description: "Filter One",
         expression: "filter_1",
         caseSensitive: true,
         exactMatch: true,
       },
       {
+        description: "Filter Two",
         expression: "filter_2",
         caseSensitive: false,
         exactMatch: false,
@@ -308,6 +310,7 @@ const repoBase: RepoSettingsQuery["repoSettings"] = {
     ],
     parsleyFilters: [
       {
+        description: "Repo Filter",
         expression: "repo-filter",
         caseSensitive: false,
         exactMatch: false,


### PR DESCRIPTION
DEVPROD-943
<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->


### Screenshots
<!-- add screenshots of visible changes -->
<img width="523" alt="Screenshot 2025-07-01 at 4 26 08 PM" src="https://github.com/user-attachments/assets/a0691462-1154-48f7-987f-aaabc8b2b567" />

<img width="656" alt="Screenshot 2025-07-01 at 4 26 36 PM" src="https://github.com/user-attachments/assets/536bbd51-ff9e-434c-98cd-d6b66c92eaee" />


