### PR TITLE
DEVPROD-23397: Add loading state to admin settings save button

### DIFF
--- a/apps/spruce/src/pages/adminSettings/AdminSaveButton.tsx
+++ b/apps/spruce/src/pages/adminSettings/AdminSaveButton.tsx
@@ -30,7 +30,7 @@ export const AdminSaveButton: React.FC<AdminSaveButtonProps> = ({
   const hasUnsavedChanges = checkHasUnsavedChanges();
   const dispatchToast = useToastContext();
 
-  const [saveAdminSettings] = useMutation<
+  const [saveAdminSettings, { loading }] = useMutation<
     SaveAdminSettingsMutation,
     SaveAdminSettingsMutationVariables
   >(SAVE_ADMIN_SETTINGS, {
@@ -63,7 +63,8 @@ export const AdminSaveButton: React.FC<AdminSaveButtonProps> = ({
   return saveable ? (
     <Button
       data-cy="save-settings-button"
-      disabled={!hasUnsavedChanges}
+      disabled={!hasUnsavedChanges || loading}
+      loading={loading}
       onClick={handleSave}
       style={{ alignSelf: "flex-end" }}
       variant={ButtonVariant.Primary}

--- a/apps/spruce/src/pages/adminSettings/AdminSaveButton.tsx
+++ b/apps/spruce/src/pages/adminSettings/AdminSaveButton.tsx
@@ -64,7 +64,7 @@ export const AdminSaveButton: React.FC<AdminSaveButtonProps> = ({
     <Button
       data-cy="save-settings-button"
       disabled={!hasUnsavedChanges || loading}
-      loading={loading}
+      isLoading={loading}
       onClick={handleSave}
       style={{ alignSelf: "flex-end" }}
       variant={ButtonVariant.Primary}


### PR DESCRIPTION
DEVPROD-23397

### Description
Added a loading spinner to the save button on the admin settings page to provide visual feedback when the save mutation is in progress. The button is also disabled during the save operation to prevent double-clicks.

Changes made:
- Destructured `loading` state from the `useMutation` hook
- Added `loading` prop to the Button component to show a spinner
- Updated `disabled` prop to include loading state to prevent double-clicks

### Testing
Manual testing of the admin settings page save functionality.