### PR TITLE
DEVPROD-25325 Fix outdated host stranded message

### DIFF
--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -3724,7 +3724,6 @@ export type ServiceFlags = {
   jiraNotificationsDisabled?: Maybe<Scalars["Boolean"]["output"]>;
   jwtTokenForCLIDisabled?: Maybe<Scalars["Boolean"]["output"]>;
   largeParserProjectsDisabled?: Maybe<Scalars["Boolean"]["output"]>;
-  legacyUIAdminPageDisabled?: Maybe<Scalars["Boolean"]["output"]>;
   monitorDisabled?: Maybe<Scalars["Boolean"]["output"]>;
   podAllocatorDisabled?: Maybe<Scalars["Boolean"]["output"]>;
   podInitDisabled?: Maybe<Scalars["Boolean"]["output"]>;
@@ -3763,7 +3762,6 @@ export type ServiceFlagsInput = {
   jiraNotificationsDisabled?: InputMaybe<Scalars["Boolean"]["input"]>;
   jwtTokenForCLIDisabled?: InputMaybe<Scalars["Boolean"]["input"]>;
   largeParserProjectsDisabled?: InputMaybe<Scalars["Boolean"]["input"]>;
-  legacyUIAdminPageDisabled?: InputMaybe<Scalars["Boolean"]["input"]>;
   monitorDisabled?: InputMaybe<Scalars["Boolean"]["input"]>;
   podAllocatorDisabled?: InputMaybe<Scalars["Boolean"]["input"]>;
   podInitDisabled?: InputMaybe<Scalars["Boolean"]["input"]>;
@@ -4116,6 +4114,7 @@ export type Task = {
   patch?: Maybe<Patch>;
   patchNumber?: Maybe<Scalars["Int"]["output"]>;
   pod?: Maybe<Pod>;
+  predictedTaskCost?: Maybe<TaskCost>;
   priority?: Maybe<Scalars["Int"]["output"]>;
   project?: Maybe<Project>;
   projectId: Scalars["String"]["output"];

--- a/apps/spruce/src/pages/task/metadata/DetailsDescription/index.tsx
+++ b/apps/spruce/src/pages/task/metadata/DetailsDescription/index.tsx
@@ -121,6 +121,6 @@ const processFailingCommand = (
 const containerTaskStrandedMessage =
   "Task failed because the container was stranded by the ECS agent.";
 const hostTaskStrandedMessage =
-  "Task failed because spot host was unexpectedly terminated by AWS.";
+  "Task failed because the host became unreachable unexpectedly";
 
 export default DetailsDescription;


### PR DESCRIPTION
The UI currently explains stranded-host failures as “spot host was unexpectedly terminated by AWS.” This was historically usually true when we ran on spot instances, but we no longer use spot hosts. Today, stranded-host failures are more commonly caused by host OOMs or underlying hardware issues, so the copy is misleading.