### PR TITLE
DEVPROD-19140: Add Files table to Build Information page

### DIFF
--- a/apps/spruce/cypress/integration/image/build_information.ts
+++ b/apps/spruce/cypress/integration/image/build_information.ts
@@ -166,6 +166,53 @@ describe("build information", () => {
       cy.dataCy("toolchains-table-row").should("have.length", 0);
     });
   });
+
+  describe("files", () => {
+    it("should show the corresponding files", () => {
+      cy.visit("/image/ubuntu2204");
+      cy.dataCy("files-table-row").should("have.length", 10);
+    });
+
+    it("should show different files on different pages", () => {
+      cy.visit("/image/ubuntu2204");
+      cy.dataCy("files-table-row").should("have.length", 10);
+
+      // First file name on first page.
+      cy.dataCy("files-table-row")
+        .first()
+        .find("td")
+        .first()
+        .invoke("text")
+        .as("firstFileName", { type: "static" });
+
+      cy.dataCy("files-card").within(() => {
+        cy.get("[data-testid=lg-pagination-next-button]").click();
+      });
+
+      // First file name on second page.
+      cy.dataCy("files-table-row")
+        .first()
+        .find("td")
+        .first()
+        .invoke("text")
+        .as("nextFileName", { type: "static" });
+
+      // File names should not be equal.
+      cy.get("@firstFileName").then((firstFileName) => {
+        cy.get("@nextFileName").then((nextFileName) => {
+          expect(nextFileName).not.to.equal(firstFileName);
+        });
+      });
+    });
+
+    it("should show no files when filtering for nonexistent item", () => {
+      cy.visit("/image/ubuntu2204");
+      cy.dataCy("files-table-row").should("have.length", 10);
+      cy.dataCy("file-name-filter").click();
+      cy.get('input[placeholder="Name regex"]').type("notarealfile{enter}");
+      cy.dataCy("files-table-row").should("have.length", 0);
+    });
+  });
 });
 
 describe("side nav", () => {

--- a/apps/spruce/src/analytics/image/useImageAnalytics.ts
+++ b/apps/spruce/src/analytics/image/useImageAnalytics.ts
@@ -11,12 +11,13 @@ type Action =
         | "Image Event Log"
         | "Operating System"
         | "Packages"
-        | "Toolchains";
+        | "Toolchains"
+        | "Files";
       "table.filters": ColumnFiltersState;
     }
   | {
       name: "Changed table pagination";
-      "table.name": "Operating System" | "Packages" | "Toolchains";
+      "table.name": "Operating System" | "Packages" | "Toolchains" | "Files";
       "table.pagination": PaginationState;
     }
   | {

--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -1540,6 +1540,7 @@ export type Image = {
   ami: Scalars["String"]["output"];
   distros: Array<Distro>;
   events: ImageEventsPayload;
+  files: ImageFilesPayload;
   id: Scalars["String"]["output"];
   lastDeployed: Scalars["Time"]["output"];
   latestTask?: Maybe<Task>;
@@ -1555,6 +1556,14 @@ export type Image = {
 export type ImageEventsArgs = {
   limit: Scalars["Int"]["input"];
   page: Scalars["Int"]["input"];
+};
+
+/**
+ * Image is returned by the image query.
+ * It contains information about an image.
+ */
+export type ImageFilesArgs = {
+  opts: ImageFileOpts;
 };
 
 /**
@@ -1605,6 +1614,7 @@ export enum ImageEventEntryAction {
 }
 
 export enum ImageEventType {
+  File = "FILE",
   OperatingSystem = "OPERATING_SYSTEM",
   Package = "PACKAGE",
   Toolchain = "TOOLCHAIN",
@@ -1614,6 +1624,26 @@ export type ImageEventsPayload = {
   __typename?: "ImageEventsPayload";
   count: Scalars["Int"]["output"];
   eventLogEntries: Array<ImageEvent>;
+};
+
+export type ImageFile = {
+  __typename?: "ImageFile";
+  name: Scalars["String"]["output"];
+  path: Scalars["String"]["output"];
+  version: Scalars["String"]["output"];
+};
+
+export type ImageFileOpts = {
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  name?: InputMaybe<Scalars["String"]["input"]>;
+  page?: InputMaybe<Scalars["Int"]["input"]>;
+};
+
+export type ImageFilesPayload = {
+  __typename?: "ImageFilesPayload";
+  data: Array<ImageFile>;
+  filteredCount: Scalars["Int"]["output"];
+  totalCount: Scalars["Int"]["output"];
 };
 
 export type ImageOperatingSystemPayload = {
@@ -8501,6 +8531,30 @@ export type ImageEventsQuery = {
           name: string;
           type: ImageEventType;
         }>;
+      }>;
+    };
+  } | null;
+};
+
+export type ImageFilesQueryVariables = Exact<{
+  imageId: Scalars["String"]["input"];
+  opts: ImageFileOpts;
+}>;
+
+export type ImageFilesQuery = {
+  __typename?: "Query";
+  image?: {
+    __typename?: "Image";
+    id: string;
+    files: {
+      __typename?: "ImageFilesPayload";
+      filteredCount: number;
+      totalCount: number;
+      data: Array<{
+        __typename?: "ImageFile";
+        name: string;
+        path: string;
+        version: string;
       }>;
     };
   } | null;

--- a/apps/spruce/src/gql/queries/image-files.graphql
+++ b/apps/spruce/src/gql/queries/image-files.graphql
@@ -1,0 +1,14 @@
+query ImageFiles($imageId: String!, $opts: ImageFileOpts!) {
+  image(imageId: $imageId) {
+    id
+    files(opts: $opts) {
+      data {
+        name
+        path
+        version
+      }
+      filteredCount
+      totalCount
+    }
+  }
+}

--- a/apps/spruce/src/gql/queries/index.ts
+++ b/apps/spruce/src/gql/queries/index.ts
@@ -24,6 +24,7 @@ import HOST from "./host.graphql";
 import HOSTS from "./hosts.graphql";
 import IMAGE_DISTROS from "./image-distros.graphql";
 import IMAGE_EVENTS from "./image-events.graphql";
+import IMAGE_FILES from "./image-files.graphql";
 import IMAGE_GENERAL from "./image-general.graphql";
 import IMAGE_OPERATING_SYSTEM from "./image-operating-system.graphql";
 import IMAGE_PACKAGES from "./image-packages.graphql";
@@ -119,6 +120,7 @@ export {
   HOSTS,
   IMAGE_DISTROS,
   IMAGE_EVENTS,
+  IMAGE_FILES,
   IMAGE_GENERAL,
   IMAGE_OPERATING_SYSTEM,
   IMAGE_PACKAGES,

--- a/apps/spruce/src/pages/image/FilesTable/FilesTable.test.tsx
+++ b/apps/spruce/src/pages/image/FilesTable/FilesTable.test.tsx
@@ -1,0 +1,269 @@
+import { MockedProvider } from "@apollo/client/testing";
+import { RenderFakeToastContext } from "@evg-ui/lib/context/toast/__mocks__";
+import {
+  renderWithRouterMatch as render,
+  screen,
+  userEvent,
+  waitFor,
+  within,
+} from "@evg-ui/lib/test_utils";
+import { ApolloMock } from "@evg-ui/lib/test_utils/types";
+import { ImageFilesQuery, ImageFilesQueryVariables } from "gql/generated/types";
+import { IMAGE_FILES } from "gql/queries";
+import { FilesTable } from ".";
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <MockedProvider
+    mocks={[imageFilesMock, imageFilesNextPageMock, imageFilesFilterMock]}
+  >
+    {children}
+  </MockedProvider>
+);
+
+describe("files table", () => {
+  it("shows name field data", async () => {
+    const { Component } = RenderFakeToastContext(
+      <FilesTable imageId="ubuntu2204" />,
+    );
+    render(<Component />, { wrapper });
+    await waitFor(() => {
+      expect(screen.queryAllByDataCy("files-table-row")).toHaveLength(10);
+    });
+    const expectedNames = (
+      imageFilesMock.result?.data?.image?.files.data || []
+    ).map(({ name }) => name);
+
+    const rows = screen.getAllByDataCy("files-table-row");
+    expectedNames.forEach((expectedName, i) => {
+      expect(within(rows[i]).getAllByRole("cell")[0]).toHaveTextContent(
+        expectedName,
+      );
+    });
+  });
+
+  it("shows path field data", async () => {
+    const { Component } = RenderFakeToastContext(
+      <FilesTable imageId="ubuntu2204" />,
+    );
+    render(<Component />, { wrapper });
+    await waitFor(() => {
+      expect(screen.queryAllByDataCy("files-table-row")).toHaveLength(10);
+    });
+    const expectedPaths = (
+      imageFilesMock.result?.data?.image?.files.data || []
+    ).map(({ path }) => path);
+
+    const rows = screen.getAllByDataCy("files-table-row");
+    expectedPaths.forEach((expectedPath, i) => {
+      expect(within(rows[i]).getAllByRole("cell")[1]).toHaveTextContent(
+        expectedPath,
+      );
+    });
+  });
+
+  it("shows version field data", async () => {
+    const { Component } = RenderFakeToastContext(
+      <FilesTable imageId="ubuntu2204" />,
+    );
+    render(<Component />, { wrapper });
+    await waitFor(() => {
+      expect(screen.queryAllByDataCy("files-table-row")).toHaveLength(10);
+    });
+    const expectedVersions = (
+      imageFilesMock.result?.data?.image?.files.data || []
+    ).map(({ version }) => version);
+
+    const rows = screen.getAllByDataCy("files-table-row");
+    expectedVersions.forEach((expectedVersion, i) => {
+      expect(within(rows[i]).getAllByRole("cell")[2]).toHaveTextContent(
+        expectedVersion,
+      );
+    });
+  });
+
+  it("supports name filter", async () => {
+    const user = userEvent.setup();
+    const { Component } = RenderFakeToastContext(
+      <FilesTable imageId="ubuntu2204" />,
+    );
+    render(<Component />, { wrapper });
+    await waitFor(() => {
+      expect(screen.getAllByDataCy("files-table-row")).toHaveLength(10);
+    });
+    await user.click(screen.getByDataCy("file-name-filter"));
+    await user.type(
+      screen.getByPlaceholderText("Name regex"),
+      "my-special-cert.pem{enter}",
+    );
+    await waitFor(() => {
+      expect(screen.getAllByDataCy("files-table-row")).toHaveLength(1);
+    });
+    expect(screen.getByText("1 - 1 of 1 items")).toBeInTheDocument();
+  });
+
+  it("supports pagination", async () => {
+    const user = userEvent.setup();
+    const { Component } = RenderFakeToastContext(
+      <FilesTable imageId="ubuntu2204" />,
+    );
+    render(<Component />, { wrapper });
+    await waitFor(() => {
+      expect(screen.getAllByDataCy("files-table-row")).toHaveLength(10);
+    });
+
+    const nextPageButton = screen.getByTestId("lg-pagination-next-button");
+    expect(nextPageButton).toHaveAttribute("aria-disabled", "false");
+    await user.click(nextPageButton);
+    await waitFor(() => {
+      expect(screen.getAllByDataCy("files-table-row")).toHaveLength(1);
+    });
+    expect(screen.getByText("11 - 11 of 11 items")).toBeInTheDocument();
+  });
+});
+
+const imageFilesMock: ApolloMock<ImageFilesQuery, ImageFilesQueryVariables> = {
+  request: {
+    query: IMAGE_FILES,
+    variables: { imageId: "ubuntu2204", opts: { page: 0, limit: 10 } },
+  },
+  result: {
+    data: {
+      image: {
+        __typename: "Image",
+        id: "ubuntu2204",
+        files: {
+          __typename: "ImageFilesPayload",
+          data: [
+            {
+              __typename: "ImageFile",
+              name: "certificate-1.pem",
+              path: "/etc/certs",
+              version: "sha:111111111111",
+            },
+            {
+              __typename: "ImageFile",
+              name: "certificate-2.pem",
+              path: "/etc/certs",
+              version: "sha:222222222222",
+            },
+            {
+              __typename: "ImageFile",
+              name: "certificate-3.pem",
+              path: "/etc/certs",
+              version: "sha:333333333333",
+            },
+            {
+              __typename: "ImageFile",
+              name: "certificate-4.pem",
+              path: "/etc/certs",
+              version: "sha:444444444444",
+            },
+            {
+              __typename: "ImageFile",
+              name: "certificate-5.pem",
+              path: "/etc/certs",
+              version: "sha:555555555555",
+            },
+            {
+              __typename: "ImageFile",
+              name: "certificate-6.pem",
+              path: "/etc/certs",
+              version: "sha:666666666666",
+            },
+            {
+              __typename: "ImageFile",
+              name: "certificate-7.pem",
+              path: "/etc/certs",
+              version: "sha:777777777777",
+            },
+            {
+              __typename: "ImageFile",
+              name: "certificate-8.pem",
+              path: "/etc/certs",
+              version: "sha:888888888888",
+            },
+            {
+              __typename: "ImageFile",
+              name: "certificate-9.pem",
+              path: "/etc/certs",
+              version: "sha:999999999999",
+            },
+            {
+              __typename: "ImageFile",
+              name: "certificate-10.pem",
+              path: "/etc/certs",
+              version: "sha:101010101010",
+            },
+          ],
+          filteredCount: 11,
+          totalCount: 11,
+        },
+      },
+    },
+  },
+};
+
+const imageFilesNextPageMock: ApolloMock<
+  ImageFilesQuery,
+  ImageFilesQueryVariables
+> = {
+  request: {
+    query: IMAGE_FILES,
+    variables: { imageId: "ubuntu2204", opts: { page: 1, limit: 10 } },
+  },
+  result: {
+    data: {
+      image: {
+        __typename: "Image",
+        id: "ubuntu2204",
+        files: {
+          __typename: "ImageFilesPayload",
+          data: [
+            {
+              __typename: "ImageFile",
+              name: "certificate-11.pem",
+              path: "/etc/certs",
+              version: "sha:next-page-sha",
+            },
+          ],
+          filteredCount: 11,
+          totalCount: 11,
+        },
+      },
+    },
+  },
+};
+
+const imageFilesFilterMock: ApolloMock<
+  ImageFilesQuery,
+  ImageFilesQueryVariables
+> = {
+  request: {
+    query: IMAGE_FILES,
+    variables: {
+      imageId: "ubuntu2204",
+      opts: { page: 0, limit: 10, name: "my-special-cert.pem" },
+    },
+  },
+  result: {
+    data: {
+      image: {
+        __typename: "Image",
+        id: "ubuntu2204",
+        files: {
+          __typename: "ImageFilesPayload",
+          data: [
+            {
+              __typename: "ImageFile",
+              name: "my-special-cert.pem",
+              path: "/etc/certs",
+              version: "sha:filtered-sha",
+            },
+          ],
+          filteredCount: 1,
+          totalCount: 11,
+        },
+      },
+    },
+  },
+};

--- a/apps/spruce/src/pages/image/FilesTable/index.tsx
+++ b/apps/spruce/src/pages/image/FilesTable/index.tsx
@@ -1,0 +1,128 @@
+import { useState } from "react";
+import { useQuery } from "@apollo/client";
+import { WordBreak } from "@evg-ui/lib/components/styles";
+import {
+  useLeafyGreenTable,
+  LGColumnDef,
+  ColumnFiltersState,
+  PaginationState,
+  BaseTable,
+  onChangeHandler,
+} from "@evg-ui/lib/components/Table";
+import { DEFAULT_PAGE_SIZE } from "@evg-ui/lib/constants/pagination";
+import { useToastContext } from "@evg-ui/lib/context/toast";
+import { useImageAnalytics } from "analytics";
+import {
+  ImageFilesQuery,
+  ImageFilesQueryVariables,
+  ImageFile,
+} from "gql/generated/types";
+import { IMAGE_FILES } from "gql/queries";
+
+type FilesTableProps = {
+  imageId: string;
+};
+
+export const FilesTable: React.FC<FilesTableProps> = ({ imageId }) => {
+  const dispatchToast = useToastContext();
+  const { sendEvent } = useImageAnalytics();
+  const [pagination, setPagination] = useState<PaginationState>({
+    pageIndex: 0,
+    pageSize: DEFAULT_PAGE_SIZE,
+  });
+  const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
+
+  const { data: imageData, loading } = useQuery<
+    ImageFilesQuery,
+    ImageFilesQueryVariables
+  >(IMAGE_FILES, {
+    variables: {
+      imageId,
+      opts: {
+        page: pagination.pageIndex,
+        limit: pagination.pageSize,
+        name:
+          (columnFilters.find((filter) => filter.id === "name")
+            ?.value as string) ?? undefined,
+      },
+    },
+    onError: (err) => {
+      dispatchToast.error(
+        `There was an error loading image files: ${err.message}`,
+      );
+    },
+  });
+
+  const files = imageData?.image?.files?.data ?? [];
+
+  const numTotalItems =
+    imageData?.image?.files?.filteredCount ??
+    imageData?.image?.files?.totalCount;
+
+  const table = useLeafyGreenTable<ImageFile>({
+    columns,
+    data: files,
+    defaultColumn: {
+      enableColumnFilter: false,
+    },
+    manualFiltering: true,
+    manualPagination: true,
+    onColumnFiltersChange: onChangeHandler<ColumnFiltersState>(
+      setColumnFilters,
+      (f) =>
+        sendEvent({
+          name: "Filtered table",
+          "table.name": "Files",
+          "table.filters": f,
+        }),
+    ),
+    onPaginationChange: onChangeHandler<PaginationState>(setPagination, (p) =>
+      sendEvent({
+        name: "Changed table pagination",
+        "table.name": "Files",
+        "table.pagination": p,
+      }),
+    ),
+    state: {
+      pagination,
+      columnFilters,
+    },
+  });
+
+  return (
+    <BaseTable
+      data-cy-row="files-table-row"
+      loading={loading}
+      loadingRows={pagination.pageSize}
+      numTotalItems={numTotalItems}
+      shouldAlternateRowColor
+      table={table}
+      usePagination
+    />
+  );
+};
+
+const columns: LGColumnDef<ImageFile>[] = [
+  {
+    header: "Name",
+    accessorKey: "name",
+    enableColumnFilter: true,
+    meta: {
+      search: {
+        "data-cy": "file-name-filter",
+        placeholder: "Name regex",
+      },
+    },
+    cell: ({ getValue }) => <WordBreak>{getValue() as string}</WordBreak>,
+  },
+  {
+    header: "Path",
+    accessorKey: "path",
+    cell: ({ getValue }) => <WordBreak>{getValue() as string}</WordBreak>,
+  },
+  {
+    header: "File SHA",
+    accessorKey: "version",
+    cell: ({ getValue }) => <WordBreak>{getValue() as string}</WordBreak>,
+  },
+];

--- a/apps/spruce/src/pages/image/ImageEventLog/ImageEventLogTable.tsx
+++ b/apps/spruce/src/pages/image/ImageEventLog/ImageEventLogTable.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import styled from "@emotion/styled";
 import Badge, { Variant } from "@leafygreen-ui/badge";
+import { WordBreak } from "@evg-ui/lib/components/styles";
 import {
   ColumnFiltersState,
   useLeafyGreenTable,
@@ -54,12 +55,18 @@ const imageEventTypeTreeData = [
     value: ImageEventType.OperatingSystem,
     key: ImageEventType.OperatingSystem,
   },
+  {
+    title: "File",
+    value: ImageEventType.File,
+    key: ImageEventType.File,
+  },
 ];
 
 const eventTypeToLabel = {
   [ImageEventType.Package]: "Package",
   [ImageEventType.Toolchain]: "Toolchain",
   [ImageEventType.OperatingSystem]: "OS",
+  [ImageEventType.File]: "File",
 };
 
 interface ImageEventLogTableProps {
@@ -130,7 +137,9 @@ const columns: LGColumnDef<ImageEventEntry>[] = [
         "data-cy": "image-event-log-name-filter",
         placeholder: "Search name",
       },
+      width: "25%",
     },
+    cell: ({ getValue }) => <WordBreak>{getValue() as string}</WordBreak>,
   },
   {
     header: "Type",
@@ -147,15 +156,18 @@ const columns: LGColumnDef<ImageEventEntry>[] = [
         filterOptions: true,
         options: imageEventTypeTreeData,
       },
+      width: "15%",
     },
   },
   {
     header: "Before",
     accessorKey: "before",
+    cell: ({ getValue }) => <WordBreak>{getValue() as string}</WordBreak>,
   },
   {
     header: "After",
     accessorKey: "after",
+    cell: ({ getValue }) => <WordBreak>{getValue() as string}</WordBreak>,
   },
   {
     header: "Action",
@@ -168,6 +180,7 @@ const columns: LGColumnDef<ImageEventEntry>[] = [
         filterOptions: true,
         options: imageEventEntryActionTreeData,
       },
+      width: "5%",
     },
     cell: ({ getValue }) => {
       const value = getValue() as ImageEventEntryAction;

--- a/apps/spruce/src/pages/image/tabs/BuildInformationTab/constants.ts
+++ b/apps/spruce/src/pages/image/tabs/BuildInformationTab/constants.ts
@@ -26,4 +26,9 @@ export const tocItems: {
     observedElementId: "toc-item-toolchains",
     title: "Toolchains",
   },
+  files: {
+    id: "files",
+    observedElementId: "toc-item-files",
+    title: "Files",
+  },
 };

--- a/apps/spruce/src/pages/image/tabs/BuildInformationTab/index.tsx
+++ b/apps/spruce/src/pages/image/tabs/BuildInformationTab/index.tsx
@@ -1,5 +1,6 @@
 import { SpruceFormContainer } from "components/SpruceForm";
 import { DistrosTable } from "pages/image/DistrosTable";
+import { FilesTable } from "pages/image/FilesTable";
 import { GeneralTable } from "pages/image/GeneralTable";
 import { OperatingSystemTable } from "pages/image/OperatingSystemTable";
 import { PackagesTable } from "pages/image/PackagesTable";
@@ -48,6 +49,13 @@ export const BuildInformationTab: React.FC<BuildInformationTabProps> = ({
       title={tocItems.toolchains.title}
     >
       <ToolchainsTable imageId={imageId} />
+    </SpruceFormContainer>
+    <SpruceFormContainer
+      data-cy="files-card"
+      id={tocItems.files.observedElementId}
+      title={tocItems.files.title}
+    >
+      <FilesTable imageId={imageId} />
     </SpruceFormContainer>
   </>
 );


### PR DESCRIPTION
DEVPROD-19140
<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
Adds Files table to Build Information page.

### Screenshots
<!-- add screenshots of visible changes -->

### Testing
* Cypress tests
* Unit tests
