### PR TITLE
DEVPROD-32609: Add GuideCue for updated Project navbar

### DIFF
--- a/apps/spruce/cypress/support/e2e.ts
+++ b/apps/spruce/cypress/support/e2e.ts
@@ -21,6 +21,7 @@ import {
   SEEN_TASK_HISTORY_ONBOARDING_TUTORIAL,
   SEEN_TASK_REVIEW_TOOLTIP,
   SEEN_TEST_SELECTION_GUIDE_CUE,
+  SEEN_GITHUB_NAV_GUIDE_CUE,
 } from "constants/cookies";
 import { hasOperationName, isMutation } from "../utils/graphql-test-utils";
 
@@ -158,6 +159,7 @@ const hostMutations = ["ReprovisionToNew", "RestartJasper", "UpdateHostStatus"];
     cy.setCookie(SEEN_TASK_HISTORY_ONBOARDING_TUTORIAL, "true");
     cy.setCookie(SEEN_TASK_REVIEW_TOOLTIP, "true");
     cy.setCookie(SEEN_TEST_SELECTION_GUIDE_CUE, "true");
+    cy.setCookie(SEEN_GITHUB_NAV_GUIDE_CUE, "true");
     mutationDispatched = false;
     clearAmboyDB = false;
     cy.intercept("POST", "/graphql/query", (req) => {

--- a/apps/spruce/playwright/tests/projectSettings/commit_checks.spec.ts
+++ b/apps/spruce/playwright/tests/projectSettings/commit_checks.spec.ts
@@ -1,11 +1,18 @@
+import { SEEN_GITHUB_NAV_GUIDE_CUE } from "../../../src/constants/cookies";
 import { test, expect } from "../../fixtures";
 import { validateToast } from "../../helpers";
 
 test.describe("Commit Checks project settings when GitHub webhooks are disabled", () => {
-  const origin = "/project/logkeeper/settings/commit-checks";
-
   test.beforeEach(async ({ authenticatedPage: page }) => {
-    await page.goto(origin);
+    await page.context().addCookies([
+      {
+        name: SEEN_GITHUB_NAV_GUIDE_CUE,
+        value: "true",
+        domain: "localhost",
+        path: "/",
+      },
+    ]);
+    await page.goto("/project/logkeeper/settings/commit-checks");
     await expect(page.getByTestId("save-settings-button")).toHaveAttribute(
       "aria-disabled",
       "true",
@@ -37,6 +44,14 @@ test.describe("Commit Checks project settings when GitHub webhooks are disabled"
 
 test.describe("Commit Checks project settings when GitHub webhooks are enabled", () => {
   test.beforeEach(async ({ authenticatedPage: page }) => {
+    await page.context().addCookies([
+      {
+        name: SEEN_GITHUB_NAV_GUIDE_CUE,
+        value: "true",
+        domain: "localhost",
+        path: "/",
+      },
+    ]);
     await page.goto("/project/spruce/settings/commit-checks");
     await expect(page.getByTestId("save-settings-button")).toHaveAttribute(
       "aria-disabled",

--- a/apps/spruce/playwright/tests/projectSettings/git_tags.spec.ts
+++ b/apps/spruce/playwright/tests/projectSettings/git_tags.spec.ts
@@ -1,12 +1,19 @@
 import { clickRadio } from "@evg-ui/playwright-config/helpers";
+import { SEEN_GITHUB_NAV_GUIDE_CUE } from "../../../src/constants/cookies";
 import { test, expect } from "../../fixtures";
 import { validateToast } from "../../helpers";
 
 test.describe("Git Tags project settings when GitHub webhooks are disabled", () => {
-  const origin = "/project/logkeeper/settings/git-tags";
-
   test.beforeEach(async ({ authenticatedPage: page }) => {
-    await page.goto(origin);
+    await page.context().addCookies([
+      {
+        name: SEEN_GITHUB_NAV_GUIDE_CUE,
+        value: "true",
+        domain: "localhost",
+        path: "/",
+      },
+    ]);
+    await page.goto("/project/logkeeper/settings/git-tags");
     await expect(page.getByTestId("save-settings-button")).toBeDisabled();
   });
 
@@ -34,10 +41,16 @@ test.describe("Git Tags project settings when GitHub webhooks are disabled", () 
 });
 
 test.describe("Git Tags project settings when GitHub webhooks are enabled", () => {
-  const origin = "/repo/602d70a2b2373672ee493184/settings/git-tags";
-
   test.beforeEach(async ({ authenticatedPage: page }) => {
-    await page.goto(origin);
+    await page.context().addCookies([
+      {
+        name: SEEN_GITHUB_NAV_GUIDE_CUE,
+        value: "true",
+        domain: "localhost",
+        path: "/",
+      },
+    ]);
+    await page.goto("/repo/602d70a2b2373672ee493184/settings/git-tags");
     await expect(page.getByTestId("save-settings-button")).toBeDisabled();
   });
 

--- a/apps/spruce/playwright/tests/projectSettings/merge_queue.spec.ts
+++ b/apps/spruce/playwright/tests/projectSettings/merge_queue.spec.ts
@@ -1,11 +1,18 @@
+import { SEEN_GITHUB_NAV_GUIDE_CUE } from "../../../src/constants/cookies";
 import { test, expect } from "../../fixtures";
 import { validateToast } from "../../helpers";
 
 test.describe("Merge Queue project settings when GitHub webhooks are disabled", () => {
-  const origin = "/project/logkeeper/settings/merge-queue";
-
   test.beforeEach(async ({ authenticatedPage: page }) => {
-    await page.goto(origin);
+    await page.context().addCookies([
+      {
+        name: SEEN_GITHUB_NAV_GUIDE_CUE,
+        value: "true",
+        domain: "localhost",
+        path: "/",
+      },
+    ]);
+    await page.goto("/project/logkeeper/settings/merge-queue");
     await expect(page.getByTestId("save-settings-button")).toHaveAttribute(
       "aria-disabled",
       "true",
@@ -36,10 +43,16 @@ test.describe("Merge Queue project settings when GitHub webhooks are disabled", 
 });
 
 test.describe("Merge Queue project settings when GitHub webhooks are enabled", () => {
-  const origin = "/project/spruce/settings/merge-queue";
-
   test.beforeEach(async ({ authenticatedPage: page }) => {
-    await page.goto(origin);
+    await page.context().addCookies([
+      {
+        name: SEEN_GITHUB_NAV_GUIDE_CUE,
+        value: "true",
+        domain: "localhost",
+        path: "/",
+      },
+    ]);
+    await page.goto("/project/spruce/settings/merge-queue");
     await expect(page.getByTestId("save-settings-button")).toHaveAttribute(
       "aria-disabled",
       "true",

--- a/apps/spruce/playwright/tests/projectSettings/pull_requests.spec.ts
+++ b/apps/spruce/playwright/tests/projectSettings/pull_requests.spec.ts
@@ -1,8 +1,17 @@
+import { SEEN_GITHUB_NAV_GUIDE_CUE } from "../../../src/constants/cookies";
 import { test, expect } from "../../fixtures";
 import { validateToast } from "../../helpers";
 
 test.describe("Pull Requests project settings when GitHub webhooks are disabled", () => {
   test.beforeEach(async ({ authenticatedPage: page }) => {
+    await page.context().addCookies([
+      {
+        name: SEEN_GITHUB_NAV_GUIDE_CUE,
+        value: "true",
+        domain: "localhost",
+        path: "/",
+      },
+    ]);
     await page.goto("/project/logkeeper/settings/pull-requests");
     await expect(page.getByTestId("save-settings-button")).toHaveAttribute(
       "aria-disabled",
@@ -35,6 +44,14 @@ test.describe("Pull Requests project settings when GitHub webhooks are disabled"
 
 test.describe("Pull Requests project settings when GitHub webhooks are enabled", () => {
   test.beforeEach(async ({ authenticatedPage: page }) => {
+    await page.context().addCookies([
+      {
+        name: SEEN_GITHUB_NAV_GUIDE_CUE,
+        value: "true",
+        domain: "localhost",
+        path: "/",
+      },
+    ]);
     await page.goto("/repo/602d70a2b2373672ee493184/settings/pull-requests");
     await expect(page.getByTestId("save-settings-button")).toHaveAttribute(
       "aria-disabled",

--- a/apps/spruce/src/constants/cookies.ts
+++ b/apps/spruce/src/constants/cookies.ts
@@ -18,4 +18,5 @@ export const TASK_HISTORY_INACTIVE_COMMITS_VIEW =
   "task-history-inactive-commits-view";
 export const SEEN_TASK_REVIEW_TOOLTIP = "seen-task-review-tooltip";
 export const SEEN_TEST_SELECTION_GUIDE_CUE = "seen-test-selection-guide-cue";
+export const SEEN_GITHUB_NAV_GUIDE_CUE = "seen-github-nav-guide-cue";
 export const OMIT_INACTIVE_WATERFALL_BUILDS = "omit-inactive-waterfall-builds";

--- a/apps/spruce/src/pages/projectAndRepoSettings/shared/GithubNavGuideCue.tsx
+++ b/apps/spruce/src/pages/projectAndRepoSettings/shared/GithubNavGuideCue.tsx
@@ -1,0 +1,42 @@
+// GithubNavGuideCue.tsx
+import { useState } from "react";
+import {
+  GuideCue,
+  type GuideCueProps,
+  TooltipAlign,
+} from "@leafygreen-ui/guide-cue";
+import Cookies from "js-cookie";
+import { SEEN_GITHUB_NAV_GUIDE_CUE } from "constants/cookies";
+
+type Props = {
+  refEl: GuideCueProps["refEl"];
+};
+
+export const GithubNavGuideCue: React.FC<Props> = ({ refEl }) => {
+  const [open, setOpen] = useState(
+    Cookies.get(SEEN_GITHUB_NAV_GUIDE_CUE) !== "true",
+  );
+
+  const close = () => {
+    Cookies.set(SEEN_GITHUB_NAV_GUIDE_CUE, "true", { expires: 365 });
+    setOpen(false);
+  };
+
+  return (
+    <GuideCue
+      currentStep={1}
+      data-cy="github-nav-guide-cue"
+      enabled
+      numberOfSteps={1}
+      onPrimaryButtonClick={close}
+      open={open}
+      refEl={refEl}
+      setOpen={setOpen}
+      title="New: GitHub settings group"
+      tooltipAlign={TooltipAlign.Right}
+    >
+      GitHub-related settings like Pull Requests, Commit Checks, and Git Tags
+      now live under this GitHub section.
+    </GuideCue>
+  );
+};

--- a/apps/spruce/src/pages/projectAndRepoSettings/shared/GithubNavGuideCue.tsx
+++ b/apps/spruce/src/pages/projectAndRepoSettings/shared/GithubNavGuideCue.tsx
@@ -1,8 +1,7 @@
-// GithubNavGuideCue.tsx
 import { useState } from "react";
 import {
   GuideCue,
-  type GuideCueProps,
+  GuideCueProps,
   TooltipAlign,
 } from "@leafygreen-ui/guide-cue";
 import Cookies from "js-cookie";
@@ -25,7 +24,6 @@ export const GithubNavGuideCue: React.FC<Props> = ({ refEl }) => {
   return (
     <GuideCue
       currentStep={1}
-      data-cy="github-nav-guide-cue"
       enabled
       numberOfSteps={1}
       onPrimaryButtonClick={close}

--- a/apps/spruce/src/pages/projectAndRepoSettings/shared/GithubNavGuideCue.tsx
+++ b/apps/spruce/src/pages/projectAndRepoSettings/shared/GithubNavGuideCue.tsx
@@ -6,6 +6,7 @@ import {
 } from "@leafygreen-ui/guide-cue";
 import Cookies from "js-cookie";
 import { SEEN_GITHUB_NAV_GUIDE_CUE } from "constants/cookies";
+import { showNewProjectNavigation } from "constants/featureFlags";
 
 type Props = {
   refEl: GuideCueProps["refEl"];
@@ -24,7 +25,7 @@ export const GithubNavGuideCue: React.FC<Props> = ({ refEl }) => {
   return (
     <GuideCue
       currentStep={1}
-      enabled
+      enabled={showNewProjectNavigation}
       numberOfSteps={1}
       onPrimaryButtonClick={close}
       open={open}

--- a/apps/spruce/src/pages/projectAndRepoSettings/shared/ProjectNavbar.test.tsx
+++ b/apps/spruce/src/pages/projectAndRepoSettings/shared/ProjectNavbar.test.tsx
@@ -1,10 +1,12 @@
 // TODO DEVPROD-31534: Delete this file when the feature flag is removed
+import Cookies from "js-cookie";
 import { vi } from "vitest";
 import {
   renderWithRouterMatch as render,
   screen,
   userEvent,
 } from "@evg-ui/lib/test_utils";
+import { SEEN_GITHUB_NAV_GUIDE_CUE } from "constants/cookies";
 import { ProjectType } from "./tabs/utils";
 
 vi.mock("components/ProjectSelect", () => ({
@@ -29,6 +31,7 @@ const navItems = [
 describe("Feature flag tests for DEVPROD-31534", () => {
   beforeEach(() => {
     vi.resetModules();
+    Cookies.set(SEEN_GITHUB_NAV_GUIDE_CUE, "true");
   });
 
   navItems.forEach(({ dataCy, tabLabel }) => {

--- a/apps/spruce/src/pages/projectAndRepoSettings/shared/index.tsx
+++ b/apps/spruce/src/pages/projectAndRepoSettings/shared/index.tsx
@@ -1,3 +1,4 @@
+import { useRef } from "react";
 import styled from "@emotion/styled";
 import { FormSkeleton } from "@leafygreen-ui/skeleton-loader";
 import { useParams, Link, Navigate } from "react-router-dom";
@@ -24,6 +25,7 @@ import { ProjectSettingsQuery, RepoSettingsQuery } from "gql/generated/types";
 import { ProjectSettingsProvider } from "./Context";
 import { CreateDuplicateProjectButton } from "./CreateDuplicateProjectButton";
 import { getTabTitle } from "./getTabTitle";
+import { GithubNavGuideCue } from "./GithubNavGuideCue";
 import { ProjectSettingsTabs } from "./Tabs";
 import { projectOnlyTabs } from "./tabs/types";
 import { ProjectType } from "./tabs/utils";
@@ -79,6 +81,7 @@ const SharedSettings: React.FC<SharedSettingsProps> = ({
   const otherTabs: ProjectSettingsTabRoutes[] = [
     ProjectSettingsTabRoutes.EventLog,
   ];
+  const githubGroupRef = useRef<HTMLDivElement | null>(null);
 
   if (!tabRouteValues.includes(tab as ProjectSettingsTabRoutes)) {
     return (
@@ -134,7 +137,7 @@ const SharedSettings: React.FC<SharedSettingsProps> = ({
 
           {showNewProjectNavigation ? (
             <>
-              {/* Grouped, collapsible nav when feature flag is on */}
+              {/* Grouped nav when feature flag is on */}
               <SideNavGroup
                 glyph={<Icon glyph="EvergreenLogo" />}
                 header="Evergreen"
@@ -151,25 +154,26 @@ const SharedSettings: React.FC<SharedSettingsProps> = ({
                   />
                 ))}
               </SideNavGroup>
-
-              <SideNavGroup
-                collapsible
-                glyph={<Icon glyph="GitHub" />}
-                header="GitHub"
-              >
-                {githubTabs.map((v) => (
-                  <SharedSettingsNavItem
-                    key={v}
-                    currentTab={tab ?? ProjectSettingsTabRoutes.General}
-                    getRoute={
-                      isRepo ? getRepoSettingsRoute : getProjectSettingsRoute
-                    }
-                    id={isRepo ? repoId : projectIdentifier}
-                    tab={v}
-                  />
-                ))}
-              </SideNavGroup>
-
+              <div ref={githubGroupRef}>
+                <SideNavGroup
+                  collapsible
+                  glyph={<Icon glyph="GitHub" />}
+                  header="GitHub"
+                >
+                  {githubTabs.map((v) => (
+                    <SharedSettingsNavItem
+                      key={v}
+                      currentTab={tab ?? ProjectSettingsTabRoutes.General}
+                      getRoute={
+                        isRepo ? getRepoSettingsRoute : getProjectSettingsRoute
+                      }
+                      id={isRepo ? repoId : projectIdentifier}
+                      tab={v}
+                    />
+                  ))}
+                </SideNavGroup>
+                <GithubNavGuideCue refEl={githubGroupRef} />
+              </div>
               <SideNavGroup glyph={<Icon glyph="List" />} header="ChangeLog">
                 {otherTabs.map((v) => (
                   <SharedSettingsNavItem


### PR DESCRIPTION
DEVPROD-32609

### Description
Since we have chosen to add a collapsible section for the new GitHub tabs, this PR introduces a GuideCue so that users are notified of the changes.

### Screenshots
<img width="589" height="630" alt="Screenshot 2026-05-01 at 10 23 56 AM" src="https://github.com/user-attachments/assets/2af30e31-fd24-49a0-a803-7107f73bf9b9" />

### Testing
None
