### PR TITLE
DEVPROD-24934 add debug spawn host script setting

### DIFF
--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -7844,6 +7844,10 @@ export type AdminSettingsQuery = {
         } | null;
       } | null;
     } | null;
+    debugSpawnHosts?: {
+      __typename?: "DebugSpawnHostsConfig";
+      setupScript?: string | null;
+    } | null;
     fws?: { __typename?: "FWSConfig"; url: string } | null;
     githubCheckRun?: {
       __typename?: "GitHubCheckRunConfig";

--- a/apps/spruce/src/gql/queries/admin-settings.graphql
+++ b/apps/spruce/src/gql/queries/admin-settings.graphql
@@ -134,6 +134,9 @@ query AdminSettings {
       }
       savingsPlanDiscount
     }
+    debugSpawnHosts {
+      setupScript
+    }
     disabledGQLQueries
     domainName
     expansions

--- a/apps/spruce/src/pages/adminSettings/index.tsx
+++ b/apps/spruce/src/pages/adminSettings/index.tsx
@@ -28,6 +28,7 @@ const AdminSettingsPage: React.FC = () => {
   const { data } = useQuery<AdminSettingsQuery, AdminSettingsQueryVariables>(
     ADMIN_SETTINGS,
   );
+
   return (
     <AdminSettingsProvider>
       <SideNavPageWrapper>

--- a/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/OtherTab/getFormSchema.ts
+++ b/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/OtherTab/getFormSchema.ts
@@ -8,6 +8,7 @@ import {
   hostJasper,
   jiraNotificationsFields,
   spawnHost,
+  debugSpawnHostsConfig,
   sleepSchedule,
   tracerConfiguration,
   projectCreationSettings,
@@ -66,6 +67,11 @@ export const getFormSchema = ({
               title: "Spawn Host",
               properties: spawnHost.schema,
             },
+            debugSpawnHostsConfig: {
+              type: "object" as const,
+              title: "Debug Spawn Hosts Config",
+              properties: debugSpawnHostsConfig.schema,
+            },
             sleepSchedule: {
               type: "object" as const,
               title: "Sleep Schedule",
@@ -105,6 +111,7 @@ export const getFormSchema = ({
         hostJasper: hostJasper.uiSchema,
         jiraNotificationsFields: jiraNotificationsFields.uiSchema,
         spawnHost: spawnHost.uiSchema,
+        debugSpawnHostsConfig: debugSpawnHostsConfig.uiSchema,
         sleepSchedule: sleepSchedule.uiSchema,
         tracerConfiguration: tracerConfiguration.uiSchema,
         projectCreationSettings: projectCreationSettings.uiSchema,

--- a/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/OtherTab/schemaFields.ts
+++ b/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/OtherTab/schemaFields.ts
@@ -532,6 +532,25 @@ export const spawnHost = {
   },
 };
 
+export const debugSpawnHostsConfig = {
+  schema: {
+    setupScript: {
+      type: "string" as const,
+      title: "Setup Script",
+    },
+  },
+  uiSchema: {
+    "ui:ObjectFieldTemplate": CardFieldTemplate,
+    "ui:data-cy": "debug-spawn-hosts-config",
+    setupScript: {
+      "ui:widget": "textarea",
+      "ui:fieldCss": fullWidthCss,
+      "ui:description":
+        "Optional script used to help debug spawn host setup/provisioning.",
+    },
+  },
+};
+
 export const sleepSchedule = {
   schema: {
     permanentlyExemptHosts: {

--- a/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/OtherTab/transformers.test.ts
+++ b/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/OtherTab/transformers.test.ts
@@ -101,6 +101,9 @@ const mockAdminSettings: AdminSettings = {
     unexpirableVolumesPerUser: 3,
     spawnHostsPerUser: 5,
   },
+  debugSpawnHosts: {
+    setupScript: "echo debug spawn hosts",
+  },
   sleepSchedule: {
     permanentlyExemptHosts: ["build-host-1", "build-host-2"],
   },
@@ -224,6 +227,9 @@ const expectedForm: OtherFormState = {
       unexpirableVolumesPerUser: 3,
       spawnHostsPerUser: 5,
     },
+    debugSpawnHostsConfig: {
+      setupScript: "echo debug spawn hosts",
+    },
     sleepSchedule: {
       permanentlyExemptHosts: ["build-host-1", "build-host-2"],
     },
@@ -346,6 +352,9 @@ const expectedGql: AdminSettingsInput = {
     unexpirableHostsPerUser: 2,
     unexpirableVolumesPerUser: 3,
     spawnHostsPerUser: 5,
+  },
+  debugSpawnHosts: {
+    setupScript: "echo debug spawn hosts",
   },
   sleepSchedule: {
     permanentlyExemptHosts: ["build-host-1", "build-host-2"],

--- a/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/OtherTab/transformers.ts
+++ b/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/OtherTab/transformers.ts
@@ -27,6 +27,7 @@ export const gqlToForm = ((data) => {
     buckets,
     configDir,
     cost,
+    debugSpawnHosts,
     domainName,
     expansions,
     githubCheckRun,
@@ -163,6 +164,10 @@ export const gqlToForm = ((data) => {
         spawnHostsPerUser: spawnhost?.spawnHostsPerUser ?? 0,
       },
 
+      debugSpawnHostsConfig: {
+        setupScript: debugSpawnHosts?.setupScript ?? "",
+      },
+
       sleepSchedule: {
         permanentlyExemptHosts: sleepSchedule?.permanentlyExemptHosts ?? [],
       },
@@ -197,6 +202,7 @@ export const formToGql = ((form: OtherFormState) => {
 
   const {
     bucketConfig,
+    debugSpawnHostsConfig,
     expansions,
     githubCheckRunConfigurations,
     hostJasper,
@@ -339,6 +345,10 @@ export const formToGql = ((form: OtherFormState) => {
       unexpirableVolumesPerUser:
         spawnHost.unexpirableVolumesPerUser || undefined,
       spawnHostsPerUser: spawnHost.spawnHostsPerUser || undefined,
+    },
+
+    debugSpawnHosts: {
+      setupScript: debugSpawnHostsConfig.setupScript || undefined,
     },
 
     sleepSchedule: {

--- a/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/OtherTab/types.ts
+++ b/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/OtherTab/types.ts
@@ -93,6 +93,10 @@ export interface OtherFormState {
       spawnHostsPerUser: number;
     };
 
+    debugSpawnHostsConfig: {
+      setupScript: string;
+    };
+
     sleepSchedule: {
       permanentlyExemptHosts: string[];
     };


### PR DESCRIPTION
DEVPROD-24934

### Description
add setting for debug spawn hosts

### Screenshots

<img width="793" height="276" alt="image" src="https://github.com/user-attachments/assets/9551355f-cdca-4b26-8329-998b2a4ccf7f" />

### Testing
unit testing 
graphql tests
local evergreen setting saves