### PR TITLE
DEVPROD-32254: Add a tooltip to move vars to repo to reduce scaryness

### DIFF
--- a/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/VariablesTab/PromoteVariablesModal.tsx
+++ b/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/VariablesTab/PromoteVariablesModal.tsx
@@ -185,25 +185,14 @@ export const PromoteVariablesModalButton: React.FC<
           variables={variables}
         />
       )}
-      <Tooltip
-        data-cy="promote-vars-tooltip"
-        trigger={
-          <Button
-            data-cy="promote-vars-button"
-            disabled={!canEdit}
-            onClick={() => setModalOpen(true)}
-            size={Size.Small}
-          >
-            Move variables to repo
-          </Button>
-        }
-        triggerEvent="hover"
+      <Button
+        data-cy="promote-vars-button"
+        disabled={!canEdit}
+        onClick={() => setModalOpen(true)}
+        size={Size.Small}
       >
-        <TooltipContainer>
-          Opens a confirmation modal where you can select which variables to
-          move to the repo.
-        </TooltipContainer>
-      </Tooltip>
+        Select variables to move to repo
+      </Button>
     </>
   );
 };

--- a/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/VariablesTab/PromoteVariablesModal.tsx
+++ b/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/VariablesTab/PromoteVariablesModal.tsx
@@ -190,6 +190,7 @@ export const PromoteVariablesModalButton: React.FC<
         disabled={!canEdit}
         onClick={() => setModalOpen(true)}
         size={Size.Small}
+        title="Opens a confirmation modal where you can select which variables to move to the repo."
       >
         Select variables to move to repo
       </Button>

--- a/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/VariablesTab/PromoteVariablesModal.tsx
+++ b/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/VariablesTab/PromoteVariablesModal.tsx
@@ -185,14 +185,25 @@ export const PromoteVariablesModalButton: React.FC<
           variables={variables}
         />
       )}
-      <Button
-        data-cy="promote-vars-button"
-        disabled={!canEdit}
-        onClick={() => setModalOpen(true)}
-        size={Size.Small}
+      <Tooltip
+        data-cy="promote-vars-tooltip"
+        trigger={
+          <Button
+            data-cy="promote-vars-button"
+            disabled={!canEdit}
+            onClick={() => setModalOpen(true)}
+            size={Size.Small}
+          >
+            Move variables to repo
+          </Button>
+        }
+        triggerEvent="hover"
       >
-        Move variables to repo
-      </Button>
+        <TooltipContainer>
+          Opens a confirmation modal where you can select which variables to
+          move to the repo.
+        </TooltipContainer>
+      </Tooltip>
     </>
   );
 };


### PR DESCRIPTION
[DEVPROD-32254](https://jira.mongodb.org/browse/DEVPROD-32254)

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->

<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
Changing the copy to make it less scary and action focused and implying a next step.

### Screenshots
<img width="558" height="392" alt="Screenshot 2026-05-05 at 11 08 35 AM" src="https://github.com/user-attachments/assets/3c0460da-bc85-40a0-8195-5d425d5670fa" />


### Testing
* Smoke tested locally 