### PR TITLE
DEVPROD-23988 Add warning banner for OAuth spawn hosts

### DIFF
--- a/apps/spruce/src/components/Spawn/spawnHostModal/getFormSchema.tsx
+++ b/apps/spruce/src/components/Spawn/spawnHostModal/getFormSchema.tsx
@@ -238,6 +238,9 @@ export const getFormSchema = ({
                         title:
                           "Use OAuth authentication to download the task data from Evergreen. This will soon be required, see DEVPROD-4160",
                       },
+                      warningBanner: {
+                        type: "null" as const,
+                      },
                     },
                   },
                 ],
@@ -431,6 +434,21 @@ export const getFormSchema = ({
             "ui:widget": hasValidTask ? widgets.CheckboxWidget : "hidden",
             "ui:data-cy": "use-oauth-checkbox",
             "ui:elementWrapperCSS": childCheckboxCSS,
+          },
+          warningBanner: {
+            "ui:showLabel": false,
+            "ui:warnings": [
+              <>
+                Spawn hosts with OAuth require additional setup. After SSHing in
+                to your spawnhost, please run the command{" "}
+                <InlineCode>evergreen host fetch</InlineCode>. For more details,
+                refer to the{" "}
+                <StyledRouterLink to="https://docs.devprod.prod.corp.mongodb.com/evergreen/Hosts/Spawn-Hosts#spawning-a-host-from-a-task">
+                  documentation
+                </StyledRouterLink>
+                .
+              </>,
+            ],
           },
         },
       }),

--- a/apps/spruce/src/components/Spawn/spawnHostModal/getFormSchema.tsx
+++ b/apps/spruce/src/components/Spawn/spawnHostModal/getFormSchema.tsx
@@ -238,8 +238,21 @@ export const getFormSchema = ({
                         title:
                           "Use OAuth authentication to download the task data from Evergreen. This will soon be required, see DEVPROD-4160",
                       },
-                      warningBanner: {
-                        type: "null" as const,
+                    },
+                    dependencies: {
+                      useOAuth: {
+                        oneOf: [
+                          {
+                            properties: {
+                              useOAuth: {
+                                enum: [true],
+                              },
+                              warningBanner: {
+                                type: "null" as const,
+                              },
+                            },
+                          },
+                        ],
                       },
                     },
                   },

--- a/apps/spruce/src/components/Spawn/spawnHostModal/getFormSchema.tsx
+++ b/apps/spruce/src/components/Spawn/spawnHostModal/getFormSchema.tsx
@@ -1,10 +1,11 @@
 import { css } from "@emotion/react";
 import { InlineCode } from "@leafygreen-ui/typography";
-import { StyledRouterLink } from "@evg-ui/lib/components/styles";
+import { StyledLink, StyledRouterLink } from "@evg-ui/lib/components/styles";
 import { shortenGithash } from "@evg-ui/lib/utils/string";
 import { GetFormSchema } from "components/SpruceForm/types";
 import widgets from "components/SpruceForm/Widgets";
 import { LeafyGreenTextArea } from "components/SpruceForm/Widgets/LeafyGreenWidgets";
+import { taskSpawnHostDocumentationUrl } from "constants/externalResources";
 import { PreferencesTabRoutes, getPreferencesRoute } from "constants/routes";
 import {
   MyPublicKeysQuery,
@@ -456,9 +457,13 @@ export const getFormSchema = ({
                 to your spawn host, please run the command{" "}
                 <InlineCode>evergreen host fetch</InlineCode>. For more details,
                 refer to the{" "}
-                <StyledRouterLink to="https://docs.devprod.prod.corp.mongodb.com/evergreen/Hosts/Spawn-Hosts#spawning-a-host-from-a-task">
+                <StyledLink
+                  hideExternalIcon={false}
+                  href={taskSpawnHostDocumentationUrl}
+                  target="_blank"
+                >
                   documentation
-                </StyledRouterLink>
+                </StyledLink>
                 .
               </>,
             ],

--- a/apps/spruce/src/components/Spawn/spawnHostModal/getFormSchema.tsx
+++ b/apps/spruce/src/components/Spawn/spawnHostModal/getFormSchema.tsx
@@ -440,7 +440,7 @@ export const getFormSchema = ({
             "ui:warnings": [
               <>
                 Spawn hosts with OAuth require additional setup. After SSHing in
-                to your spawnhost, please run the command{" "}
+                to your spawn host, please run the command{" "}
                 <InlineCode>evergreen host fetch</InlineCode>. For more details,
                 refer to the{" "}
                 <StyledRouterLink to="https://docs.devprod.prod.corp.mongodb.com/evergreen/Hosts/Spawn-Hosts#spawning-a-host-from-a-task">

--- a/apps/spruce/src/constants/externalResources/index.ts
+++ b/apps/spruce/src/constants/externalResources/index.ts
@@ -16,6 +16,8 @@ export const hostUptimeDocumentationUrl = `${hostsDocumentationUrl}/Spawn-Hosts#
 
 export const hostMountVolumeDocumentationUrl = `${hostsDocumentationUrl}/Spawn-Hosts#mounting-additional-storage`;
 
+export const taskSpawnHostDocumentationUrl = `${hostsDocumentationUrl}/Spawn-Hosts#spawning-a-host-from-a-task`;
+
 export const projectDistroSettingsDocumentationUrl = `${projectSettingsDocumentationUrl}/Project-and-Distro-Settings`;
 
 export const projectSettingsRepoSettingsDocumentationUrl = `${projectSettingsDocumentationUrl}/Repo-Level-Settings`;


### PR DESCRIPTION
DEVPROD-23988
<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
<!-- add description, context, thought process, etc -->
Users often get confused about OAuth with spawn hosts, since it's a new workflow and hard to communicate to the users that need it. This helps that workflow, hopefully the new warning helps guide users on how to use spawn hosts with oauth.


### Additional Context
In a follow up PR, I want to make that checkbox for OAuth enabled based off a feature flag (which we will soon enable). This will force OAuth on all spawnhosts. I think it should not even let the user disable it, because the spawn host will simply **not** work unless it's checked (which is something that happened that confused users)

### Screenshots
<!-- add screenshots of visible changes -->
Checked:
<img width="568" height="322" alt="Screenshot 2026-01-06 at 9 48 51 AM" src="https://github.com/user-attachments/assets/22c7b42c-895b-4adc-a355-9949912a64ca" />

Unchecked:
<img width="567" height="244" alt="Screenshot 2026-01-06 at 9 48 40 AM" src="https://github.com/user-attachments/assets/6431f861-66a2-441b-be30-671a62083087" />



### Testing
<!-- add a description of how you tested it -->
I didn't modify the existing tests because I wasn't sure if any were needed for this banner, please let me know if they are! I'm happy to put some in!