### PR TITLE
DEVPROD-21432 followup: Link users to spruce prod from parsley beta

### DIFF
--- a/apps/parsley/.env-cmdrc.json
+++ b/apps/parsley/.env-cmdrc.json
@@ -29,7 +29,7 @@
     "REACT_APP_GRAPHQL_URL": "https://evergreen.mongodb.com/graphql/query",
     "REACT_APP_LOGKEEPER_URL": "https://logkeeper2.build.10gen.cc",
     "REACT_APP_PARSLEY_URL": "https://parsley-beta.corp.mongodb.com",
-    "REACT_APP_SPRUCE_URL": "https://spruce-beta.corp.mongodb.com",
+    "REACT_APP_SPRUCE_URL": "https://spruce.mongodb.com",
     "REACT_APP_HONEYCOMB_BASE_URL": "https://ui.honeycomb.io/mongodb-4b/environments/production",
     "VITE_PARSLEY_AI_URL": "https://sage.prod.corp.mongodb.com"
   },


### PR DESCRIPTION
DEVPROD-21432
<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
<!-- add description, context, thought process, etc -->
If a user is on Parsley beta using AI, any links to Spruce should direct to the prod website. Since this is a temporary setup I think the easiest approach is to just change the hardcoded env var.