### PR TITLE
DEVPROD-15817: Only show available regions in spawn host modal

### DIFF
--- a/apps/spruce/src/components/Spawn/spawnHostModal/getFormSchema.tsx
+++ b/apps/spruce/src/components/Spawn/spawnHostModal/getFormSchema.tsx
@@ -20,10 +20,11 @@ import { validateTask } from "./utils";
 import { DistroDropdown } from "./Widgets/DistroDropdown";
 
 interface Props {
-  awsRegions: string[];
+  availableRegions: string[];
   disableExpirationCheckbox: boolean;
   distroIdQueryParam?: string;
   distros: {
+    availableRegions: string[];
     adminOnly: boolean;
     isVirtualWorkStation: boolean;
     name?: string;
@@ -46,7 +47,7 @@ interface Props {
 }
 
 export const getFormSchema = ({
-  awsRegions,
+  availableRegions,
   disableExpirationCheckbox,
   distroIdQueryParam,
   distros,
@@ -106,9 +107,12 @@ export const getFormSchema = ({
             region: {
               type: "string" as const,
               title: "Region",
-              default: userAwsRegion || (awsRegions?.length && awsRegions[0]),
+              default:
+                userAwsRegion && availableRegions.includes(userAwsRegion)
+                  ? userAwsRegion
+                  : availableRegions[0],
               oneOf: [
-                ...(awsRegions?.map((r) => ({
+                ...(availableRegions.map((r) => ({
                   type: "string" as const,
                   title: r,
                   enum: [r],
@@ -348,7 +352,7 @@ export const getFormSchema = ({
         },
         region: {
           "ui:data-cy": "region-select",
-          "ui:disabled": isMigration,
+          "ui:disabled": isMigration || availableRegions.length === 0,
           "ui:elementWrapperCSS": dropdownWrapperClassName,
           "ui:placeholder": "Select a region",
           "ui:allowDeselect": false,

--- a/apps/spruce/src/components/Spawn/spawnHostModal/useLoadFormSchemaData.ts
+++ b/apps/spruce/src/components/Spawn/spawnHostModal/useLoadFormSchemaData.ts
@@ -2,14 +2,12 @@ import { useQuery } from "@apollo/client";
 import {
   DistrosQuery,
   DistrosQueryVariables,
-  AwsRegionsQuery,
-  AwsRegionsQueryVariables,
   MyPublicKeysQuery,
   MyPublicKeysQueryVariables,
   MyVolumesQuery,
   MyHostsQueryVariables,
 } from "gql/generated/types";
-import { AWS_REGIONS, DISTROS, MY_PUBLIC_KEYS, MY_VOLUMES } from "gql/queries";
+import { DISTROS, MY_PUBLIC_KEYS, MY_VOLUMES } from "gql/queries";
 import {
   useDisableSpawnExpirationCheckbox,
   useSpruceConfig,
@@ -21,11 +19,6 @@ interface Props {
   host: { noExpiration: boolean };
 }
 export const useLoadFormSchemaData = (p?: Props) => {
-  const { data: awsData, loading: awsLoading } = useQuery<
-    AwsRegionsQuery,
-    AwsRegionsQueryVariables
-  >(AWS_REGIONS);
-
   const { data: distrosData, loading: distrosLoading } = useQuery<
     DistrosQuery,
     DistrosQueryVariables
@@ -62,7 +55,6 @@ export const useLoadFormSchemaData = (p?: Props) => {
   });
   return {
     formSchemaInput: {
-      awsRegions: awsData?.awsRegions,
       disableExpirationCheckbox,
       distros: distrosData?.distros,
       myPublicKeys: publicKeysData?.myPublicKeys,
@@ -70,6 +62,6 @@ export const useLoadFormSchemaData = (p?: Props) => {
       userAwsRegion,
       volumes: volumesData?.myVolumes,
     },
-    loading: distrosLoading || publicKeyLoading || awsLoading || volumesLoading,
+    loading: distrosLoading || publicKeyLoading || volumesLoading,
   };
 };

--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -75,6 +75,27 @@ export type AddFavoriteProjectInput = {
   projectIdentifier: Scalars["String"]["input"];
 };
 
+export type AdminEvent = {
+  __typename?: "AdminEvent";
+  after?: Maybe<Scalars["Map"]["output"]>;
+  before?: Maybe<Scalars["Map"]["output"]>;
+  section?: Maybe<Scalars["String"]["output"]>;
+  timestamp: Scalars["Time"]["output"];
+  user: Scalars["String"]["output"];
+};
+
+/** AdminEventsInput is the input to the adminEvents query. */
+export type AdminEventsInput = {
+  before?: InputMaybe<Scalars["Time"]["input"]>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+};
+
+export type AdminEventsPayload = {
+  __typename?: "AdminEventsPayload";
+  count: Scalars["Int"]["output"];
+  eventLogEntries: Array<AdminEvent>;
+};
+
 export type AdminSettings = {
   __typename?: "AdminSettings";
   api?: Maybe<ApiConfig>;
@@ -2287,6 +2308,7 @@ export type PublicKeyInput = {
 
 export type Query = {
   __typename?: "Query";
+  adminEvents: AdminEventsPayload;
   adminSettings?: Maybe<AdminSettings>;
   awsRegions?: Maybe<Array<Scalars["String"]["output"]>>;
   bbGetCreatedTickets: Array<JiraTicket>;
@@ -2333,6 +2355,10 @@ export type Query = {
   version: Version;
   viewableProjectRefs: Array<GroupedProjects>;
   waterfall: Waterfall;
+};
+
+export type QueryAdminEventsArgs = {
+  opts: AdminEventsInput;
 };
 
 export type QueryBbGetCreatedTicketsArgs = {
@@ -2688,10 +2714,6 @@ export type SesConfigInput = {
   senderAddress: Scalars["String"]["input"];
 };
 
-/**
- * SpruceConfig defines settings that apply to all users of Evergreen.
- * For example, if the banner field is populated, then a sitewide banner will be shown to all users.
- */
 export type SaveAdminSettingsInput = {
   adminSettings: AdminSettingsInput;
 };
@@ -2964,6 +2986,10 @@ export type SpawnVolumeInput = {
   type: Scalars["String"]["input"];
 };
 
+/**
+ * SpruceConfig defines settings that apply to all users of Evergreen.
+ * For example, if the banner field is populated, then a sitewide banner will be shown to all users.
+ */
 export type SpruceConfig = {
   __typename?: "SpruceConfig";
   banner?: Maybe<Scalars["String"]["output"]>;
@@ -6781,6 +6807,7 @@ export type DistrosQuery = {
   distros: Array<{
     __typename?: "Distro";
     adminOnly: boolean;
+    availableRegions: Array<string>;
     isVirtualWorkStation: boolean;
     name: string;
   }>;

--- a/apps/spruce/src/gql/queries/distros.graphql
+++ b/apps/spruce/src/gql/queries/distros.graphql
@@ -1,6 +1,7 @@
 query Distros($onlySpawnable: Boolean!) {
   distros(onlySpawnable: $onlySpawnable) {
     adminOnly
+    availableRegions
     isVirtualWorkStation
     name
   }

--- a/apps/spruce/src/pages/distroSettings/DistroSelect/DistroSelect.test.tsx
+++ b/apps/spruce/src/pages/distroSettings/DistroSelect/DistroSelect.test.tsx
@@ -78,18 +78,21 @@ const distrosMock: ApolloMock<DistrosQuery, DistrosQueryVariables> = {
         {
           __typename: "Distro",
           adminOnly: false,
+          availableRegions: [],
           isVirtualWorkStation: true,
           name: "localhost",
         },
         {
           __typename: "Distro",
           adminOnly: true,
+          availableRegions: [],
           isVirtualWorkStation: false,
           name: "localhost2",
         },
         {
           __typename: "Distro",
           adminOnly: true,
+          availableRegions: [],
           isVirtualWorkStation: true,
           name: "abc",
         },

--- a/apps/spruce/src/pages/spawn/spawnHost/spawnHostButton/SpawnHostModal.tsx
+++ b/apps/spruce/src/pages/spawn/spawnHost/spawnHostButton/SpawnHostModal.tsx
@@ -109,6 +109,7 @@ export const SpawnHostModal: React.FC<SpawnHostModalProps> = ({
   // @ts-expect-error: FIXME. This comment was added by an automated script.
   const { schema, uiSchema } = getFormSchema({
     ...formSchemaInput,
+    availableRegions: selectedDistro?.availableRegions ?? [],
     distroIdQueryParam,
     hostUptimeWarnings,
     isMigration: false,


### PR DESCRIPTION
DEVPROD-15817
<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
Instead of showing all AWS regions we support, only show the regions that each distro supports.

### Screenshots
<!-- add screenshots of visible changes -->
<img width="615" height="239" alt="Screenshot 2025-07-15 at 5 09 35 PM" src="https://github.com/user-attachments/assets/156737e1-335d-4163-ab6e-e28ac0ef9284" />
