### PR TITLE
DEVPROD-22098: Fix date overwriting time in datetime widget

### DIFF
--- a/apps/spruce/src/components/SpruceForm/SpruceForm.stories.tsx
+++ b/apps/spruce/src/components/SpruceForm/SpruceForm.stories.tsx
@@ -264,7 +264,9 @@ const dateTimeSchema = {
       nextRunTime: {
         type: "string" as const,
         title: "Next Run Time",
-        default: new Date().toUTCString(),
+        default: new Date(
+          "Tue Sep 16 2025 11:19:00 GMT-0400 (Eastern Daylight Time)",
+        ).toString(),
       },
     },
   },

--- a/apps/spruce/src/components/SpruceForm/SpruceForm.stories.tsx
+++ b/apps/spruce/src/components/SpruceForm/SpruceForm.stories.tsx
@@ -53,6 +53,17 @@ export const Example4: CustomStoryObj<typeof SpruceForm> = {
   ),
 };
 
+export const DateTimePicker: CustomStoryObj<typeof SpruceForm> = {
+  render: () => (
+    <BaseForm
+      data={dateTimeSchema.formData}
+      schema={dateTimeSchema.schema}
+      title="Periodic Builds"
+      uiSchema={dateTimeSchema.uiSchema}
+    />
+  ),
+};
+
 // @ts-expect-error: FIXME. This comment was added by an automated script.
 const BaseForm = ({ data, schema, title, uiSchema }) => {
   const [formState, setFormState] = useState(data);
@@ -242,5 +253,24 @@ const example4Def = {
   },
   formData: {
     testText: ["text1", "text2", "text3"],
+  },
+};
+
+const dateTimeSchema = {
+  formData: {},
+  schema: {
+    type: "object" as const,
+    properties: {
+      nextRunTime: {
+        type: "string" as const,
+        title: "Next Run Time",
+        default: new Date().toUTCString(),
+      },
+    },
+  },
+  uiSchema: {
+    nextRunTime: {
+      "ui:widget": "date-time",
+    },
   },
 };

--- a/apps/spruce/src/components/SpruceForm/Widgets/DateTimePicker.tsx
+++ b/apps/spruce/src/components/SpruceForm/Widgets/DateTimePicker.tsx
@@ -9,6 +9,11 @@ import { useUserTimeZone } from "hooks/useUserTimeZone";
 import ElementWrapper from "../ElementWrapper";
 import { SpruceWidgetProps } from "./types";
 
