### PR TITLE
DEVPROD-26705: Add sage base URL to admin settings

### DIFF
--- a/apps/spruce/cypress/integration/adminSettings/external_communications.ts
+++ b/apps/spruce/cypress/integration/adminSettings/external_communications.ts
@@ -114,6 +114,14 @@ describe("external communications", () => {
       cy.get("@cedarSpsKanopyUrlInput").type("sps-kanopy.test.com");
     });
 
+    // Sage section.
+    cy.dataCy("sage").within(() => {
+      const sageBaseUrl = "Base URL";
+      cy.getInputByLabel(sageBaseUrl).as("sageBaseUrlInput");
+      cy.get("@sageBaseUrlInput").clear();
+      cy.get("@sageBaseUrlInput").type("sage.test.com");
+    });
+
     clickSave();
     cy.validateToast("success", "Settings saved successfully");
 
@@ -174,6 +182,11 @@ describe("external communications", () => {
         "have.value",
         "sps-kanopy.test.com",
       );
+    });
+
+    // Sage section.
+    cy.dataCy("sage").within(() => {
+      cy.getInputByLabel("Base URL").should("have.value", "sage.test.com");
     });
   });
 });

--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -7165,6 +7165,7 @@ export type SaveAdminSettingsMutation = {
       maxRepoRevisionsToSearch?: number | null;
       numNewRepoRevisionsToFetch?: number | null;
     } | null;
