### PR TITLE
DEVPROD-23624: Add authorize button to patch configure page

### DIFF
--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -9179,6 +9179,10 @@ export type ConfigurePatchQuery = {
         tasks: Array<string>;
       }>;
     }> | null;
+    githubPatchData?: {
+      __typename?: "GithubPatch";
+      prNumber?: number | null;
+    } | null;
     patchTriggerAliases: Array<{
       __typename?: "PatchTriggerAlias";
       alias: string;
@@ -9200,6 +9204,7 @@ export type ConfigurePatchQuery = {
       }>;
     } | null;
     time?: { __typename?: "PatchTime"; submittedAt: string } | null;
+    versionFull?: { __typename?: "Version"; id: string } | null;
     parameters: Array<{ __typename?: "Parameter"; key: string; value: string }>;
     variantsTasks: Array<{
       __typename?: "VariantTask";

--- a/apps/spruce/src/gql/queries/patch-configure.graphql
+++ b/apps/spruce/src/gql/queries/patch-configure.graphql
@@ -15,6 +15,9 @@ query ConfigurePatch($id: String!) {
         tasks
       }
     }
+    githubPatchData {
+      prNumber
+    }
     patchTriggerAliases {
       alias
       childProjectId
@@ -34,6 +37,9 @@ query ConfigurePatch($id: String!) {
     projectIdentifier
     time {
       submittedAt
+    }
+    versionFull {
+      id
     }
   }
 }

--- a/apps/spruce/src/pages/configurePatch/configurePatchCore/index.tsx
+++ b/apps/spruce/src/pages/configurePatch/configurePatchCore/index.tsx
@@ -69,7 +69,7 @@ const ConfigurePatchCore: React.FC<ConfigurePatchCoreProps> = ({
     projectIdentifier,
     time,
     variantsTasks,
-    version,
+    versionFull,
   } = patch;
   const { variants = [] } = project || {};
 
@@ -171,7 +171,7 @@ const ConfigurePatchCore: React.FC<ConfigurePatchCoreProps> = ({
     );
   }
 
-  const isUnauthorizedGHPatch = !version.id && githubPatchData.prNumber !== 0;
+  const isUnauthorizedGHPatch = !versionFull?.id && githubPatchData?.prNumber;
 
   const estimatedActivatedTasksCount = sumActivatedTasksInVariantsTasks(
     selectedBuildVariantTasks,
@@ -375,6 +375,7 @@ const ButtonWrapper = styled.div`
   margin-top: ${size.m};
   display: flex;
   gap: ${size.s};
+  white-space: nowrap;
 `;
 
 const FlexRow = styled.div`

--- a/apps/spruce/src/pages/configurePatch/configurePatchCore/index.tsx
+++ b/apps/spruce/src/pages/configurePatch/configurePatchCore/index.tsx
@@ -61,6 +61,7 @@ const ConfigurePatchCore: React.FC<ConfigurePatchCoreProps> = ({
     author,
     childPatchAliases,
     childPatches,
+    githubPatchData,
     id,
     patchTriggerAliases,
     project,
@@ -68,6 +69,7 @@ const ConfigurePatchCore: React.FC<ConfigurePatchCoreProps> = ({
     projectIdentifier,
     time,
     variantsTasks,
+    version,
   } = patch;
   const { variants = [] } = project || {};
 
@@ -169,6 +171,8 @@ const ConfigurePatchCore: React.FC<ConfigurePatchCoreProps> = ({
     );
   }
 
+  const isUnauthorizedGHPatch = !version.id && githubPatchData.prNumber !== 0;
+
   const estimatedActivatedTasksCount = sumActivatedTasksInVariantsTasks(
     selectedBuildVariantTasks,
     generatedTaskCounts || [],
@@ -206,11 +210,11 @@ const ConfigurePatchCore: React.FC<ConfigurePatchCoreProps> = ({
             title={
               loadingGeneratedTaskCounts
                 ? "Still estimating total task count"
-                : "Schedule"
+                : undefined
             }
             variant="primary"
           >
-            Schedule
+            {isUnauthorizedGHPatch ? "Authorize & Schedule" : "Schedule"}
           </LoadingButton>
         </ButtonWrapper>
       </FlexRow>


### PR DESCRIPTION
DEVPROD-23264
<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
<!-- add description, context, thought process, etc -->
Evergreen explicitly has an "authorize" button to schedule unauthorized patches. "Schedule" does this functionally, but we can add "Authorize" to the button when appropriate to make this more clear to users using the same [logic](https://github.com/evergreen-ci/evergreen/blob/46264607ec53f5e7278eb587b15c0514c6e1f856/public/static/js/patch_new.js#L107) present in Evergreen.

This change enables removing the legacy configure patch page.

### Screenshots
<!-- add screenshots of visible changes -->
<img width="1464" height="976" alt="image" src="https://github.com/user-attachments/assets/d3ab0a8b-6dbb-473f-ae3a-b7d94a5c1922" />

### Testing
<!-- add a description of how you tested it -->

From this PR, visit https://spruce-local.corp.mongodb.com:8443/patch/6903c59b694f010007229390/configure/tasks (an unauthorized PR opened by Copilot)