### PR TITLE
DEVPROD-22827 Add regex search on BuildVariantCard

### DIFF
--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -1974,6 +1974,7 @@ export type Mutation = {
   moveAnnotationIssue: Scalars["Boolean"]["output"];
   overrideTaskDependencies: Task;
   promoteVarsToRepo: Scalars["Boolean"]["output"];
+  quarantineTest: QuarantineTestPayload;
   removeAnnotationIssue: Scalars["Boolean"]["output"];
   removeFavoriteProject: Project;
   removePublicKey: Array<PublicKey>;
@@ -2130,6 +2131,10 @@ export type MutationOverrideTaskDependenciesArgs = {
 
 export type MutationPromoteVarsToRepoArgs = {
   opts: PromoteVarsToRepoInput;
+};
+
+export type MutationQuarantineTestArgs = {
+  opts: QuarantineTestInput;
 };
 
 export type MutationRemoveAnnotationIssueArgs = {
@@ -2815,6 +2820,7 @@ export type Project = {
   stepbackBisect?: Maybe<Scalars["Boolean"]["output"]>;
   stepbackDisabled?: Maybe<Scalars["Boolean"]["output"]>;
   taskAnnotationSettings: TaskAnnotationSettings;
+  testSelection?: Maybe<TestSelectionSettings>;
   tracksPushEvents?: Maybe<Scalars["Boolean"]["output"]>;
   triggers?: Maybe<Array<TriggerAlias>>;
   versionControlEnabled?: Maybe<Scalars["Boolean"]["output"]>;
@@ -2966,6 +2972,7 @@ export type ProjectInput = {
   stepbackBisect?: InputMaybe<Scalars["Boolean"]["input"]>;
   stepbackDisabled?: InputMaybe<Scalars["Boolean"]["input"]>;
   taskAnnotationSettings?: InputMaybe<TaskAnnotationSettingsInput>;
+  testSelection?: InputMaybe<TestSelectionSettingsInput>;
   tracksPushEvents?: InputMaybe<Scalars["Boolean"]["input"]>;
   triggers?: InputMaybe<Array<TriggerAliasInput>>;
   versionControlEnabled?: InputMaybe<Scalars["Boolean"]["input"]>;
@@ -3027,6 +3034,7 @@ export enum ProjectSettingsSection {
   PatchAliases = "PATCH_ALIASES",
   PeriodicBuilds = "PERIODIC_BUILDS",
   Plugins = "PLUGINS",
+  TestSelection = "TEST_SELECTION",
   Triggers = "TRIGGERS",
   Variables = "VARIABLES",
   ViewsAndFilters = "VIEWS_AND_FILTERS",
@@ -3083,6 +3091,16 @@ export type PublicKey = {
 export type PublicKeyInput = {
   key: Scalars["String"]["input"];
   name: Scalars["String"]["input"];
+};
+
+export type QuarantineTestInput = {
+  taskId: Scalars["String"]["input"];
+  testName: Scalars["String"]["input"];
+};
+
+export type QuarantineTestPayload = {
+  __typename?: "QuarantineTestPayload";
+  success: Scalars["Boolean"]["output"];
 };
 
 export type Query = {
@@ -3370,6 +3388,7 @@ export type RepoRef = {
   stepbackBisect?: Maybe<Scalars["Boolean"]["output"]>;
   stepbackDisabled: Scalars["Boolean"]["output"];
   taskAnnotationSettings: TaskAnnotationSettings;
+  testSelection?: Maybe<RepoTestSelectionSettings>;
   tracksPushEvents: Scalars["Boolean"]["output"];
   triggers: Array<TriggerAlias>;
   versionControlEnabled: Scalars["Boolean"]["output"];
@@ -3417,6 +3436,7 @@ export type RepoRefInput = {
   stepbackBisect?: InputMaybe<Scalars["Boolean"]["input"]>;
   stepbackDisabled?: InputMaybe<Scalars["Boolean"]["input"]>;
   taskAnnotationSettings?: InputMaybe<TaskAnnotationSettingsInput>;
+  testSelection?: InputMaybe<TestSelectionSettingsInput>;
   tracksPushEvents?: InputMaybe<Scalars["Boolean"]["input"]>;
   triggers?: InputMaybe<Array<TriggerAliasInput>>;
   versionControlEnabled?: InputMaybe<Scalars["Boolean"]["input"]>;
@@ -3447,6 +3467,12 @@ export type RepoSettingsInput = {
   repoId: Scalars["String"]["input"];
   subscriptions?: InputMaybe<Array<SubscriptionInput>>;
   vars?: InputMaybe<ProjectVarsInput>;
+};
+
+export type RepoTestSelectionSettings = {
+  __typename?: "RepoTestSelectionSettings";
+  allowed: Scalars["Boolean"]["output"];
+  defaultEnabled: Scalars["Boolean"]["output"];
 };
 
 export type RepoWorkstationConfig = {
@@ -4093,6 +4119,7 @@ export type Task = {
   taskGroupMaxHosts?: Maybe<Scalars["Int"]["output"]>;
   taskLogs: TaskLogs;
   taskOwnerTeam?: Maybe<TaskOwnerTeam>;
+  testSelectionEnabled: Scalars["Boolean"]["output"];
   tests: TaskTestResult;
   timeTaken?: Maybe<Scalars["Duration"]["output"]>;
   totalTestCount: Scalars["Int"]["output"];
@@ -4438,6 +4465,17 @@ export type TestSelectionConfig = {
 
 export type TestSelectionConfigInput = {
   url: Scalars["String"]["input"];
+};
+
+export type TestSelectionSettings = {
+  __typename?: "TestSelectionSettings";
+  allowed?: Maybe<Scalars["Boolean"]["output"]>;
+  defaultEnabled?: Maybe<Scalars["Boolean"]["output"]>;
+};
+
+export type TestSelectionSettingsInput = {
+  allowed?: InputMaybe<Scalars["Boolean"]["input"]>;
+  defaultEnabled?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
 export enum TestSortCategory {

--- a/apps/spruce/src/pages/configurePatch/configurePatchCore/ConfigureBuildVariants/BuildVariantCard.tsx
+++ b/apps/spruce/src/pages/configurePatch/configurePatchCore/ConfigureBuildVariants/BuildVariantCard.tsx
@@ -1,8 +1,12 @@
+import { useEffect, useRef, useState } from "react";
 import { css } from "@emotion/react";
 import styled from "@emotion/styled";
 import Badge, { Variant } from "@leafygreen-ui/badge";
+import IconButton from "@leafygreen-ui/icon-button";
 import { palette } from "@leafygreen-ui/palette";
+import { SearchInput } from "@leafygreen-ui/search-input";
 import { Body, Description } from "@leafygreen-ui/typography";
+import Icon from "@evg-ui/lib/components/Icon";
 import { size } from "@evg-ui/lib/constants/tokens";
 import { SiderCard } from "components/styles";
 import { Divider } from "components/styles/divider";
@@ -25,50 +29,100 @@ const BuildVariantCard: React.FC<BuildVariantCardProps> = ({
   onClick,
   selectedMenuItems,
   title,
-}) => (
-  <StyledSiderCard>
-    <Container>
-      <Body weight="medium">{title}</Body>
-      <Description>
-        Use Shift + Click to edit multiple variants simultaneously.
-      </Description>
-      <Divider />
-    </Container>
-    <ScrollableBuildVariantContainer>
-      {menuItems.map(({ displayName, name, taskCount }) => {
-        const isSelected = selectedMenuItems.includes(name);
-        return (
-          <BuildVariant
-            key={name}
-            data-cy={dataCy}
-            data-selected={isSelected}
-            isSelected={isSelected}
-            onClick={onClick(name)}
-          >
-            <VariantName>
-              <Body weight={isSelected || taskCount > 0 ? "medium" : "regular"}>
-                {displayName}
-              </Body>
-            </VariantName>
-            {taskCount > 0 && (
-              <StyledBadge
-                data-cy="task-count-badge"
-                variant={isSelected ? Variant.DarkGray : Variant.LightGray}
-              >
-                {taskCount}
-              </StyledBadge>
-            )}
-          </BuildVariant>
-        );
-      })}
-    </ScrollableBuildVariantContainer>
-  </StyledSiderCard>
-);
+}) => {
+  const [filteredMenuItems, setFilteredMenuItems] =
+    useState<MenuItemProps[]>(menuItems);
+  const searchRef = useRef<HTMLInputElement>(null);
+  const [showSearch, setShowSearch] = useState(false);
+
+  useEffect(() => {
+    if (showSearch) {
+      searchRef.current?.focus();
+    }
+  }, [showSearch]);
+
+  const onSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setFilteredMenuItems(
+      menuItems.filter((item) => {
+        try {
+          const regex = new RegExp(e.target.value, "i");
+          return regex.test(item.displayName) || regex.test(item.name);
+        } catch {
+          // If invalid regex, fallback to substring match
+          const val = e.target.value.toLowerCase();
+          return (
+            item.displayName.toLowerCase().includes(val) ||
+            item.name.toLowerCase().includes(val)
+          );
+        }
+      }),
+    );
+  };
+  return (
+    <StyledSiderCard>
+      <Container>
+        <TitleContainer>
+          <Body weight="medium">{title} </Body>
+          <IconButton onClick={() => setShowSearch(!showSearch)}>
+            <Icon glyph="MagnifyingGlass" />
+          </IconButton>
+        </TitleContainer>
+        {showSearch && (
+          <SearchInput
+            ref={searchRef}
+            aria-labelledby={title}
+            onChange={onSearchChange}
+            placeholder="Search build variants regex"
+          />
+        )}
+        <Description>
+          Use Shift + Click to edit multiple variants simultaneously.
+        </Description>
+        <Divider />
+      </Container>
+      <ScrollableBuildVariantContainer>
+        {filteredMenuItems.map(({ displayName, name, taskCount }) => {
+          const isSelected = selectedMenuItems.includes(name);
+          return (
+            <BuildVariant
+              key={name}
+              data-cy={dataCy}
+              data-selected={isSelected}
+              isSelected={isSelected}
+              onClick={onClick(name)}
+            >
+              <VariantName>
+                <Body
+                  weight={isSelected || taskCount > 0 ? "medium" : "regular"}
+                >
+                  {displayName}
+                </Body>
+              </VariantName>
+              {taskCount > 0 && (
+                <StyledBadge
+                  data-cy="task-count-badge"
+                  variant={isSelected ? Variant.DarkGray : Variant.LightGray}
+                >
+                  {taskCount}
+                </StyledBadge>
+              )}
+            </BuildVariant>
+          );
+        })}
+      </ScrollableBuildVariantContainer>
+    </StyledSiderCard>
+  );
+};
 
 interface VariantProps {
   isSelected: boolean;
 }
 
+const TitleContainer = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+`;
 const cardSidePadding = css`
   padding-left: ${size.xs};
   padding-right: ${size.xs};


### PR DESCRIPTION
DEVPROD-22827 
<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
Adds a regex filter to the build variant list on the configure page. 
### Screenshots
<img width="295" height="538" alt="image" src="https://github.com/user-attachments/assets/2c6266a3-11eb-42fc-b355-cc08610c56f4" />
<img width="315" height="496" alt="image" src="https://github.com/user-attachments/assets/6ae51e5f-dc30-47f9-b449-c431cd02cabe" />

