### PR TITLE
DEVPROD-21708: Add failed tasks log bucket field

### DIFF
--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -486,6 +486,7 @@ export type BucketsConfig = {
   credentials?: Maybe<S3Credentials>;
   internalBuckets?: Maybe<Array<Scalars["String"]["output"]>>;
   logBucket?: Maybe<BucketConfig>;
+  logBucketFailedTasks?: Maybe<BucketConfig>;
   logBucketLongRetention?: Maybe<BucketConfig>;
   longRetentionProjects?: Maybe<Array<Scalars["String"]["output"]>>;
   testResultsBucket?: Maybe<BucketConfig>;
@@ -495,6 +496,7 @@ export type BucketsConfigInput = {
   credentials?: InputMaybe<S3CredentialsInput>;
   internalBuckets?: InputMaybe<Array<Scalars["String"]["input"]>>;
   logBucket?: InputMaybe<BucketConfigInput>;
+  logBucketFailedTasks?: InputMaybe<BucketConfigInput>;
   logBucketLongRetention?: InputMaybe<BucketConfigInput>;
   longRetentionProjects?: InputMaybe<Array<Scalars["String"]["input"]>>;
   testResultsBucket?: InputMaybe<BucketConfigInput>;

--- a/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/OtherTab/schemaFields.ts
+++ b/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/OtherTab/schemaFields.ts
@@ -245,6 +245,10 @@ export const bucketConfig = {
       type: "string" as const,
       title: "S3 Secret",
     },
+    failedTasksLogBucket: {
+      type: "string" as const,
+      title: "Failed Tasks Log Bucket",
+    },
   },
   uiSchema: {
     "ui:ObjectFieldTemplate": CardFieldTemplate,

--- a/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/OtherTab/transformers.test.ts
+++ b/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/OtherTab/transformers.test.ts
@@ -58,6 +58,9 @@ const mockAdminSettings: AdminSettings = {
       key: "cred-key",
       secret: "cred-secret",
     },
+    logBucketFailedTasks: {
+      name: "evergreen-failed-tasks",
+    },
   },
   ssh: {
     taskHostKey: {
@@ -161,6 +164,7 @@ const expectedForm: OtherFormState = {
       testResultsBucketRoleARN: "arn:aws:iam::123456789:role/TestRole",
       credentialsKey: "cred-key",
       credentialsSecret: "cred-secret",
+      failedTasksLogBucket: "evergreen-failed-tasks",
     },
     sshPairs: {
       taskHostKey: {
@@ -276,6 +280,9 @@ const expectedGql: AdminSettingsInput = {
     credentials: {
       key: "cred-key",
       secret: "cred-secret",
+    },
+    logBucketFailedTasks: {
+      name: "failed-tasks-log-bucket",
     },
   },
   ssh: {

--- a/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/OtherTab/transformers.ts
+++ b/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/OtherTab/transformers.ts
@@ -90,6 +90,7 @@ export const gqlToForm = ((data) => {
         testResultsBucketRoleARN: buckets?.testResultsBucket?.roleARN ?? "",
         credentialsKey: buckets?.credentials?.key ?? "",
         credentialsSecret: buckets?.credentials?.secret ?? "",
+        failedTasksLogBucket: buckets?.logBucketFailedTasks?.name ?? "",
       },
 
       sshPairs: {
@@ -258,6 +259,7 @@ export const formToGql = ((form: OtherFormState) => {
         key: bucketConfig.credentialsKey || undefined,
         secret: bucketConfig.credentialsSecret || undefined,
       },
+      failedTasksLogBucket: bucketConfig?.failedTasksLogBucket || undefined,
     },
 
     ssh: {

--- a/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/OtherTab/types.ts
+++ b/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/OtherTab/types.ts
@@ -38,6 +38,7 @@ export interface OtherFormState {
       testResultsBucketRoleARN: string;
       credentialsKey: string;
       credentialsSecret: string;
+      failedTasksLogBucket: string;
     };
 
     sshPairs: {


### PR DESCRIPTION
[DEVPROD-21708](https://jira.mongodb.org/browse/DEVPROD-21708)


### Description
Ads the failed tasks log bucket field 
