### PR TITLE
DEVPROD-15509: Allow toggling admin-only for private variables

### DIFF
--- a/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/VariablesTab/VariableRow.tsx
+++ b/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/VariablesTab/VariableRow.tsx
@@ -10,10 +10,12 @@ const { yellow } = palette;
 export const VariableRow: React.FC<
   Pick<ObjectFieldTemplateProps, "formData" | "properties" | "uiSchema">
 > = ({ formData, properties, uiSchema }) => {
-  const [variableName, variableValue, isPrivate, isAdminOnly] = getFields(
+  const [variableName, variableValue, isPrivate] = getFields(
     properties,
     formData.isDisabled,
   );
+  const [, , , isAdminOnly] = getFields(properties, false);
+
   const repoData = uiSchema?.options?.repoData;
   const inRepo = repoData
     ? // @ts-expect-error: FIXME. This comment was added by an automated script.


### PR DESCRIPTION
DEVPROD-15509
<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
Make the admin-only checkbox toggleable regardless of variable private-ness

### Screenshots
<img width="678" height="135" alt="Screenshot 2025-07-21 at 10 48 49 AM" src="https://github.com/user-attachments/assets/576e1e4e-4767-4c3e-9ee6-0f52f5e9f8af" />

<!-- add screenshots of visible changes -->
