### PR TITLE
DEVPROD-25351 add release mode description

### DIFF
--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -3714,6 +3714,7 @@ export type ServiceFlags = {
   checkBlockedTasksDisabled?: Maybe<Scalars["Boolean"]["output"]>;
   cliUpdatesDisabled?: Maybe<Scalars["Boolean"]["output"]>;
   cloudCleanupDisabled?: Maybe<Scalars["Boolean"]["output"]>;
+  debugSpawnHostDisabled?: Maybe<Scalars["Boolean"]["output"]>;
   degradedModeDisabled?: Maybe<Scalars["Boolean"]["output"]>;
   elasticIPsDisabled?: Maybe<Scalars["Boolean"]["output"]>;
   emailNotificationsDisabled?: Maybe<Scalars["Boolean"]["output"]>;
@@ -3752,6 +3753,7 @@ export type ServiceFlagsInput = {
   checkBlockedTasksDisabled?: InputMaybe<Scalars["Boolean"]["input"]>;
   cliUpdatesDisabled?: InputMaybe<Scalars["Boolean"]["input"]>;
   cloudCleanupDisabled?: InputMaybe<Scalars["Boolean"]["input"]>;
+  debugSpawnHostDisabled?: InputMaybe<Scalars["Boolean"]["input"]>;
   degradedModeDisabled?: InputMaybe<Scalars["Boolean"]["input"]>;
   elasticIPsDisabled?: InputMaybe<Scalars["Boolean"]["input"]>;
   emailNotificationsDisabled?: InputMaybe<Scalars["Boolean"]["input"]>;

--- a/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/OtherTab/schemaFields.ts
+++ b/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/OtherTab/schemaFields.ts
@@ -51,8 +51,6 @@ export const miscSettings = {
     releaseMode: {
       type: "object" as const,
       title: "Release Mode",
-      description:
-        "Release mode allows Evergreen to scale more aggressively by affecting the following factors. Note that it doesn't change task queue ordering; this is still handled by adjusting priorities.",
       properties: {
         distroMaxHostsFactor: {
           type: "number" as const,
@@ -103,6 +101,8 @@ export const miscSettings = {
       "ui:fieldCss": fullWidthCss,
     },
     releaseMode: {
+      "ui:description":
+        "Release mode allows Evergreen to scale more aggressively by affecting the following factors. Note that it doesn't change task queue ordering; this is still handled by adjusting priorities.",
       "ui:fieldCss": nestedObjectGridCss,
       distroMaxHostsFactor: {
         "ui:description":

--- a/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/OtherTab/schemaFields.ts
+++ b/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/OtherTab/schemaFields.ts
@@ -51,6 +51,8 @@ export const miscSettings = {
     releaseMode: {
       type: "object" as const,
       title: "Release Mode",
+      description:
+        "Release mode allows Evergreen to scale more aggressively by affecting the following factors. Note that it doesn't change task queue ordering; this is still handled by adjusting priorities.",
       properties: {
         distroMaxHostsFactor: {
           type: "number" as const,

--- a/apps/spruce/src/pages/adminSettings/tabs/sharedStyles.ts
+++ b/apps/spruce/src/pages/adminSettings/tabs/sharedStyles.ts
@@ -39,6 +39,7 @@ export const nestedObjectGridCss = css`
     // Makes description span all columns.
     > p:first-of-type {
       ${fullWidthCss};
+    }
   }
 `;
 

--- a/apps/spruce/src/pages/adminSettings/tabs/sharedStyles.ts
+++ b/apps/spruce/src/pages/adminSettings/tabs/sharedStyles.ts
@@ -32,9 +32,13 @@ export const nestedObjectGridCss = css`
   ${fullWidthCss};
   > fieldset {
     ${gridWrapCss};
+    // Makes title span all columns.
     > div:first-of-type {
       ${fullWidthCss};
     }
+    // Makes description span all columns.
+    > p:first-of-type {
+      ${fullWidthCss};
   }
 `;
 


### PR DESCRIPTION
DEVPROD-25351 

### Description
Just adding a small description to the admin page; this came up during the 24 hour release process.

I can't figure out how to make the css allow the description to be full size and the labels to still be nested; lmk if you know how to make this better.

Also, I don't understand the codegen thing that was needed, but I just did things until I got through the pre-commit hooks 🤷‍♀️😭

### Screenshots
<img width="1130" height="266" alt="image" src="https://github.com/user-attachments/assets/943337cf-3e23-455a-aecf-783bf2d5223e" />

