### PR TITLE
DEVPROD-21399 Encode build variant when generating variant history urls

### DIFF
--- a/apps/spruce/src/constants/routes.test.ts
+++ b/apps/spruce/src/constants/routes.test.ts
@@ -173,6 +173,11 @@ describe("getVariantHistoryRoute", () => {
       getVariantHistoryRoute(identifierWithSpecialCharacters, "someVariantId"),
     ).toBe(`/variant-history/${escapedIdentifier}/someVariantId`);
   });
+  it("escapes special characters variantName", () => {
+    expect(getVariantHistoryRoute("someProject", "!?variant@")).toBe(
+      `/variant-history/someProject/!%3Fvariant%40`,
+    );
+  });
   it("generates a link with failing or passing tests", () => {
     expect(
       getVariantHistoryRoute("someProject", "someVariant", {

--- a/apps/spruce/src/constants/routes.ts
+++ b/apps/spruce/src/constants/routes.ts
@@ -373,7 +373,7 @@ export const getVariantHistoryRoute = (
   return getHistoryRoute(
     `${paths.variantHistory}/${encodeURIComponent(
       projectIdentifier,
-    )}/${variantName}`,
+    )}/${encodeURIComponent(variantName)}`,
     filters,
     selectedCommit,
   );


### PR DESCRIPTION
DEVPROD-21399
<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
Adds some url encoding for variant names


### Testing
Unit tests