### PR TITLE
DEVPROD-17659 Add merge queue subscriber type

### DIFF
--- a/apps/spruce/src/constants/triggers.ts
+++ b/apps/spruce/src/constants/triggers.ts
@@ -58,6 +58,7 @@ export const requesterSubscriberOptions = {
   [Requester.Gitter]: "Commit",
   [Requester.Patch]: "Patch",
   [Requester.GitHubPR]: "Pull Request",
+  [Requester.GitHubMergeQueue]: "Merge Queue",
   [Requester.AdHoc]: "Periodic Build",
   [Requester.GitTag]: "Git Tag",
 };


### PR DESCRIPTION
DEVPROD-17659
<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
This adds the merge queue subscriber type. I tested this on the app side, by manually setting the subscriber values to the merge queue, and it worked as expected. This just needs to be added to the UI.

### Screenshots
<!-- add screenshots of visible changes -->
The UI:
<img width="619" height="570" alt="Screenshot 2025-07-28 at 12 24 27 PM" src="https://github.com/user-attachments/assets/4540b276-0f1b-4909-9818-82cabfe4f1ec" />
<img width="611" height="563" alt="Screenshot 2025-07-28 at 12 24 39 PM" src="https://github.com/user-attachments/assets/76b70983-5c71-4620-8c49-87317665d0ae" />

After doing it, the DB:
<img width="415" height="274" alt="Screenshot 2025-07-28 at 12 25 22 PM" src="https://github.com/user-attachments/assets/fdc7374e-3ce4-4ec4-abdd-13ff63764149" />


### Testing
<!-- add a description of how you tested it -->
Deployed to spruce staging, changed the subscription type back and forth. Ran a MQ and it emailed me:
<img width="671" height="248" alt="Screenshot 2025-07-28 at 12 26 08 PM" src="https://github.com/user-attachments/assets/021e0343-a66e-47ff-8eae-12a78b7a3379" />

<!-- Have you have updated the analytics documentation if necessary?  
https://docs.google.com/spreadsheets/d/1s4_nq8ZiphXp5Uq_-9HT6GPqz-KOyaq6HuvmXYaSNzg/edit?usp=sharing -->

### Evergreen PR
<!-- link to a corresponding Evergreen PR if applicable -->
NA