### PR TITLE
DEVPROD-31585 Ensure variant and task name query params don't get parsed as arrays

### DIFF
--- a/apps/spruce/src/pages/version/Tabs/useQueryVariables/index.ts
+++ b/apps/spruce/src/pages/version/Tabs/useQueryVariables/index.ts
@@ -20,8 +20,13 @@ export const useQueryVariables = (
     TableQueryParams.Sorts,
     undefined,
   );
-  const [variant] = useQueryParam<string>(PatchTasksQueryParams.Variant, "");
-  const [taskName] = useQueryParam<string>(PatchTasksQueryParams.TaskName, "");
+  const [variant] = useQueryParam<string>(PatchTasksQueryParams.Variant, "", {
+    arrayFormat: "none",
+  });
+  const [taskName] = useQueryParam<string>(PatchTasksQueryParams.TaskName, "", {
+    arrayFormat: "none",
+  });
+
   const [statuses] = useQueryParam<string[]>(
     PatchTasksQueryParams.Statuses,
     [],

--- a/apps/spruce/src/pages/version/Tabs/useQueryVariables/useQueryVariables.test.tsx
+++ b/apps/spruce/src/pages/version/Tabs/useQueryVariables/useQueryVariables.test.tsx
@@ -10,6 +10,29 @@ vi.mock("js-cookie");
 const mockedGet = vi.spyOn(Cookies, "get") as MockInstance;
 
 describe("useQueryVariables", () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      "localStorage",
+      (() => {
+        const store: Record<string, string> = {};
+        return {
+          getItem: (key: string) => store[key] ?? null,
+          setItem: (key: string, value: string) => {
+            store[key] = value;
+          },
+          removeItem: (key: string) => {
+            delete store[key];
+          },
+          clear: () => Object.keys(store).forEach((k) => delete store[k]),
+        };
+      })(),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   const getWrapper = (search: string) => {
     const Wrapper = ({ children }: { children: React.ReactNode }) => (
       <MemoryRouter initialEntries={[`?${search}`]}>{children}</MemoryRouter>
@@ -88,6 +111,39 @@ describe("useQueryVariables", () => {
         variant: "",
       },
     });
+  });
+
+  it("should not parse commas in variant as array values", () => {
+    const versionId = "version";
+    const search = "page=0&limit=20&variant=ubuntu1804,rhel70";
+    const { result } = renderHook(() => useQueryVariables(versionId), {
+      wrapper: getWrapper(search),
+    });
+    expect(result.current.taskFilterOptions.variant).toBe("ubuntu1804,rhel70");
+  });
+
+  it("should not parse commas in taskName as array values", () => {
+    const versionId = "version";
+    const search = "page=0&limit=20&taskName=compile,lint";
+    const { result } = renderHook(() => useQueryVariables(versionId), {
+      wrapper: getWrapper(search),
+    });
+    expect(result.current.taskFilterOptions.taskName).toBe("compile,lint");
+  });
+
+  it("should still parse statuses with commas as arrays", () => {
+    const versionId = "version";
+    const search =
+      "page=0&limit=20&taskName=compile,lint&variant=ubuntu1804,rhel70&statuses=failed,succeeded";
+    const { result } = renderHook(() => useQueryVariables(versionId), {
+      wrapper: getWrapper(search),
+    });
+    expect(result.current.taskFilterOptions.taskName).toBe("compile,lint");
+    expect(result.current.taskFilterOptions.variant).toBe("ubuntu1804,rhel70");
+    expect(result.current.taskFilterOptions.statuses).toStrictEqual([
+      "failed",
+      "succeeded",
+    ]);
   });
 
   it("uses cookie when includeNeverActivatedTasks is not in the search string", () => {


### PR DESCRIPTION
DEVPROD-31585

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->

<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
The user had a comma in the taskName parameter of their query which `useQueryParam` was  interperetting as an array separator. This caused the value of `taskName` to be transformed into an array which broke the validation of the underlying qraphql query


### Testing
Confirmed with the same url as the user and added unit tests