+    sage?: { __typename?: "SageConfig"; baseUrl?: string | null } | null;
     scheduler?: {
       __typename?: "SchedulerConfig";
       acceptableHostIdleTimeSeconds?: number | null;
@@ -7242,7 +7243,6 @@ export type SaveAdminSettingsMutation = {
       maxTaskExecution?: number | null;
       maxTasksPerVersion?: number | null;
     } | null;
-    sage?: { __typename?: "SageConfig"; baseUrl?: string | null } | null;
     ui?: {
       __typename?: "UIConfig";
       cacheTemplates?: boolean | null;

--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -197,6 +197,7 @@ export type AdminSettings = {
   releaseMode?: Maybe<ReleaseModeConfig>;
   repotracker?: Maybe<RepotrackerConfig>;
   runtimeEnvironments?: Maybe<RuntimeEnvironmentConfig>;
+  sage?: Maybe<SageConfig>;
   scheduler?: Maybe<SchedulerConfig>;
   serviceFlags?: Maybe<ServiceFlags>;
   shutdownWaitSeconds?: Maybe<Scalars["Int"]["output"]>;
@@ -253,6 +254,7 @@ export type AdminSettingsInput = {
   releaseMode?: InputMaybe<ReleaseModeConfigInput>;
   repotracker?: InputMaybe<RepotrackerConfigInput>;
   runtimeEnvironments?: InputMaybe<RuntimeEnvironmentConfigInput>;
+  sage?: InputMaybe<SageConfigInput>;
   scheduler?: InputMaybe<SchedulerConfigInput>;
   serviceFlags?: InputMaybe<ServiceFlagsInput>;
   shutdownWaitSeconds?: InputMaybe<Scalars["Int"]["input"]>;
@@ -3670,6 +3672,15 @@ export type SshKeyPair = {
 export type SshKeyPairInput = {
   name?: InputMaybe<Scalars["String"]["input"]>;
   secretARN?: InputMaybe<Scalars["String"]["input"]>;
+};
+
+export type SageConfig = {
+  __typename?: "SageConfig";
+  baseUrl?: Maybe<Scalars["String"]["output"]>;
+};
+
+export type SageConfigInput = {
+  baseUrl?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type SaveAdminSettingsInput = {
@@ -7231,6 +7242,7 @@ export type SaveAdminSettingsMutation = {
       maxTaskExecution?: number | null;
       maxTasksPerVersion?: number | null;
     } | null;
+    sage?: { __typename?: "SageConfig"; baseUrl?: string | null } | null;
     ui?: {
       __typename?: "UIConfig";
       cacheTemplates?: boolean | null;
@@ -7942,6 +7954,7 @@ export type AdminSettingsQuery = {
       apiKey?: string | null;
       baseUrl: string;
     } | null;
+    sage?: { __typename?: "SageConfig"; baseUrl?: string | null } | null;
     scheduler?: {
       __typename?: "SchedulerConfig";
       acceptableHostIdleTimeSeconds?: number | null;

--- a/apps/spruce/src/gql/mutations/save-admin-settings.graphql
+++ b/apps/spruce/src/gql/mutations/save-admin-settings.graphql
@@ -43,6 +43,9 @@ mutation SaveAdminSettings($adminSettings: AdminSettingsInput!) {
       maxRepoRevisionsToSearch
       numNewRepoRevisionsToFetch
     }
+    sage {
+      baseUrl
+    }
     scheduler {
       acceptableHostIdleTimeSeconds
       cacheDurationSeconds
@@ -63,6 +66,7 @@ mutation SaveAdminSettings($adminSettings: AdminSettingsInput!) {
       targetTimeSeconds
       taskFinder
     }
+
     serviceFlags {
       agentStartDisabled
       alertsDisabled
@@ -103,7 +107,6 @@ mutation SaveAdminSettings($adminSettings: AdminSettingsInput!) {
       useGitForGitHubFilesDisabled
       webhookNotificationsDisabled
     }
-
     taskLimits {
       maxConcurrentLargeParserProjectTasks
       maxDailyAutomaticRestarts
@@ -117,9 +120,6 @@ mutation SaveAdminSettings($adminSettings: AdminSettingsInput!) {
       maxPendingGeneratedTasks
       maxTaskExecution
       maxTasksPerVersion
-    }
-    sage {
-      baseUrl
     }
     ui {
       betaFeatures {

--- a/apps/spruce/src/gql/mutations/save-admin-settings.graphql
+++ b/apps/spruce/src/gql/mutations/save-admin-settings.graphql
@@ -118,6 +118,9 @@ mutation SaveAdminSettings($adminSettings: AdminSettingsInput!) {
       maxTaskExecution
       maxTasksPerVersion
     }
+    sage {
+      baseUrl
+    }
     ui {
       betaFeatures {
         parsleyAIEnabled

--- a/apps/spruce/src/gql/queries/admin-settings.graphql
+++ b/apps/spruce/src/gql/queries/admin-settings.graphql
@@ -304,6 +304,9 @@ query AdminSettings {
       apiKey
       baseUrl
     }
+    sage {
+      baseUrl
+    }
     scheduler {
       acceptableHostIdleTimeSeconds
       cacheDurationSeconds

--- a/apps/spruce/src/pages/adminSettings/index.tsx
+++ b/apps/spruce/src/pages/adminSettings/index.tsx
@@ -350,6 +350,16 @@ const AdminSettingsPage: React.FC = () => {
               >
                 Cedar
               </SideNavItem>
+              <SideNavItem
+                as={Link}
+                data-cy="navitem-admin-sage"
+                to={getAdminSettingsRoute(
+                  AdminSettingsTabRoutes.General,
+                  "sage",
+                )}
+              >
+                Sage
+              </SideNavItem>
             </SideNavGroup>
             <SideNavGroup header="Background Processing">
               <SideNavItem

--- a/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/ExternalCommunicationsTab/getFormSchema.ts
+++ b/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/ExternalCommunicationsTab/getFormSchema.ts
@@ -5,6 +5,7 @@ import {
   graphite,
   jira,
   runtimeEnvironments,
+  sage,
   slack,
   splunk,
   testSelection,
@@ -55,6 +56,11 @@ export const formSchema: ReturnType<GetFormSchema> = {
         title: "Cedar",
         properties: cedar.schema,
       },
+      sage: {
+        type: "object" as const,
+        title: "Sage",
+        properties: sage.schema,
+      },
     },
   },
   uiSchema: {
@@ -66,5 +72,6 @@ export const formSchema: ReturnType<GetFormSchema> = {
     fws: fws.uiSchema,
     graphite: graphite.uiSchema,
     cedar: cedar.uiSchema,
+    sage: sage.uiSchema,
   },
 };

--- a/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/ExternalCommunicationsTab/schemaFields.ts
+++ b/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/ExternalCommunicationsTab/schemaFields.ts
@@ -286,3 +286,21 @@ export const cedar = {
     "ui:data-cy": "cedar",
   },
 };
+
+export const sage = {
+  schema: {
+    baseUrl: {
+      type: "string" as const,
+      title: "Base URL",
+    },
+  },
+  uiSchema: {
+    "ui:ObjectFieldTemplate": CardFieldTemplate,
+    "ui:data-cy": "sage",
+    baseUrl: {
+      "ui:fullWidth": true,
+      "ui:description":
+        "The base URL for Sage API (e.g., https://sage.prod.corp.mongodb.com)",
+    },
+  },
+};

--- a/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/ExternalCommunicationsTab/transformers.test.ts
+++ b/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/ExternalCommunicationsTab/transformers.test.ts
@@ -120,7 +120,7 @@ const gql: AdminSettingsInput = {
   perfMonitoringKanopyURL: "sps-kanopy.example.com",
   sage: {
     baseUrl: "https://sage.devprod.prod.corp.mongodb.com",
-  }
+  },
 };
 
 const mockAdminSettings: AdminSettings = {
@@ -177,5 +177,5 @@ const mockAdminSettings: AdminSettings = {
   perfMonitoringKanopyURL: "sps-kanopy.example.com",
   sage: {
     baseUrl: "https://sage.devprod.prod.corp.mongodb.com",
-  }
+  },
 };

--- a/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/ExternalCommunicationsTab/transformers.test.ts
+++ b/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/ExternalCommunicationsTab/transformers.test.ts
@@ -62,6 +62,9 @@ const form: ExternalCommunicationsFormState = {
     spsUrl: "sps.example.com",
     spsKanopyUrl: "sps-kanopy.example.com",
   },
+  sage: {
+    baseUrl: "https://sage.devprod.prod.corp.mongodb.com",
+  },
 };
 
 const gql: AdminSettingsInput = {
@@ -115,6 +118,9 @@ const gql: AdminSettingsInput = {
   },
   perfMonitoringURL: "sps.example.com",
   perfMonitoringKanopyURL: "sps-kanopy.example.com",
+  sage: {
+    baseUrl: "https://sage.devprod.prod.corp.mongodb.com",
+  }
 };
 
 const mockAdminSettings: AdminSettings = {
@@ -169,4 +175,7 @@ const mockAdminSettings: AdminSettings = {
   },
   perfMonitoringURL: "sps.example.com",
   perfMonitoringKanopyURL: "sps-kanopy.example.com",
+  sage: {
+    baseUrl: "https://sage.devprod.prod.corp.mongodb.com",
+  }
 };

--- a/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/ExternalCommunicationsTab/transformers.ts
+++ b/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/ExternalCommunicationsTab/transformers.ts
@@ -13,6 +13,7 @@ export const gqlToForm = ((data) => {
     graphite,
     jira,
     runtimeEnvironments,
+    sage,
     slack,
     splunk,
     testSelection,
@@ -66,6 +67,9 @@ export const gqlToForm = ((data) => {
       spsKanopyUrl: data.perfMonitoringKanopyURL ?? "",
       spsUrl: data.perfMonitoringURL ?? "",
     },
+    sage: {
+      baseUrl: sage?.baseUrl ?? "",
+    },
   };
 }) satisfies GqlToFormFunction<Tab>;
 
@@ -76,6 +80,7 @@ export const formToGql = ((form) => {
     graphite,
     jira,
     runtimeEnvironments,
+    sage,
     slack,
     splunk,
     testSelection,
@@ -139,5 +144,8 @@ export const formToGql = ((form) => {
     },
     perfMonitoringKanopyURL: cedar.spsKanopyUrl,
     perfMonitoringURL: cedar.spsUrl,
+    sage: {
+      baseUrl: sage.baseUrl || undefined,
+    },
   };
 }) satisfies FormToGqlFunction<Tab>;

--- a/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/ExternalCommunicationsTab/types.ts
+++ b/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/ExternalCommunicationsTab/types.ts
@@ -46,6 +46,9 @@ export interface ExternalCommunicationsFormState {
     spsUrl: string;
     spsKanopyUrl: string;
   };
+  sage: {
+    baseUrl: string;
+  };
 }
 
 export type TabProps = {


### PR DESCRIPTION
DEVPROD-26705

### Description
Add the ability to configure the Sage base URL in the admin settings External Communications tab.

This is part 1 of the Sage Bot integration. A follow-up PR will add user-facing API key management settings.

### Screenshots
Deployed to staging:

<img width="1573" height="1382" alt="image" src="https://github.com/user-attachments/assets/0670757b-0f2e-4506-aa70-d9c1b7f9f71a"/>

### Testing
- Verified the new field appears in the External Communications tab
- Tested saving and loading the sage base URL setting

### Evergreen PR
https://github.com/evergreen-ci/evergreen/pull/9731

🤖 Generated with [Claude Code](https://claude.com/claude-code)