### PR TITLE
DEVPROD-32213 Use PR head ref for chromatic

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,6 +19,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
 
       - name: Use Node 22
         uses: actions/setup-node@v4

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -18,6 +18,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.ref }}
 
       - name: Use Node 22
         uses: actions/setup-node@v4


### PR DESCRIPTION
DEVPROD-32213

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->

<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
From Suki's email about improving chromatic

> TurboSnap bail root cause: incorrect ref for pull request builds
In the current workflow (example run linked below), the checkout step is not using the PR head ref:
https://github.com/evergreen-ci/ui/actions/runs/24534063999/workflow?pr=1557#L20
> For TurboSnap to correctly determine what actually changed, it needs to evaluate the true PR branch state (the head commit), not the default merge commit that GitHub Actions provides.
> 
> When the ref isn’t explicitly set to:
> 
> ${{ github.event.pull_request.head.ref }}
> GitHub checks out a synthetic merge commit. This causes a few issues:
> 
> The dependency graph no longer reflects just the PR changes
> TurboSnap sees a much broader set of file changes than expected
> This frequently results in preview file bails and full rebuilds
> The behavior appears “global” (across projects), even when changes are isolated
> This aligns with what we’re seeing in your repo: widespread preview file bails that look like shared dependency impact, but are actually coming from how the commit is being evaluated.
> 
> Recommended fix
> Update your checkout step to explicitly use the PR head ref:
> 
> - uses: actions/checkout@v4
>   with:
>     fetch-depth: 0
>     ref: ${{ github.event.pull_request.head.ref }}
> This ensures:
> 
> TurboSnap evaluates the correct diff
> Dependency tracing works as expected
> Preview file bails are reduced to only true global-impact changes
> 

