### PR TITLE
DEVPROD-25596: Add Evergreen cost documentation link

### DIFF
--- a/apps/parsley/src/gql/generated/types.ts
+++ b/apps/parsley/src/gql/generated/types.ts
@@ -3178,6 +3178,7 @@ export type Query = {
   task?: Maybe<Task>;
   taskAllExecutions: Array<Task>;
   taskHistory: TaskHistory;
+  taskHistoryByCreateTime: TaskHistoryByCreateTime;
   taskNamesForBuildVariant?: Maybe<Array<Scalars["String"]["output"]>>;
   taskQueueDistros: Array<TaskQueueDistro>;
   taskTestSample?: Maybe<Array<TaskTestResultSample>>;
@@ -3312,6 +3313,10 @@ export type QueryTaskAllExecutionsArgs = {
 };
 
 export type QueryTaskHistoryArgs = {
+  options: TaskHistoryOpts;
+};
+
+export type QueryTaskHistoryByCreateTimeArgs = {
   options: TaskHistoryOpts;
 };
 
@@ -4263,6 +4268,18 @@ export type TaskHistory = {
   __typename?: "TaskHistory";
   pagination: TaskHistoryPagination;
   tasks: Array<Task>;
+};
+
+export type TaskHistoryByCreateTime = {
+  __typename?: "TaskHistoryByCreateTime";
+  pagination: TaskHistoryByCreateTimePagination;
+  tasks: Array<Task>;
+};
+
+export type TaskHistoryByCreateTimePagination = {
+  __typename?: "TaskHistoryByCreateTimePagination";
+  mostRecentTaskCreateTime: Scalars["Time"]["output"];
+  oldestTaskCreateTime: Scalars["Time"]["output"];
 };
 
 export enum TaskHistoryDirection {

--- a/apps/spruce/src/components/CostModal/CostModal.test.tsx
+++ b/apps/spruce/src/components/CostModal/CostModal.test.tsx
@@ -21,7 +21,9 @@ describe("CostModal", () => {
 
   it("renders the docs link", () => {
     render(<CostModal {...defaultProps} />);
-    expect(screen.getByDataCy("cost-docs-link")).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /evergreen cost documentation/i }),
+    ).toBeInTheDocument();
   });
 
   it("renders cost rows with values when costs are provided", () => {

--- a/apps/spruce/src/components/CostModal/index.tsx
+++ b/apps/spruce/src/components/CostModal/index.tsx
@@ -7,6 +7,7 @@ import {
   useLeafyGreenTable,
 } from "@evg-ui/lib/components/Table";
 import { DisplayModal } from "components/DisplayModal";
+import { costDocumentationUrl } from "constants/externalResources";
 import { getHoneycombTaskCostUrl } from "constants/externalResources/honeycomb";
 import { Cost } from "gql/generated/types";
 
@@ -93,9 +94,13 @@ export const CostModal: React.FC<CostModalProps> = ({
       setOpen={setOpen}
       title={`Cost breakdown for ${name}`}
     >
-      <span data-cy="cost-docs-link">
-        Evergreen cost documentation (coming soon)
-      </span>
+      <StyledLink
+        data-cy="cost-docs-link"
+        hideExternalIcon={false}
+        href={costDocumentationUrl}
+      >
+        Evergreen cost documentation
+      </StyledLink>
       <BaseTable data-cy="cost-breakdown-table" table={table} />
       <StyledLink
         data-cy="task-cost-link"

--- a/apps/spruce/src/components/CostModal/index.tsx
+++ b/apps/spruce/src/components/CostModal/index.tsx
@@ -6,6 +6,7 @@ import {
   LGColumnDef,
   useLeafyGreenTable,
 } from "@evg-ui/lib/components/Table";
+import { size } from "@evg-ui/lib/constants/tokens";
 import { DisplayModal } from "components/DisplayModal";
 import { costDocumentationUrl } from "constants/externalResources";
 import { getHoneycombTaskCostUrl } from "constants/externalResources/honeycomb";
@@ -51,6 +52,10 @@ const columns: LGColumnDef<CostRow>[] = [
   },
 ];
 
+const Content = styled.div`
+  padding: ${size.xxs} 0;
+`;
+
 const TabularNum = styled.span`
   font-variant-numeric: tabular-nums;
 `;
@@ -94,25 +99,23 @@ export const CostModal: React.FC<CostModalProps> = ({
       setOpen={setOpen}
       title={`Cost breakdown for ${name}`}
     >
-      <StyledLink
-        data-cy="cost-docs-link"
-        hideExternalIcon={false}
-        href={costDocumentationUrl}
-      >
-        Evergreen cost documentation
-      </StyledLink>
-      <BaseTable data-cy="cost-breakdown-table" table={table} />
-      <StyledLink
-        data-cy="task-cost-link"
-        hideExternalIcon={false}
-        href={getHoneycombTaskCostUrl(taskId)}
-      >
-        Cost breakdown in Honeycomb
-      </StyledLink>
-      <Disclaimer>
-        * Costs are calculated using a Finance Team formula with applicable
-        discounts applied.
-      </Disclaimer>
+      <Content>
+        <StyledLink hideExternalIcon={false} href={costDocumentationUrl}>
+          Evergreen cost documentation
+        </StyledLink>
+        <BaseTable data-cy="cost-breakdown-table" table={table} />
+        <StyledLink
+          data-cy="task-cost-link"
+          hideExternalIcon={false}
+          href={getHoneycombTaskCostUrl(taskId)}
+        >
+          Cost breakdown in Honeycomb
+        </StyledLink>
+        <Disclaimer>
+          * Costs are calculated using a Finance Team formula with applicable
+          discounts applied.
+        </Disclaimer>
+      </Content>
     </DisplayModal>
   );
 };

--- a/apps/spruce/src/constants/externalResources/index.ts
+++ b/apps/spruce/src/constants/externalResources/index.ts
@@ -57,6 +57,8 @@ export const taskSchedulingLimitsDocumentationUrl = `${wikiBaseUrl}/Reference/Li
 
 export const dataRetentionDocumentationUrl = `${wikiBaseUrl}/Reference/Data-Retention`;
 
+export const costDocumentationUrl = `${wikiBaseUrl}/FAQ/Cost-FAQ`;
+
 export const windowsPasswordRulesURL =
   "https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2003/cc786468(v=ws.10)?redirectedfrom=MSDN";
 

--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -3175,6 +3175,7 @@ export type Query = {
   task?: Maybe<Task>;
   taskAllExecutions: Array<Task>;
   taskHistory: TaskHistory;
+  taskHistoryByCreateTime: TaskHistoryByCreateTime;
   taskNamesForBuildVariant?: Maybe<Array<Scalars["String"]["output"]>>;
   taskQueueDistros: Array<TaskQueueDistro>;
   taskTestSample?: Maybe<Array<TaskTestResultSample>>;
@@ -3309,6 +3310,10 @@ export type QueryTaskAllExecutionsArgs = {
 };
 
 export type QueryTaskHistoryArgs = {
+  options: TaskHistoryOpts;
+};
+
+export type QueryTaskHistoryByCreateTimeArgs = {
   options: TaskHistoryOpts;
 };
 
@@ -4261,6 +4266,18 @@ export type TaskHistory = {
   __typename?: "TaskHistory";
   pagination: TaskHistoryPagination;
   tasks: Array<Task>;
+};
+
+export type TaskHistoryByCreateTime = {
+  __typename?: "TaskHistoryByCreateTime";
+  pagination: TaskHistoryByCreateTimePagination;
+  tasks: Array<Task>;
+};
+
+export type TaskHistoryByCreateTimePagination = {
+  __typename?: "TaskHistoryByCreateTimePagination";
+  mostRecentTaskCreateTime: Scalars["Time"]["output"];
+  oldestTaskCreateTime: Scalars["Time"]["output"];
 };
 
 export enum TaskHistoryDirection {


### PR DESCRIPTION
DEVPROD-25596

### Description
Adding a link to the Cost Docs in the Cost Modal

### Screenshots
<img width="1152" height="840" alt="image" src="https://github.com/user-attachments/assets/f3fa0b2b-1b64-4c39-a925-c2b097768999" />

If you look at the bottom left you see the Cost FAQ URL
### Testing
Tested in Staging

### Evergreen PR
[App PR](https://github.com/evergreen-ci/evergreen/pull/10156)
