### PR TITLE
DEVPROD-19304: Add pagination buttons to bottom of patches page

### DIFF
--- a/apps/spruce/src/components/PatchesPage/PaginationButtons.tsx
+++ b/apps/spruce/src/components/PatchesPage/PaginationButtons.tsx
@@ -1,0 +1,51 @@
+import styled from "@emotion/styled";
+import PageSizeSelector from "@evg-ui/lib/components/PageSizeSelector";
+import Pagination from "@evg-ui/lib/components/Pagination";
+import { size } from "@evg-ui/lib/constants/tokens";
+import usePagination from "@evg-ui/lib/src/hooks/usePagination";
+import { useProjectPatchesAnalytics, useUserPatchesAnalytics } from "analytics";
+import { usePatchesQueryParams } from "./usePatchesQueryParams";
+
+interface PaginationButtonsProps {
+  pageType: "project" | "user";
+  filteredPatchCount?: number;
+}
+
+export const PaginationButtons: React.FC<PaginationButtonsProps> = ({
+  filteredPatchCount = 0,
+  pageType,
+}) => {
+  const userPatchesAnalytics = useUserPatchesAnalytics();
+  const projectPatchesAnalytics = useProjectPatchesAnalytics();
+  const analytics =
+    pageType === "project" ? projectPatchesAnalytics : userPatchesAnalytics;
+
+  const { setLimit } = usePagination();
+  const { limit, page } = usePatchesQueryParams();
+  const handlePageSizeChange = (pageSize: number): void => {
+    setLimit(pageSize);
+    analytics.sendEvent({ name: "Changed page size" });
+  };
+
+  return (
+    <PaginationRow>
+      <Pagination
+        currentPage={page}
+        pageSize={limit}
+        totalResults={filteredPatchCount}
+      />
+      <PageSizeSelector
+        data-cy="my-patches-page-size-selector"
+        onChange={handlePageSizeChange}
+        value={limit}
+      />
+    </PaginationRow>
+  );
+};
+
+const PaginationRow = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  margin-top: ${size.s};
+`;

--- a/apps/spruce/src/components/PatchesPage/index.tsx
+++ b/apps/spruce/src/components/PatchesPage/index.tsx
@@ -1,12 +1,9 @@
 import styled from "@emotion/styled";
 import Checkbox from "@leafygreen-ui/checkbox";
 import Cookies from "js-cookie";
-import PageSizeSelector from "@evg-ui/lib/components/PageSizeSelector";
-import Pagination from "@evg-ui/lib/components/Pagination";
 import { size } from "@evg-ui/lib/constants/tokens";
 import { useQueryParam } from "@evg-ui/lib/hooks";
 import { usePageTitle } from "@evg-ui/lib/hooks/usePageTitle";
-import usePagination from "@evg-ui/lib/src/hooks/usePagination";
 import { useProjectPatchesAnalytics, useUserPatchesAnalytics } from "analytics";
 import { PageWrapper, FiltersWrapper, PageTitle } from "components/styles";
 import TextInputWithValidation from "components/TextInputWithValidation";
@@ -16,8 +13,8 @@ import { useFilterInputChangeHandler } from "hooks";
 import { PatchPageQueryParams } from "types/patch";
 import { validateRegexp } from "utils/validators";
 import ListArea from "./ListArea";
+import { PaginationButtons } from "./PaginationButtons";
 import { StatusSelector } from "./StatusSelector";
-import { usePatchesQueryParams } from "./usePatchesQueryParams";
 
 interface Props {
   filterComp?: React.ReactNode;
@@ -39,14 +36,6 @@ export const PatchesPage: React.FC<Props> = ({
   const projectPatchesAnalytics = useProjectPatchesAnalytics();
   const analytics =
     pageType === "project" ? projectPatchesAnalytics : userPatchesAnalytics;
-
-  // Handle pagination logic.
-  const { setLimit } = usePagination();
-  const { limit, page } = usePatchesQueryParams();
-  const handlePageSizeChange = (pageSize: number): void => {
-    setLimit(pageSize);
-    analytics.sendEvent({ name: "Changed page size" });
-  };
 
   // Handle filtering by patch description.
   const { setAndSubmitInputValue } = useFilterInputChangeHandler({
@@ -97,32 +86,24 @@ export const PatchesPage: React.FC<Props> = ({
           onChange={includeHiddenCheckboxOnChange}
         />
       </FiltersWrapperSpaceBetween>
-      <PaginationRow>
-        <Pagination
-          currentPage={page}
-          pageSize={limit}
-          totalResults={patches?.filteredPatchCount ?? 0}
-        />
-        <PageSizeSelector
-          data-cy="my-patches-page-size-selector"
-          onChange={handlePageSizeChange}
-          value={limit}
-        />
-      </PaginationRow>
+      <PaginationButtons
+        filteredPatchCount={patches?.filteredPatchCount}
+        pageType={pageType}
+      />
       <ListArea
         loading={loading}
         pageType={pageType}
         patches={patches?.patches || []}
       />
+      {!loading && (
+        <PaginationButtons
+          filteredPatchCount={patches?.filteredPatchCount}
+          pageType={pageType}
+        />
+      )}
     </PageWrapper>
   );
 };
-
-const PaginationRow = styled.div`
-  display: flex;
-  justify-content: flex-end;
-  align-items: center;
-`;
 
 const FiltersWrapperSpaceBetween = styled(FiltersWrapper)`
   display: grid;

