### PR TITLE
DEVPROD-21748: Add dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,7 @@ updates:
     commit-message:
       prefix: "CHORE(NPM) - "
     cooldown:
+      semver-minor-days: 14
       semver-patch-days: 30
       include:
         - "@sentry/*"


### PR DESCRIPTION
DEVPROD-21748
<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
<!-- add description, context, thought process, etc -->
Add dependabot patch [cooldown](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#cooldown-) period for packages that update very frequently.

Also set labels to be only `dependencies` because I think the javascript label is useless 😄 and set updates to Monday (I think they currently fire Tuesday)