### PR TITLE
DEVPROD-19315: Stabilize useQueryParam hooks

### DIFF
--- a/packages/lib/src/hooks/useQueryParam/index.ts
+++ b/packages/lib/src/hooks/useQueryParam/index.ts
@@ -43,7 +43,7 @@ const useQueryParam = <T>(
   defaultParam: T,
   parseOptions?: ParseOptions,
 ): readonly [T, (set: T) => void] => {
-  const [searchParams, setSearchParams] = useQueryParams(parseOptions ?? {});
+  const [searchParams, setSearchParams] = useQueryParams(parseOptions);
 
   const setQueryParam = useCallback(
     (value: T) => {


### PR DESCRIPTION
DEVPROD-19315
<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
<!-- add description, context, thought process, etc -->
A waterfall page was encountering an infinite loop due to the result of `useQueryParams` continuously triggering a `useEffect` hook. This turned out to be the fault of a default parameter in `useQueryParams`; its reassignment was causing a `useMemo` within that hook to constantly reevaluate.

I was honestly kinda surprised by this! It's a good gotcha to be aware of. I also fixed it in `useQueryParam` but would note that this hook is still not totally stable due to https://github.com/remix-run/react-router/issues/9991

### Testing
<!-- add a description of how you tested it -->
Check out https://spruce-local.corp.mongodb.com:8443/project/mms-v20250716/waterfall?buildVariants=ACAD2, there's no more infinite loop.
