### PR TITLE
DEVPROD-27160: Remove useFirstDistro from navbar component

### DIFF
--- a/apps/spruce/cypress/integration/nav_bar.ts
+++ b/apps/spruce/cypress/integration/nav_bar.ts
@@ -18,15 +18,7 @@ describe("Nav Bar", () => {
     cy.dataCy("auxiliary-dropdown-project-patches").click();
     cy.location("pathname").should("eq", "/project/spruce/patches");
   });
-  it("Nav Dropdown should link to the first distro returned by the distros resolver", () => {
-    cy.visit(SPRUCE_URLS.version);
-    cy.dataCy("auxiliary-dropdown-link").click();
-    cy.dataCy("auxiliary-dropdown-distro-settings").should(
-      "have.attr",
-      "href",
-      "/distro/archlinux-test/settings/general",
-    );
-  });
+
   it("Nav Dropdown should link to patches page of default project in SpruceConfig if cookie does not exist", () => {
     cy.clearCookie(projectCookie);
     cy.visit(SPRUCE_URLS.userPatches);

--- a/apps/spruce/src/components/Header/AuxiliaryDropdown.tsx
+++ b/apps/spruce/src/components/Header/AuxiliaryDropdown.tsx
@@ -1,12 +1,11 @@
 import { useNavbarAnalytics } from "analytics";
 import {
   routes,
-  getDistroSettingsRoute,
+  redirectRoutes,
   getProjectPatchesRoute,
   getProjectSettingsRoute,
   getTaskQueueRoute,
 } from "constants/routes";
-import { useFirstDistro } from "hooks";
 import { NavDropdown } from "./NavDropdown";
 
 interface AuxiliaryDropdownProps {
@@ -17,7 +16,6 @@ export const AuxiliaryDropdown: React.FC<AuxiliaryDropdownProps> = ({
   projectIdentifier,
 }) => {
   const { sendEvent } = useNavbarAnalytics();
-  const { distro } = useFirstDistro();
 
   const menuItems = [
     {
@@ -32,7 +30,7 @@ export const AuxiliaryDropdown: React.FC<AuxiliaryDropdownProps> = ({
     },
     {
       "data-cy": "auxiliary-dropdown-distro-settings",
-      to: getDistroSettingsRoute(distro),
+      to: redirectRoutes.distroSettings,
       text: "Distro Settings",
       onClick: () => sendEvent({ name: "Clicked distro settings link" }),
     },

--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -4824,6 +4824,7 @@ export type UserConfig = {
 
 export type UserServiceFlags = {
   __typename?: "UserServiceFlags";
+  debugSpawnHostDisabled?: Maybe<Scalars["Boolean"]["output"]>;
   jwtTokenForCLIDisabled?: Maybe<Scalars["Boolean"]["output"]>;
 };
 


### PR DESCRIPTION
DEVPROD-27160

### Description
This PR removes the `useFirstDistro` query from the navbar's `AuxiliaryDropdown` component. Previously, this query was executed on every session for all users, contributing significantly to the Apollo cache size.

The "Distro Settings" link now points to a redirect route (`/distros`). The `useFirstDistro` query is now only executed on-demand within the `DistroSettingsRedirect` component when a user explicitly navigates to Distro Settings. This implements a lazy-loading pattern, similar to other redirect routes, optimizing performance by reducing unnecessary Apollo cache usage.

### Screenshots
No visible changes.

### Testing
- Verified TypeScript compilation and linting.
- Ensured existing tests continue to pass.
- Confirmed `useFirstDistro` is now only used in the `DistroSettingsRedirect` component.

---
<a href="https://cursor.com/background-agent?bcId=bc-e9ab57e4-0e26-4d5a-b695-e4a8280416e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e9ab57e4-0e26-4d5a-b695-e4a8280416e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