--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -75,6 +75,27 @@ export type AddFavoriteProjectInput = {
   projectIdentifier: Scalars["String"]["input"];
 };
 
+export type AdminEvent = {
+  __typename?: "AdminEvent";
+  after?: Maybe<Scalars["Map"]["output"]>;
+  before?: Maybe<Scalars["Map"]["output"]>;
+  section?: Maybe<Scalars["String"]["output"]>;
+  timestamp: Scalars["Time"]["output"];
+  user: Scalars["String"]["output"];
+};
+
+/** AdminEventsInput is the input to the adminEvents query. */
+export type AdminEventsInput = {
+  before?: InputMaybe<Scalars["Time"]["input"]>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+};
+
+export type AdminEventsPayload = {
+  __typename?: "AdminEventsPayload";
+  count: Scalars["Int"]["output"];
+  eventLogEntries: Array<AdminEvent>;
+};
+
 export type AdminSettings = {
   __typename?: "AdminSettings";
   api?: Maybe<ApiConfig>;
@@ -2287,6 +2308,7 @@ export type PublicKeyInput = {
 
 export type Query = {
   __typename?: "Query";
+  adminEvents: AdminEventsPayload;
   adminSettings?: Maybe<AdminSettings>;
   awsRegions?: Maybe<Array<Scalars["String"]["output"]>>;
   bbGetCreatedTickets: Array<JiraTicket>;
@@ -2333,6 +2355,10 @@ export type Query = {
   version: Version;
   viewableProjectRefs: Array<GroupedProjects>;
   waterfall: Waterfall;
+};
+
+export type QueryAdminEventsArgs = {
+  opts: AdminEventsInput;
 };
 
 export type QueryBbGetCreatedTicketsArgs = {
@@ -2688,10 +2714,6 @@ export type SesConfigInput = {
   senderAddress: Scalars["String"]["input"];
 };
 
-/**
- * SpruceConfig defines settings that apply to all users of Evergreen.
- * For example, if the banner field is populated, then a sitewide banner will be shown to all users.
- */
 export type SaveAdminSettingsInput = {
   adminSettings: AdminSettingsInput;
 };
@@ -2964,6 +2986,10 @@ export type SpawnVolumeInput = {
   type: Scalars["String"]["input"];
 };
 
+/**
+ * SpruceConfig defines settings that apply to all users of Evergreen.
+ * For example, if the banner field is populated, then a sitewide banner will be shown to all users.
+ */
 export type SpruceConfig = {
   __typename?: "SpruceConfig";
   banner?: Maybe<Scalars["String"]["output"]>;


### PR DESCRIPTION
DEVPROD-19304
<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
Add pagination buttons to bottom of the patches page so that users don't have to scroll all of the way up to go to the next page.

### Screenshots
<!-- add screenshots of visible changes -->
<img width="1443" height="297" alt="Screenshot 2025-07-16 at 11 42 45 AM" src="https://github.com/user-attachments/assets/5129c098-baec-4e4b-a42b-df594537b438" />


