### PR TITLE
DEVPROD-26290 Don't block spawn host authentication button when one is pending

### DIFF
--- a/apps/spruce/src/components/Spawn/spawnHostModal/getFormSchema.test.tsx
+++ b/apps/spruce/src/components/Spawn/spawnHostModal/getFormSchema.test.tsx
@@ -103,7 +103,7 @@ describe("getFormSchema spawn host token exchange callout", () => {
     expect(button).toHaveAttribute("aria-disabled", "true");
   });
 
-  it("shows loading on the authenticate button when exchange is pending", () => {
+  it("shows waiting text and keeps button clickable when exchange is pending", () => {
     const { uiSchema } = getFormSchema({
       ...baseSchemaInput,
       tokenExchangeState: TokenExchangeState.ExchangePending,
@@ -111,7 +111,11 @@ describe("getFormSchema spawn host token exchange callout", () => {
     });
     const node = tokenAuthDescription(uiSchema!);
     render(node);
-    expect(screen.getByDataCy("spawn-host-authenticate-button")).toBeVisible();
-    expect(screen.getByTestId("lg-button-spinner")).toBeVisible();
+    const button = screen.getByDataCy("spawn-host-authenticate-button");
+    expect(button).toBeVisible();
+    expect(button).not.toHaveAttribute("aria-disabled", "true");
+    expect(
+      screen.getByText("Waiting for authentication to complete..."),
+    ).toBeVisible();
   });
 });

--- a/apps/spruce/src/components/Spawn/spawnHostModal/getFormSchema.tsx
+++ b/apps/spruce/src/components/Spawn/spawnHostModal/getFormSchema.tsx
@@ -1,9 +1,9 @@
 import { css } from "@emotion/react";
 import { Banner, Variant } from "@leafygreen-ui/banner";
+import { Button } from "@leafygreen-ui/button";
 import { InlineCode } from "@leafygreen-ui/typography";
 import { StyledLink, StyledRouterLink } from "@evg-ui/lib/components/styles";
 import { shortenGithash } from "@evg-ui/lib/utils/string";
-import { LoadingButton } from "components/Buttons";
 import { GetFormSchema } from "components/SpruceForm/types";
 import widgets from "components/SpruceForm/Widgets";
 import { LeafyGreenTextArea } from "components/SpruceForm/Widgets/LeafyGreenWidgets";
@@ -569,13 +569,10 @@ export const getFormSchema = ({
                     </>
                   )}
                 </div>
-                <LoadingButton
+                <Button
                   data-cy="spawn-host-authenticate-button"
                   disabled={
                     tokenExchangeState === TokenExchangeState.TokenValid
-                  }
-                  loading={
-                    tokenExchangeState === TokenExchangeState.ExchangePending
                   }
                   onClick={() => {
                     window.open(
@@ -587,7 +584,10 @@ export const getFormSchema = ({
                   type="button"
                 >
                   Authenticate spawn hosts
-                </LoadingButton>
+                </Button>
+                {tokenExchangeState === TokenExchangeState.ExchangePending && (
+                  <div>Waiting for authentication to complete...</div>
+                )}
                 {tokenExchangeState === TokenExchangeState.TokenValid && (
                   <div>Host has been temporarily authenticated.</div>
                 )}


### PR DESCRIPTION
DEVPROD-26290

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->

<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
<!-- add description, context, thought process, etc -->
A user can soft-lock themselves when authenticating their spawn hosts by aborting the auth flow (e.g. closing the window, or not following through). This updates the button so it is not possible to soft-lock yourself.

### Screenshots
<!-- add screenshots of visible changes -->
I tested it in staging, I forgot to save the screenshot with the text example- but it looks the same as the "your hosts are authenticated until". I can make a new recording if needed in ~10m if the reviewer wants!

### Testing
Updated the tests to account for this.