### PR TITLE
DEVPROD-30358: Add Quarantine status with option to quarantine task to the evergreen UI

### DIFF
--- a/apps/parsley/src/gql/generated/types.ts
+++ b/apps/parsley/src/gql/generated/types.ts
@@ -1966,7 +1966,7 @@ export type Mutation = {
   moveAnnotationIssue: Scalars["Boolean"]["output"];
   overrideTaskDependencies: Task;
   promoteVarsToRepo: Scalars["Boolean"]["output"];
-  quarantineTest: QuarantineTestPayload;
+  quarantineTest: TestResult;
   refreshGitHubStatuses?: Maybe<RefreshGitHubStatusesPayload>;
   removeAnnotationIssue: Scalars["Boolean"]["output"];
   removeFavoriteProject: Project;
@@ -1997,6 +1997,7 @@ export type Mutation = {
   setVersionPriority?: Maybe<Scalars["String"]["output"]>;
   spawnHost: Host;
   spawnVolume: Scalars["Boolean"]["output"];
+  unquarantineTest: TestResult;
   unscheduleTask: Task;
   unscheduleVersionTasks?: Maybe<Scalars["String"]["output"]>;
   updateBetaFeatures?: Maybe<UpdateBetaFeaturesPayload>;
@@ -2256,6 +2257,10 @@ export type MutationSpawnHostArgs = {
 
 export type MutationSpawnVolumeArgs = {
   spawnVolumeInput: SpawnVolumeInput;
+};
+
+export type MutationUnquarantineTestArgs = {
+  opts: UnquarantineTestInput;
 };
 
 export type MutationUnscheduleTaskArgs = {
@@ -3129,11 +3134,6 @@ export type PublicKeyInput = {
 export type QuarantineTestInput = {
   taskId: Scalars["String"]["input"];
   testName: Scalars["String"]["input"];
-};
-
-export type QuarantineTestPayload = {
-  __typename?: "QuarantineTestPayload";
-  success: Scalars["Boolean"]["output"];
 };
 
 export type Query = {
@@ -4528,6 +4528,7 @@ export type TestResult = {
   exitCode?: Maybe<Scalars["Int"]["output"]>;
   groupID?: Maybe<Scalars["String"]["output"]>;
   id: Scalars["String"]["output"];
+  isManuallyQuarantined: Scalars["Boolean"]["output"];
   logs: TestLog;
   startTime?: Maybe<Scalars["Time"]["output"]>;
   status: Scalars["String"]["output"];
@@ -4681,6 +4682,11 @@ export type UiConfigInput = {
   uiv2Url: Scalars["String"]["input"];
   url: Scalars["String"]["input"];
   userVoice: Scalars["String"]["input"];
+};
+
+export type UnquarantineTestInput = {
+  taskId: Scalars["String"]["input"];
+  testName: Scalars["String"]["input"];
 };
 
 export type UpdateBetaFeaturesInput = {

--- a/apps/spruce/src/analytics/task/useTaskAnalytics.ts
+++ b/apps/spruce/src/analytics/task/useTaskAnalytics.ts
@@ -57,6 +57,10 @@ type Action =
       name: "Clicked quarantine test button";
       "test.name": string;
     }
+  | {
+      name: "Clicked unquarantine test button";
+      "test.name": string;
+    }
   | { name: "Clicked annotation link"; "link.text": string }
   | { name: "Changed log preview type"; "log.type": LogTypes }
   | { name: "Viewed notification modal" }

--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -1963,7 +1963,7 @@ export type Mutation = {
   moveAnnotationIssue: Scalars["Boolean"]["output"];
   overrideTaskDependencies: Task;
   promoteVarsToRepo: Scalars["Boolean"]["output"];
-  quarantineTest: QuarantineTestPayload;
+  quarantineTest: TestResult;
   refreshGitHubStatuses?: Maybe<RefreshGitHubStatusesPayload>;
   removeAnnotationIssue: Scalars["Boolean"]["output"];
   removeFavoriteProject: Project;
@@ -1994,6 +1994,7 @@ export type Mutation = {
   setVersionPriority?: Maybe<Scalars["String"]["output"]>;
   spawnHost: Host;
   spawnVolume: Scalars["Boolean"]["output"];
+  unquarantineTest: TestResult;
   unscheduleTask: Task;
   unscheduleVersionTasks?: Maybe<Scalars["String"]["output"]>;
   updateBetaFeatures?: Maybe<UpdateBetaFeaturesPayload>;
@@ -2253,6 +2254,10 @@ export type MutationSpawnHostArgs = {
 
 export type MutationSpawnVolumeArgs = {
   spawnVolumeInput: SpawnVolumeInput;
+};
+
+export type MutationUnquarantineTestArgs = {
+  opts: UnquarantineTestInput;
 };
 
 export type MutationUnscheduleTaskArgs = {
@@ -3126,11 +3131,6 @@ export type PublicKeyInput = {
 export type QuarantineTestInput = {
   taskId: Scalars["String"]["input"];
   testName: Scalars["String"]["input"];
-};
-
-export type QuarantineTestPayload = {
-  __typename?: "QuarantineTestPayload";
-  success: Scalars["Boolean"]["output"];
 };
 
 export type Query = {
@@ -4526,6 +4526,7 @@ export type TestResult = {
   exitCode?: Maybe<Scalars["Int"]["output"]>;
   groupID?: Maybe<Scalars["String"]["output"]>;
   id: Scalars["String"]["output"];
+  isManuallyQuarantined: Scalars["Boolean"]["output"];
   logs: TestLog;
   startTime?: Maybe<Scalars["Time"]["output"]>;
   status: Scalars["String"]["output"];
@@ -4679,6 +4680,11 @@ export type UiConfigInput = {
   uiv2Url: Scalars["String"]["input"];
   url: Scalars["String"]["input"];
   userVoice: Scalars["String"]["input"];
+};
+
+export type UnquarantineTestInput = {
+  taskId: Scalars["String"]["input"];
+  testName: Scalars["String"]["input"];
 };
 
 export type UpdateBetaFeaturesInput = {
@@ -6891,7 +6897,11 @@ export type QuarantineTestMutationVariables = Exact<{
 
 export type QuarantineTestMutation = {
   __typename?: "Mutation";
-  quarantineTest: { __typename?: "QuarantineTestPayload"; success: boolean };
+  quarantineTest: {
+    __typename?: "TestResult";
+    id: string;
+    isManuallyQuarantined: boolean;
+  };
 };
 
 export type RefreshGithubStatusesMutationVariables = Exact<{
@@ -7396,6 +7406,20 @@ export type SpawnVolumeMutationVariables = Exact<{
 export type SpawnVolumeMutation = {
   __typename?: "Mutation";
   spawnVolume: boolean;
+};
+
+export type UnquarantineTestMutationVariables = Exact<{
+  taskId: Scalars["String"]["input"];
+  testName: Scalars["String"]["input"];
+}>;
+
+export type UnquarantineTestMutation = {
+  __typename?: "Mutation";
+  unquarantineTest: {
+    __typename?: "TestResult";
+    id: string;
+    isManuallyQuarantined: boolean;
+  };
 };
 
 export type UnscheduleTaskMutationVariables = Exact<{
@@ -11270,6 +11294,7 @@ export type TaskTestsQuery = {
         id: string;
         baseStatus?: string | null;
         duration?: number | null;
+        isManuallyQuarantined: boolean;
         status: string;
         testFile: string;
         logs: {
@@ -11308,6 +11333,7 @@ export type TaskQuery = {
     canSchedule: boolean;
     canSetPriority: boolean;
     canUnschedule: boolean;
+    displayOnly?: boolean | null;
     distroId: string;
     errors?: Array<string> | null;
     estimatedStart?: number | null;

--- a/apps/spruce/src/gql/mutations/index.ts
+++ b/apps/spruce/src/gql/mutations/index.ts
@@ -55,6 +55,7 @@ export { SET_TASK_PRIORITY } from "./set-task-priority";
 export { SET_VERSION_PRIORITY } from "./set-version-priority";
 export { SPAWN_HOST } from "./spawn-host";
 export { SPAWN_VOLUME } from "./spawn-volume";
+export { UNQUARANTINE_TEST } from "./unquarantine-test";
 export { UNSCHEDULE_TASK } from "./unschedule-task";
 export { UNSCHEDULE_VERSION_TASKS } from "./unschedule-version-tasks";
 export { UPDATE_HOST_STATUS } from "./update-host-status";

--- a/apps/spruce/src/gql/mutations/quarantine-test.ts
+++ b/apps/spruce/src/gql/mutations/quarantine-test.ts
@@ -3,7 +3,8 @@ import { gql } from "@apollo/client";
 export const QUARANTINE_TEST = gql`
   mutation QuarantineTest($taskId: String!, $testName: String!) {
     quarantineTest(opts: { taskId: $taskId, testName: $testName }) {
-      success
+      id
+      isManuallyQuarantined
     }
   }
 `;

--- a/apps/spruce/src/gql/mutations/unquarantine-test.ts
+++ b/apps/spruce/src/gql/mutations/unquarantine-test.ts
@@ -1,0 +1,10 @@
+import { gql } from "@apollo/client";
+
+export const UNQUARANTINE_TEST = gql`
+  mutation UnquarantineTest($taskId: String!, $testName: String!) {
+    unquarantineTest(opts: { taskId: $taskId, testName: $testName }) {
+      id
+      isManuallyQuarantined
+    }
+  }
+`;

--- a/apps/spruce/src/gql/queries/task-tests.ts
+++ b/apps/spruce/src/gql/queries/task-tests.ts
@@ -27,6 +27,7 @@ export const TASK_TESTS = gql`
           id
           baseStatus
           duration
+          isManuallyQuarantined
           logs {
             lineNum
             testName

--- a/apps/spruce/src/gql/queries/task.ts
+++ b/apps/spruce/src/gql/queries/task.ts
@@ -69,6 +69,7 @@ export const TASK = gql`
         traceID
         type
       }
+      displayOnly
       displayTask {
         id
         displayName

--- a/apps/spruce/src/pages/task/taskTabs/TaskHistory/CommitDetailsCard/CommitDetailsCard.stories.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/TaskHistory/CommitDetailsCard/CommitDetailsCard.stories.tsx
@@ -122,6 +122,7 @@ const testResults: TestResult[] = Array.from({ length: 15 }, (_, idx) => ({
   id: `e2e_test_${idx}`,
   testFile: `e2e_test_${idx}`,
   status: idx % 3 === 0 ? TestStatus.SilentFail : TestStatus.Fail,
+  isManuallyQuarantined: false,
   logs: { urlParsley: `${idx}-parsley-url.mongodb.com` },
 }));
 

--- a/apps/spruce/src/pages/task/taskTabs/TaskHistory/CommitDetailsCard/FailedTestsTable.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/TaskHistory/CommitDetailsCard/FailedTestsTable.tsx
@@ -18,13 +18,15 @@ import { size } from "@evg-ui/lib/constants/tokens";
 import { useQueryParam } from "@evg-ui/lib/hooks";
 import { TestStatus } from "@evg-ui/lib/types/test";
 import { useTaskHistoryAnalytics } from "analytics";
-import { TaskTestResult, TestResult } from "gql/generated/types";
-import { TaskHistoryOptions } from "../types";
+import { TaskHistoryOptions, TaskHistoryTask } from "../types";
+
+type FailedTests = TaskHistoryTask["tests"];
+type FailedTestResult = FailedTests["testResults"][number];
 
 const DEFAULT_PAGE_SIZE = 5;
 
 interface CommitDetailsCardProps {
-  tests: Omit<TaskTestResult, "filteredTestCount" | "totalTestCount">;
+  tests: FailedTests;
 }
 
 const FailedTestsTable: React.FC<CommitDetailsCardProps> = ({ tests }) => {
@@ -57,7 +59,7 @@ const FailedTestsTable: React.FC<CommitDetailsCardProps> = ({ tests }) => {
     [sendEvent, setFailingTest],
   );
 
-  const table = useLeafyGreenTable<TestResult>({
+  const table = useLeafyGreenTable<FailedTestResult>({
     columns,
     data: testResults ?? [],
     defaultColumn: {
@@ -121,7 +123,7 @@ const getColumns = ({
 }: {
   onClickLogs: (testName: string) => void;
   onClickSearchFailure: (testName: string) => void;
-}): LGColumnDef<TestResult>[] => [
+}): LGColumnDef<FailedTestResult>[] => [
   {
     accessorKey: "testFile",
     header: "Test Failure Name",

--- a/apps/spruce/src/pages/task/taskTabs/testsTable/ActionMenu/ActionMenu.stories.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/testsTable/ActionMenu/ActionMenu.stories.tsx
@@ -1,0 +1,81 @@
+import { userEvent } from "storybook/test";
+import WithToastContext from "@evg-ui/lib/test_utils/toast-decorator";
+import { CustomMeta, CustomStoryObj } from "@evg-ui/lib/test_utils/types";
+import { TestStatus } from "@evg-ui/lib/types/test";
+import { TaskQuery, TestResult } from "gql/generated/types";
+import { taskQuery } from "gql/mocks/taskData";
+import { ActionMenu } from ".";
+
+export default {
+  component: ActionMenu,
+  decorators: [(Story: () => React.JSX.Element) => WithToastContext(Story)],
+  play: async ({ canvasElement }) => {
+    const trigger = canvasElement.querySelector<HTMLElement>(
+      '[data-cy="ellipsis-btn"]',
+    );
+    if (trigger) {
+      await userEvent.click(trigger);
+    }
+  },
+} satisfies CustomMeta<typeof ActionMenu>;
+
+const taskWithTestSelection: NonNullable<TaskQuery["task"]> = {
+  ...taskQuery.task,
+  testSelectionEnabled: true,
+};
+
+const failingTest: TestResult = {
+  id: "1",
+  testFile: "test_1",
+  status: TestStatus.Fail,
+  isManuallyQuarantined: false,
+  logs: {},
+};
+
+const passingTest: TestResult = {
+  id: "2",
+  testFile: "test_2",
+  status: TestStatus.Pass,
+  isManuallyQuarantined: false,
+  logs: {},
+};
+
+const quarantinedTest: TestResult = {
+  id: "3",
+  testFile: "test_3",
+  status: TestStatus.Pass,
+  isManuallyQuarantined: true,
+  logs: {},
+};
+
+export const TestSelectionDisabled: CustomStoryObj<typeof ActionMenu> = {
+  render: () => (
+    <ActionMenu
+      task={{ ...taskWithTestSelection, testSelectionEnabled: false }}
+      test={failingTest}
+    />
+  ),
+};
+
+export const DisplayTask: CustomStoryObj<typeof ActionMenu> = {
+  render: () => (
+    <ActionMenu
+      task={{ ...taskWithTestSelection, displayOnly: true }}
+      test={failingTest}
+    />
+  ),
+};
+
+export const Quarantined: CustomStoryObj<typeof ActionMenu> = {
+  render: () => (
+    <ActionMenu task={taskWithTestSelection} test={quarantinedTest} />
+  ),
+};
+
+export const FailingTest: CustomStoryObj<typeof ActionMenu> = {
+  render: () => <ActionMenu task={taskWithTestSelection} test={failingTest} />,
+};
+
+export const PassingTest: CustomStoryObj<typeof ActionMenu> = {
+  render: () => <ActionMenu task={taskWithTestSelection} test={passingTest} />,
+};

--- a/apps/spruce/src/pages/task/taskTabs/testsTable/ActionMenu/ActionMenu.test.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/testsTable/ActionMenu/ActionMenu.test.tsx
@@ -11,18 +11,28 @@ import { TestStatus } from "@evg-ui/lib/types/test";
 import {
   QuarantineTestMutation,
   QuarantineTestMutationVariables,
+  UnquarantineTestMutation,
+  UnquarantineTestMutationVariables,
   TestResult,
 } from "gql/generated/types";
 import { taskQuery } from "gql/mocks/taskData";
-import { QUARANTINE_TEST } from "gql/mutations";
+import { QUARANTINE_TEST, UNQUARANTINE_TEST } from "gql/mutations";
 import { ActionMenu } from ".";
 
+const taskWithTestSelection = {
+  ...taskQuery.task,
+  testSelectionEnabled: true,
+};
+
 describe("action menu for tests table", () => {
-  it("can open menu", async () => {
+  it("shows disabled message when test selection is not enabled", async () => {
     const user = userEvent.setup();
     const { Component } = RenderFakeToastContext(
-      <MockedProvider mocks={[quarantineTestMock]}>
-        <ActionMenu task={taskQuery.task} test={failingTest} />
+      <MockedProvider mocks={[]}>
+        <ActionMenu
+          task={{ ...taskWithTestSelection, testSelectionEnabled: false }}
+          test={failingTest}
+        />
       </MockedProvider>,
     );
     render(<Component />);
@@ -30,19 +40,44 @@ describe("action menu for tests table", () => {
     await waitFor(() => {
       expect(screen.getByDataCy("card-dropdown")).toBeVisible();
     });
+    expect(
+      screen.getByText("Test selection is disabled for this task."),
+    ).toBeVisible();
   });
 
-  it("cannot quarantine if test is passing'", async () => {
+  it("shows disabled message on display tasks", async () => {
     const user = userEvent.setup();
     const { Component } = RenderFakeToastContext(
-      <MockedProvider mocks={[quarantineTestMock]}>
-        <ActionMenu task={taskQuery.task} test={passingTest} />
+      <MockedProvider mocks={[]}>
+        <ActionMenu
+          task={{ ...taskWithTestSelection, displayOnly: true }}
+          test={failingTest}
+        />
       </MockedProvider>,
     );
     render(<Component />);
     await user.click(screen.getByDataCy("ellipsis-btn"));
     await waitFor(() => {
       expect(screen.getByDataCy("card-dropdown")).toBeVisible();
+    });
+    expect(
+      screen.getByText(
+        "Select an execution task to manage test quarantine status.",
+      ),
+    ).toBeVisible();
+  });
+
+  it("disables quarantine option when test is passing and not quarantined", async () => {
+    const user = userEvent.setup();
+    const { Component } = RenderFakeToastContext(
+      <MockedProvider mocks={[]}>
+        <ActionMenu task={taskWithTestSelection} test={passingTest} />
+      </MockedProvider>,
+    );
+    render(<Component />);
+    await user.click(screen.getByDataCy("ellipsis-btn"));
+    await waitFor(() => {
+      expect(screen.getByDataCy("quarantine-test")).toBeVisible();
     });
     expect(screen.getByDataCy("quarantine-test")).toHaveAttribute(
       "aria-disabled",
@@ -50,28 +85,39 @@ describe("action menu for tests table", () => {
     );
   });
 
-  it("can quarantine if test is failing", async () => {
+  it("quarantines a failing test", async () => {
     const user = userEvent.setup();
     const { Component, dispatchToast } = RenderFakeToastContext(
       <MockedProvider mocks={[quarantineTestMock]}>
-        <ActionMenu task={taskQuery.task} test={failingTest} />
+        <ActionMenu task={taskWithTestSelection} test={failingTest} />
       </MockedProvider>,
     );
     render(<Component />);
     await user.click(screen.getByDataCy("ellipsis-btn"));
     await waitFor(() => {
-      expect(screen.getByDataCy("card-dropdown")).toBeVisible();
+      expect(screen.getByDataCy("quarantine-test")).toBeVisible();
     });
-    expect(screen.getByDataCy("quarantine-test")).toHaveAttribute(
-      "aria-disabled",
-      "false",
-    );
     await user.click(screen.getByDataCy("quarantine-test"));
     await waitFor(() => {
       expect(dispatchToast.success).toHaveBeenCalledTimes(1);
     });
+  });
+
+  it("unquarantines a quarantined test", async () => {
+    const user = userEvent.setup();
+    const { Component, dispatchToast } = RenderFakeToastContext(
+      <MockedProvider mocks={[unquarantineTestMock]}>
+        <ActionMenu task={taskWithTestSelection} test={quarantinedTest} />
+      </MockedProvider>,
+    );
+    render(<Component />);
+    await user.click(screen.getByDataCy("ellipsis-btn"));
     await waitFor(() => {
-      expect(screen.queryByDataCy("card-dropdown")).not.toBeInTheDocument();
+      expect(screen.getByDataCy("unquarantine-test")).toBeVisible();
+    });
+    await user.click(screen.getByDataCy("unquarantine-test"));
+    await waitFor(() => {
+      expect(dispatchToast.success).toHaveBeenCalledTimes(1);
     });
   });
 });
@@ -80,6 +126,7 @@ const failingTest: TestResult = {
   id: "1",
   testFile: "test_1",
   status: TestStatus.Fail,
+  isManuallyQuarantined: false,
   logs: {},
 };
 
@@ -87,6 +134,15 @@ const passingTest: TestResult = {
   id: "2",
   testFile: "test_2",
   status: TestStatus.Pass,
+  isManuallyQuarantined: false,
+  logs: {},
+};
+
+const quarantinedTest: TestResult = {
+  id: "3",
+  testFile: "test_3",
+  status: TestStatus.Pass,
+  isManuallyQuarantined: true,
   logs: {},
 };
 
@@ -104,8 +160,31 @@ const quarantineTestMock: ApolloMock<
   result: {
     data: {
       quarantineTest: {
-        __typename: "QuarantineTestPayload",
-        success: true,
+        __typename: "TestResult",
+        id: "1",
+        isManuallyQuarantined: true,
+      },
+    },
+  },
+};
+
+const unquarantineTestMock: ApolloMock<
+  UnquarantineTestMutation,
+  UnquarantineTestMutationVariables
+> = {
+  request: {
+    query: UNQUARANTINE_TEST,
+    variables: {
+      taskId: taskQuery.task.id,
+      testName: "test_3",
+    },
+  },
+  result: {
+    data: {
+      unquarantineTest: {
+        __typename: "TestResult",
+        id: "3",
+        isManuallyQuarantined: false,
       },
     },
   },

--- a/apps/spruce/src/pages/task/taskTabs/testsTable/ActionMenu/ActionMenu.test.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/testsTable/ActionMenu/ActionMenu.test.tsx
@@ -62,7 +62,7 @@ describe("action menu for tests table", () => {
     });
     expect(
       screen.getByText(
-        "Select an execution task to manage test quarantine status.",
+        "Cannot manage test quarantine status from display status. Click on an execution task instead.",
       ),
     ).toBeVisible();
   });

--- a/apps/spruce/src/pages/task/taskTabs/testsTable/ActionMenu/index.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/testsTable/ActionMenu/index.tsx
@@ -10,8 +10,10 @@ import {
   TestResult,
   QuarantineTestMutation,
   QuarantineTestMutationVariables,
+  UnquarantineTestMutation,
+  UnquarantineTestMutationVariables,
 } from "gql/generated/types";
-import { QUARANTINE_TEST } from "gql/mutations";
+import { QUARANTINE_TEST, UNQUARANTINE_TEST } from "gql/mutations";
 
 interface ActionMenuProps {
   task: NonNullable<TaskQuery["task"]>;
@@ -21,8 +23,7 @@ interface ActionMenuProps {
 export const ActionMenu: React.FC<ActionMenuProps> = ({ task, test }) => {
   const { sendEvent } = useTaskAnalytics();
   const dispatchToast = useToastContext();
-
-  const [menuOpen, setMenuOpen] = useState(false);
+  const [open, setOpen] = useState(false);
 
   const [quarantineTest] = useMutation<
     QuarantineTestMutation,
@@ -38,38 +39,88 @@ export const ActionMenu: React.FC<ActionMenuProps> = ({ task, test }) => {
     },
   });
 
+  const [unquarantineTest] = useMutation<
+    UnquarantineTestMutation,
+    UnquarantineTestMutationVariables
+  >(UNQUARANTINE_TEST, {
+    onCompleted: () => {
+      dispatchToast.success("Successfully unquarantined test.");
+    },
+    onError: (err) => {
+      dispatchToast.error(
+        `Error when attempting to unquarantine test: ${err.message}`,
+      );
+    },
+  });
+
   const onQuarantineTest = () => {
+    setOpen(false);
     sendEvent({
       name: "Clicked quarantine test button",
       "test.name": test.testFile,
     });
     quarantineTest({ variables: { taskId: task.id, testName: test.testFile } });
-    setMenuOpen(false);
   };
 
-  const canQuarantine = test.status === TestStatus.Fail;
+  const onUnquarantineTest = () => {
+    setOpen(false);
+    sendEvent({
+      name: "Clicked unquarantine test button",
+      "test.name": test.testFile,
+    });
+    unquarantineTest({
+      variables: { taskId: task.id, testName: test.testFile },
+    });
+  };
 
-  const dropdownItems = [
-    <DropdownItem
-      key="quarantine"
-      data-cy="quarantine-test"
-      description={
-        canQuarantine
-          ? "Quarantine test so that it does not run in future task runs."
-          : "Passing tests cannot be quarantined."
-      }
-      disabled={!canQuarantine}
-      onClick={onQuarantineTest}
-    >
-      Quarantine
-    </DropdownItem>,
-  ];
+  let dropdownItems: React.ReactNode[];
+  if (!task.testSelectionEnabled) {
+    dropdownItems = [
+      <DropdownItem key="disabled" disabled>
+        Test selection is disabled for this task.
+      </DropdownItem>,
+    ];
+  } else if (task.displayOnly) {
+    dropdownItems = [
+      <DropdownItem key="display-task" disabled>
+        Select an execution task to manage test quarantine status.
+      </DropdownItem>,
+    ];
+  } else if (test.isManuallyQuarantined) {
+    dropdownItems = [
+      <DropdownItem
+        key="unquarantine"
+        data-cy="unquarantine-test"
+        description="Allow this test to run in future task runs."
+        onClick={onUnquarantineTest}
+      >
+        Unquarantine
+      </DropdownItem>,
+    ];
+  } else {
+    const canQuarantine = test.status === TestStatus.Fail;
+    dropdownItems = [
+      <DropdownItem
+        key="quarantine"
+        data-cy="quarantine-test"
+        description={
+          canQuarantine
+            ? "Quarantine test so that it does not run in future task runs."
+            : "Passing tests cannot be quarantined."
+        }
+        disabled={!canQuarantine}
+        onClick={onQuarantineTest}
+      >
+        Quarantine
+      </DropdownItem>,
+    ];
+  }
 
   return (
     <ButtonDropdown
       dropdownItems={dropdownItems}
-      open={menuOpen}
-      setOpen={setMenuOpen}
+      open={open}
+      setOpen={setOpen}
       size={ButtonSize.XSmall}
     />
   );

--- a/apps/spruce/src/pages/task/taskTabs/testsTable/ActionMenu/index.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/testsTable/ActionMenu/index.tsx
@@ -83,7 +83,8 @@ export const ActionMenu: React.FC<ActionMenuProps> = ({ task, test }) => {
   } else if (task.displayOnly) {
     dropdownItems = [
       <DropdownItem key="display-task" disabled>
-        Select an execution task to manage test quarantine status.
+        Cannot manage test quarantine status from display status. Click on an
+        execution task instead.
       </DropdownItem>,
     ];
   } else if (test.isManuallyQuarantined) {

--- a/apps/spruce/src/pages/task/taskTabs/testsTable/getColumnsTemplate.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/testsTable/getColumnsTemplate.tsx
@@ -1,6 +1,9 @@
+import styled from "@emotion/styled";
+import { Badge, Variant } from "@leafygreen-ui/badge";
 import { LGColumnDef } from "@leafygreen-ui/table";
 import TestStatusBadge from "@evg-ui/lib/components/Badge/TestStatusBadge";
 import { WordBreak } from "@evg-ui/lib/components/styles";
+import { size } from "@evg-ui/lib/constants/tokens";
 import { testStatusesFilterTreeData } from "constants/test";
 import { TestSortCategory, TaskQuery, TestResult } from "gql/generated/types";
 import { string } from "utils";
@@ -20,7 +23,16 @@ export const getColumnsTemplate = ({
     header: "Name",
     accessorKey: "testFile",
     id: TestSortCategory.TestName,
-    cell: ({ getValue }) => <WordBreak>{getValue() as string}</WordBreak>,
+    cell: ({ getValue, row }) => (
+      <NameCell>
+        <WordBreak>{getValue() as string}</WordBreak>
+        {row.original.isManuallyQuarantined && (
+          <Badge data-cy="quarantined-badge" variant={Variant.Yellow}>
+            Quarantined
+          </Badge>
+        )}
+      </NameCell>
+    ),
     enableColumnFilter: true,
     enableSorting: true,
     meta: {
@@ -91,3 +103,9 @@ export const getColumnsTemplate = ({
     },
   },
 ];
+
+const NameCell = styled.div`
+  display: flex;
+  align-items: center;
+  gap: ${size.xs};
+`;

--- a/apps/spruce/src/pages/waterfall/TaskOverviewPopup/TaskOverviewPopup.stories.tsx
+++ b/apps/spruce/src/pages/waterfall/TaskOverviewPopup/TaskOverviewPopup.stories.tsx
@@ -261,6 +261,7 @@ const failingTestsMock: ApolloMock<TaskTestsQuery, TaskTestsQueryVariables> = {
               id: "test-1",
               baseStatus: null,
               duration: 1234,
+              isManuallyQuarantined: false,
               logs: {
                 lineNum: 42,
                 testName: "test_authentication_flow",
@@ -275,6 +276,7 @@ const failingTestsMock: ApolloMock<TaskTestsQuery, TaskTestsQueryVariables> = {
               id: "test-2",
               baseStatus: null,
               duration: 890,
+              isManuallyQuarantined: false,
               logs: {
                 lineNum: 156,
                 testName: "test_user_permissions",
@@ -290,6 +292,7 @@ const failingTestsMock: ApolloMock<TaskTestsQuery, TaskTestsQueryVariables> = {
               id: "test-3",
               baseStatus: null,
               duration: 2345,
+              isManuallyQuarantined: false,
               logs: {
                 lineNum: 89,
                 testName: "test_database_connection",

--- a/packages/lib/src/gql/generated/types.ts
+++ b/packages/lib/src/gql/generated/types.ts
@@ -1966,7 +1966,7 @@ export type Mutation = {
   moveAnnotationIssue: Scalars["Boolean"]["output"];
   overrideTaskDependencies: Task;
   promoteVarsToRepo: Scalars["Boolean"]["output"];
-  quarantineTest: QuarantineTestPayload;
+  quarantineTest: TestResult;
   refreshGitHubStatuses?: Maybe<RefreshGitHubStatusesPayload>;
   removeAnnotationIssue: Scalars["Boolean"]["output"];
   removeFavoriteProject: Project;
@@ -1997,6 +1997,7 @@ export type Mutation = {
   setVersionPriority?: Maybe<Scalars["String"]["output"]>;
   spawnHost: Host;
   spawnVolume: Scalars["Boolean"]["output"];
+  unquarantineTest: TestResult;
   unscheduleTask: Task;
   unscheduleVersionTasks?: Maybe<Scalars["String"]["output"]>;
   updateBetaFeatures?: Maybe<UpdateBetaFeaturesPayload>;
@@ -2256,6 +2257,10 @@ export type MutationSpawnHostArgs = {
 
 export type MutationSpawnVolumeArgs = {
   spawnVolumeInput: SpawnVolumeInput;
+};
+
+export type MutationUnquarantineTestArgs = {
+  opts: UnquarantineTestInput;
 };
 
 export type MutationUnscheduleTaskArgs = {
@@ -3129,11 +3134,6 @@ export type PublicKeyInput = {
 export type QuarantineTestInput = {
   taskId: Scalars["String"]["input"];
   testName: Scalars["String"]["input"];
-};
-
-export type QuarantineTestPayload = {
-  __typename?: "QuarantineTestPayload";
-  success: Scalars["Boolean"]["output"];
 };
 
 export type Query = {
@@ -4528,6 +4528,7 @@ export type TestResult = {
   exitCode?: Maybe<Scalars["Int"]["output"]>;
   groupID?: Maybe<Scalars["String"]["output"]>;
   id: Scalars["String"]["output"];
+  isManuallyQuarantined: Scalars["Boolean"]["output"];
   logs: TestLog;
   startTime?: Maybe<Scalars["Time"]["output"]>;
   status: Scalars["String"]["output"];
@@ -4681,6 +4682,11 @@ export type UiConfigInput = {
   uiv2Url: Scalars["String"]["input"];
   url: Scalars["String"]["input"];
   userVoice: Scalars["String"]["input"];
+};
+
+export type UnquarantineTestInput = {
+  taskId: Scalars["String"]["input"];
+  testName: Scalars["String"]["input"];
 };
 
 export type UpdateBetaFeaturesInput = {


### PR DESCRIPTION
DEVPROD-30358

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->

<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
Adding support for quarantine, un-quarantining, and simple error states in the UI such as 404s
 
### Screenshots
https://github.com/user-attachments/assets/78842604-2afe-4a38-9a58-d714e2bd4448


### Testing
* Smoke tests on staging

### Evergreen PR
https://github.com/evergreen-ci/evergreen/pull/10043