### PR TITLE
DEVPROD-20269: Add copy format flexibility and improve toast UX in SharingMenu 

### DIFF
--- a/apps/parsley/src/components/DetailsMenu/DetailsMenuCard/ButtonRow/CopyTextButton.tsx
+++ b/apps/parsley/src/components/DetailsMenu/DetailsMenuCard/ButtonRow/CopyTextButton.tsx
@@ -13,16 +13,12 @@ import { SentryBreadcrumbTypes } from "@evg-ui/lib/utils/sentry/types";
 import { copyToClipboard } from "@evg-ui/lib/utils/string";
 import { usePreferencesAnalytics } from "analytics";
 import { COPY_FORMAT } from "constants/cookies";
+import { CopyFormat } from "constants/enums";
 import { QueryParams } from "constants/queryParams";
 import { useLogContext } from "context/LogContext";
 import { getJiraFormat, getRawLines } from "utils/string";
 
 const COPIED_SUCCESS_DURATION = 1500;
-
-enum CopyFormat {
-  Jira = "jira",
-  Raw = "raw",
-}
 
 export const CopyTextButton: React.FC = () => {
   const [bookmarks] = useQueryParam<number[]>(QueryParams.Bookmarks, []);

--- a/apps/parsley/src/components/LogRow/BaseRow/SharingMenu/SharingMenu.test.tsx
+++ b/apps/parsley/src/components/LogRow/BaseRow/SharingMenu/SharingMenu.test.tsx
@@ -1,3 +1,4 @@
+import Cookies from "js-cookie";
 import { RenderFakeToastContext } from "@evg-ui/lib/context/toast/__mocks__";
 import {
   MockedProvider,
@@ -7,6 +8,7 @@ import {
   screen,
   userEvent,
 } from "@evg-ui/lib/test_utils";
+import { COPY_FORMAT } from "constants/cookies";
 import { LogTypes } from "constants/enums";
 import { LogContextProvider, useLogContext } from "context/LogContext";
 import {
@@ -54,6 +56,10 @@ const renderSharingMenu = () => {
 };
 
 describe("sharingMenu", () => {
+  beforeEach(() => {
+    Cookies.remove(COPY_FORMAT);
+  });
+
   it("should render an open menu after setting it to open", async () => {
     const { hook } = renderSharingMenu();
     expect(screen.queryByText("Copy share link to selected lines")).toBeNull();
@@ -80,7 +86,7 @@ describe("sharingMenu", () => {
     ).toBeInTheDocument();
     expect(screen.getByText("Only search on range")).toBeInTheDocument();
   });
-  it("clicking `copy selected contents` should copy the line range to the clipboard", async () => {
+  it("clicking `copy selected contents` should copy the line range to the clipboard in Jira format by default", async () => {
     const user = userEvent.setup({ writeToClipboard: true });
 
     const { hook } = renderSharingMenu();
@@ -97,7 +103,7 @@ describe("sharingMenu", () => {
       "{noformat}\nline 2\nline 3\nline 4\n{noformat}",
     );
   });
-  it("clicking `copy selected contents` should copy a single selected line to the clipboard", async () => {
+  it("clicking `copy selected contents` should copy a single selected line to the clipboard in Jira format by default", async () => {
     const user = userEvent.setup({ writeToClipboard: true });
 
     const { hook } = renderSharingMenu();
@@ -110,6 +116,37 @@ describe("sharingMenu", () => {
     await user.click(screen.getByText("Copy selected contents"));
     const clipboardText = await navigator.clipboard.readText();
     expect(clipboardText).toBe("{noformat}\nline 2\n{noformat}");
+  });
+  it("clicking `copy selected contents` should copy the line range to the clipboard in raw format when cookie is set to raw", async () => {
+    const user = userEvent.setup({ writeToClipboard: true });
+    Cookies.set(COPY_FORMAT, "raw");
+
+    const { hook } = renderSharingMenu();
+    act(() => {
+      hook.current.handleSelectLine(1, false);
+    });
+    act(() => {
+      hook.current.handleSelectLine(3, true);
+    });
+    expect(screen.getByText("Copy selected contents")).toBeInTheDocument();
+    await user.click(screen.getByText("Copy selected contents"));
+    const clipboardText = await navigator.clipboard.readText();
+    expect(clipboardText).toBe("line 2\nline 3\nline 4");
+  });
+  it("clicking `copy selected contents` should copy a single selected line to the clipboard in raw format when cookie is set to raw", async () => {
+    const user = userEvent.setup({ writeToClipboard: true });
+    Cookies.set(COPY_FORMAT, "raw");
+
+    const { hook } = renderSharingMenu();
+    act(() => {
+      hook.current.setOpenMenu(true);
+      hook.current.handleSelectLine(1, false);
+    });
+
+    expect(screen.getByText("Copy selected contents")).toBeInTheDocument();
+    await user.click(screen.getByText("Copy selected contents"));
+    const clipboardText = await navigator.clipboard.readText();
+    expect(clipboardText).toBe("line 2");
   });
   it("clicking `share link to selected lines` should copy the link to the clipboard", async () => {
     const user = userEvent.setup({ writeToClipboard: true });

--- a/apps/parsley/src/components/LogRow/BaseRow/SharingMenu/SharingMenu.test.tsx
+++ b/apps/parsley/src/components/LogRow/BaseRow/SharingMenu/SharingMenu.test.tsx
@@ -131,7 +131,7 @@ describe("sharingMenu", () => {
     expect(screen.getByText("Copy selected contents")).toBeInTheDocument();
     await user.click(screen.getByText("Copy selected contents"));
     const clipboardText = await navigator.clipboard.readText();
-    expect(clipboardText).toBe("line 2\nline 3\nline 4");
+    expect(clipboardText).toBe("line 2\nline 3\nline 4\n");
   });
   it("clicking `copy selected contents` should copy a single selected line to the clipboard in raw format when cookie is set to raw", async () => {
     const user = userEvent.setup({ writeToClipboard: true });
@@ -146,7 +146,7 @@ describe("sharingMenu", () => {
     expect(screen.getByText("Copy selected contents")).toBeInTheDocument();
     await user.click(screen.getByText("Copy selected contents"));
     const clipboardText = await navigator.clipboard.readText();
-    expect(clipboardText).toBe("line 2");
+    expect(clipboardText).toBe("line 2\n");
   });
   it("clicking `share link to selected lines` should copy the link to the clipboard", async () => {
     const user = userEvent.setup({ writeToClipboard: true });

--- a/apps/parsley/src/components/styles/GlobalStyles.tsx
+++ b/apps/parsley/src/components/styles/GlobalStyles.tsx
@@ -25,6 +25,11 @@ export const globalStyles = css`
       display: none;
     }
   }
+
+  /* Ensure toasts appear above the side panel (z-index: 2) */
+  .parsley-toast-portal {
+    z-index: 10;
+  }
 `;
 
 export const GlobalStyles = () => <Global styles={globalStyles} />;

--- a/apps/parsley/src/constants/enums.ts
+++ b/apps/parsley/src/constants/enums.ts
@@ -37,8 +37,14 @@ enum WordWrapFormat {
   Standard = "standard",
 }
 
+enum CopyFormat {
+  Jira = "jira",
+  Raw = "raw",
+}
+
 export {
   CaseSensitivity,
+  CopyFormat,
   FilterLogic,
   LogRenderingTypes,
   LogTypes,

--- a/apps/parsley/src/context/GlobalProviders.tsx
+++ b/apps/parsley/src/context/GlobalProviders.tsx
@@ -4,6 +4,7 @@ import { ChatProvider } from "components/Chatbot";
 import GQLProvider from "gql/GQLProvider";
 import { LogContextProvider } from "./LogContext";
 import { MultiLineSelectContextProvider } from "./MultiLineSelectContext";
+
 /**
  * GlobalProviders wrap our application with our global contexts
  * @param props - React props
@@ -14,7 +15,7 @@ const GlobalProviders: React.FC<{ children: React.ReactElement }> = ({
   children,
 }) => (
   <LeafyGreenProvider>
-    <ToastProvider>
+    <ToastProvider portalClassName="parsley-toast-portal">
       <GQLProvider>
         <LogContextProvider>
           <MultiLineSelectContextProvider>

--- a/apps/spruce/src/components/TimePicker/TimePicker.test.tsx
+++ b/apps/spruce/src/components/TimePicker/TimePicker.test.tsx
@@ -96,7 +96,9 @@ describe("time picker", () => {
 
     const hourOptions = screen.getByDataCy("hour-options");
     await user.click(within(hourOptions).getByText("04"));
-    expect(onScroll).toHaveBeenCalledTimes(3);
+    await waitFor(() => {
+      expect(onScroll).toHaveBeenCalled();
+    });
     expect(onDateChange).toHaveBeenCalledTimes(1);
     expect(onDateChange).toHaveBeenCalledWith(
       new Date("2025-01-01T04:33:00.000Z"),
@@ -104,7 +106,9 @@ describe("time picker", () => {
 
     const minuteOptions = screen.getByDataCy("minute-options");
     await user.click(within(minuteOptions).getByText("40"));
-    expect(onScroll).toHaveBeenCalledTimes(4);
+    await waitFor(() => {
+      expect(onScroll).toHaveBeenCalled();
+    });
     expect(onDateChange).toHaveBeenCalledTimes(2);
     expect(onDateChange).toHaveBeenCalledWith(
       new Date("2025-01-01T04:40:00.000Z"),

--- a/packages/lib/src/context/toast/index.tsx
+++ b/packages/lib/src/context/toast/index.tsx
@@ -45,10 +45,20 @@ const ToastProviderCore: React.FC<{ children: ReactNode }> = ({ children }) => {
       onClose,
       progress,
       shouldTimeout,
+      timeout,
       title,
       variant,
-    }: ToastParams) =>
-      pushToast({
+    }: ToastParams) => {
+      let toastTimeout: number | null;
+      if (timeout !== undefined) {
+        toastTimeout = timeout;
+      } else if (shouldTimeout) {
+        toastTimeout = TOAST_TIMEOUT;
+      } else {
+        toastTimeout = null;
+      }
+
+      return pushToast({
         // @ts-expect-error: data-cy doesn't exist as a prop on Toast but it will be propagated correctly.
         "data-cy": "toast",
         "data-variant": mapLeafyGreenVariantToToast[variant],
@@ -56,10 +66,11 @@ const ToastProviderCore: React.FC<{ children: ReactNode }> = ({ children }) => {
         dismissible: closable,
         onClose: closable ? onClose : undefined,
         progress,
-        timeout: shouldTimeout ? TOAST_TIMEOUT : null,
+        timeout: toastTimeout,
         title: title || mapLeafyGreenVariantToTitle[variant],
         variant,
-      }),
+      });
+    },
     [pushToast],
   );
 
@@ -122,8 +133,11 @@ const ToastProviderCore: React.FC<{ children: ReactNode }> = ({ children }) => {
   );
 };
 
-const ToastProvider: React.FC<{ children?: ReactNode }> = ({ children }) => (
-  <LGToastProvider>
+const ToastProvider: React.FC<{
+  children?: ReactNode;
+  portalClassName?: string;
+}> = ({ children, portalClassName }) => (
+  <LGToastProvider portalClassName={portalClassName}>
     <ToastProviderCore>{children}</ToastProviderCore>
   </LGToastProvider>
 );

--- a/packages/lib/src/context/toast/index.tsx
+++ b/packages/lib/src/context/toast/index.tsx
@@ -49,13 +49,11 @@ const ToastProviderCore: React.FC<{ children: ReactNode }> = ({ children }) => {
       title,
       variant,
     }: ToastParams) => {
-      let toastTimeout: number | null;
+      let toastTimeout = null;
       if (timeout !== undefined) {
         toastTimeout = timeout;
       } else if (shouldTimeout) {
         toastTimeout = TOAST_TIMEOUT;
-      } else {
-        toastTimeout = null;
       }
 
       return pushToast({

--- a/packages/lib/src/context/toast/types.ts
+++ b/packages/lib/src/context/toast/types.ts
@@ -15,6 +15,7 @@ export type ToastParams = {
   shouldTimeout: boolean;
   title: string;
   progress?: number;
+  timeout?: number | null;
 };
 
 // This is a function definition.
@@ -25,6 +26,7 @@ export type DispatchToast = (
     onClose?: () => void;
     shouldTimeout?: boolean;
     title?: string;
+    timeout?: number;
   },
 ) => void;
 
@@ -37,5 +39,6 @@ export type DispatchToastWithProgress = (
     onClose?: () => void;
     shouldTimeout?: boolean;
     title?: string;
+    timeout?: number;
   },
 ) => void;


### PR DESCRIPTION
### Description
- Add support for copying log lines in raw format (plain text) in addition to Jira format
- Respect user's copy format preference from Details Menu via COPY_FORMAT cookie
- Move CopyFormat enum to shared constants/enums.ts to eliminate duplication
- Fix toast z-index issue by adding portalClassName support to ToastProvider
- Add custom timeout option for toasts (5s for copy actions, 30s default for others)
- Add tests for raw format copying
- Update toast messages to indicate which format was used

DEVPROD-20269

### Screenshots
https://github.com/user-attachments/assets/f0f6c759-5444-4d52-80fc-1c142c792fa4

### Testing
- Smoke tested it locally
- Added tests to verify