### PR TITLE
DEVPROD-26143: add feature flag for using git to fetch GitHub API files 

### DIFF
--- a/apps/parsley/src/gql/generated/types.ts
+++ b/apps/parsley/src/gql/generated/types.ts
@@ -3758,6 +3758,7 @@ export type ServiceFlags = {
   podInitDisabled?: Maybe<Scalars["Boolean"]["output"]>;
   releaseModeDisabled?: Maybe<Scalars["Boolean"]["output"]>;
   repotrackerDisabled?: Maybe<Scalars["Boolean"]["output"]>;
+  s3LifecycleSyncDisabled?: Maybe<Scalars["Boolean"]["output"]>;
   schedulerDisabled?: Maybe<Scalars["Boolean"]["output"]>;
   slackNotificationsDisabled?: Maybe<Scalars["Boolean"]["output"]>;
   sleepScheduleDisabled?: Maybe<Scalars["Boolean"]["output"]>;
@@ -3767,7 +3768,7 @@ export type ServiceFlags = {
   taskLoggingDisabled?: Maybe<Scalars["Boolean"]["output"]>;
   taskReliabilityDisabled?: Maybe<Scalars["Boolean"]["output"]>;
   unrecognizedPodCleanupDisabled?: Maybe<Scalars["Boolean"]["output"]>;
-  useGitForGitHubFiles?: Maybe<Scalars["Boolean"]["output"]>;
+  useGitForGitHubFilesDisabled?: Maybe<Scalars["Boolean"]["output"]>;
   webhookNotificationsDisabled?: Maybe<Scalars["Boolean"]["output"]>;
 };
 
@@ -3798,6 +3799,7 @@ export type ServiceFlagsInput = {
   podInitDisabled?: InputMaybe<Scalars["Boolean"]["input"]>;
   releaseModeDisabled?: InputMaybe<Scalars["Boolean"]["input"]>;
   repotrackerDisabled?: InputMaybe<Scalars["Boolean"]["input"]>;
+  s3LifecycleSyncDisabled?: InputMaybe<Scalars["Boolean"]["input"]>;
   schedulerDisabled?: InputMaybe<Scalars["Boolean"]["input"]>;
   slackNotificationsDisabled?: InputMaybe<Scalars["Boolean"]["input"]>;
   sleepScheduleDisabled?: InputMaybe<Scalars["Boolean"]["input"]>;

--- a/apps/parsley/src/gql/generated/types.ts
+++ b/apps/parsley/src/gql/generated/types.ts
@@ -3767,6 +3767,7 @@ export type ServiceFlags = {
   taskLoggingDisabled?: Maybe<Scalars["Boolean"]["output"]>;
   taskReliabilityDisabled?: Maybe<Scalars["Boolean"]["output"]>;
   unrecognizedPodCleanupDisabled?: Maybe<Scalars["Boolean"]["output"]>;
+  useGitForGitHubFiles?: Maybe<Scalars["Boolean"]["output"]>;
   webhookNotificationsDisabled?: Maybe<Scalars["Boolean"]["output"]>;
 };
 
@@ -3806,6 +3807,7 @@ export type ServiceFlagsInput = {
   taskLoggingDisabled?: InputMaybe<Scalars["Boolean"]["input"]>;
   taskReliabilityDisabled?: InputMaybe<Scalars["Boolean"]["input"]>;
   unrecognizedPodCleanupDisabled?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useGitForGitHubFilesDisabled?: InputMaybe<Scalars["Boolean"]["input"]>;
   webhookNotificationsDisabled?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 

--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -3755,6 +3755,7 @@ export type ServiceFlags = {
   podInitDisabled?: Maybe<Scalars["Boolean"]["output"]>;
   releaseModeDisabled?: Maybe<Scalars["Boolean"]["output"]>;
   repotrackerDisabled?: Maybe<Scalars["Boolean"]["output"]>;
+  s3LifecycleSyncDisabled?: Maybe<Scalars["Boolean"]["output"]>;
   schedulerDisabled?: Maybe<Scalars["Boolean"]["output"]>;
   slackNotificationsDisabled?: Maybe<Scalars["Boolean"]["output"]>;
   sleepScheduleDisabled?: Maybe<Scalars["Boolean"]["output"]>;
@@ -3795,6 +3796,7 @@ export type ServiceFlagsInput = {
   podInitDisabled?: InputMaybe<Scalars["Boolean"]["input"]>;
   releaseModeDisabled?: InputMaybe<Scalars["Boolean"]["input"]>;
   repotrackerDisabled?: InputMaybe<Scalars["Boolean"]["input"]>;
+  s3LifecycleSyncDisabled?: InputMaybe<Scalars["Boolean"]["input"]>;
   schedulerDisabled?: InputMaybe<Scalars["Boolean"]["input"]>;
   slackNotificationsDisabled?: InputMaybe<Scalars["Boolean"]["input"]>;
   sleepScheduleDisabled?: InputMaybe<Scalars["Boolean"]["input"]>;

--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -3764,6 +3764,7 @@ export type ServiceFlags = {
   taskLoggingDisabled?: Maybe<Scalars["Boolean"]["output"]>;
   taskReliabilityDisabled?: Maybe<Scalars["Boolean"]["output"]>;
   unrecognizedPodCleanupDisabled?: Maybe<Scalars["Boolean"]["output"]>;
+  useGitForGitHubFilesDisabled?: Maybe<Scalars["Boolean"]["output"]>;
   webhookNotificationsDisabled?: Maybe<Scalars["Boolean"]["output"]>;
 };
 
@@ -3803,6 +3804,7 @@ export type ServiceFlagsInput = {
   taskLoggingDisabled?: InputMaybe<Scalars["Boolean"]["input"]>;
   taskReliabilityDisabled?: InputMaybe<Scalars["Boolean"]["input"]>;
   unrecognizedPodCleanupDisabled?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useGitForGitHubFilesDisabled?: InputMaybe<Scalars["Boolean"]["input"]>;
   webhookNotificationsDisabled?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
@@ -7155,6 +7157,7 @@ export type SaveAdminSettingsMutation = {
       taskLoggingDisabled?: boolean | null;
       taskReliabilityDisabled?: boolean | null;
       unrecognizedPodCleanupDisabled?: boolean | null;
+      useGitForGitHubFilesDisabled?: boolean | null;
       webhookNotificationsDisabled?: boolean | null;
     } | null;
     taskLimits?: {
@@ -7929,6 +7932,7 @@ export type AdminSettingsQuery = {
       taskLoggingDisabled?: boolean | null;
       taskReliabilityDisabled?: boolean | null;
       unrecognizedPodCleanupDisabled?: boolean | null;
+      useGitForGitHubFilesDisabled?: boolean | null;
       webhookNotificationsDisabled?: boolean | null;
     } | null;
     singleTaskDistro?: {

--- a/apps/spruce/src/gql/mutations/save-admin-settings.graphql
+++ b/apps/spruce/src/gql/mutations/save-admin-settings.graphql
@@ -85,6 +85,7 @@ mutation SaveAdminSettings($adminSettings: AdminSettingsInput!) {
       taskLoggingDisabled
       taskReliabilityDisabled
       unrecognizedPodCleanupDisabled
+      useGitForGitHubFilesDisabled
       webhookNotificationsDisabled
     }
 

--- a/apps/spruce/src/gql/queries/admin-settings.graphql
+++ b/apps/spruce/src/gql/queries/admin-settings.graphql
@@ -352,6 +352,7 @@ query AdminSettings {
       taskLoggingDisabled
       taskReliabilityDisabled
       unrecognizedPodCleanupDisabled
+      useGitForGitHubFilesDisabled
       webhookNotificationsDisabled
     }
     shutdownWaitSeconds

--- a/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/FeatureFlagsTab/getFormSchema.ts
+++ b/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/FeatureFlagsTab/getFormSchema.ts
@@ -44,6 +44,7 @@ const featureItems: Record<string, string> = {
   staticAPIKeysDisabled: "Static API Keys credentials for users",
   backgroundReauthDisabled: "Background Reauthentication",
   debugSpawnHostDisabled: "Debug spawn hosts",
+  useGitForGitHubFilesDisabled: "Use git to fetch files from GitHub",
 };
 
 const batchJobItems: Record<string, string> = {

--- a/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/FeatureFlagsTab/transformers.test.ts
+++ b/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/FeatureFlagsTab/transformers.test.ts
@@ -53,6 +53,7 @@ const form: FeatureFlagsFormState = {
       elasticIPsDisabled: true,
       releaseModeDisabled: true,
       debugSpawnHostDisabled: true,
+      useGitForGitHubFilesDisabled: true,
     },
     batchJobs: {
       backgroundStatsDisabled: true,
@@ -99,6 +100,7 @@ const gql: AdminSettingsInput = {
     taskLoggingDisabled: true,
     taskReliabilityDisabled: true,
     unrecognizedPodCleanupDisabled: true,
+    useGitForGitHubFilesDisabled: true,
     webhookNotificationsDisabled: true,
   },
 };

--- a/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/FeatureFlagsTab/transformers.ts
+++ b/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/FeatureFlagsTab/transformers.ts
@@ -59,6 +59,8 @@ export const gqlToForm = ((data) => ({
       releaseModeDisabled: data.serviceFlags?.releaseModeDisabled ?? false,
       debugSpawnHostDisabled:
         data.serviceFlags?.debugSpawnHostDisabled ?? false,
+      useGitForGitHubFilesDisabled:
+        data.serviceFlags?.useGitForGitHubFilesDisabled ?? false,
     },
 
     batchJobs: {

--- a/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/FeatureFlagsTab/types.ts
+++ b/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/FeatureFlagsTab/types.ts
@@ -40,6 +40,7 @@ export interface FeatureFlagsFormState {
       staticAPIKeysDisabled: boolean;
       backgroundReauthDisabled: boolean;
       debugSpawnHostDisabled: boolean;
+      useGitForGitHubFilesDisabled: boolean;
     };
 
     batchJobs: {

--- a/apps/spruce/src/pages/adminSettings/tabs/testData.ts
+++ b/apps/spruce/src/pages/adminSettings/tabs/testData.ts
@@ -91,6 +91,7 @@ export const adminSettings: AdminSettings = {
     taskLoggingDisabled: true,
     taskReliabilityDisabled: true,
     unrecognizedPodCleanupDisabled: true,
+    useGitForGitHubFilesDisabled: true,
     webhookNotificationsDisabled: true,
   },
   taskLimits: {

--- a/packages/lib/src/gql/generated/types.ts
+++ b/packages/lib/src/gql/generated/types.ts
@@ -3758,6 +3758,7 @@ export type ServiceFlags = {
   podInitDisabled?: Maybe<Scalars["Boolean"]["output"]>;
   releaseModeDisabled?: Maybe<Scalars["Boolean"]["output"]>;
   repotrackerDisabled?: Maybe<Scalars["Boolean"]["output"]>;
+  s3LifecycleSyncDisabled?: InputMaybe<Scalars["Boolean"]["output"]>;
   schedulerDisabled?: Maybe<Scalars["Boolean"]["output"]>;
   slackNotificationsDisabled?: Maybe<Scalars["Boolean"]["output"]>;
   sleepScheduleDisabled?: Maybe<Scalars["Boolean"]["output"]>;
@@ -3798,6 +3799,7 @@ export type ServiceFlagsInput = {
   podInitDisabled?: InputMaybe<Scalars["Boolean"]["input"]>;
   releaseModeDisabled?: InputMaybe<Scalars["Boolean"]["input"]>;
   repotrackerDisabled?: InputMaybe<Scalars["Boolean"]["input"]>;
+  s3LifecycleSyncDisabled?: InputMaybe<Scalars["Boolean"]["input"]>;
   schedulerDisabled?: InputMaybe<Scalars["Boolean"]["input"]>;
   slackNotificationsDisabled?: InputMaybe<Scalars["Boolean"]["input"]>;
   sleepScheduleDisabled?: InputMaybe<Scalars["Boolean"]["input"]>;

--- a/packages/lib/src/gql/generated/types.ts
+++ b/packages/lib/src/gql/generated/types.ts
@@ -3767,6 +3767,7 @@ export type ServiceFlags = {
   taskLoggingDisabled?: Maybe<Scalars["Boolean"]["output"]>;
   taskReliabilityDisabled?: Maybe<Scalars["Boolean"]["output"]>;
   unrecognizedPodCleanupDisabled?: Maybe<Scalars["Boolean"]["output"]>;
+  useGitForGitHubFilesDisabled?: Maybe<Scalars["Boolean"]["output"]>;
   webhookNotificationsDisabled?: Maybe<Scalars["Boolean"]["output"]>;
 };
 
@@ -3806,6 +3807,7 @@ export type ServiceFlagsInput = {
   taskLoggingDisabled?: InputMaybe<Scalars["Boolean"]["input"]>;
   taskReliabilityDisabled?: InputMaybe<Scalars["Boolean"]["input"]>;
   unrecognizedPodCleanupDisabled?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useGitForGitHubFilesDisabled?: InputMaybe<Scalars["Boolean"]["input"]>;
   webhookNotificationsDisabled?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 

--- a/packages/lib/src/gql/generated/types.ts
+++ b/packages/lib/src/gql/generated/types.ts
@@ -3758,7 +3758,7 @@ export type ServiceFlags = {
   podInitDisabled?: Maybe<Scalars["Boolean"]["output"]>;
   releaseModeDisabled?: Maybe<Scalars["Boolean"]["output"]>;
   repotrackerDisabled?: Maybe<Scalars["Boolean"]["output"]>;
-  s3LifecycleSyncDisabled?: InputMaybe<Scalars["Boolean"]["output"]>;
+  s3LifecycleSyncDisabled?: Maybe<Scalars["Boolean"]["output"]>;
   schedulerDisabled?: Maybe<Scalars["Boolean"]["output"]>;
   slackNotificationsDisabled?: Maybe<Scalars["Boolean"]["output"]>;
   sleepScheduleDisabled?: Maybe<Scalars["Boolean"]["output"]>;


### PR DESCRIPTION
DEVPROD-26143

Add experimental feature flag to use git to fetch files. This is to try replacing calls to get files using the GitHub API.

### Screenshots
* Setting can be enabled/disabled in local Evergreen.
<img width="824" height="567" alt="image" src="https://github.com/user-attachments/assets/9262b9ba-7dc0-4931-885b-fb3cffc27e80" />

### Evergreen PR
https://github.com/evergreen-ci/evergreen/pull/9714
