### PR TITLE
DEVPROD-17219 remove spot fleet options from distro UI

### DIFF
--- a/apps/spruce/cypress/integration/distroSettings/provider_section.ts
+++ b/apps/spruce/cypress/integration/distroSettings/provider_section.ts
@@ -93,13 +93,6 @@ describe("provider section", () => {
     });
 
     it("shows and hides fields correctly", () => {
-      // Fleet options.
-      cy.getInputByLabel("Fleet Instance Type").contains("On-demand");
-      cy.contains("Capacity optimization").should("not.exist");
-
-      cy.selectLGOption("Fleet Instance Type", "Spot");
-      cy.contains("Capacity optimization").should("exist");
-
       // VPC options.
       cy.dataCy("use-vpc").should("be.checked");
       cy.contains("Default VPC Subnet ID").should("exist");
@@ -123,7 +116,7 @@ describe("provider section", () => {
       cy.getInputByLabel("SSH Key Name").as("keyNameInput");
       cy.get("@keyNameInput").clear();
       cy.get("@keyNameInput").type("my ssh key");
-      cy.selectLGOption("Fleet Instance Type", "Spot");
+
       cy.contains("button", "Add mount point").click();
       cy.getInputByLabel("Device Name").type("device name");
       cy.getInputByLabel("Size").type("200");
@@ -134,7 +127,7 @@ describe("provider section", () => {
       cy.selectLGOption("Region", "us-east-1");
       cy.get("@keyNameInput").clear();
       cy.get("@keyNameInput").type("mci");
-      cy.selectLGOption("Fleet Instance Type", "On-demand");
+
       cy.dataCy("mount-points").within(() => {
         cy.dataCy("delete-item-button").click();
       });

--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -75,6 +75,27 @@ export type AddFavoriteProjectInput = {
   projectIdentifier: Scalars["String"]["input"];
 };
 
+export type AdminEvent = {
+  __typename?: "AdminEvent";
+  after?: Maybe<Scalars["Map"]["output"]>;
+  before?: Maybe<Scalars["Map"]["output"]>;
+  section?: Maybe<Scalars["String"]["output"]>;
+  timestamp: Scalars["Time"]["output"];
+  user: Scalars["String"]["output"];
+};
+
+/** AdminEventsInput is the input to the adminEvents query. */
+export type AdminEventsInput = {
+  before?: InputMaybe<Scalars["Time"]["input"]>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+};
+
+export type AdminEventsPayload = {
+  __typename?: "AdminEventsPayload";
+  count: Scalars["Int"]["output"];
+  eventLogEntries: Array<AdminEvent>;
+};
+
 export type AdminSettings = {
   __typename?: "AdminSettings";
   api?: Maybe<ApiConfig>;
@@ -2287,6 +2308,7 @@ export type PublicKeyInput = {
 
 export type Query = {
   __typename?: "Query";
+  adminEvents: AdminEventsPayload;
   adminSettings?: Maybe<AdminSettings>;
   awsRegions?: Maybe<Array<Scalars["String"]["output"]>>;
   bbGetCreatedTickets: Array<JiraTicket>;
@@ -2333,6 +2355,10 @@ export type Query = {
   version: Version;
   viewableProjectRefs: Array<GroupedProjects>;
   waterfall: Waterfall;
+};
+
+export type QueryAdminEventsArgs = {
+  opts: AdminEventsInput;
 };
 
 export type QueryBbGetCreatedTicketsArgs = {
@@ -2688,10 +2714,6 @@ export type SesConfigInput = {
   senderAddress: Scalars["String"]["input"];
 };
 
-/**
- * SpruceConfig defines settings that apply to all users of Evergreen.
- * For example, if the banner field is populated, then a sitewide banner will be shown to all users.
- */
 export type SaveAdminSettingsInput = {
   adminSettings: AdminSettingsInput;
 };
@@ -2964,6 +2986,10 @@ export type SpawnVolumeInput = {
   type: Scalars["String"]["input"];
 };
 
+/**
+ * SpruceConfig defines settings that apply to all users of Evergreen.
+ * For example, if the banner field is populated, then a sitewide banner will be shown to all users.
+ */
 export type SpruceConfig = {
   __typename?: "SpruceConfig";
   banner?: Maybe<Scalars["String"]["output"]>;

--- a/apps/spruce/src/pages/distroSettings/tabs/ProviderTab/schemaFields.ts
+++ b/apps/spruce/src/pages/distroSettings/tabs/ProviderTab/schemaFields.ts
@@ -1,11 +1,6 @@
 import { AccordionFieldTemplate } from "components/SpruceForm/FieldTemplates";
-import {
-  textAreaCSS,
-  mergeCheckboxCSS,
-  capacityCheckboxCSS,
-  indentCSS,
-} from "./styles";
-import { BuildType, FleetInstanceType } from "./types";
+import { textAreaCSS, mergeCheckboxCSS, indentCSS } from "./styles";
+import { BuildType } from "./types";
 
 const userData = {
   schema: {
@@ -164,77 +159,6 @@ const sshKeyName = {
   },
   uiSchema: {
     "ui:description": "SSH key to add to the host machine.",
-  },
-};
-
-const fleetOptions = {
-  schema: {
-    type: "object" as const,
-    title: "",
-    properties: {
-      fleetInstanceType: {
-        type: "string" as const,
-        title: "Fleet Instance Type",
-        default: FleetInstanceType.Spot,
-        oneOf: [
-          {
-            type: "string" as const,
-            title: "Spot",
-            enum: [FleetInstanceType.Spot],
-          },
-          {
-            type: "string" as const,
-            title: "Spot with on-demand fallback",
-            enum: [FleetInstanceType.SpotWithOnDemandFallback],
-          },
-          {
-            type: "string" as const,
-            title: "On-demand",
-            enum: [FleetInstanceType.OnDemand],
-          },
-        ],
-      },
-    },
-    dependencies: {
-      fleetInstanceType: {
-        oneOf: [
-          {
-            properties: {
-              fleetInstanceType: {
-                enum: [FleetInstanceType.OnDemand],
-              },
-            },
-          },
-          {
-            properties: {
-              fleetInstanceType: {
-                enum: [
-                  FleetInstanceType.Spot,
-                  FleetInstanceType.SpotWithOnDemandFallback,
-                ],
-              },
-              useCapacityOptimization: {
-                type: "boolean" as const,
-                title: "Capacity optimization",
-                default: false,
-              },
-            },
-          },
-        ],
-      },
-    },
-  },
-  uiSchema: {
-    fleetInstanceType: {
-      "ui:allowDeselect": false,
-    },
-    useCapacityOptimization: {
-      "ui:data-cy": "use-capacity-optimization",
-      "ui:bold": true,
-      "ui:description":
-        "Use the capacity-optimized allocation strategy for spot (default: lowest-cost)",
-      "ui:elementWrapperCSS": capacityCheckboxCSS,
-    },
   },
 };
 
@@ -399,7 +323,6 @@ export const ec2FleetProviderSettings = {
     amiId: amiId.schema,
     instanceType: instanceType.schema,
     sshKeyName: sshKeyName.schema,
-    fleetOptions: fleetOptions.schema,
     instanceProfileARN: instanceProfileARN.schema,
     doNotAssignPublicIPv4Address: doNotAssignPublicIPv4Address.schema,
     mergeUserData: mergeUserData.schema,
@@ -413,7 +336,6 @@ export const ec2FleetProviderSettings = {
     instanceType: instanceType.uiSchema,
     sshKeyName: sshKeyName.uiSchema,
     instanceProfileARN: instanceProfileARN.uiSchema,
-    fleetOptions: fleetOptions.uiSchema,
     doNotAssignPublicIPv4Address: doNotAssignPublicIPv4Address.uiSchema,
     mergeUserData: mergeUserData.uiSchema,
     userData: userData.uiSchema,

--- a/apps/spruce/src/pages/distroSettings/tabs/ProviderTab/styles.ts
+++ b/apps/spruce/src/pages/distroSettings/tabs/ProviderTab/styles.ts
@@ -1,7 +1,6 @@
 import { css } from "@emotion/react";
 import { fontFamilies } from "@leafygreen-ui/tokens";
 import { size } from "@evg-ui/lib/constants/tokens";
-import { STANDARD_FIELD_WIDTH } from "components/SpruceForm/utils";
 
 const textAreaCSS = css`
   box-sizing: border-box;
@@ -16,13 +15,9 @@ const mergeCheckboxCSS = css`
   margin-bottom: -20px;
 `;
 
-const capacityCheckboxCSS = css`
-  max-width: ${STANDARD_FIELD_WIDTH}px;
-`;
-
 const indentCSS = css`
   box-sizing: border-box;
   padding-left: ${size.m};
 `;
 
-export { textAreaCSS, mergeCheckboxCSS, capacityCheckboxCSS, indentCSS };
+export { textAreaCSS, mergeCheckboxCSS, indentCSS };

--- a/apps/spruce/src/pages/distroSettings/tabs/ProviderTab/transformerUtils.ts
+++ b/apps/spruce/src/pages/distroSettings/tabs/ProviderTab/transformerUtils.ts
@@ -17,7 +17,6 @@ interface ProviderSettingsList {
   instance_type: string;
   key_name: string;
 
-  fallback: boolean;
   iam_instance_profile_arn: string;
   do_not_assign_public_ipv4_address: boolean;
   is_vpc: boolean;

--- a/apps/spruce/src/pages/distroSettings/tabs/ProviderTab/transformerUtils.ts
+++ b/apps/spruce/src/pages/distroSettings/tabs/ProviderTab/transformerUtils.ts
@@ -1,5 +1,5 @@
 import { Unpacked } from "@evg-ui/lib/types/utils";
-import { BuildType, ProviderFormState, FleetInstanceType } from "./types";
+import { BuildType, ProviderFormState } from "./types";
 
 /**
  * The provider settings list is untyped in the backend, so we manually define types here.
@@ -16,10 +16,7 @@ interface ProviderSettingsList {
   ami: string;
   instance_type: string;
   key_name: string;
-  fleet_options: {
-    use_on_demand: boolean;
-    use_capacity_optimized: boolean;
-  };
+
   fallback: boolean;
   iam_instance_profile_arn: string;
   do_not_assign_public_ipv4_address: boolean;
@@ -36,21 +33,6 @@ interface ProviderSettingsList {
   }>;
   region: string;
 }
-
-const getFleetInstanceType = (
-  providerSettings: Partial<ProviderSettingsList> = {},
-) => {
-  if (providerSettings.fleet_options?.use_on_demand) {
-    return FleetInstanceType.OnDemand;
-  }
-  if (
-    !providerSettings.fleet_options?.use_on_demand &&
-    providerSettings.fallback
-  ) {
-    return FleetInstanceType.SpotWithOnDemandFallback;
-  }
-  return FleetInstanceType.Spot;
-};
 
 export const formProviderSettings = (
   providerSettings: Partial<ProviderSettingsList> = {},
@@ -78,11 +60,6 @@ export const formProviderSettings = (
     amiId: providerSettings.ami ?? "",
     instanceType: providerSettings.instance_type ?? "",
     sshKeyName: providerSettings.key_name ?? "",
-    fleetOptions: {
-      fleetInstanceType: getFleetInstanceType(providerSettings),
-      useCapacityOptimization:
-        providerSettings.fleet_options?.use_capacity_optimized ?? false,
-    },
     instanceProfileARN: providerSettings.iam_instance_profile_arn ?? "",
     doNotAssignPublicIPv4Address:
       providerSettings.do_not_assign_public_ipv4_address ?? false,
@@ -137,7 +114,7 @@ type ProviderSettings = ProviderFormState["staticProviderSettings"] &
 export const gqlProviderSettings = (
   providerSettings: Partial<ProviderSettings> = {},
 ) => {
-  const { fleetOptions, vpcOptions } = providerSettings;
+  const { vpcOptions } = providerSettings;
   return {
     staticProviderSettings: {
       user_data: providerSettings.userData,
@@ -165,17 +142,6 @@ export const gqlProviderSettings = (
       ami: providerSettings.amiId,
       instance_type: providerSettings.instanceType,
       key_name: providerSettings.sshKeyName,
-      fleet_options: {
-        use_on_demand:
-          fleetOptions?.fleetInstanceType === FleetInstanceType.OnDemand,
-        use_capacity_optimized:
-          fleetOptions?.fleetInstanceType === FleetInstanceType.OnDemand
-            ? false
-            : fleetOptions?.useCapacityOptimization,
-      },
-      fallback:
-        fleetOptions?.fleetInstanceType ===
-        FleetInstanceType.SpotWithOnDemandFallback,
       iam_instance_profile_arn: providerSettings.instanceProfileARN,
       do_not_assign_public_ipv4_address:
         providerSettings.doNotAssignPublicIPv4Address,

--- a/apps/spruce/src/pages/distroSettings/tabs/ProviderTab/transformers.test.ts
+++ b/apps/spruce/src/pages/distroSettings/tabs/ProviderTab/transformers.test.ts
@@ -1,7 +1,7 @@
 import { DistroInput, Provider } from "gql/generated/types";
 import { distroData } from "../testData";
 import { formToGql, gqlToForm } from "./transformers";
-import { BuildType, FleetInstanceType, ProviderFormState } from "./types";
+import { BuildType, ProviderFormState } from "./types";
 
 const defaultFormState = {
   staticProviderSettings: {
@@ -26,10 +26,6 @@ const defaultFormState = {
       region: "",
       displayTitle: undefined,
       amiId: "",
-      fleetOptions: {
-        fleetInstanceType: FleetInstanceType.Spot,
-        useCapacityOptimization: false,
-      },
       instanceProfileARN: "",
       instanceType: "",
       mergeUserData: false,
@@ -208,10 +204,7 @@ describe("provider tab", () => {
           ami: "ami-east",
           instance_type: "m5.xlarge",
           key_name: "admin",
-          fleet_options: {
-            use_on_demand: false,
-            use_capacity_optimized: true,
-          },
+
           fallback: true,
           iam_instance_profile_arn: "profile-east",
           is_vpc: true,
@@ -243,10 +236,6 @@ describe("provider tab", () => {
           region: "us-east-1",
           displayTitle: "us-east-1",
           amiId: "ami-east",
-          fleetOptions: {
-            fleetInstanceType: FleetInstanceType.SpotWithOnDemandFallback,
-            useCapacityOptimization: true,
-          },
           instanceProfileARN: "profile-east",
           instanceType: "m5.xlarge",
           mergeUserData: false,
@@ -322,10 +311,7 @@ describe("provider tab", () => {
           ami: "ami-east",
           instance_type: "m5.xlarge",
           key_name: "admin",
-          fleet_options: {
-            use_on_demand: false,
-            use_capacity_optimized: true,
-          },
+
           fallback: true,
           iam_instance_profile_arn: "profile-east",
           is_vpc: true,
@@ -400,10 +386,6 @@ describe("provider tab", () => {
           region: "us-east-1",
           displayTitle: "us-east-1",
           amiId: "ami-east",
-          fleetOptions: {
-            fleetInstanceType: FleetInstanceType.Spot,
-            useCapacityOptimization: false,
-          },
           instanceProfileARN: "profile-east",
           instanceType: "m5.xlarge",
           mergeUserData: false,

--- a/apps/spruce/src/pages/distroSettings/tabs/ProviderTab/transformers.test.ts
+++ b/apps/spruce/src/pages/distroSettings/tabs/ProviderTab/transformers.test.ts
@@ -205,7 +205,6 @@ describe("provider tab", () => {
           instance_type: "m5.xlarge",
           key_name: "admin",
 
-          fallback: true,
           iam_instance_profile_arn: "profile-east",
           is_vpc: true,
           subnet_id: "subnet-east",
@@ -312,7 +311,6 @@ describe("provider tab", () => {
           instance_type: "m5.xlarge",
           key_name: "admin",
 
-          fallback: true,
           iam_instance_profile_arn: "profile-east",
           is_vpc: true,
           subnet_id: "subnet-east",

--- a/apps/spruce/src/pages/distroSettings/tabs/ProviderTab/types.ts
+++ b/apps/spruce/src/pages/distroSettings/tabs/ProviderTab/types.ts
@@ -5,12 +5,6 @@ export enum BuildType {
   Pull = "pull",
 }
 
-export enum FleetInstanceType {
-  Spot = "spot",
-  OnDemand = "on-demand",
-  SpotWithOnDemandFallback = "fallback",
-}
-
 export type ProviderFormState = {
   provider: {
     providerName: Provider;
@@ -41,10 +35,6 @@ export type ProviderFormState = {
     amiId: string;
     instanceType: string;
     sshKeyName: string;
-    fleetOptions: {
-      fleetInstanceType: FleetInstanceType;
-      useCapacityOptimization: boolean;
-    };
     instanceProfileARN: string;
     doNotAssignPublicIPv4Address: boolean;
     vpcOptions: {


### PR DESCRIPTION
DEVPROD-17219
### Description
Remove fleet options from the the distro UI; we should only have on-demand for this.

### Screenshots
Screenshot is kind of lame since I removed something haha, but it looks normal, and i was able to save without issues.
<img width="524" height="493" alt="image" src="https://github.com/user-attachments/assets/ca6a8c13-0579-4772-a0c1-99b0f5df733b" />

### Testing
Removed from tests; I think this doesn't have to update the analytics table.

### Evergreen PR
https://github.com/evergreen-ci/evergreen/pull/9223