### PR TITLE
DEVPROD-21270: Added section for cost

### DIFF
--- a/apps/spruce/cypress/integration/adminSettings/other.ts
+++ b/apps/spruce/cypress/integration/adminSettings/other.ts
@@ -47,6 +47,38 @@ describe("other", () => {
     });
   });
 
+  it.only("can save cost settings changes", () => {
+    cy.dataCy("save-settings-button").should(
+      "have.attr",
+      "aria-disabled",
+      "true",
+    );
+
+    // Cost Settings section.
+    const financeFormula = "Finance Formula";
+    cy.getInputByLabel(financeFormula).as("financeFormulaInput");
+    cy.get("@financeFormulaInput").clear();
+    cy.get("@financeFormulaInput").type("0.5");
+
+    const savingsPlanDiscount = "Savings Plan Discount";
+    cy.getInputByLabel(savingsPlanDiscount).as("savingsPlanDiscountInput");
+    cy.get("@savingsPlanDiscountInput").clear();
+    cy.get("@savingsPlanDiscountInput").type("0.15");
+
+    const onDemandDiscount = "On-Demand Discount";
+    cy.getInputByLabel(onDemandDiscount).as("onDemandDiscountInput");
+    cy.get("@onDemandDiscountInput").clear();
+    cy.get("@onDemandDiscountInput").type("0.08");
+
+    clickSave();
+    cy.validateToast("success", "Settings saved successfully");
+    cy.reload();
+
+    cy.getInputByLabel(financeFormula).should("have.value", "0.5");
+    cy.getInputByLabel(savingsPlanDiscount).should("have.value", "0.15");
+    cy.getInputByLabel(onDemandDiscount).should("have.value", "0.08");
+  });
+
   it("can save single task host changes", () => {
     cy.dataCy("save-settings-button").should(
       "have.attr",

--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -168,6 +168,7 @@ export type AdminSettings = {
   cedar?: Maybe<CedarConfig>;
   configDir?: Maybe<Scalars["String"]["output"]>;
   containerPools?: Maybe<ContainerPoolsConfig>;
+  cost?: Maybe<CostConfig>;
   disabledGQLQueries: Array<Scalars["String"]["output"]>;
   domainName?: Maybe<Scalars["String"]["output"]>;
   expansions?: Maybe<Scalars["StringMap"]["output"]>;
@@ -221,6 +222,7 @@ export type AdminSettingsInput = {
   cedar?: InputMaybe<CedarConfigInput>;
   configDir?: InputMaybe<Scalars["String"]["input"]>;
   containerPools?: InputMaybe<ContainerPoolsConfigInput>;
+  cost?: InputMaybe<CostConfigInput>;
   disabledGQLQueries?: InputMaybe<Array<Scalars["String"]["input"]>>;
   domainName?: InputMaybe<Scalars["String"]["input"]>;
   expansions?: InputMaybe<Scalars["StringMap"]["input"]>;
@@ -677,6 +679,19 @@ export type CopyProjectInput = {
   newProjectId?: InputMaybe<Scalars["String"]["input"]>;
   newProjectIdentifier: Scalars["String"]["input"];
   projectIdToCopy: Scalars["String"]["input"];
+};
+
+export type CostConfig = {
+  __typename?: "CostConfig";
+  financeFormula?: Maybe<Scalars["Float"]["output"]>;
+  onDemandDiscount?: Maybe<Scalars["Float"]["output"]>;
+  savingsPlanDiscount?: Maybe<Scalars["Float"]["output"]>;
+};
+
+export type CostConfigInput = {
+  financeFormula?: InputMaybe<Scalars["Float"]["input"]>;
+  onDemandDiscount?: InputMaybe<Scalars["Float"]["input"]>;
+  savingsPlanDiscount?: InputMaybe<Scalars["Float"]["input"]>;
 };
 
 export type CostData = {
@@ -7493,6 +7508,12 @@ export type AdminSettingsQuery = {
         maxContainers: number;
         port: number;
       }>;
+    } | null;
+    cost?: {
+      __typename?: "CostConfig";
+      financeFormula?: number | null;
+      onDemandDiscount?: number | null;
+      savingsPlanDiscount?: number | null;
     } | null;
     fws?: { __typename?: "FWSConfig"; url: string } | null;
     githubCheckRun?: {

--- a/apps/spruce/src/gql/queries/admin-settings.graphql
+++ b/apps/spruce/src/gql/queries/admin-settings.graphql
@@ -111,6 +111,11 @@ query AdminSettings {
         port
       }
     }
+    cost {
+      financeFormula
+      onDemandDiscount
+      savingsPlanDiscount
+    }
     disabledGQLQueries
     domainName
     expansions

--- a/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/OtherTab/schemaFields.ts
+++ b/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/OtherTab/schemaFields.ts
@@ -63,6 +63,24 @@ export const miscSettings = {
         },
       },
     },
+    cost: {
+      type: "object" as const,
+      title: "Cost",
+      properties: {
+        financeFormula: {
+          type: "number" as const,
+          title: "Finance Formula",
+        },
+        savingsPlanDiscount: {
+          type: "number" as const,
+          title: "Savings Plan Discount",
+        },
+        onDemandDiscount: {
+          type: "number" as const,
+          title: "On-Demand Discount",
+        },
+      },
+    },
   },
   uiSchema: {
     "ui:ObjectFieldTemplate": CardFieldTemplate,

--- a/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/OtherTab/schemaFields.ts
+++ b/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/OtherTab/schemaFields.ts
@@ -105,6 +105,9 @@ export const miscSettings = {
           "Override for the acceptable host idle time (ignored if 0).",
       },
     },
+    cost: {
+      "ui:fieldCss": nestedObjectGridCss,
+    },
   },
 };
 

