### PR TITLE
DEVPROD-25967: Logs tab enhancements

### DIFF
--- a/apps/spruce/src/components/styles/Layout.tsx
+++ b/apps/spruce/src/components/styles/Layout.tsx
@@ -69,7 +69,7 @@ export const PageButtonRow = styled.div`
   align-items: flex-start;
   gap: ${size.xs};
 
-  button {
+  > * {
     min-width: fit-content;
   }
 `;

--- a/apps/spruce/src/pages/task/taskTabs/logs/index.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/logs/index.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import styled from "@emotion/styled";
-import { Button } from "@leafygreen-ui/button";
+import { Button, Variant } from "@leafygreen-ui/button";
 import {
   SegmentedControl,
   SegmentedControlOption,
@@ -89,69 +89,78 @@ const Logs: React.FC<Props> = ({ execution, logLinks, taskId }) => {
             Event Logs
           </SegmentedControlOption>
           <SegmentedControlOption id="cy-all-option" value={LogTypes.All}>
-            All Logs
+            Combined Logs
           </SegmentedControlOption>
         </SegmentedControl>
-
-        {(htmlLink || rawLink || parsleyLink) && (
-          <ButtonContainer>
-            {parsleyLink && (
-              <Button
-                data-cy="parsley-log-btn"
-                disabled={noLogs}
-                href={parsleyLink}
-                onClick={() =>
-                  sendEvent({
-                    name: "Clicked log link",
-                    "log.type": currentLog,
-                    "log.viewer": "parsley",
-                  })
-                }
-                title="High-powered log viewer"
-              >
-                Parsley
-              </Button>
-            )}
-            {htmlLink && (
-              <Button
-                data-cy="html-log-btn"
-                disabled={noLogs}
-                href={htmlLink}
-                onClick={() =>
-                  sendEvent({
-                    name: "Clicked log link",
-                    "log.type": currentLog,
-                    "log.viewer": "html",
-                  })
-                }
-                title="Plain, colorized log viewer"
-              >
-                HTML
-              </Button>
-            )}
-            {rawLink && (
-              <Button
-                data-cy="raw-log-btn"
-                disabled={noLogs}
-                href={rawLink}
-                onClick={() =>
-                  sendEvent({
-                    name: "Clicked log link",
-                    "log.type": currentLog,
-                    "log.viewer": "raw",
-                  })
-                }
-                title="Plain text log viewer"
-              >
-                Raw
-              </Button>
-            )}
-          </ButtonContainer>
-        )}
       </LogHeader>
-      {LogComp && (
-        <LogComp execution={execution} setNoLogs={setNoLogs} taskId={taskId} />
-      )}
+      <LogContentWrapper>
+        {LogComp && (
+          <LogComp
+            execution={execution}
+            setNoLogs={setNoLogs}
+            taskId={taskId}
+          />
+        )}
+        {(htmlLink || rawLink || parsleyLink) && (
+          <>
+            <LogFadeOverlay />
+            <FloatingButtonContainer>
+              {parsleyLink && (
+                <Button
+                  data-cy="parsley-log-btn"
+                  disabled={noLogs}
+                  href={parsleyLink}
+                  onClick={() =>
+                    sendEvent({
+                      name: "Clicked log link",
+                      "log.type": currentLog,
+                      "log.viewer": "parsley",
+                    })
+                  }
+                  title="View complete logs in Parsley"
+                  variant={Variant.BaseGreen}
+                >
+                  Complete Logs on Parsley
+                </Button>
+              )}
+              {htmlLink && (
+                <Button
+                  data-cy="html-log-btn"
+                  disabled={noLogs}
+                  href={htmlLink}
+                  onClick={() =>
+                    sendEvent({
+                      name: "Clicked log link",
+                      "log.type": currentLog,
+                      "log.viewer": "html",
+                    })
+                  }
+                  title="Plain, colorized log viewer"
+                >
+                  HTML
+                </Button>
+              )}
+              {rawLink && (
+                <Button
+                  data-cy="raw-log-btn"
+                  disabled={noLogs}
+                  href={rawLink}
+                  onClick={() =>
+                    sendEvent({
+                      name: "Clicked log link",
+                      "log.type": currentLog,
+                      "log.viewer": "raw",
+                    })
+                  }
+                  title="Plain text log viewer"
+                >
+                  Raw
+                </Button>
+              )}
+            </FloatingButtonContainer>
+          </>
+        )}
+      </LogContentWrapper>
     </LogContainer>
   );
 };
