### PR TITLE
DEVPROD-25194: Remove delete -> add Github App Credential Flow and instead use replace flow

### DIFF
--- a/apps/spruce/cypress/integration/projectSettings/github_app_settings.ts
+++ b/apps/spruce/cypress/integration/projectSettings/github_app_settings.ts
@@ -27,53 +27,39 @@ describe("GitHub app settings", () => {
     saveButtonEnabled(false);
   });
 
-  it("should be able to delete & save app credentials", () => {
-    cy.dataCy("github-app-id-input").as("appId");
-    cy.dataCy("github-private-key-input").as("privateKey");
+  it("should be able to replace app credentials", () => {
+    // Replace button should be visible when app is defined.
+    cy.dataCy("replace-app-credentials-button").should("be.visible");
+    cy.dataCy("replace-app-credentials-button").click();
+    cy.dataCy("replace-github-credentials-modal").should("be.visible");
 
-    // Delete GitHub app credentials.
-    cy.dataCy("delete-app-credentials-button").should("be.visible");
-    cy.dataCy("delete-app-credentials-button").click();
-    cy.dataCy("delete-github-credentials-modal").should("be.visible");
-    cy.dataCy("delete-github-credentials-modal")
+    // Replace button in modal should be disabled without input.
+    cy.dataCy("replace-github-credentials-modal")
       .find("button")
-      .contains("Delete")
+      .contains("Replace")
+      .parent()
+      .should("have.attr", "aria-disabled", "true");
+
+    // Fill in new credentials.
+    cy.dataCy("replace-app-id-input").type("99999");
+    cy.dataCy("replace-private-key-input").type("new-private-key");
+
+    // Replace button should now be enabled.
+    cy.dataCy("replace-github-credentials-modal")
+      .find("button")
+      .contains("Replace")
+      .parent()
+      .should("not.have.attr", "aria-disabled", "true");
+
+    cy.dataCy("replace-github-credentials-modal")
+      .find("button")
+      .contains("Replace")
       .parent()
       .click();
     cy.validateToast(
       "success",
-      "GitHub app credentials were successfully deleted.",
+      "GitHub app credentials were successfully replaced.",
     );
-
-    cy.dataCy("github-app-credentials-banner").should("be.visible");
-    cy.get("@appId").should("have.value", "");
-    cy.get("@privateKey").should("have.value", "");
-    cy.get("@appId").should("have.attr", "aria-disabled", "false");
-    cy.get("@privateKey").should("have.attr", "aria-disabled", "false");
-
-    cy.reload();
-    cy.dataCy("github-app-credentials-banner").should("be.visible");
-    cy.get("@appId").should("have.value", "");
-    cy.get("@privateKey").should("have.value", "");
-
-    // Add GitHub app credentials.
-    cy.get("@appId").type("12345");
-    cy.get("@privateKey").type("secret");
-    cy.dataCy("save-settings-button").scrollIntoView();
-    saveButtonEnabled(true);
-    clickSave();
-    cy.validateToast("success", "Successfully updated project");
-
-    cy.dataCy("github-app-credentials-banner").should("not.exist");
-    cy.get("@appId").should("have.value", "12345");
-    cy.get("@privateKey").should("have.value", "{REDACTED}");
-    cy.get("@appId").should("have.attr", "aria-disabled", "true");
-    cy.get("@privateKey").should("have.attr", "aria-disabled", "true");
-
-    cy.reload();
-    cy.dataCy("github-app-credentials-banner").should("not.exist");
-    cy.get("@appId").should("have.value", "12345");
-    cy.get("@privateKey").should("have.value", "{REDACTED}");
   });
 
   it("should be able to save different permission groups for requesters, then return to defaults", () => {

--- a/apps/spruce/src/pages/projectAndRepoSettings/shared/HeaderButtons.tsx
+++ b/apps/spruce/src/pages/projectAndRepoSettings/shared/HeaderButtons.tsx
@@ -130,17 +130,20 @@ export const HeaderButtons: React.FC<Props> = ({ id, projectType, tab }) => {
     });
   };
 
-  // Let users with without a Github App on their project page
-  // default to repo to use the repo Github settings for the project settings.
-  let hasExistingGithubApp = false;
+  // Prevent users from defaulting to repo if their project has a Github App
+  // but the repo does not, which would result in losing credentials entirely.
+  // If the repo has credentials, defaulting to repo is safe.
+  let disableDefaultToRepo = false;
   if (tab === ProjectSettingsTabRoutes.GithubAppSettings) {
     const appFormData = formData as AppSettingsFormState;
-    const githubAppId = appFormData?.appCredentials?.githubAppAuth?.appId ?? 0;
-    hasExistingGithubApp = githubAppId > 0;
+    const projectAppId = appFormData?.appCredentials?.githubAppAuth?.appId ?? 0;
+    const repoAppId =
+      appFormData?.repoData?.appCredentials?.githubAppAuth?.appId ?? 0;
+    disableDefaultToRepo = projectAppId > 0 && !(repoAppId > 0);
   }
 
   const canDefaultToRepo =
-    !defaultToRepoDisabled.has(tab) && !hasExistingGithubApp;
+    !defaultToRepoDisabled.has(tab) && !disableDefaultToRepo;
 
   return (
     <ButtonRow>

--- a/apps/spruce/src/pages/projectAndRepoSettings/shared/HeaderButtons.tsx
+++ b/apps/spruce/src/pages/projectAndRepoSettings/shared/HeaderButtons.tsx
@@ -24,6 +24,7 @@ import {
 import { useHasProjectOrRepoEditPermission } from "hooks";
 import { useProjectSettingsContext } from "./Context";
 import { DefaultSectionToRepoModal } from "./DefaultSectionToRepoModal";
+import { AppSettingsFormState } from "./tabs/GithubAppSettingsTab/types";
 import { formToGqlMap } from "./tabs/transformers";
 import { FormToGqlFunction, WritableProjectSettingsType } from "./tabs/types";
 import { ProjectType } from "./tabs/utils";
@@ -33,7 +34,6 @@ const defaultToRepoDisabled: Set<WritableProjectSettingsType> = new Set([
   ProjectSettingsTabRoutes.Plugins,
   ProjectSettingsTabRoutes.ViewsAndFilters,
   ProjectSettingsTabRoutes.GithubPermissionGroups,
-  ProjectSettingsTabRoutes.GithubAppSettings,
 ]);
 
 interface Props {
@@ -130,7 +130,17 @@ export const HeaderButtons: React.FC<Props> = ({ id, projectType, tab }) => {
     });
   };
 
-  const canDefaultToRepo = !defaultToRepoDisabled.has(tab);
+  // Let users with a Github App on the Github App Settings page
+  // default to repo to use the repo Github settings for the project settings.
+  let hasExistingGithubApp = false;
+  if (tab === ProjectSettingsTabRoutes.GithubAppSettings) {
+    const appFormData = formData as AppSettingsFormState;
+    const githubAppId = appFormData?.appCredentials?.githubAppAuth?.appId ?? 0;
+    hasExistingGithubApp = githubAppId > 0;
+  }
+
+  const canDefaultToRepo =
+    !defaultToRepoDisabled.has(tab) && !hasExistingGithubApp;
 
   return (
     <ButtonRow>

--- a/apps/spruce/src/pages/projectAndRepoSettings/shared/HeaderButtons.tsx
+++ b/apps/spruce/src/pages/projectAndRepoSettings/shared/HeaderButtons.tsx
@@ -33,6 +33,7 @@ const defaultToRepoDisabled: Set<WritableProjectSettingsType> = new Set([
   ProjectSettingsTabRoutes.Plugins,
   ProjectSettingsTabRoutes.ViewsAndFilters,
   ProjectSettingsTabRoutes.GithubPermissionGroups,
+  ProjectSettingsTabRoutes.GithubAppSettings,
 ]);
 
 interface Props {

--- a/apps/spruce/src/pages/projectAndRepoSettings/shared/HeaderButtons.tsx
+++ b/apps/spruce/src/pages/projectAndRepoSettings/shared/HeaderButtons.tsx
@@ -130,7 +130,7 @@ export const HeaderButtons: React.FC<Props> = ({ id, projectType, tab }) => {
     });
   };
 
-  // Let users with a Github App on the Github App Settings page
+  // Let users with without a Github App on their project page
   // default to repo to use the repo Github settings for the project settings.
   let hasExistingGithubApp = false;
   if (tab === ProjectSettingsTabRoutes.GithubAppSettings) {

--- a/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/GithubAppSettingsTab/AppSettingsTab.tsx
+++ b/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/GithubAppSettingsTab/AppSettingsTab.tsx
@@ -25,6 +25,7 @@ export const AppSettingsTab: React.FC<TabProps> = ({
   projectId,
   projectType,
   repoData,
+  repoId,
 }) => {
   const initialFormState = useMemo(
     () => getInitialFormState(projectData, repoData),
@@ -48,10 +49,10 @@ export const AppSettingsTab: React.FC<TabProps> = ({
         githubPermissionGroups,
         identifier,
         isAppDefined,
-        projectId,
+        isRepo,
+        projectId: projectId || repoId,
         repoData,
         defaultsToRepo,
-        hasRepoApp: !isRepo && repoAppId > 0,
       }),
     [
       githubPermissionGroups,
@@ -60,8 +61,8 @@ export const AppSettingsTab: React.FC<TabProps> = ({
       isRepo,
       projectId,
       repoData,
+      repoId,
       defaultsToRepo,
-      repoAppId,
     ],
   );
 

--- a/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/GithubAppSettingsTab/AppSettingsTab.tsx
+++ b/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/GithubAppSettingsTab/AppSettingsTab.tsx
@@ -51,14 +51,17 @@ export const AppSettingsTab: React.FC<TabProps> = ({
         projectId,
         repoData,
         defaultsToRepo,
+        hasRepoApp: !isRepo && repoAppId > 0,
       }),
     [
       githubPermissionGroups,
       identifier,
       isAppDefined,
+      isRepo,
       projectId,
       repoData,
       defaultsToRepo,
+      repoAppId,
     ],
   );
 

--- a/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/GithubAppSettingsTab/AppSettingsTab.tsx
+++ b/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/GithubAppSettingsTab/AppSettingsTab.tsx
@@ -50,7 +50,7 @@ export const AppSettingsTab: React.FC<TabProps> = ({
         identifier,
         isAppDefined,
         isRepo,
-        projectId: projectId || repoId,
+        projectOrRepoId: projectId || repoId,
         repoData,
         defaultsToRepo,
       }),

--- a/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/GithubAppSettingsTab/Fields/GithubAppActions.test.tsx
+++ b/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/GithubAppSettingsTab/Fields/GithubAppActions.test.tsx
@@ -14,6 +14,7 @@ import {
   SaveProjectSettingsForSectionMutationVariables,
 } from "gql/generated/types";
 import { SAVE_PROJECT_SETTINGS_FOR_SECTION } from "gql/mutations";
+import { ProjectSettingsProvider } from "pages/projectAndRepoSettings/shared/Context";
 import { GithubAppActions } from ".";
 
 const Field = ({
@@ -24,16 +25,18 @@ const Field = ({
   isRepo?: boolean;
 }) => (
   <MockedProvider mocks={[replaceAppCredentialsMock]}>
-    <GithubAppActions
-      {...({} as unknown as FieldProps)}
-      uiSchema={{
-        options: {
-          projectId: "evergreen",
-          isAppDefined,
-          isRepo,
-        },
-      }}
-    />
+    <ProjectSettingsProvider>
+      <GithubAppActions
+        {...({} as unknown as FieldProps)}
+        uiSchema={{
+          options: {
+            projectId: "evergreen",
+            isAppDefined,
+            isRepo,
+          },
+        }}
+      />
+    </ProjectSettingsProvider>
   </MockedProvider>
 );
 
@@ -114,7 +117,7 @@ const replaceAppCredentialsMock: ApolloMock<
           appId: 99999,
           privateKey: "new-private-key",
         },
-        projectRef: { id: "evergreen" },
+        projectRef: { id: "evergreen", githubPermissionGroupByRequester: {} },
       },
       section: ProjectSettingsSection.GithubAppSettings,
     },

--- a/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/GithubAppSettingsTab/Fields/GithubAppActions.test.tsx
+++ b/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/GithubAppSettingsTab/Fields/GithubAppActions.test.tsx
@@ -15,7 +15,13 @@ import {
 import { DELETE_GITHUB_APP_CREDENTIALS } from "gql/mutations";
 import { GithubAppActions } from ".";
 
-const Field = ({ isAppDefined }: { isAppDefined: boolean }) => (
+const Field = ({
+  hasRepoApp = false,
+  isAppDefined,
+}: {
+  hasRepoApp?: boolean;
+  isAppDefined: boolean;
+}) => (
   <MockedProvider mocks={[deleteAppCredentialsMock]}>
     <GithubAppActions
       {...({} as unknown as FieldProps)}
@@ -23,6 +29,7 @@ const Field = ({ isAppDefined }: { isAppDefined: boolean }) => (
         options: {
           projectId: "evergreen",
           isAppDefined,
+          hasRepoApp,
         },
       }}
     />
@@ -45,16 +52,30 @@ describe("githubAppActions", () => {
     });
   });
 
-  describe("app is defined", () => {
-    it("renders the button and not the banner", () => {
+  describe("app is defined and no repo app", () => {
+    it("renders the delete button and rate limit warnings", () => {
       const { Component } = RenderFakeToastContext(<Field isAppDefined />);
       render(<Component />);
       expect(
         screen.getByDataCy("delete-app-credentials-button"),
       ).toBeInTheDocument();
       expect(
+        screen.getByDataCy("github-app-rate-limit-banner"),
+      ).toBeInTheDocument();
+      expect(
         screen.queryByDataCy("github-app-credentials-banner"),
       ).not.toBeInTheDocument();
+    });
+
+    it("shows warning in the delete modal", async () => {
+      const user = userEvent.setup();
+
+      const { Component } = RenderFakeToastContext(<Field isAppDefined />);
+      render(<Component />);
+      await user.click(screen.getByDataCy("delete-app-credentials-button"));
+      expect(
+        screen.getByDataCy("delete-credentials-warning-banner"),
+      ).toBeInTheDocument();
     });
 
     it("can delete the credentials via the modal", async () => {
@@ -65,9 +86,6 @@ describe("githubAppActions", () => {
       );
       render(<Component />);
       await user.click(screen.getByDataCy("delete-app-credentials-button"));
-      expect(
-        screen.getByDataCy("delete-github-credentials-modal"),
-      ).toBeInTheDocument();
       const deleteButton = screen.getByRole("button", {
         name: "Delete",
       });
@@ -78,6 +96,34 @@ describe("githubAppActions", () => {
           "GitHub app credentials were successfully deleted.",
         );
       });
+    });
+  });
+
+  describe("app is defined and repo app exists", () => {
+    it("renders the delete button without rate limit warnings", () => {
+      const { Component } = RenderFakeToastContext(
+        <Field hasRepoApp isAppDefined />,
+      );
+      render(<Component />);
+      expect(
+        screen.getByDataCy("delete-app-credentials-button"),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByDataCy("github-app-rate-limit-banner"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("does not show warning in the delete modal", async () => {
+      const user = userEvent.setup();
+
+      const { Component } = RenderFakeToastContext(
+        <Field hasRepoApp isAppDefined />,
+      );
+      render(<Component />);
+      await user.click(screen.getByDataCy("delete-app-credentials-button"));
+      expect(
+        screen.queryByDataCy("delete-credentials-warning-banner"),
+      ).not.toBeInTheDocument();
     });
   });
 });

--- a/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/GithubAppSettingsTab/Fields/GithubAppActions.test.tsx
+++ b/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/GithubAppSettingsTab/Fields/GithubAppActions.test.tsx
@@ -9,27 +9,28 @@ import {
 } from "@evg-ui/lib/test_utils";
 import { ApolloMock } from "@evg-ui/lib/test_utils/types";
 import {
-  DeleteGithubAppCredentialsMutation,
-  DeleteGithubAppCredentialsMutationVariables,
+  ProjectSettingsSection,
+  SaveProjectSettingsForSectionMutation,
+  SaveProjectSettingsForSectionMutationVariables,
 } from "gql/generated/types";
-import { DELETE_GITHUB_APP_CREDENTIALS } from "gql/mutations";
+import { SAVE_PROJECT_SETTINGS_FOR_SECTION } from "gql/mutations";
 import { GithubAppActions } from ".";
 
 const Field = ({
-  hasRepoApp = false,
   isAppDefined,
+  isRepo = false,
 }: {
-  hasRepoApp?: boolean;
   isAppDefined: boolean;
+  isRepo?: boolean;
 }) => (
-  <MockedProvider mocks={[deleteAppCredentialsMock]}>
+  <MockedProvider mocks={[replaceAppCredentialsMock]}>
     <GithubAppActions
       {...({} as unknown as FieldProps)}
       uiSchema={{
         options: {
           projectId: "evergreen",
           isAppDefined,
-          hasRepoApp,
+          isRepo,
         },
       }}
     />
@@ -38,7 +39,7 @@ const Field = ({
 
 describe("githubAppActions", () => {
   describe("app is not defined", () => {
-    it("renders the banner and not the button", () => {
+    it("renders the banner and not the replace button", () => {
       const { Component } = RenderFakeToastContext(
         <Field isAppDefined={false} />,
       );
@@ -47,101 +48,84 @@ describe("githubAppActions", () => {
         screen.getByDataCy("github-app-credentials-banner"),
       ).toBeInTheDocument();
       expect(
-        screen.queryByDataCy("delete-app-credentials-button"),
+        screen.queryByDataCy("replace-app-credentials-button"),
       ).not.toBeInTheDocument();
     });
   });
 
-  describe("app is defined and no repo app", () => {
-    it("renders the delete button and rate limit warnings", () => {
+  describe("app is defined", () => {
+    it("renders the replace button and not the banner", () => {
       const { Component } = RenderFakeToastContext(<Field isAppDefined />);
       render(<Component />);
       expect(
-        screen.getByDataCy("delete-app-credentials-button"),
-      ).toBeInTheDocument();
-      expect(
-        screen.getByDataCy("github-app-rate-limit-banner"),
+        screen.getByDataCy("replace-app-credentials-button"),
       ).toBeInTheDocument();
       expect(
         screen.queryByDataCy("github-app-credentials-banner"),
       ).not.toBeInTheDocument();
     });
 
-    it("shows warning in the delete modal", async () => {
-      const user = userEvent.setup();
-
-      const { Component } = RenderFakeToastContext(<Field isAppDefined />);
-      render(<Component />);
-      await user.click(screen.getByDataCy("delete-app-credentials-button"));
-      expect(
-        screen.getByDataCy("delete-credentials-warning-banner"),
-      ).toBeInTheDocument();
-    });
-
-    it("can delete the credentials via the modal", async () => {
+    it("can replace credentials via the modal", async () => {
       const user = userEvent.setup();
 
       const { Component, dispatchToast } = RenderFakeToastContext(
         <Field isAppDefined />,
       );
       render(<Component />);
-      await user.click(screen.getByDataCy("delete-app-credentials-button"));
-      const deleteButton = screen.getByRole("button", {
-        name: "Delete",
+      await user.click(screen.getByDataCy("replace-app-credentials-button"));
+      expect(
+        screen.getByDataCy("replace-github-credentials-modal"),
+      ).toBeInTheDocument();
+
+      // Replace button should be disabled without input
+      const replaceButton = screen.getByRole("button", {
+        name: "Replace",
       });
-      expect(deleteButton).toBeEnabled();
-      await user.click(deleteButton);
+      expect(replaceButton).toHaveAttribute("aria-disabled", "true");
+
+      // Fill in new credentials
+      await user.type(screen.getByDataCy("replace-app-id-input"), "99999");
+      await user.type(
+        screen.getByDataCy("replace-private-key-input"),
+        "new-private-key",
+      );
+      expect(replaceButton).not.toHaveAttribute("aria-disabled", "true");
+
+      await user.click(replaceButton);
       await waitFor(() => {
         expect(dispatchToast.success).toHaveBeenCalledWith(
-          "GitHub app credentials were successfully deleted.",
+          "GitHub app credentials were successfully replaced.",
         );
       });
     });
   });
-
-  describe("app is defined and repo app exists", () => {
-    it("renders the delete button without rate limit warnings", () => {
-      const { Component } = RenderFakeToastContext(
-        <Field hasRepoApp isAppDefined />,
-      );
-      render(<Component />);
-      expect(
-        screen.getByDataCy("delete-app-credentials-button"),
-      ).toBeInTheDocument();
-      expect(
-        screen.queryByDataCy("github-app-rate-limit-banner"),
-      ).not.toBeInTheDocument();
-    });
-
-    it("does not show warning in the delete modal", async () => {
-      const user = userEvent.setup();
-
-      const { Component } = RenderFakeToastContext(
-        <Field hasRepoApp isAppDefined />,
-      );
-      render(<Component />);
-      await user.click(screen.getByDataCy("delete-app-credentials-button"));
-      expect(
-        screen.queryByDataCy("delete-credentials-warning-banner"),
-      ).not.toBeInTheDocument();
-    });
-  });
 });
 
-const deleteAppCredentialsMock: ApolloMock<
-  DeleteGithubAppCredentialsMutation,
-  DeleteGithubAppCredentialsMutationVariables
+const replaceAppCredentialsMock: ApolloMock<
+  SaveProjectSettingsForSectionMutation,
+  SaveProjectSettingsForSectionMutationVariables
 > = {
   request: {
-    query: DELETE_GITHUB_APP_CREDENTIALS,
+    query: SAVE_PROJECT_SETTINGS_FOR_SECTION,
     variables: {
-      projectId: "evergreen",
+      projectSettings: {
+        projectId: "evergreen",
+        githubAppAuth: {
+          appId: 99999,
+          privateKey: "new-private-key",
+        },
+        projectRef: { id: "evergreen" },
+      },
+      section: ProjectSettingsSection.GithubAppSettings,
     },
   },
   result: {
     data: {
-      deleteGithubAppCredentials: {
-        oldAppId: 12344,
+      saveProjectSettingsForSection: {
+        projectRef: {
+          id: "evergreen",
+          identifier: "evergreen",
+        },
       },
     },
   },

--- a/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/GithubAppSettingsTab/Fields/GithubAppActions.test.tsx
+++ b/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/GithubAppSettingsTab/Fields/GithubAppActions.test.tsx
@@ -30,7 +30,7 @@ const Field = ({
         {...({} as unknown as FieldProps)}
         uiSchema={{
           options: {
-            projectId: "evergreen",
+            projectOrRepoId: "evergreen",
             isAppDefined,
             isRepo,
           },

--- a/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/GithubAppSettingsTab/Fields/GithubAppActions.tsx
+++ b/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/GithubAppSettingsTab/Fields/GithubAppActions.tsx
@@ -2,89 +2,159 @@ import { useState } from "react";
 import { useMutation } from "@apollo/client/react";
 import { css } from "@emotion/react";
 import { Banner, Variant as BannerVariant } from "@leafygreen-ui/banner";
-import { Button, Variant as ButtonVariant } from "@leafygreen-ui/button";
-import {
-  ConfirmationModal,
-  Variant as ModalVariant,
-} from "@leafygreen-ui/confirmation-modal";
+import { Button } from "@leafygreen-ui/button";
+import { ConfirmationModal } from "@leafygreen-ui/confirmation-modal";
+import { NumberInput } from "@leafygreen-ui/number-input";
+import TextArea from "@leafygreen-ui/text-area";
 import { Field } from "@rjsf/core";
 import { StyledLink } from "@evg-ui/lib/components/styles";
 import { size } from "@evg-ui/lib/constants/tokens";
 import { useToastContext } from "@evg-ui/lib/context/toast";
 import { githubAppCredentialsDocumentationUrl } from "constants/externalResources";
 import {
-  DeleteGithubAppCredentialsMutation,
-  DeleteGithubAppCredentialsMutationVariables,
+  ProjectSettingsSection,
+  SaveProjectSettingsForSectionMutation,
+  SaveProjectSettingsForSectionMutationVariables,
+  SaveRepoSettingsForSectionMutation,
+  SaveRepoSettingsForSectionMutationVariables,
 } from "gql/generated/types";
-import { DELETE_GITHUB_APP_CREDENTIALS } from "gql/mutations";
+import {
+  SAVE_PROJECT_SETTINGS_FOR_SECTION,
+  SAVE_REPO_SETTINGS_FOR_SECTION,
+} from "gql/mutations";
 
-const DeleteAppCredentialsButton: React.FC<{
-  ["data-cy"]: string;
+const ReplaceAppCredentialsButton: React.FC<{
   projectId: string;
   disabled: boolean;
-  hasRepoApp: boolean;
-}> = ({ "data-cy": dataCy, disabled, hasRepoApp, projectId }) => {
+  isRepo: boolean;
+}> = ({ disabled, isRepo, projectId }) => {
   const [open, setOpen] = useState(false);
+  const [appId, setAppId] = useState("");
+  const [privateKey, setPrivateKey] = useState("");
   const dispatchToast = useToastContext();
 
-  const [deleteGithubAppCredentials, { loading }] = useMutation<
-    DeleteGithubAppCredentialsMutation,
-    DeleteGithubAppCredentialsMutationVariables
-  >(DELETE_GITHUB_APP_CREDENTIALS, {
+  const refetchQueries = isRepo ? ["RepoSettings"] : ["ProjectSettings"];
+
+  const [saveProjectSettings, { loading: projectLoading }] = useMutation<
+    SaveProjectSettingsForSectionMutation,
+    SaveProjectSettingsForSectionMutationVariables
+  >(SAVE_PROJECT_SETTINGS_FOR_SECTION, {
     onCompleted: () => {
       dispatchToast.success(
-        "GitHub app credentials were successfully deleted.",
+        "GitHub app credentials were successfully replaced.",
       );
+      handleClose();
     },
     onError: (err) => {
       dispatchToast.error(
-        `There was an error deleting the GitHub app credentials: ${err.message}`,
+        `There was an error replacing the GitHub app credentials: ${err.message}`,
       );
     },
-    refetchQueries: ["ProjectSettings"],
+    refetchQueries,
   });
+
+  const [saveRepoSettings, { loading: repoLoading }] = useMutation<
+    SaveRepoSettingsForSectionMutation,
+    SaveRepoSettingsForSectionMutationVariables
+  >(SAVE_REPO_SETTINGS_FOR_SECTION, {
+    onCompleted: () => {
+      dispatchToast.success(
+        "GitHub app credentials were successfully replaced.",
+      );
+      handleClose();
+    },
+    onError: (err) => {
+      dispatchToast.error(
+        `There was an error replacing the GitHub app credentials: ${err.message}`,
+      );
+    },
+    refetchQueries,
+  });
+
+  const loading = projectLoading || repoLoading;
+  const isValid = Number(appId) > 0 && privateKey.length > 0;
+
+  const handleClose = () => {
+    setOpen(false);
+    setAppId("");
+    setPrivateKey("");
+  };
+
+  const handleReplace = () => {
+    const githubAppAuth = {
+      appId: Number(appId),
+      privateKey,
+    };
+    if (isRepo) {
+      saveRepoSettings({
+        variables: {
+          repoSettings: {
+            repoId: projectId,
+            githubAppAuth,
+            projectRef: { id: projectId },
+          },
+          section: ProjectSettingsSection.GithubAppSettings,
+        },
+      });
+    } else {
+      saveProjectSettings({
+        variables: {
+          projectSettings: {
+            projectId,
+            githubAppAuth,
+            projectRef: { id: projectId },
+          },
+          section: ProjectSettingsSection.GithubAppSettings,
+        },
+      });
+    }
+  };
 
   return (
     <>
       <ConfirmationModal
         cancelButtonProps={{
-          onClick: () => setOpen(false),
+          onClick: handleClose,
         }}
         confirmButtonProps={{
-          children: "Delete",
-          disabled: loading,
-          onClick: () => {
-            deleteGithubAppCredentials({ variables: { projectId } });
-            setOpen(false);
-          },
+          children: "Replace",
+          disabled: loading || !isValid,
+          onClick: handleReplace,
         }}
-        data-cy="delete-github-credentials-modal"
+        data-cy="replace-github-credentials-modal"
         open={open}
-        title="Delete GitHub app credentials?"
-        variant={ModalVariant.Danger}
+        title="Replace GitHub app credentials"
       >
-        <p>
-          Confirm that you want to remove the GitHub app credentials associated
-          with this project.
-        </p>
-        {!hasRepoApp && (
-          <Banner
-            data-cy="delete-credentials-warning-banner"
-            variant={BannerVariant.Warning}
-          >
-            Deleting your project&apos;s GitHub app credentials will cause this
-            project to use the shared GitHub app, which has lower rate limits.
-            To avoid reduced rate limits, add a new GitHub app after deleting.
-          </Banner>
-        )}
+        <div
+          css={css`
+            display: flex;
+            flex-direction: column;
+            gap: ${size.s};
+          `}
+        >
+          <p>Enter new GitHub app credentials to replace the existing ones.</p>
+          <NumberInput
+            data-cy="replace-app-id-input"
+            label="New App ID"
+            onChange={(e) => setAppId(e.target.value)}
+            placeholder="Enter app ID"
+            value={appId}
+          />
+          <TextArea
+            data-cy="replace-private-key-input"
+            label="New Private Key"
+            onChange={(e) => setPrivateKey(e.target.value)}
+            placeholder="Enter private key"
+            value={privateKey}
+          />
+        </div>
       </ConfirmationModal>
       <Button
-        data-cy={dataCy}
+        data-cy="replace-app-credentials-button"
         disabled={disabled}
         onClick={() => setOpen(true)}
-        variant={ButtonVariant.Danger}
       >
-        Delete key
+        Replace key
       </Button>
     </>
   );
@@ -92,39 +162,20 @@ const DeleteAppCredentialsButton: React.FC<{
 
 const GithubAppActions: Field = ({ disabled, uiSchema }) => {
   const {
-    options: { defaultsToRepo, hasRepoApp, isAppDefined, projectId },
+    options: { defaultsToRepo, isAppDefined, isRepo, projectId },
   } = uiSchema;
 
-  // You should not be able to delete the repo GitHub app from a project.
+  // You should not be able to modify the repo GitHub app from a project.
   if (defaultsToRepo) {
     return null;
   }
 
   return isAppDefined ? (
-    <div
-      css={css`
-        display: flex;
-        flex-direction: column;
-        gap: ${size.xs};
-      `}
-    >
-      {!hasRepoApp && (
-        <Banner
-          data-cy="github-app-rate-limit-banner"
-          variant={BannerVariant.Warning}
-        >
-          Removing your project&apos;s GitHub app credentials without adding a
-          replacement will cause this project to fall back to the shared GitHub
-          app, which has lower rate limits.
-        </Banner>
-      )}
-      <DeleteAppCredentialsButton
-        data-cy="delete-app-credentials-button"
-        disabled={disabled}
-        hasRepoApp={hasRepoApp}
-        projectId={projectId}
-      />
-    </div>
+    <ReplaceAppCredentialsButton
+      disabled={disabled}
+      isRepo={isRepo}
+      projectId={projectId}
+    />
   ) : (
     <Banner
       data-cy="github-app-credentials-banner"

--- a/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/GithubAppSettingsTab/Fields/GithubAppActions.tsx
+++ b/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/GithubAppSettingsTab/Fields/GithubAppActions.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { useMutation } from "@apollo/client/react";
+import { css } from "@emotion/react";
 import { Banner, Variant as BannerVariant } from "@leafygreen-ui/banner";
 import { Button, Variant as ButtonVariant } from "@leafygreen-ui/button";
 import {
@@ -8,6 +9,7 @@ import {
 } from "@leafygreen-ui/confirmation-modal";
 import { Field } from "@rjsf/core";
 import { StyledLink } from "@evg-ui/lib/components/styles";
+import { size } from "@evg-ui/lib/constants/tokens";
 import { useToastContext } from "@evg-ui/lib/context/toast";
 import { githubAppCredentialsDocumentationUrl } from "constants/externalResources";
 import {
@@ -20,7 +22,8 @@ const DeleteAppCredentialsButton: React.FC<{
   ["data-cy"]: string;
   projectId: string;
   disabled: boolean;
-}> = ({ "data-cy": dataCy, disabled, projectId }) => {
+  hasRepoApp: boolean;
+}> = ({ "data-cy": dataCy, disabled, hasRepoApp, projectId }) => {
   const [open, setOpen] = useState(false);
   const dispatchToast = useToastContext();
 
@@ -64,6 +67,16 @@ const DeleteAppCredentialsButton: React.FC<{
           Confirm that you want to remove the GitHub app credentials associated
           with this project.
         </p>
+        {!hasRepoApp && (
+          <Banner
+            data-cy="delete-credentials-warning-banner"
+            variant={BannerVariant.Warning}
+          >
+            Deleting your project&apos;s GitHub app credentials will cause this
+            project to use the shared GitHub app, which has lower rate limits.
+            To avoid reduced rate limits, add a new GitHub app after deleting.
+          </Banner>
+        )}
       </ConfirmationModal>
       <Button
         data-cy={dataCy}
@@ -79,7 +92,7 @@ const DeleteAppCredentialsButton: React.FC<{
 
 const GithubAppActions: Field = ({ disabled, uiSchema }) => {
   const {
-    options: { defaultsToRepo, isAppDefined, projectId },
+    options: { defaultsToRepo, hasRepoApp, isAppDefined, projectId },
   } = uiSchema;
 
   // You should not be able to delete the repo GitHub app from a project.
@@ -88,11 +101,30 @@ const GithubAppActions: Field = ({ disabled, uiSchema }) => {
   }
 
   return isAppDefined ? (
-    <DeleteAppCredentialsButton
-      data-cy="delete-app-credentials-button"
-      disabled={disabled}
-      projectId={projectId}
-    />
+    <div
+      css={css`
+        display: flex;
+        flex-direction: column;
+        gap: ${size.xs};
+      `}
+    >
+      {!hasRepoApp && (
+        <Banner
+          data-cy="github-app-rate-limit-banner"
+          variant={BannerVariant.Warning}
+        >
+          Removing your project&apos;s GitHub app credentials without adding a
+          replacement will cause this project to fall back to the shared GitHub
+          app, which has lower rate limits.
+        </Banner>
+      )}
+      <DeleteAppCredentialsButton
+        data-cy="delete-app-credentials-button"
+        disabled={disabled}
+        hasRepoApp={hasRepoApp}
+        projectId={projectId}
+      />
+    </div>
   ) : (
     <Banner
       data-cy="github-app-credentials-banner"

--- a/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/GithubAppSettingsTab/Fields/GithubAppActions.tsx
+++ b/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/GithubAppSettingsTab/Fields/GithubAppActions.tsx
@@ -1,16 +1,13 @@
 import { useState } from "react";
 import { useMutation } from "@apollo/client/react";
-import { css } from "@emotion/react";
 import { Banner, Variant as BannerVariant } from "@leafygreen-ui/banner";
 import { Button } from "@leafygreen-ui/button";
 import { ConfirmationModal } from "@leafygreen-ui/confirmation-modal";
-import { NumberInput } from "@leafygreen-ui/number-input";
-import { TextArea } from "@leafygreen-ui/text-area";
 import { Field } from "@rjsf/core";
 import { StyledLink } from "@evg-ui/lib/components/styles";
-import { size } from "@evg-ui/lib/constants/tokens";
 import { useToastContext } from "@evg-ui/lib/context/toast";
-import { StringMap } from "@evg-ui/lib/types/utils";
+import { SpruceForm } from "components/SpruceForm";
+import { SpruceFormProps } from "components/SpruceForm/types";
 import { githubAppCredentialsDocumentationUrl } from "constants/externalResources";
 import { ProjectSettingsTabRoutes } from "constants/routes";
 import {
@@ -25,17 +22,53 @@ import {
   SAVE_REPO_SETTINGS_FOR_SECTION,
 } from "gql/mutations";
 import { useProjectSettingsContext } from "pages/projectAndRepoSettings/shared/Context";
+import { formToGql } from "../transformers";
 import { AppSettingsFormState } from "../types";
+
+interface ReplaceFormState {
+  appId?: number | null;
+  privateKey?: string;
+}
+
+const replaceFormSchema: SpruceFormProps = {
+  schema: {
+    type: "object" as const,
+    description:
+      "Enter new GitHub app credentials to replace the existing ones.",
+    properties: {
+      appId: {
+        type: "number" as const,
+        title: "New App ID",
+        minimum: 1,
+      },
+      privateKey: {
+        type: "string" as const,
+        title: "New Private Key",
+        minLength: 1,
+      },
+    },
+    required: ["appId", "privateKey"],
+  },
+  uiSchema: {
+    appId: {
+      "ui:data-cy": "replace-app-id-input",
+    },
+    privateKey: {
+      "ui:data-cy": "replace-private-key-input",
+      "ui:widget": "textarea",
+    },
+  },
+};
 
 const ReplaceAppCredentialsButton: React.FC<{
   projectId: string;
   disabled: boolean;
   isRepo: boolean;
-  githubPermissionGroupByRequester: StringMap;
+  githubPermissionGroupByRequester: Record<string, string>;
 }> = ({ disabled, githubPermissionGroupByRequester, isRepo, projectId }) => {
   const [open, setOpen] = useState(false);
-  const [appId, setAppId] = useState("");
-  const [privateKey, setPrivateKey] = useState("");
+  const [formState, setFormState] = useState<ReplaceFormState>({});
+  const [hasFormError, setHasFormError] = useState(true);
   const dispatchToast = useToastContext();
 
   const refetchQueries = isRepo ? ["RepoSettings"] : ["ProjectSettings"];
@@ -77,18 +110,17 @@ const ReplaceAppCredentialsButton: React.FC<{
   });
 
   const loading = projectLoading || repoLoading;
-  const isValid = Number(appId) > 0 && privateKey.trim().length > 0;
 
   const handleClose = () => {
     setOpen(false);
-    setAppId("");
-    setPrivateKey("");
+    setFormState({});
+    setHasFormError(true);
   };
 
   const handleReplace = () => {
     const githubAppAuth = {
-      appId: Number(appId),
-      privateKey,
+      appId: formState.appId ?? 0,
+      privateKey: formState.privateKey ?? "",
     };
     const projectRef = {
       id: projectId,
@@ -127,36 +159,22 @@ const ReplaceAppCredentialsButton: React.FC<{
         }}
         confirmButtonProps={{
           children: "Replace",
-          disabled: loading || !isValid,
+          disabled: loading || hasFormError,
           onClick: handleReplace,
         }}
         data-cy="replace-github-credentials-modal"
         open={open}
         title="Replace GitHub app credentials"
       >
-        <div
-          css={css`
-            display: flex;
-            flex-direction: column;
-            gap: ${size.s};
-          `}
-        >
-          <p>Enter new GitHub app credentials to replace the existing ones.</p>
-          <NumberInput
-            data-cy="replace-app-id-input"
-            label="New App ID"
-            onChange={(e) => setAppId(e.target.value)}
-            placeholder="Enter app ID"
-            value={appId}
-          />
-          <TextArea
-            data-cy="replace-private-key-input"
-            label="New Private Key"
-            onChange={(e) => setPrivateKey(e.target.value)}
-            placeholder="Enter private key"
-            value={privateKey}
-          />
-        </div>
+        <SpruceForm
+          formData={formState}
+          onChange={({ errors, formData }) => {
+            setHasFormError(!!errors.length);
+            setFormState(formData);
+          }}
+          schema={replaceFormSchema.schema}
+          uiSchema={replaceFormSchema.uiSchema}
+        />
       </ConfirmationModal>
       <Button
         data-cy="replace-app-credentials-button"
@@ -171,21 +189,17 @@ const ReplaceAppCredentialsButton: React.FC<{
 
 const GithubAppActions: Field = ({ disabled, uiSchema }) => {
   const {
-    options: { defaultsToRepo, isAppDefined, isRepo, projectId },
+    options: { defaultsToRepo, isAppDefined, isRepo, projectOrRepoId },
   } = uiSchema;
 
   const { getTab } = useProjectSettingsContext();
   const { formData } = getTab(ProjectSettingsTabRoutes.GithubAppSettings);
   const appFormData = formData as AppSettingsFormState;
 
-  const githubPermissionGroupByRequester: StringMap = {};
-  appFormData?.tokenPermissionRestrictions?.permissionsByRequester?.forEach(
-    (p) => {
-      if (p.permissionGroup) {
-        githubPermissionGroupByRequester[p.requesterType] = p.permissionGroup;
-      }
-    },
-  );
+  const githubPermissionGroupByRequester = appFormData
+    ? formToGql(appFormData, isRepo, projectOrRepoId).projectRef
+        .githubPermissionGroupByRequester
+    : {};
 
   // You should not be able to modify the repo GitHub app from a project.
   if (defaultsToRepo) {
@@ -197,7 +211,7 @@ const GithubAppActions: Field = ({ disabled, uiSchema }) => {
       disabled={disabled}
       githubPermissionGroupByRequester={githubPermissionGroupByRequester}
       isRepo={isRepo}
-      projectId={projectId}
+      projectId={projectOrRepoId}
     />
   ) : (
     <Banner

--- a/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/GithubAppSettingsTab/Fields/GithubAppActions.tsx
+++ b/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/GithubAppSettingsTab/Fields/GithubAppActions.tsx
@@ -5,7 +5,7 @@ import { Banner, Variant as BannerVariant } from "@leafygreen-ui/banner";
 import { Button } from "@leafygreen-ui/button";
 import { ConfirmationModal } from "@leafygreen-ui/confirmation-modal";
 import { NumberInput } from "@leafygreen-ui/number-input";
-import TextArea from "@leafygreen-ui/text-area";
+import { TextArea } from "@leafygreen-ui/text-area";
 import { Field } from "@rjsf/core";
 import { StyledLink } from "@evg-ui/lib/components/styles";
 import { size } from "@evg-ui/lib/constants/tokens";

--- a/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/GithubAppSettingsTab/Fields/GithubAppActions.tsx
+++ b/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/GithubAppSettingsTab/Fields/GithubAppActions.tsx
@@ -72,7 +72,7 @@ const ReplaceAppCredentialsButton: React.FC<{
   });
 
   const loading = projectLoading || repoLoading;
-  const isValid = Number(appId) > 0 && privateKey.length > 0;
+  const isValid = Number(appId) > 0 && privateKey.trim().length > 0;
 
   const handleClose = () => {
     setOpen(false);

--- a/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/GithubAppSettingsTab/Fields/GithubAppActions.tsx
+++ b/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/GithubAppSettingsTab/Fields/GithubAppActions.tsx
@@ -10,7 +10,9 @@ import { Field } from "@rjsf/core";
 import { StyledLink } from "@evg-ui/lib/components/styles";
 import { size } from "@evg-ui/lib/constants/tokens";
 import { useToastContext } from "@evg-ui/lib/context/toast";
+import { StringMap } from "@evg-ui/lib/types/utils";
 import { githubAppCredentialsDocumentationUrl } from "constants/externalResources";
+import { ProjectSettingsTabRoutes } from "constants/routes";
 import {
   ProjectSettingsSection,
   SaveProjectSettingsForSectionMutation,
@@ -22,12 +24,15 @@ import {
   SAVE_PROJECT_SETTINGS_FOR_SECTION,
   SAVE_REPO_SETTINGS_FOR_SECTION,
 } from "gql/mutations";
+import { useProjectSettingsContext } from "pages/projectAndRepoSettings/shared/Context";
+import { AppSettingsFormState } from "../types";
 
 const ReplaceAppCredentialsButton: React.FC<{
   projectId: string;
   disabled: boolean;
   isRepo: boolean;
-}> = ({ disabled, isRepo, projectId }) => {
+  githubPermissionGroupByRequester: StringMap;
+}> = ({ disabled, githubPermissionGroupByRequester, isRepo, projectId }) => {
   const [open, setOpen] = useState(false);
   const [appId, setAppId] = useState("");
   const [privateKey, setPrivateKey] = useState("");
@@ -85,13 +90,17 @@ const ReplaceAppCredentialsButton: React.FC<{
       appId: Number(appId),
       privateKey,
     };
+    const projectRef = {
+      id: projectId,
+      githubPermissionGroupByRequester,
+    };
     if (isRepo) {
       saveRepoSettings({
         variables: {
           repoSettings: {
             repoId: projectId,
             githubAppAuth,
-            projectRef: { id: projectId },
+            projectRef,
           },
           section: ProjectSettingsSection.GithubAppSettings,
         },
@@ -102,7 +111,7 @@ const ReplaceAppCredentialsButton: React.FC<{
           projectSettings: {
             projectId,
             githubAppAuth,
-            projectRef: { id: projectId },
+            projectRef,
           },
           section: ProjectSettingsSection.GithubAppSettings,
         },
@@ -165,6 +174,19 @@ const GithubAppActions: Field = ({ disabled, uiSchema }) => {
     options: { defaultsToRepo, isAppDefined, isRepo, projectId },
   } = uiSchema;
 
+  const { getTab } = useProjectSettingsContext();
+  const { formData } = getTab(ProjectSettingsTabRoutes.GithubAppSettings);
+  const appFormData = formData as AppSettingsFormState;
+
+  const githubPermissionGroupByRequester: StringMap = {};
+  appFormData?.tokenPermissionRestrictions?.permissionsByRequester?.forEach(
+    (p) => {
+      if (p.permissionGroup) {
+        githubPermissionGroupByRequester[p.requesterType] = p.permissionGroup;
+      }
+    },
+  );
+
   // You should not be able to modify the repo GitHub app from a project.
   if (defaultsToRepo) {
     return null;
@@ -173,6 +195,7 @@ const GithubAppActions: Field = ({ disabled, uiSchema }) => {
   return isAppDefined ? (
     <ReplaceAppCredentialsButton
       disabled={disabled}
+      githubPermissionGroupByRequester={githubPermissionGroupByRequester}
       isRepo={isRepo}
       projectId={projectId}
     />

--- a/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/GithubAppSettingsTab/getFormSchema.tsx
+++ b/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/GithubAppSettingsTab/getFormSchema.tsx
@@ -30,14 +30,14 @@ export const getFormSchema = ({
   identifier,
   isAppDefined,
   isRepo,
-  projectId,
+  projectOrRepoId,
   repoData,
 }: {
   githubPermissionGroups: GitHubDynamicTokenPermissionGroup[];
   identifier: string;
   isAppDefined: boolean;
   isRepo: boolean;
-  projectId: string;
+  projectOrRepoId: string;
   repoData?: any;
   defaultsToRepo: boolean;
 }): ReturnType<GetFormSchema> => ({
@@ -150,7 +150,7 @@ export const getFormSchema = ({
       actions: {
         "ui:field": GithubAppActions,
         "ui:showLabel": false,
-        options: { isAppDefined, isRepo, projectId, defaultsToRepo },
+        options: { isAppDefined, isRepo, projectOrRepoId, defaultsToRepo },
       },
     },
     tokenPermissionRestrictions: {

--- a/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/GithubAppSettingsTab/getFormSchema.tsx
+++ b/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/GithubAppSettingsTab/getFormSchema.tsx
@@ -27,19 +27,19 @@ const noPermissionsGroup = "No Permissions";
 export const getFormSchema = ({
   defaultsToRepo,
   githubPermissionGroups,
-  hasRepoApp,
   identifier,
   isAppDefined,
+  isRepo,
   projectId,
   repoData,
 }: {
   githubPermissionGroups: GitHubDynamicTokenPermissionGroup[];
   identifier: string;
   isAppDefined: boolean;
+  isRepo: boolean;
   projectId: string;
   repoData?: any;
   defaultsToRepo: boolean;
-  hasRepoApp: boolean;
 }): ReturnType<GetFormSchema> => ({
   fields: {},
   schema: {
@@ -150,7 +150,7 @@ export const getFormSchema = ({
       actions: {
         "ui:field": GithubAppActions,
         "ui:showLabel": false,
-        options: { isAppDefined, projectId, defaultsToRepo, hasRepoApp },
+        options: { isAppDefined, isRepo, projectId, defaultsToRepo },
       },
     },
     tokenPermissionRestrictions: {

--- a/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/GithubAppSettingsTab/getFormSchema.tsx
+++ b/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/GithubAppSettingsTab/getFormSchema.tsx
@@ -27,6 +27,7 @@ const noPermissionsGroup = "No Permissions";
 export const getFormSchema = ({
   defaultsToRepo,
   githubPermissionGroups,
+  hasRepoApp,
   identifier,
   isAppDefined,
   projectId,
@@ -38,6 +39,7 @@ export const getFormSchema = ({
   projectId: string;
   repoData?: any;
   defaultsToRepo: boolean;
+  hasRepoApp: boolean;
 }): ReturnType<GetFormSchema> => ({
   fields: {},
   schema: {
@@ -148,7 +150,7 @@ export const getFormSchema = ({
       actions: {
         "ui:field": GithubAppActions,
         "ui:showLabel": false,
-        options: { isAppDefined, projectId, defaultsToRepo },
+        options: { isAppDefined, projectId, defaultsToRepo, hasRepoApp },
       },
     },
     tokenPermissionRestrictions: {


### PR DESCRIPTION
DEVPROD-25194

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->

<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
Removing delete and instead forcing a replace of Github "App Credentials" for project and repo level settings. This is to prevent people from removing Github App Credentials

### Screenshots
https://github.com/user-attachments/assets/5a5ec03e-7849-456b-b0b0-1fd66d491c04


### Testing
* Smoke tested
* Added tests
