### PR TITLE
DEVPROD-23203: Fix filename parsing in file diff viewer

### DIFF
--- a/apps/spruce/src/components/CodeChanges/useFileDiffStream.test.ts
+++ b/apps/spruce/src/components/CodeChanges/useFileDiffStream.test.ts
@@ -137,4 +137,31 @@ describe("useFileDiffStream", () => {
       style: undefined,
     });
   });
+
+  it("correctly matches file paths containing 'b/'", () => {
+    renderHook(() =>
+      useFileDiffStream({
+        url: "https://example.com/diff",
+        containerRef: mockContainerRef,
+        fileName: "buildscripts/resmokelib/config.py",
+      }),
+    );
+
+    const result1 = processLine(
+      "diff --git a/buildscripts/resmokelib/config.py b/buildscripts/resmokelib/config.py",
+    );
+    expect(result1.htmlContent).toBeTruthy();
+    expect(result1.style).toBeDefined();
+
+    const result2 = processLine("index 34fefb98beb..5c9f2d43018 100644");
+    expect(result2.htmlContent).toBeTruthy();
+
+    const result3 = processLine(
+      "diff --git a/buildscripts/resmokelib/run/__init__.py b/buildscripts/resmokelib/run/__init__.py",
+    );
+    expect(result3).toEqual({
+      htmlContent: "",
+      style: undefined,
+    });
+  });
 });

--- a/apps/spruce/src/components/CodeChanges/useFileDiffStream.ts
+++ b/apps/spruce/src/components/CodeChanges/useFileDiffStream.ts
@@ -35,7 +35,7 @@ export const useFileDiffStream = ({
 
       if (isNewFile) {
         // Extract filename from after 'b/' in git diff output
-        const filePathMatch = lineContent.match(/b\/(.+)$/);
+        const filePathMatch = lineContent.match(/^diff --git a\/.+ b\/(.+)$/);
         if (filePathMatch) {
           const filePath = filePathMatch[1].trim();
           const normalizedFileName = fileName.trim();

--- a/apps/spruce/src/hooks/useHTMLStream/utils.ts
+++ b/apps/spruce/src/hooks/useHTMLStream/utils.ts
@@ -103,6 +103,7 @@ export const styles = css`
     padding: 0 4px;
     opacity: 0.4;
     transition: opacity 0.2s;
+    user-select: none;
   }
 
   .${CLASSNAME_LINE_LINK}:hover {


### PR DESCRIPTION
DEVPROD-23203
<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
<!-- add description, context, thought process, etc -->
We were accidentally matching on any `b/` instead of the correct instance in the `git diff` line 🤦‍♀️ this led to some empty pages when users clicked on the diff links.

Also add CSS to omit the 🔗 icon from copied text!

### Testing
<!-- add a description of how you tested it -->
Add test for filename that includes `b/`. It fails without these changes.

Broken patch on prod, fixed with these changes: https://spruce.mongodb.com/version/6938231106903e00070bc00b/changes?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC