### PR TITLE
DEVPROD-21726 Update tool labels to reflect new log analysis tool names

### DIFF
--- a/packages/fungi/src/MessageRenderer/MessageRenderer.stories.tsx
+++ b/packages/fungi/src/MessageRenderer/MessageRenderer.stories.tsx
@@ -1,8 +1,9 @@
+import { CustomMeta, CustomStoryObj } from "@evg-ui/lib/test_utils/types";
 import { MessageRenderer } from ".";
 
 export default {
   component: MessageRenderer,
-};
+} satisfies CustomMeta<typeof MessageRenderer>;
 
 export const Default = {
   args: {
@@ -15,21 +16,11 @@ export const Default = {
     id: "123",
     role: "user",
   },
-};
+} satisfies CustomStoryObj<typeof MessageRenderer>;
 
 export const Agent = {
-  argTypes: {
-    toolState: {
-      control: { type: "select" },
-      options: ["output-error", "input-streaming", "output-available"],
-      type: "string",
-    },
-  },
-  args: {
-    toolState: "output-available",
-  },
-  // @ts-expect-error
-  render: ({ toolState }) => {
+  // @ts-expect-error - toolState is a custom storybook arg, not a MessageRenderer prop
+  render: ({ toolState = "output-available" }: { toolState?: string }) => {
     const message = {
       id: "iHbTMI7vnSuBYpQ1",
       role: "assistant",
@@ -42,11 +33,10 @@ export const Agent = {
         {
           type: "text",
           text: 'The task spruce_ubuntu1604_test_2c9056df66d42fb1908d52eed096750a91f1f089_22_03_02_16_45_12 has not failed before; its status has always been "success" in its history. This is not the first time it has run, but it has not previously failed.',
-          state: "done",
         },
       ],
     };
-    // @ts-expect-error
+    // @ts-expect-error - message structure doesn't match exact MessageRenderer props
     return <MessageRenderer {...message} />;
   },
-};
+} satisfies CustomStoryObj<typeof MessageRenderer>;

--- a/packages/fungi/src/MessageRenderer/ToolRenderer.stories.tsx
+++ b/packages/fungi/src/MessageRenderer/ToolRenderer.stories.tsx
@@ -1,0 +1,51 @@
+import { size } from "@evg-ui/lib/constants/tokens";
+import { CustomMeta, CustomStoryObj } from "@evg-ui/lib/test_utils/types";
+import { renderableToolLabels } from "./constants";
+import { ToolRenderer } from "./ToolRenderer";
+
+export default {
+  component: ToolRenderer,
+} satisfies CustomMeta<typeof ToolRenderer>;
+
+const allToolStates = [
+  "output-error",
+  "input-streaming",
+  "input-available",
+  "output-available",
+];
+export const Default = {
+  argTypes: {
+    type: {
+      control: { type: "select" },
+      options: Object.keys(renderableToolLabels),
+    },
+    state: {
+      control: { type: "select" },
+      options: allToolStates,
+      type: "string",
+    },
+  },
+  args: {
+    type: "tool-askEvergreenAgentTool",
+    state: "output-available",
+  },
+} satisfies CustomStoryObj<typeof ToolRenderer>;
+
+export const AllTools = {
+  argTypes: {
+    state: {
+      control: { type: "select" },
+      options: allToolStates,
+      type: "string",
+    },
+  },
+  render: (args) => (
+    <>
+      {Object.keys(renderableToolLabels).map((tool) => (
+        <div key={tool} style={{ padding: `${size.xs} 0` }}>
+          <ToolRenderer {...args} type={tool as `tool-${string}`} />
+        </div>
+      ))}
+    </>
+  ),
+} satisfies CustomStoryObj<typeof ToolRenderer>;

--- a/packages/fungi/src/MessageRenderer/ToolRenderer.tsx
+++ b/packages/fungi/src/MessageRenderer/ToolRenderer.tsx
@@ -2,30 +2,36 @@ import styled from "@emotion/styled";
 import Banner, { Variant } from "@leafygreen-ui/banner";
 import { ToolUIPart } from "ai";
 import Icon from "@evg-ui/lib/components/Icon";
+import { size } from "@evg-ui/lib/constants/tokens";
 import { AnimatedEllipsis } from "../AnimatedEllipsis";