+enum Caller {
+  Date,
+  Time,
+}
+
 export const DateTimePicker: React.FC<
   {
     options: {
@@ -32,9 +37,18 @@ export const DateTimePicker: React.FC<
     ? toZonedTime(new Date(value || null), timezone)
     : new Date(value || null);
 
-  const handleChange = (newDate?: DateType) => {
+  const handleChange = (caller: Caller) => (newDate?: DateType) => {
     if (!newDate) return;
     if (isInvalidDateObject(newDate)) return;
+
+    // LG DatePicker overwrites the time, so preserve it as such
+    if (caller === Caller.Date) {
+      const hours = currentDateTime.getUTCHours();
+      const minutes = currentDateTime.getUTCMinutes();
+      newDate.setUTCHours(hours);
+      newDate.setUTCMinutes(minutes);
+    }
+
     if (timezone) {
       onChange(fromZonedTime(newDate, timezone).toString());
     } else {
@@ -57,7 +71,7 @@ export const DateTimePicker: React.FC<
           disabled={isDisabled}
           max={disableAfter}
           min={disableBefore}
-          onDateChange={handleChange}
+          onDateChange={handleChange(Caller.Date)}
           value={currentDateTime}
         />
         {/* TODO: Replace with official component following completion of LG-3931.
@@ -65,7 +79,7 @@ export const DateTimePicker: React.FC<
         <LGTimePicker
           data-cy="time-picker"
           disabled={isDisabled}
-          onDateChange={handleChange}
+          onDateChange={handleChange(Caller.Time)}
           value={currentDateTime}
         />
       </DateTimeContainer>

--- a/apps/spruce/src/components/SpruceForm/__snapshots__/SpruceForm_DateTimePicker.storyshot
+++ b/apps/spruce/src/components/SpruceForm/__snapshots__/SpruceForm_DateTimePicker.storyshot
@@ -1,0 +1,287 @@
+<div>
+  <div
+    class="emotion-0"
+  >
+    <a
+      href="#periodic-builds"
+      id="periodic-builds"
+    >
+      <h3
+        class="emotion-SettingsCardTitle e1h7idos1 leafygreen-ui-feh85s"
+      >
+        Periodic Builds
+      </h3>
+    </a>
+    <div
+      class="emotion-SettingsCard e1h7idos0 leafygreen-ui-1ecxdul"
+    >
+      <form
+        class="rjsf"
+        novalidate=""
+      >
+        <div
+          class="form-group field field-object emotion-DefaultFieldContainer eny4k1v1"
+          id=" root"
+        >
+          <fieldset
+            class="emotion-0"
+            id="root"
+          >
+            <div
+              class="form-group field field-string emotion-DefaultFieldContainer eny4k1v1"
+              id=" root_nextRunTime"
+            >
+              <div
+                class="emotion-ElementWrapper ee4bs9n0"
+              >
+                <label
+                  class="leafygreen-ui-ms04bw"
+                  data-lgid="lg-label"
+                  for="root_nextRunTime"
+                >
+                  Next Run Time
+                </label>
+                <div
+                  class="emotion-DateTimeContainer e1xi0150"
+                >
+                  <div
+                    class="leafygreen-ui-1br9h7w"
+                    data-cy="date-picker"
+                    data-lgid="lg-form_field"
+                    data-testid="lg-form_field"
+                  >
+                    <div
+                      class="leafygreen-ui-1iyoj2o"
+                    />
+                    <div
+                      aria-controls="lg-date-picker-menu-7"
+                      aria-expanded="false"
+                      aria-invalid="false"
+                      aria-label="date-picker"
+                      class="leafygreen-ui-1on3uho"
+                      role="combobox"
+                      tabindex="-1"
+                    >
+                      <div
+                        class="leafygreen-ui-1ago99h"
+                      >
+                        <div
+                          aria-describedby=""
+                          aria-disabled="false"
+                          aria-invalid="false"
+                          class="leafygreen-ui-188k96w lg-ui-form-field-input-0000"
+                          id="lg-form_field-input-6"
+                        >
+                          <input
+                            aria-label="year"
+                            autocomplete="off"
+                            class="leafygreen-ui-17osm3l"
+                            data-segment="year"
+                            data-testid="lg-date_picker_input-segment"
+                            id="year"
+                            max="2038"
+                            min="1970"
+                            pattern="[0-9]{4}"
+                            placeholder="Y​Y​Y​Y"
+                            role="spinbutton"
+                            type="text"
+                            value="2025"
+                          />
+                          <span
+                            class="leafygreen-ui-15xv5ui"
+                          >
+                            -
+                          </span>
+                          <input
+                            aria-label="month"
+                            autocomplete="off"
+                            class="leafygreen-ui-1bk33zo"
+                            data-segment="month"
+                            data-testid="lg-date_picker_input-segment"
+                            id="month"
+                            max="12"
+                            min="1"
+                            pattern="[0-9]{2}"
+                            placeholder="M​M"
+                            role="spinbutton"
+                            type="text"
+                            value="09"
+                          />
+                          <span
+                            class="leafygreen-ui-15xv5ui"
+                          >
+                            -
+                          </span>
+                          <input
+                            aria-label="day"
+                            autocomplete="off"
+                            class="leafygreen-ui-boe9vc"
+                            data-segment="day"
+                            data-testid="lg-date_picker_input-segment"
+                            id="day"
+                            max="30"
+                            min="1"
+                            pattern="[0-9]{2}"
+                            placeholder="D​D"
+                            role="spinbutton"
+                            type="text"
+                            value="16"
+                          />
+                        </div>
+                      </div>
+                      <div
+                        class="leafygreen-ui-44gx6g"
+                      >
+                        <button
+                          aria-disabled="false"
+                          aria-label="Open calendar menu"
+                          class="lg-ui-form-field-icon-0000 leafygreen-ui-at6vvf"
+                          data-lgid="lg-form_field-content_end"
+                          data-testid="lg-form_field-content_end"
+                          tabindex="0"
+                          type="button"
+                        >
+                          <div
+                            class="leafygreen-ui-xhlipt"
+                          >
+                            <svg
+                              aria-label="Calendar Icon"
+                              class=""
+                              fill="none"
+                              height="16"
+                              role="img"
+                              viewBox="0 0 16 16"
+                              width="16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M4 2a1 1 0 0 1 2 0v1a1 1 0 0 1-2 0z"
+                                fill="currentColor"
+                              />
+                              <path
+                                clip-rule="evenodd"
+                                d="M9 3H7a2 2 0 1 1-4 0 2 2 0 0 0-2 2v7a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V5a2 2 0 0 0-2-2 2 2 0 1 1-4 0m3 4H9v3h3z"
+                                fill="currentColor"
+                                fill-rule="evenodd"
+                              />
+                              <path
+                                d="M10 3a1 1 0 1 0 2 0V2a1 1 0 1 0-2 0z"
+                                fill="currentColor"
+                              />
+                            </svg>
+                          </div>
+                        </button>
+                      </div>
+                    </div>
+                    <div
+                      aria-live="polite"
+                      aria-relevant="all"
+                      class="leafygreen-ui-11ydt2g"
+                      data-lgid="lg-form_field-feedback"
+                      data-testid="lg-form_field-feedback"
+                      id="lg-form_field-feedback-5"
+                    />
+                  </div>
+                  <span
+                    class="leafygreen-ui-38lglc"
+                  />
+                  <div
+                    aria-label="Time picker form"
+                    class="leafygreen-ui-1br9h7w"
+                    data-cy="time-picker"
+                  >
+                    <div
+                      class="leafygreen-ui-1iyoj2o"
+                    />
+                    <div
+                      class="leafygreen-ui-14vpn2b"
+                      role="combobox"
+                      tabindex="-1"
+                    >
+                      <div
+                        class="leafygreen-ui-1ago99h"
+                      >
+                        <div
+                          aria-describedby=""
+                          aria-disabled="false"
+                          aria-invalid="false"
+                          aria-label="Time picker form"
+                          class="lg-ui-form-field-input-0000 emotion-ContentWrapper e9c2bxn0"
+                          id="lg-form_field-input-4"
+                        >
+                          <input
+                            class="emotion-StyledInput evefz8k0"
+                            data-cy="hour-input"
+                            maxlength="2"
+                            placeholder="00"
+                            type="text"
+                            value="16"
+                          />
+                          <span
+                            class="emotion-Colon e9c2bxn2"
+                          >
+                            :
+                          </span>
+                          <input
+                            class="emotion-StyledInput evefz8k0"
+                            data-cy="minute-input"
+                            maxlength="2"
+                            placeholder="00"
+                            type="text"
+                            value="51"
+                          />
+                        </div>
+                      </div>
+                      <div
+                        class="leafygreen-ui-44gx6g"
+                      >
+                        <button
+                          aria-disabled="false"
+                          aria-label="Clock Icon"
+                          class="lg-ui-form-field-icon-0000 leafygreen-ui-1bxz6zl"
+                          data-lgid="lg-form_field-content_end"
+                          data-testid="lg-form_field-content_end"
+                          tabindex="0"
+                        >
+                          <div
+                            class="leafygreen-ui-xhlipt"
+                          >
+                            <svg
+                              aria-label="Clock Icon"
+                              class=""
+                              fill="none"
+                              height="16"
+                              role="img"
+                              viewBox="0 0 16 16"
+                              width="16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                clip-rule="evenodd"
+                                d="M8 14A6 6 0 1 0 8 2a6 6 0 0 0 0 12m-.75-9.25a.75.75 0 0 1 1.5 0v3.16l1.744 1.526a.75.75 0 0 1-.988 1.128L7.511 8.818a.8.8 0 0 1-.19-.25.75.75 0 0 1-.071-.318z"
+                                fill="currentColor"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </div>
+                        </button>
+                      </div>
+                    </div>
+                    <div
+                      aria-live="polite"
+                      aria-relevant="all"
+                      class="leafygreen-ui-11ydt2g"
+                      data-lgid="lg-form_field-feedback"
+                      data-testid="lg-form_field-feedback"
+                      id="lg-form_field-feedback-3"
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </fieldset>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>

--- a/apps/spruce/src/components/SpruceForm/__snapshots__/SpruceForm_DateTimePicker.storyshot
+++ b/apps/spruce/src/components/SpruceForm/__snapshots__/SpruceForm_DateTimePicker.storyshot
@@ -215,7 +215,7 @@
                             maxlength="2"
                             placeholder="00"
                             type="text"
-                            value="16"
+                            value="15"
                           />
                           <span
                             class="emotion-Colon e9c2bxn2"
@@ -228,7 +228,7 @@
                             maxlength="2"
                             placeholder="00"
                             type="text"
-                            value="51"
+                            value="19"
                           />
                         </div>
                       </div>

--- a/apps/spruce/src/components/TimePicker/TimeInput.tsx
+++ b/apps/spruce/src/components/TimePicker/TimeInput.tsx
@@ -1,5 +1,4 @@
 import styled from "@emotion/styled";
-import { useBaseFontSize } from "@leafygreen-ui/leafygreen-provider";
 import { palette } from "@leafygreen-ui/palette";
 import { size } from "@evg-ui/lib/constants/tokens";
 
@@ -17,26 +16,22 @@ const TimeInput: React.FC<TimeInputProps> = ({
   disabled,
   setPopoverOpen,
   value,
-}) => {
-  const fontSize = useBaseFontSize();
-  return (
-    <StyledInput
-      data-cy={dataCy}
-      disabled={disabled}
-      fontSize={fontSize}
-      maxLength={2}
-      onClick={() => setPopoverOpen(true)}
-      placeholder="00"
-      type="text"
-      value={value}
-    />
-  );
-};
+}) => (
+  <StyledInput
+    data-cy={dataCy}
+    disabled={disabled}
+    maxLength={2}
+    onClick={() => setPopoverOpen(true)}
+    placeholder="00"
+    type="text"
+    value={value}
+  />
+);
 TimeInput.displayName = "TimeInput";
 
-const StyledInput = styled.input<{ fontSize: number }>`
+const StyledInput = styled.input`
   font-family: inherit;
-  font-size: ${({ fontSize }) => fontSize}px;
+  font-size: inherit;
   font-variant-numeric: tabular-nums;
   text-align: center;
 

--- a/apps/spruce/src/components/TimePicker/TimeInput.tsx
+++ b/apps/spruce/src/components/TimePicker/TimeInput.tsx
@@ -1,4 +1,5 @@
 import styled from "@emotion/styled";
+import { useBaseFontSize } from "@leafygreen-ui/leafygreen-provider";
 import { palette } from "@leafygreen-ui/palette";
 import { size } from "@evg-ui/lib/constants/tokens";
 
@@ -16,21 +17,26 @@ const TimeInput: React.FC<TimeInputProps> = ({
   disabled,
   setPopoverOpen,
   value,
-}) => (
-  <StyledInput
-    data-cy={dataCy}
-    disabled={disabled}
-    maxLength={2}
-    onClick={() => setPopoverOpen(true)}
-    placeholder="00"
-    type="text"
-    value={value}
-  />
-);
+}) => {
+  const fontSize = useBaseFontSize();
+  return (
+    <StyledInput
+      data-cy={dataCy}
+      disabled={disabled}
+      fontSize={fontSize}
+      maxLength={2}
+      onClick={() => setPopoverOpen(true)}
+      placeholder="00"
+      type="text"
+      value={value}
+    />
+  );
+};
 TimeInput.displayName = "TimeInput";
 
-const StyledInput = styled.input`
+const StyledInput = styled.input<{ fontSize: number }>`
   font-family: inherit;
+  font-size: ${({ fontSize }) => fontSize}px;
   font-variant-numeric: tabular-nums;
   text-align: center;
 

--- a/apps/spruce/src/components/TimePicker/__snapshots__/TimePicker_Default.storyshot
+++ b/apps/spruce/src/components/TimePicker/__snapshots__/TimePicker_Default.storyshot
@@ -23,7 +23,7 @@
             aria-invalid="false"
             aria-label="Time picker form"
             class="lg-ui-form-field-input-0000 emotion-ContentWrapper e9c2bxn0"
-            id="lg-form_field-input-4"
+            id="lg-form_field-input-8"
           >
             <input
               class="emotion-StyledInput evefz8k0"
@@ -89,7 +89,7 @@
         class="leafygreen-ui-11ydt2g"
         data-lgid="lg-form_field-feedback"
         data-testid="lg-form_field-feedback"
-        id="lg-form_field-feedback-3"
+        id="lg-form_field-feedback-7"
       />
     </div>
   </div>


### PR DESCRIPTION
DEVPROD-22098
<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
<!-- add description, context, thought process, etc -->
Fix bug where LG's DatePicker was setting time to midnight, overriding user-specified time

This facilitates fixing DEVPROD-20523

### Testing
<!-- add a description of how you tested it -->
- Add tests that fail without changes
- SpruceForm story