### PR TITLE
DEVPROD-32092: Use tabular nums for task event log

### DIFF
--- a/apps/spruce/src/pages/task/taskTabs/logs/logTypes/TaskEventLogLine.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/logs/logTypes/TaskEventLogLine.tsx
@@ -132,5 +132,6 @@ const Row = styled.div`
 `;
 
 const Timestamp = styled.span`
+  font-variant-numeric: tabular-nums;
   margin-right: ${size.s};
 `;

--- a/apps/spruce/src/pages/waterfall/TaskStatsTooltip.tsx
+++ b/apps/spruce/src/pages/waterfall/TaskStatsTooltip.tsx
@@ -131,6 +131,6 @@ const Cell = styled.td`
 `;
 
 const Count = styled(Cell)`
-  font-feature-settings: "tnum";
+  font-variant-numeric: tabular-nums;
   text-align: right;
 `;


### PR DESCRIPTION
DEVPROD-32092

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->

<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
<!-- add description, context, thought process, etc -->
Biggest nit PR ever: use [tabular numbers](https://practicaltypography.com/alternate-figures.html#tabular-and-proportional-figures) to evenly align task event log entries.

Also update waterfall task stats to use the preferred CSS property syntax.

### Screenshots
<!-- add screenshots of visible changes -->

| Before | After |
|--------|--------|
| <img width="595" height="368" alt="image" src="https://github.com/user-attachments/assets/781822ef-86ab-49fc-8744-3af2fa1a5ae7" /> | <img width="603" height="375" alt="image" src="https://github.com/user-attachments/assets/360281d2-7d04-41ad-9651-797673fd1195" /> | 