-import { toolLabels } from "./constants";
+import { renderableToolLabels } from "./constants";
 
+const loadingStates = ["input-streaming", "input-available"];
+const toolStateToLabelState = (state: ToolUIPart["state"]) => {
+  if (state === "output-error") return "errorCopy";
+  if (state === "output-available") return "completedCopy";
+  return "loadingCopy";
+};
 export const ToolRenderer: React.FC<ToolUIPart> = (tool) => {
-  const toolName = toolNameToLabel(tool.type, tool.state);
-  if (!toolName) {
-    return null;
-  }
-
+  const toolLabel = renderableToolLabels[tool.type];
+  if (!toolLabel) return null;
   const variant = tool.state === "output-error" ? Variant.Danger : Variant.Info;
+  const isLoading = loadingStates.includes(tool.state);
 
   return (
     <StyledBanner
       data-cy="tool-use-chip"
-      image={<StyledIcon glyph="Wrench" />}
+      image={<StyledIcon glyph={toolLabel.glyph as string} />}
       variant={variant}
     >
-      {toolName}
+      {toolLabel[toolStateToLabelState(tool.state)]}
+      {isLoading && <AnimatedEllipsis />}
     </StyledBanner>
   );
 };
 
 const StyledBanner = styled(Banner)`
-  padding: 6px 12px;
+  padding: ${size.xs} ${size.s};
   width: fit-content;
 `;
 
@@ -33,23 +39,3 @@ const StyledIcon = styled(Icon)`
   width: 14px;
   height: 14px;
 `;
-
-const toolNameToLabel = (name: string, state: ToolUIPart["state"]) => {
-  const label = toolLabels[name];
-  if (!label) {
-    return null;
-  }
-
-  if (state === "output-error") {
-    return label.error;
-  }
-  if (state === "input-streaming") {
-    return (
-      <>
-        {label.loading}
-        <AnimatedEllipsis />
-      </>
-    );
-  }
-  return label.done;
-};

--- a/packages/fungi/src/MessageRenderer/constants.ts
+++ b/packages/fungi/src/MessageRenderer/constants.ts
@@ -1,24 +1,29 @@
+import { glyphs } from "@evg-ui/lib/components/Icon";
+
 /**
  * Mapping of tool names to their various states.
  * This should be updated as new tools are added to the agent.
  * Only include labels for tools that are visible to the user.
  */
-export const toolLabels: Record<
-  string,
+export const renderableToolLabels: Record<
+  `tool-${string}`,
   {
-    loading: string;
-    done: string;
-    error: string;
+    loadingCopy: string;
+    completedCopy: string;
+    errorCopy: string;
+    glyph: keyof typeof glyphs;
   }
 > = {
   "tool-askEvergreenAgentTool": {
-    loading: "Asking Evergreen Agent for more information",
-    done: "Asked Evergreen Agent for more information",
-    error: "Error fetching information from Evergreen Agent",
+    loadingCopy: "Asking Evergreen Agent for more information",
+    completedCopy: "Received information from the Evergreen Agent",
+    errorCopy: "Error fetching information from Evergreen Agent",
+    glyph: "EvergreenLogo",
   },
-  "tool-logCoreAnalyzerWorkflow": {
-    loading: "Analyzing logs",
-    done: "Analyzed logs",
-    error: "Error analyzing logs",
+  "tool-logCoreAnalyzerTool": {
+    loadingCopy: "Analyzing logs",
+    completedCopy: "Analyzed logs",
+    errorCopy: "Error analyzing logs",
+    glyph: "File",
   },
 };


### PR DESCRIPTION
DEVPROD-21726
<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
As part of https://github.com/evergreen-ci/sage/pull/74 we needed to rename the log analysis workflow so this renames it on the frontend. 
While here I made a change to how the tool usage state is determined since I realized we were not reading the correct state to determine if the tool was used as well as a custom glyph for each tool usage. 

### Screenshots
<img width="252" height="78" alt="image" src="https://github.com/user-attachments/assets/11fd3618-0849-4fb3-97d0-cdd648e94164" />
<img width="461" height="399" alt="image" src="https://github.com/user-attachments/assets/0f986ce2-010f-4b01-bf7d-8ed2123c2777" />

### Testing
Added some stories 