--- a/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/OtherTab/transformers.test.ts
+++ b/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/OtherTab/transformers.test.ts
@@ -27,6 +27,11 @@ const mockAdminSettings: AdminSettings = {
     targetTimeSecondsOverride: 300,
     idleTimeSecondsOverride: 600,
   },
+  cost: {
+    financeFormula: 1.5,
+    savingsPlanDiscount: 0.1,
+    onDemandDiscount: 0.05,
+  },
   singleTaskDistro: {
     projectTasksPairs: [
       {
@@ -131,6 +136,11 @@ const expectedForm: OtherFormState = {
         distroMaxHostsFactor: 2,
         targetTimeSecondsOverride: 300,
         idleTimeSecondsOverride: 600,
+      },
+      cost: {
+        financeFormula: 1.5,
+        savingsPlanDiscount: 0.1,
+        onDemandDiscount: 0.05,
       },
     },
     singleTaskDistro: {
@@ -240,6 +250,11 @@ const expectedGql: AdminSettingsInput = {
     distroMaxHostsFactor: 2,
     targetTimeSecondsOverride: 300,
     idleTimeSecondsOverride: 600,
+  },
+  cost: {
+    financeFormula: 1.5,
+    savingsPlanDiscount: 0.1,
+    onDemandDiscount: 0.05,
   },
   singleTaskDistro: {
     projectTasksPairs: [

--- a/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/OtherTab/transformers.ts
+++ b/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/OtherTab/transformers.ts
@@ -26,6 +26,7 @@ export const gqlToForm = ((data) => {
   const {
     buckets,
     configDir,
+    cost,
     domainName,
     expansions,
     githubCheckRun,
@@ -62,6 +63,11 @@ export const gqlToForm = ((data) => {
           targetTimeSecondsOverride:
             releaseMode?.targetTimeSecondsOverride ?? 0,
           idleTimeSecondsOverride: releaseMode?.idleTimeSecondsOverride ?? 0,
+        },
+        cost: {
+          financeFormula: cost?.financeFormula ?? 0,
+          savingsPlanDiscount: cost?.savingsPlanDiscount ?? 0,
+          onDemandDiscount: cost?.onDemandDiscount ?? 0,
         },
       },
 
@@ -213,6 +219,12 @@ export const formToGql = ((form: OtherFormState) => {
         miscSettings.releaseMode.targetTimeSecondsOverride || undefined,
       idleTimeSecondsOverride:
         miscSettings.releaseMode.idleTimeSecondsOverride || undefined,
+    },
+
+    cost: {
+      financeFormula: miscSettings.cost.financeFormula || undefined,
+      savingsPlanDiscount: miscSettings.cost.savingsPlanDiscount || undefined,
+      onDemandDiscount: miscSettings.cost.onDemandDiscount || undefined,
     },
 
     singleTaskDistro: {

--- a/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/OtherTab/types.ts
+++ b/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/OtherTab/types.ts
@@ -14,6 +14,11 @@ export interface OtherFormState {
         targetTimeSecondsOverride: number;
         idleTimeSecondsOverride: number;
       };
+      cost: {
+        financeFormula: number;
+        savingsPlanDiscount: number;
+        onDemandDiscount: number;
+      };
     };
 
     singleTaskDistro: {


### PR DESCRIPTION
[DEVPROD-21270](https://jira.mongodb.org/browse/DEVPROD-21270)


### Description
Adds cost section to the other section 

### Screenshots
<img width="885" height="277" alt="image" src="https://github.com/user-attachments/assets/744297f6-aeba-4d0e-8baf-33ced73988c1" />


### Testing
local testing

[backend pr ](https://github.com/evergreen-ci/evergreen/pull/9331)
