### PR TITLE
DEVPROD-27703: Fix e2e test due to aria label changes

### DIFF
--- a/apps/spruce/cypress/integration/spawn/host.ts
+++ b/apps/spruce/cypress/integration/spawn/host.ts
@@ -297,7 +297,7 @@ describe("Navigating to Spawn Host page", () => {
             cy.wrap($nextCell).click();
           } else {
             cy.log("Current date is the last day of the month");
-            cy.get('button[aria-label="Next month"]').click();
+            cy.get('button[aria-label^="Next month"]').click();
             cy.get('td[data-testid="lg-date_picker-calendar_cell"]')
               .first()
               .click();


### PR DESCRIPTION
DEVPROD-XXXX

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->

<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
<!-- add description, context, thought process, etc -->
A small tweak to test logic to fix issues caused by the change to the aria-label format in leafygreen. See [here](https://github.com/mongodb/leafygreen-ui/blob/a048363a1397c54efac4eaf3139af80e85957053/packages/date-picker/src/DatePicker/DatePickerMenu/DatePickerMenuHeader/DatePickerMenuHeader.tsx#L113) for the code that adds a suffix now.

I noticed this issue in some PR downstream tasks from the evergreen repo

### Screenshots
<!-- add screenshots of visible changes -->

### Testing
<!-- add a description of how you tested it -->
CI passes

### Evergreen PR
<!-- link to a corresponding Evergreen PR if applicable -->
