### PR TITLE
DEVPROD-26270 Add scopes and audience to Okta service setting

### DIFF
--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -7757,8 +7757,10 @@ export type AdminSettingsQuery = {
     } | null;
     oktaServiceConfig?: {
       __typename?: "OktaServiceConfig";
+      audience?: string | null;
       clientId?: string | null;
       clientSecret?: string | null;
+      scopes?: Array<string> | null;
     } | null;
     parameterStore?: {
       __typename?: "ParameterStoreConfig";

--- a/apps/spruce/src/gql/queries/admin-settings.graphql
+++ b/apps/spruce/src/gql/queries/admin-settings.graphql
@@ -203,8 +203,10 @@ query AdminSettings {
       }
     }
     oktaServiceConfig {
+      audience
       clientId
       clientSecret
+      scopes
     }
     oldestAllowedCLIVersion
     parameterStore {

--- a/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/OtherTab/schemaFields.ts
+++ b/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/OtherTab/schemaFields.ts
@@ -9,6 +9,10 @@ import {
 
 export const oktaServiceConfig = {
   schema: {
+    audience: {
+      type: "string" as const,
+      title: "Audience",
+    },
     clientId: {
       type: "string" as const,
       title: "Client ID",
@@ -16,6 +20,13 @@ export const oktaServiceConfig = {
     clientSecret: {
       type: "string" as const,
       title: "Client Secret",
+    },
+    scopes: {
+      type: "array" as const,
+      title: "Scopes",
+      items: {
+        type: "string" as const,
+      },
     },
   },
   uiSchema: {

--- a/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/OtherTab/transformers.test.ts
+++ b/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/OtherTab/transformers.test.ts
@@ -22,8 +22,10 @@ const mockAdminSettings: AdminSettingsData = {
   githubWebhookSecret: "webhook-secret",
   logPath: "/var/log/evergreen",
   oktaServiceConfig: {
+    audience: "https://example.okta.com",
     clientId: "okta-service-client-id",
     clientSecret: "okta-service-client-secret",
+    scopes: ["scope1", "scope2"],
   },
   oldestAllowedCLIVersion: "",
   pprofPort: "8080",
@@ -165,8 +167,10 @@ const expectedForm: OtherFormState = {
       },
     },
     oktaServiceConfig: {
+      audience: "https://example.okta.com",
       clientId: "okta-service-client-id",
       clientSecret: "okta-service-client-secret",
+      scopes: ["scope1", "scope2"],
     },
     singleTaskDistro: {
       projectTasksPairs: [
@@ -273,8 +277,10 @@ const expectedGql: AdminSettingsInput = {
   githubWebhookSecret: "webhook-secret",
   logPath: "/var/log/evergreen",
   oktaServiceConfig: {
+    audience: "https://example.okta.com",
     clientId: "okta-service-client-id",
     clientSecret: "okta-service-client-secret",
+    scopes: ["scope1", "scope2"],
   },
   oldestAllowedCLIVersion: "",
   pprofPort: "8080",

--- a/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/OtherTab/transformers.ts
+++ b/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/OtherTab/transformers.ts
@@ -84,8 +84,10 @@ export const gqlToForm = ((data) => {
       },
 
       oktaServiceConfig: {
+        audience: oktaServiceConfig?.audience ?? "",
         clientId: oktaServiceConfig?.clientId ?? "",
         clientSecret: oktaServiceConfig?.clientSecret ?? "",
+        scopes: oktaServiceConfig?.scopes ?? [],
       },
 
       singleTaskDistro: {
@@ -267,8 +269,10 @@ export const formToGql = ((form: OtherFormState) => {
     },
 
     oktaServiceConfig: {
+      audience: oktaServiceConfig.audience || undefined,
       clientId: oktaServiceConfig.clientId || undefined,
       clientSecret: oktaServiceConfig.clientSecret || undefined,
+      scopes: oktaServiceConfig.scopes || undefined,
     },
 
     singleTaskDistro: {

--- a/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/OtherTab/types.ts
+++ b/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/OtherTab/types.ts
@@ -29,8 +29,10 @@ export interface OtherFormState {
     };
 
     oktaServiceConfig: {
+      audience: string;
       clientId: string;
       clientSecret: string;
+      scopes: string[];
     };
 
     singleTaskDistro: {


### PR DESCRIPTION
DEVPROD-26270

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->

<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
<!-- add description, context, thought process, etc -->
This adds scopes and audience to the Okta service settings

### Screenshots
<!-- add screenshots of visible changes -->

https://github.com/user-attachments/assets/0fbf3a13-35de-4d75-9a89-fef643d5321f



### Testing
<!-- add a description of how you tested it -->
Added to the existing tests

### Evergreen PR
[#10033](https://github.com/evergreen-ci/evergreen/pull/10033)
