### PR TITLE
DEVPROD-29280: Fix save button being disabled after toggling items

### DIFF
--- a/apps/spruce/src/pages/adminSettings/AdminSaveButton.tsx
+++ b/apps/spruce/src/pages/adminSettings/AdminSaveButton.tsx
@@ -46,6 +46,8 @@ export const AdminSaveButton: React.FC<AdminSaveButtonProps> = ({
     onError: (err) => {
       dispatchToast.error(`Error saving settings: ${err.message}`);
     },
+    awaitRefetchQueries: true,
+    refetchQueries: ["AdminSettings"],
   });
 
   const handleSave = () => {


### PR DESCRIPTION
DEVPROD-29280

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->

<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
When you toggled a setting and saved, if you unchecked that toggle, you couldn't save as the save button would be disabled. This is because we were using the initialData as the source of truth for what changed and comparing against it.
<img width="470" height="284" alt="Screenshot 2026-03-11 at 3 22 01 PM" src="https://github.com/user-attachments/assets/c5b7c1f3-1f64-481f-9eae-8a494c71babe" />

Changing initialData like that is a bit of a code smell imo but I think to fix this case more naturally would required a larger refactor compared to this simple change.

### Screenshots
<!-- add screenshots of visible changes -->


### Before
https://github.com/user-attachments/assets/44e591ae-bea3-4a74-a4e3-68a599e2e1ca


### After
https://github.com/user-attachments/assets/3dff2175-7991-4c79-a424-9a2c6dfbd0e1


### Testing
* Tested on local host
* Added tests