@@ -167,9 +176,33 @@ const LogHeader = styled.div`
   margin-bottom: ${size.s};
 `;
 
-const ButtonContainer = styled.div`
+const LogContentWrapper = styled.div`
+  position: relative;
+`;
+
+const LogFadeOverlay = styled.div`
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 80px;
+  background: linear-gradient(
+    to bottom,
+    rgba(255, 255, 255, 0.95) 0%,
+    rgba(255, 255, 255, 0.7) 50%,
+    rgba(255, 255, 255, 0) 100%
+  );
+  pointer-events: none;
+  z-index: 1;
+`;
+
+const FloatingButtonContainer = styled.div`
+  position: absolute;
+  top: ${size.xs};
+  right: ${size.xs};
   display: flex;
   gap: ${size.xs};
+  z-index: 2;
 `;
 
 interface GetLinksResult {

--- a/apps/spruce/src/pages/task/taskTabs/logs/index.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/logs/index.tsx
@@ -117,10 +117,9 @@ const Logs: React.FC<Props> = ({ execution, logLinks, taskId }) => {
                       "log.viewer": "parsley",
                     })
                   }
-                  title="View complete logs in Parsley"
                   variant={Variant.Primary}
                 >
-                  Complete Logs on Parsley
+                  Complete logs on Parsley
                 </Button>
               )}
               {htmlLink && (
@@ -135,7 +134,6 @@ const Logs: React.FC<Props> = ({ execution, logLinks, taskId }) => {
                       "log.viewer": "html",
                     })
                   }
-                  title="Plain, colorized log viewer"
                 >
                   HTML
                 </Button>
@@ -152,7 +150,6 @@ const Logs: React.FC<Props> = ({ execution, logLinks, taskId }) => {
                       "log.viewer": "raw",
                     })
                   }
-                  title="Plain text log viewer"
                 >
                   Raw
                 </Button>
@@ -182,18 +179,17 @@ const LogContentWrapper = styled.div`
 
 const LogFadeOverlay = styled.div`
   position: absolute;
+  margin: 2px;
   top: 0;
   left: 0;
   right: 0;
-  height: 80px;
+  height: 100px;
   background: linear-gradient(
     to bottom,
     rgba(255, 255, 255, 0.95) 0%,
     rgba(255, 255, 255, 0.7) 50%,
     rgba(255, 255, 255, 0) 100%
   );
-  pointer-events: none;
-  z-index: 1;
 `;
 
 const FloatingButtonContainer = styled.div`

--- a/apps/spruce/src/pages/task/taskTabs/logs/index.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/logs/index.tsx
@@ -89,7 +89,7 @@ const Logs: React.FC<Props> = ({ execution, logLinks, taskId }) => {
             Event Logs
           </SegmentedControlOption>
           <SegmentedControlOption id="cy-all-option" value={LogTypes.All}>
-            Combined Logs
+            Combined
           </SegmentedControlOption>
         </SegmentedControl>
       </LogHeader>
@@ -118,7 +118,7 @@ const Logs: React.FC<Props> = ({ execution, logLinks, taskId }) => {
                     })
                   }
                   title="View complete logs in Parsley"
-                  variant={Variant.BaseGreen}
+                  variant={Variant.Primary}
                 >
                   Complete Logs on Parsley
                 </Button>


### PR DESCRIPTION
DEVPROD-25967

### Description
Some UI improvements to the logs tab aimed at discoverability/new users

*   Rename "All logs" to "Combined" in the segmented control.
*   Add an opacity fade overlay at the top of the log tail to visually indicate it's a partial view.
*   Floating the Parsley, HTML, and Raw buttons over the right side of the log tail, above the fade.

### Screenshots

I think GH image uploading is broken rn...
![Uploading Screenshot 2026-02-26 at 10.45.16 AM.png…]()


### Evergreen PR
N/A

---
<p><a href="https://cursor.com/agents/bc-47e879ea-8887-4f8e-bfbd-8812f460e1cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-47e879ea-8887-4f8e-bfbd-8812f460e1cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

