### PR TITLE
DEVPROD-32098: Use `textarea` for Admin Settings banner

### DIFF
--- a/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/AnnouncementsTab/getFormSchema.ts
+++ b/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/AnnouncementsTab/getFormSchema.ts
@@ -1,6 +1,11 @@
+import { css } from "@emotion/react";
 import { GetFormSchema } from "components/SpruceForm";
 import { CardFieldTemplate } from "components/SpruceForm/FieldTemplates";
 import { BannerTheme } from "gql/generated/types";
+
+const textAreaCSS = css`
+  max-width: 400px;
+`;
 
 export const formSchema: ReturnType<GetFormSchema> = {
   fields: {},
@@ -32,6 +37,11 @@ export const formSchema: ReturnType<GetFormSchema> = {
   uiSchema: {
     announcements: {
       "ui:ObjectFieldTemplate": CardFieldTemplate,
+      banner: {
+        "ui:widget": "textarea",
+        "ui:elementWrapperCSS": textAreaCSS,
+        "ui:rows": 4,
+      },
       bannerTheme: {
         "ui:allowDeselect": false,
       },

--- a/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/AnnouncementsTab/getFormSchema.ts
+++ b/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/AnnouncementsTab/getFormSchema.ts
@@ -1,11 +1,6 @@
-import { css } from "@emotion/react";
 import { GetFormSchema } from "components/SpruceForm";
 import { CardFieldTemplate } from "components/SpruceForm/FieldTemplates";
 import { BannerTheme } from "gql/generated/types";
-
-const textAreaCSS = css`
-  max-width: 400px;
-`;
 
 export const formSchema: ReturnType<GetFormSchema> = {
   fields: {},
@@ -39,8 +34,7 @@ export const formSchema: ReturnType<GetFormSchema> = {
       "ui:ObjectFieldTemplate": CardFieldTemplate,
       banner: {
         "ui:widget": "textarea",
-        "ui:elementWrapperCSS": textAreaCSS,
-        "ui:rows": 4,
+        "ui:rows": 2,
       },
       bannerTheme: {
         "ui:allowDeselect": false,


### PR DESCRIPTION
DEVPROD-32098

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->

<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
When we were updating banners yesterday I feel like it was annoying to use the small input. I think a text area for the banner would be better.

### Screenshots
<!-- add screenshots of visible changes -->
<img width="1223" height="435" alt="Screenshot 2026-04-22 at 11 35 56 AM" src="https://github.com/user-attachments/assets/e6e31c39-ad52-4751-8adc-01bc3da3811d" />
