### PR TITLE
DEVPROD-26582: Remove `notifyOnNetworkStatusChange` at global level

### DIFF
--- a/apps/spruce/src/gql/client/useCreateGQLClient/index.ts
+++ b/apps/spruce/src/gql/client/useCreateGQLClient/index.ts
@@ -69,12 +69,6 @@ export const useCreateGQLClient = (): ApolloClient | undefined => {
       new ApolloClient({
         cache,
         localState: new LocalState(), // Must define if using @client fields.
-        defaultOptions: {
-          watchQuery: {
-            // TODO DEVPROD-26582: It's probably better to use the new default of 'true', but this avoids many errors for now.
-            notifyOnNetworkStatusChange: false,
-          },
-        },
         link: authenticateIfSuccessfulLink(() =>
           dispatchAuthenticatedRef.current(),
         )


### PR DESCRIPTION
DEVPROD-26582

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->

<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
The default is true so we should probably stick to the recommended default