### PR TITLE
DEVPROD-30255: Add spawn host from task analytics attribute

### DIFF
--- a/apps/spruce/src/analytics/spawn/useSpawnAnalytics.ts
+++ b/apps/spruce/src/analytics/spawn/useSpawnAnalytics.ts
@@ -20,6 +20,7 @@ type Action =
       "host.is_workstation": boolean;
       "host.distro.id": string;
       "host.is_unexpirable": boolean;
+      "host.is_from_task": boolean;
     }
   | { name: "Viewed spawn volume modal" }
   | {

--- a/apps/spruce/src/pages/spawn/spawnHost/spawnHostButton/SpawnHostModal.tsx
+++ b/apps/spruce/src/pages/spawn/spawnHost/spawnHostButton/SpawnHostModal.tsx
@@ -138,6 +138,7 @@ export const SpawnHostModal: React.FC<SpawnHostModalProps> = ({
       "host.is_workstation": selectedDistro?.isVirtualWorkStation || false,
       "host.distro.id": selectedDistro?.name || "",
       "host.is_unexpirable": mutationInput?.noExpiration || false,
+      "host.is_from_task": !!(taskIdQueryParam && distroIdQueryParam),
     });
     spawnHostMutation({
       variables: { spawnHostInput: mutationInput },

--- a/apps/spruce/src/pages/spawn/spawnVolume/spawnVolumeTableActions/MigrateVolumeModal.tsx
+++ b/apps/spruce/src/pages/spawn/spawnVolume/spawnVolumeTableActions/MigrateVolumeModal.tsx
@@ -129,6 +129,7 @@ export const MigrateVolumeModal: React.FC<MigrateVolumeModalProps> = ({
       "host.distro.id": mutationInput?.distroId || "",
       "host.is_unexpirable": mutationInput?.noExpiration || false,
       "host.is_workstation": mutationInput?.isVirtualWorkStation || false,
+      "host.is_from_task": false,
     });
     migrateVolumeMutation({
       variables: {


### PR DESCRIPTION
## Summary
- Adds a `host.is_from_task` boolean attribute to the "Created a spawn host" analytics event
- Set to `true` when the spawn host modal is opened from a task context (taskId and distroId query params present), `false` otherwise (including volume migrations)

## Testing
- Verified TypeScript type checks pass
- Lint checks pass

Generated with [Claude Code](https://claude.com/claude-code)