### PR TITLE
DEVPROD-27470: Fix Parsley AI login

### DIFF
--- a/packages/fungi/src/Auth/Login.test.tsx
+++ b/packages/fungi/src/Auth/Login.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen, userEvent } from "@evg-ui/lib/test_utils";
+import { ChatProvider } from "../Context";
+import { AuthProvider } from "./AuthProvider";
+import { Login } from "./Login";
+
+const LOGIN_URL = "https://example.com/login";
+
+const wrapper = ({ children }: React.PropsWithChildren) => (
+  <ChatProvider appName="Parsley AI">
+    <AuthProvider loginUrl={LOGIN_URL}>{children}</AuthProvider>
+  </ChatProvider>
+);
+
+describe("Login", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.spyOn(window, "open").mockImplementation(vi.fn());
+  });
+
+  it("calls beginPollingAuth when Log in is clicked", async () => {
+    const user = userEvent.setup();
+    render(<Login />, { wrapper });
+
+    await user.click(screen.getByText("Log in"));
+
+    expect(screen.getByText("Waiting for login...")).toBeInTheDocument();
+  });
+
+  it("opens auth URL in a new tab when user clicks Log in", async () => {
+    const user = userEvent.setup();
+    render(<Login />, { wrapper });
+
+    await user.click(screen.getByText("Log in"));
+
+    expect(window.open).toHaveBeenCalledTimes(1);
+    expect(window.open).toHaveBeenCalledWith(
+      LOGIN_URL,
+      "_blank",
+      "noopener,noreferrer",
+    );
+  });
+
+  it("shows app name in the message", () => {
+    render(<Login />, { wrapper });
+    expect(
+      screen.getByText(/Parsley AI requires separate authentication/),
+    ).toBeInTheDocument();
+  });
+});

--- a/packages/fungi/src/Auth/Login.tsx
+++ b/packages/fungi/src/Auth/Login.tsx
@@ -8,15 +8,18 @@ export const Login: React.FC = () => {
   const { appName } = useChatContext();
   const { beginPollingAuth, isPolling, loginUrl } = useAuthContext();
 
+  const handleLoginClick = () => {
+    beginPollingAuth();
+    // Open window here instead of via href to avoid an LG race condition between href and an onClick that updates isLoading/disabled
+    window.open(loginUrl, "_blank", "noopener,noreferrer");
+  };
+
   return (
     <Container>
       <MessageText>{appName} requires separate authentication.</MessageText>
       <Button
-        as="a"
         disabled={isPolling}
-        href={loginUrl}
-        onClick={beginPollingAuth}
-        target="_blank"
+        onClick={handleLoginClick}
         variant={Variant.BaseGreen}
       >
         {isPolling ? "Waiting for login..." : "Log in"}


### PR DESCRIPTION
DEVPROD-27470

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->

<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
<!-- add description, context, thought process, etc -->
LeafyGreen commit [`9ee19a2`](https://github.com/mongodb/leafygreen-ui/commit/9ee19a2b6988bdde4a8be5489fd36e6e25d60856) introduced behavior where a button that is `disabled` has any `href` props set to `undefined`.

The fact that we set `isPolling = true` to disable the button on click introduced a race condition where the `href` was erased before it was actually opened. To get around this, we can just open the authentication directly from the onClick function.

### Testing
<!-- add a description of how you tested it -->
Add unit tests, validated locally