### PR TITLE
DEVPROD-18889: Preserve escaped quotes when pretty printing

### DIFF
--- a/apps/parsley/src/utils/prettyPrint/index.ts
+++ b/apps/parsley/src/utils/prettyPrint/index.ts
@@ -76,7 +76,7 @@ export const formatPrettyPrint = (logLine: string) => {
     // Add prettified JSON, and use regex to remove quotes around fields.
     formatted += parseJson(
       logLine.substring(jsonIndices[i][0], jsonIndices[i][1] + 1),
-    ).replace(/"([^"]+)"\s*:/g, "$1:");
+    ).replace(/"([^"\\]*(\\.[^"\\]*)*)"\s*:/g, "$1:");
     formatted += "\n";
 
     currIndex = jsonIndices[i][1] + 1;

--- a/apps/parsley/src/utils/prettyPrint/prettyPrint.test.ts
+++ b/apps/parsley/src/utils/prettyPrint/prettyPrint.test.ts
@@ -102,6 +102,19 @@ describe("prettyPrintFormat", () => {
     );
   });
 
+  it("should preserve escaped quotes around fields", () => {
+    const logLine = `[js_test:command_diagnostics] d20040| 2025-07-01T16:45:38.237+00:00 F  ASSERT   4106400     [conn1] "ScopedDebugInfo","attr":{"scopedDebugInfo":["{\\"curOpDiagnostics\\": \\"{\\"currentOp\\": { op: \\"query\\" }}\\"}"]}`;
+    const result = formatPrettyPrint(logLine);
+    expect(result).toBe(
+      '[js_test:command_diagnostics] d20040| 2025-07-01T16:45:38.237+00:00 F  ASSERT   4106400     [conn1] "ScopedDebugInfo","attr":\n' +
+        "{\n" +
+        "    scopedDebugInfo: [\n" +
+        '        "{\\"curOpDiagnostics\\": \\"{\\"currentOp\\": { op: \\"query\\" }}\\"}"\n' +
+        "    ]\n" +
+        "}\n",
+    );
+  });
+
   it("should be able to pretty print multiple JSON objects in a log line", () => {
     const logLine =
       '[js_test:backup_restore_rolling] 2020-03-02T08:52:04.781+0000 d20521| {"t":{"$date":"2020-03-02T08:52:04.780+0000"},"s":"I",  "c":"RECOVERY","id":23987,"bigNum":123456789098765432134,"ctx":"initandlisten","msg":"WiredTiger recoveryTimestamp. Ts: {recoveryTimestamp}","attr":{"recoveryTimestamp":{"$timestamp":{"t":0,"i":0}}}}and then some more text{"std_get_0_envDataEntry":"distmod","std_get_1_envDataEntry":"rhel62"}a little more text';


### PR DESCRIPTION
DEVPROD-18889
<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
<!-- add description, context, thought process, etc -->
Preserve escaped quotes in key names when pretty printing resmoke logs. I used the regex introduced here: https://github.com/evergreen-ci/parsley/pull/145

### Screenshots
<!-- add screenshots of visible changes -->
Before:
<img width="296" height="126" alt="image" src="https://github.com/user-attachments/assets/b601c98a-e0a8-4474-a8c8-a466037f2219" />
After:
<img width="308" height="125" alt="image" src="https://github.com/user-attachments/assets/a65e313b-cd91-4447-b137-fe9933049362" />

### Testing
<!-- add a description of how you tested it -->
Add unit test