### PR TITLE
DEVPROD-13241: Remove baseTaskStatuses

### DIFF
--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -11112,8 +11112,12 @@ export type TaskStatusesQuery = {
   version: {
     __typename?: "Version";
     id: string;
-    baseTaskStatuses: Array<string>;
     taskStatuses: Array<string>;
+    baseVersion?: {
+      __typename?: "Version";
+      id: string;
+      taskStatuses: Array<string>;
+    } | null;
   };
 };
 

--- a/apps/spruce/src/gql/queries/task-statuses.graphql
+++ b/apps/spruce/src/gql/queries/task-statuses.graphql
@@ -1,7 +1,10 @@
 query TaskStatuses($id: String!) {
   version(versionId: $id) {
     id
-    baseTaskStatuses
+    baseVersion {
+      id
+      taskStatuses
+    }
     taskStatuses
   }
 }

--- a/apps/spruce/src/hooks/useTaskStatuses/index.ts
+++ b/apps/spruce/src/hooks/useTaskStatuses/index.ts
@@ -38,16 +38,21 @@ export const useTaskStatuses = ({
   });
 
   const { version } = data || {};
-  const { baseTaskStatuses, taskStatuses } = version || {};
+  const { baseVersion, taskStatuses } = version || {};
   const currentStatuses = useMemo(
     () => getCurrentStatuses(taskStatuses ?? [], taskStatusesFilterTreeData),
     [taskStatuses],
   );
-  const baseStatuses = useMemo(
-    () =>
-      getCurrentStatuses(baseTaskStatuses ?? [], taskStatusesFilterTreeData),
-    [baseTaskStatuses],
-  );
+  const baseStatuses = useMemo(() => {
+    // Only include statuses that appear in both the base version and the current version
+    const baseTaskStatuses = baseVersion?.taskStatuses.filter((s) =>
+      taskStatuses?.includes(s),
+    );
+    return getCurrentStatuses(
+      baseTaskStatuses ?? [],
+      taskStatusesFilterTreeData,
+    );
+  }, [baseVersion?.taskStatuses, taskStatuses]);
 
   return { currentStatuses, baseStatuses };
 };

--- a/apps/spruce/src/pages/version/Tabs/Tasks/VersionTasksTable/testData.ts
+++ b/apps/spruce/src/pages/version/Tabs/Tasks/VersionTasksTable/testData.ts
@@ -21,8 +21,12 @@ export const taskStatusesMock: ApolloMock<
       version: {
         __typename: "Version",
         id: versionId,
-        baseTaskStatuses: [TaskStatus.Failed, TaskStatus.Unscheduled],
         taskStatuses: [TaskStatus.Started, TaskStatus.Succeeded],
+        baseVersion: {
+          __typename: "Version",
+          id: "base-version-id",
+          taskStatuses: [TaskStatus.Failed, TaskStatus.Unscheduled],
+        },
       },
     },
   },


### PR DESCRIPTION
DEVPROD-13241

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->

<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
<!-- add description, context, thought process, etc -->
Removing this resolver will facilitate removing `DisplayStatus` calculations. This field is significantly slower than `Version.taskStatuses` because it filters out statuses that do not appear in the main version. We can just use `Version.baseVersion.taskStatuses` and apply that filtering on the client side.