### PR TITLE
DEVPROD-23988 Spawn hosts oauth option should respect service flags

### DIFF
--- a/apps/parsley/src/gql/generated/types.ts
+++ b/apps/parsley/src/gql/generated/types.ts
@@ -3992,6 +3992,7 @@ export type SpruceConfig = {
   jira?: Maybe<JiraConfig>;
   providers?: Maybe<CloudProviderConfig>;
   secretFields: Array<Scalars["String"]["output"]>;
+  serviceFlags: UserServiceFlags;
   singleTaskDistro?: Maybe<SingleTaskDistroConfig>;
   slack?: Maybe<SlackConfig>;
   spawnHost: SpawnHostConfig;
@@ -4731,6 +4732,11 @@ export type UserConfig = {
   oauth_issuer: Scalars["String"]["output"];
   ui_server_host: Scalars["String"]["output"];
   user: Scalars["String"]["output"];
+};
+
+export type UserServiceFlags = {
+  __typename?: "UserServiceFlags";
+  jwtTokenForCLIDisabled?: Maybe<Scalars["Boolean"]["output"]>;
 };
 
 /**

--- a/apps/parsley/src/gql/generated/types.ts
+++ b/apps/parsley/src/gql/generated/types.ts
@@ -694,6 +694,13 @@ export type CopyProjectInput = {
   projectIdToCopy: Scalars["String"]["input"];
 };
 
+/** Cost represents the cost breakdown for a task or version. */
+export type Cost = {
+  __typename?: "Cost";
+  adjustedEC2Cost?: Maybe<Scalars["Float"]["output"]>;
+  onDemandEC2Cost?: Maybe<Scalars["Float"]["output"]>;
+};
+
 export type CostConfig = {
   __typename?: "CostConfig";
   financeFormula?: Maybe<Scalars["Float"]["output"]>;
@@ -4125,7 +4132,7 @@ export type Task = {
   patch?: Maybe<Patch>;
   patchNumber?: Maybe<Scalars["Int"]["output"]>;
   pod?: Maybe<Pod>;
-  predictedTaskCost?: Maybe<TaskCost>;
+  predictedTaskCost?: Maybe<Cost>;
   priority?: Maybe<Scalars["Int"]["output"]>;
   project?: Maybe<Project>;
   projectId: Scalars["String"]["output"];
@@ -4141,7 +4148,7 @@ export type Task = {
   /** taskLogs returns the tail 100 lines of the task's logs. */
   stepbackInfo?: Maybe<StepbackInfo>;
   tags: Array<Scalars["String"]["output"]>;
-  taskCost?: Maybe<TaskCost>;
+  taskCost?: Maybe<Cost>;
   taskGroup?: Maybe<Scalars["String"]["output"]>;
   taskGroupMaxHosts?: Maybe<Scalars["Int"]["output"]>;
   taskLogs: TaskLogs;
@@ -4175,13 +4182,6 @@ export type TaskContainerCreationOpts = {
   memoryMB: Scalars["Int"]["output"];
   os: Scalars["String"]["output"];
   workingDir: Scalars["String"]["output"];
-};
-
-/** TaskCost represents the cost breakdown for a task. */
-export type TaskCost = {
-  __typename?: "TaskCost";
-  adjustedCost?: Maybe<Scalars["Float"]["output"]>;
-  onDemandCost?: Maybe<Scalars["Float"]["output"]>;
 };
 
 /** TaskCountOptions defines the parameters that are used when counting tasks from a Version. */
@@ -4810,6 +4810,7 @@ export type Version = {
   order: Scalars["Int"]["output"];
   parameters: Array<Parameter>;
   patch?: Maybe<Patch>;
+  predictedCost?: Maybe<Cost>;
   previousVersion?: Maybe<Version>;
   project: Scalars["String"]["output"];
   projectIdentifier: Scalars["String"]["output"];

--- a/apps/spruce/src/components/Spawn/spawnHostModal/getFormSchema.tsx
+++ b/apps/spruce/src/components/Spawn/spawnHostModal/getFormSchema.tsx
@@ -36,7 +36,7 @@ interface Props {
   };
   isMigration: boolean;
   isVirtualWorkstation: boolean;
-  jwtTokenForCLIDisabled?: boolean;
+  oAuthDisabled?: boolean;
   myPublicKeys: MyPublicKeysQuery["myPublicKeys"];
   noExpirationCheckboxTooltip: string;
   spawnTaskData?: SpawnTaskQuery["task"];
@@ -56,9 +56,9 @@ export const getFormSchema = ({
   hostUptimeWarnings,
   isMigration,
   isVirtualWorkstation,
-  jwtTokenForCLIDisabled = false,
   myPublicKeys,
   noExpirationCheckboxTooltip,
+  oAuthDisabled = false,
   spawnTaskData,
   timeZone,
   useProjectSetupScript = false,
@@ -240,7 +240,7 @@ export const getFormSchema = ({
                         type: "boolean" as const,
                         title:
                           "Use OAuth authentication to download the task data from Evergreen. This will soon be required, see DEVPROD-4160",
-                        default: !jwtTokenForCLIDisabled,
+                        default: !oAuthDisabled,
                       },
                     },
                     dependencies: {
@@ -450,7 +450,7 @@ export const getFormSchema = ({
           useOAuth: {
             "ui:widget": hasValidTask ? widgets.CheckboxWidget : "hidden",
             "ui:data-cy": "use-oauth-checkbox",
-            "ui:disabled": !jwtTokenForCLIDisabled,
+            "ui:disabled": !oAuthDisabled,
             "ui:elementWrapperCSS": childCheckboxCSS,
           },
           warningBanner: {

--- a/apps/spruce/src/components/Spawn/spawnHostModal/getFormSchema.tsx
+++ b/apps/spruce/src/components/Spawn/spawnHostModal/getFormSchema.tsx
@@ -36,6 +36,7 @@ interface Props {
   };
   isMigration: boolean;
   isVirtualWorkstation: boolean;
+  jwtTokenForCLIDisabled?: boolean;
   myPublicKeys: MyPublicKeysQuery["myPublicKeys"];
   noExpirationCheckboxTooltip: string;
   spawnTaskData?: SpawnTaskQuery["task"];
@@ -55,6 +56,7 @@ export const getFormSchema = ({
   hostUptimeWarnings,
   isMigration,
   isVirtualWorkstation,
+  jwtTokenForCLIDisabled = false,
   myPublicKeys,
   noExpirationCheckboxTooltip,
   spawnTaskData,
@@ -238,6 +240,7 @@ export const getFormSchema = ({
                         type: "boolean" as const,
                         title:
                           "Use OAuth authentication to download the task data from Evergreen. This will soon be required, see DEVPROD-4160",
+                        default: !jwtTokenForCLIDisabled,
                       },
                     },
                     dependencies: {
@@ -447,6 +450,7 @@ export const getFormSchema = ({
           useOAuth: {
             "ui:widget": hasValidTask ? widgets.CheckboxWidget : "hidden",
             "ui:data-cy": "use-oauth-checkbox",
+            "ui:disabled": !jwtTokenForCLIDisabled,
             "ui:elementWrapperCSS": childCheckboxCSS,
           },
           warningBanner: {

--- a/apps/spruce/src/components/Spawn/spawnHostModal/getFormSchema.tsx
+++ b/apps/spruce/src/components/Spawn/spawnHostModal/getFormSchema.tsx
@@ -89,6 +89,10 @@ export const getFormSchema = ({
   });
   const publicKeys = getPublicKeySchema({ myPublicKeys });
 
+  // If OAuth is enabled, the spawn host modal should force the option for OAuth.
+  const oAuthCheckboxIsDisabled = !oAuthDisabled;
+  const defaultOAuthValue = !oAuthDisabled;
+
   return {
     fields: {},
     schema: {
@@ -240,7 +244,7 @@ export const getFormSchema = ({
                         type: "boolean" as const,
                         title:
                           "Use OAuth authentication to download the task data from Evergreen. This will soon be required, see DEVPROD-4160",
-                        default: !oAuthDisabled,
+                        default: defaultOAuthValue,
                       },
                     },
                     dependencies: {
@@ -450,7 +454,7 @@ export const getFormSchema = ({
           useOAuth: {
             "ui:widget": hasValidTask ? widgets.CheckboxWidget : "hidden",
             "ui:data-cy": "use-oauth-checkbox",
-            "ui:disabled": !oAuthDisabled,
+            "ui:disabled": oAuthCheckboxIsDisabled,
             "ui:elementWrapperCSS": childCheckboxCSS,
           },
           warningBanner: {

--- a/apps/spruce/src/components/Spawn/spawnHostModal/useLoadFormSchemaData.ts
+++ b/apps/spruce/src/components/Spawn/spawnHostModal/useLoadFormSchemaData.ts
@@ -56,7 +56,6 @@ export const useLoadFormSchemaData = (p?: Props) => {
       isVolume: false,
     }) ?? "";
 
-  // If OAuth is enabled, the spawn host modal should force the option for OAuth.
   const oAuthDisabled =
     spruceConfig?.serviceFlags?.jwtTokenForCLIDisabled ?? false;
 

--- a/apps/spruce/src/components/Spawn/spawnHostModal/useLoadFormSchemaData.ts
+++ b/apps/spruce/src/components/Spawn/spawnHostModal/useLoadFormSchemaData.ts
@@ -56,10 +56,14 @@ export const useLoadFormSchemaData = (p?: Props) => {
       isVolume: false,
     }) ?? "";
 
+  const jwtTokenForCLIDisabled =
+    spruceConfig?.serviceFlags?.jwtTokenForCLIDisabled ?? false;
+
   return {
     formSchemaInput: {
       disableExpirationCheckbox,
       distros: distrosData?.distros ?? [],
+      jwtTokenForCLIDisabled,
       myPublicKeys: publicKeysData?.myPublicKeys ?? [],
       noExpirationCheckboxTooltip,
       userAwsRegion: userAwsRegion ?? defaultEC2Region,

--- a/apps/spruce/src/components/Spawn/spawnHostModal/useLoadFormSchemaData.ts
+++ b/apps/spruce/src/components/Spawn/spawnHostModal/useLoadFormSchemaData.ts
@@ -56,14 +56,15 @@ export const useLoadFormSchemaData = (p?: Props) => {
       isVolume: false,
     }) ?? "";
 
-  const jwtTokenForCLIDisabled =
+  // If OAuth is enabled, the spawn host modal should force the option for OAuth.
+  const oAuthDisabled =
     spruceConfig?.serviceFlags?.jwtTokenForCLIDisabled ?? false;
 
   return {
     formSchemaInput: {
       disableExpirationCheckbox,
       distros: distrosData?.distros ?? [],
-      jwtTokenForCLIDisabled,
+      oAuthDisabled,
       myPublicKeys: publicKeysData?.myPublicKeys ?? [],
       noExpirationCheckboxTooltip,
       userAwsRegion: userAwsRegion ?? defaultEC2Region,

--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -3989,6 +3989,7 @@ export type SpruceConfig = {
   jira?: Maybe<JiraConfig>;
   providers?: Maybe<CloudProviderConfig>;
   secretFields: Array<Scalars["String"]["output"]>;
+  serviceFlags: UserServiceFlags;
   singleTaskDistro?: Maybe<SingleTaskDistroConfig>;
   slack?: Maybe<SlackConfig>;
   spawnHost: SpawnHostConfig;
@@ -4729,6 +4730,11 @@ export type UserConfig = {
   oauth_issuer: Scalars["String"]["output"];
   ui_server_host: Scalars["String"]["output"];
   user: Scalars["String"]["output"];
+};
+
+export type UserServiceFlags = {
+  __typename?: "UserServiceFlags";
+  jwtTokenForCLIDisabled?: Maybe<Scalars["Boolean"]["output"]>;
 };
 
 /**
@@ -10892,6 +10898,10 @@ export type SpruceConfigQuery = {
         } | null;
       } | null;
     } | null;
+    serviceFlags: {
+      __typename?: "UserServiceFlags";
+      jwtTokenForCLIDisabled?: boolean | null;
+    };
     slack?: { __typename?: "SlackConfig"; name?: string | null } | null;
     spawnHost: {
       __typename?: "SpawnHostConfig";

--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -691,6 +691,13 @@ export type CopyProjectInput = {
   projectIdToCopy: Scalars["String"]["input"];
 };
 
+/** Cost represents the cost breakdown for a task or version. */
+export type Cost = {
+  __typename?: "Cost";
+  adjustedEC2Cost?: Maybe<Scalars["Float"]["output"]>;
+  onDemandEC2Cost?: Maybe<Scalars["Float"]["output"]>;
+};
+
 export type CostConfig = {
   __typename?: "CostConfig";
   financeFormula?: Maybe<Scalars["Float"]["output"]>;
@@ -4122,7 +4129,7 @@ export type Task = {
   patch?: Maybe<Patch>;
   patchNumber?: Maybe<Scalars["Int"]["output"]>;
   pod?: Maybe<Pod>;
-  predictedTaskCost?: Maybe<TaskCost>;
+  predictedTaskCost?: Maybe<Cost>;
   priority?: Maybe<Scalars["Int"]["output"]>;
   project?: Maybe<Project>;
   projectId: Scalars["String"]["output"];
@@ -4139,7 +4146,7 @@ export type Task = {
   /** taskLogs returns the tail 100 lines of the task's logs. */
   stepbackInfo?: Maybe<StepbackInfo>;
   tags: Array<Scalars["String"]["output"]>;
-  taskCost?: Maybe<TaskCost>;
+  taskCost?: Maybe<Cost>;
   taskGroup?: Maybe<Scalars["String"]["output"]>;
   taskGroupMaxHosts?: Maybe<Scalars["Int"]["output"]>;
   taskLogs: TaskLogs;
@@ -4173,13 +4180,6 @@ export type TaskContainerCreationOpts = {
   memoryMB: Scalars["Int"]["output"];
   os: Scalars["String"]["output"];
   workingDir: Scalars["String"]["output"];
-};
-
-/** TaskCost represents the cost breakdown for a task. */
-export type TaskCost = {
-  __typename?: "TaskCost";
-  adjustedCost?: Maybe<Scalars["Float"]["output"]>;
-  onDemandCost?: Maybe<Scalars["Float"]["output"]>;
 };
 
 /** TaskCountOptions defines the parameters that are used when counting tasks from a Version. */
@@ -4808,6 +4808,7 @@ export type Version = {
   order: Scalars["Int"]["output"];
   parameters: Array<Parameter>;
   patch?: Maybe<Patch>;
+  predictedCost?: Maybe<Cost>;
   previousVersion?: Maybe<Version>;
   project: Scalars["String"]["output"];
   projectIdentifier: Scalars["String"]["output"];

--- a/apps/spruce/src/gql/mocks/getSpruceConfig.ts
+++ b/apps/spruce/src/gql/mocks/getSpruceConfig.ts
@@ -52,6 +52,9 @@ export const getSpruceConfigMock: ApolloMock<
           },
           __typename: "CloudProviderConfig",
         },
+        serviceFlags: {
+          jwtTokenForCLIDisabled: true,
+        },
         slack: {
           name: "everygreen_slack",
         },

--- a/apps/spruce/src/gql/queries/spruce-config.graphql
+++ b/apps/spruce/src/gql/queries/spruce-config.graphql
@@ -25,6 +25,9 @@ query SpruceConfig {
         }
       }
     }
+    serviceFlags {
+      jwtTokenForCLIDisabled
+    }
     slack {
       name
     }

--- a/apps/spruce/src/pages/spawn/spawnHost/spawnHostButton/SpawnHostModal.tsx
+++ b/apps/spruce/src/pages/spawn/spawnHost/spawnHostButton/SpawnHostModal.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useMemo, useState, useEffect } from "react";
 import { useQuery, useMutation } from "@apollo/client";
 import { ConfirmationModal } from "@leafygreen-ui/confirmation-modal";
 import { useLocation } from "react-router-dom";
@@ -105,6 +105,29 @@ export const SpawnHostModal: React.FC<SpawnHostModalProps> = ({
     });
     return { enabledHoursCount, warnings };
   }, [formState?.expirationDetails?.hostUptime]);
+
+  // Force useOAuth to true when jwtTokenForCLIDisabled is false
+  useEffect(() => {
+    if (
+      !formSchemaInput.jwtTokenForCLIDisabled &&
+      spawnTaskData?.task &&
+      formState?.loadData?.loadDataOntoHostAtStartup &&
+      formState?.loadData?.useOAuth !== true
+    ) {
+      setFormState((prev) => ({
+        ...prev,
+        loadData: {
+          ...prev.loadData,
+          useOAuth: true,
+        },
+      }));
+    }
+  }, [
+    formSchemaInput.jwtTokenForCLIDisabled,
+    spawnTaskData?.task,
+    formState?.loadData?.loadDataOntoHostAtStartup,
+    formState?.loadData?.useOAuth,
+  ]);
 
   const { schema, uiSchema } = getFormSchema({
     ...formSchemaInput,

--- a/apps/spruce/src/pages/spawn/spawnHost/spawnHostButton/SpawnHostModal.tsx
+++ b/apps/spruce/src/pages/spawn/spawnHost/spawnHostButton/SpawnHostModal.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState, useEffect } from "react";
+import { useMemo, useState } from "react";
 import { useQuery, useMutation } from "@apollo/client";
 import { ConfirmationModal } from "@leafygreen-ui/confirmation-modal";
 import { useLocation } from "react-router-dom";

--- a/apps/spruce/src/pages/spawn/spawnHost/spawnHostButton/SpawnHostModal.tsx
+++ b/apps/spruce/src/pages/spawn/spawnHost/spawnHostButton/SpawnHostModal.tsx
@@ -106,29 +106,6 @@ export const SpawnHostModal: React.FC<SpawnHostModalProps> = ({
     return { enabledHoursCount, warnings };
   }, [formState?.expirationDetails?.hostUptime]);
 
-  // Force useOAuth to true when jwtTokenForCLIDisabled is false
-  useEffect(() => {
-    if (
-      !formSchemaInput.jwtTokenForCLIDisabled &&
-      spawnTaskData?.task &&
-      formState?.loadData?.loadDataOntoHostAtStartup &&
-      formState?.loadData?.useOAuth !== true
-    ) {
-      setFormState((prev) => ({
-        ...prev,
-        loadData: {
-          ...prev.loadData,
-          useOAuth: true,
-        },
-      }));
-    }
-  }, [
-    formSchemaInput.jwtTokenForCLIDisabled,
-    spawnTaskData?.task,
-    formState?.loadData?.loadDataOntoHostAtStartup,
-    formState?.loadData?.useOAuth,
-  ]);
-
   const { schema, uiSchema } = getFormSchema({
     ...formSchemaInput,
     availableRegions: selectedDistro?.availableRegions ?? [],


### PR DESCRIPTION
DEVPROD-23988
<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->
<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
<!-- add description, context, thought process, etc -->
This makes the spawn host modal respect the service flag for jwt (oauth) usage. It forces the checkbox checked when it is enabled

### Screenshots
<!-- add screenshots of visible changes -->
With the feature flag enabled:
<img width="588" height="353" alt="Screenshot 2026-01-08 at 2 34 14 PM" src="https://github.com/user-attachments/assets/b14c1906-d8a0-4551-b8ca-96618bb94366" />


Demo video: 

https://github.com/user-attachments/assets/61329605-82e8-4607-9d87-5ffdce5cb33a

### Testing
<!-- add a description of how you tested it -->
I updated the mock and deployed to staging, demo videoo above ^!

### Evergreen PR
<!-- link to a corresponding Evergreen PR if applicable -->
[#9653](https://github.com/evergreen-ci/evergreen/pull/9653)