### PR TITLE
DEVPROD-32874: Fix bug where Test Selection tab is missing from Project Settings

### DIFF
--- a/apps/spruce/src/pages/projectAndRepoSettings/shared/index.tsx
+++ b/apps/spruce/src/pages/projectAndRepoSettings/shared/index.tsx
@@ -66,6 +66,7 @@ const SharedSettings: React.FC<SharedSettingsProps> = ({
     ProjectSettingsTabRoutes.ViewsAndFilters,
     ProjectSettingsTabRoutes.ProjectTriggers,
     ProjectSettingsTabRoutes.PeriodicBuilds,
+    ProjectSettingsTabRoutes.TestSelection,
     ProjectSettingsTabRoutes.Plugins,
   ];
   const githubTabs: ProjectSettingsTabRoutes[] = [


### PR DESCRIPTION
DEVPROD-32874

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->

<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
The tab is missing from the page
