### PR TITLE
DEVPROD-32887: Use retryable assertions in Playwright tests

### DIFF
--- a/apps/parsley/playwright/helpers/index.ts
+++ b/apps/parsley/playwright/helpers/index.ts
@@ -136,14 +136,15 @@ export const isNotContainedInViewport = async (
 };
 
 export const toggleDetailsPanel = async (page: Page, open: boolean) => {
-  await expect(page.getByTestId("details-button")).toBeEnabled();
+  const detailsButton = page.getByRole("button", { name: "Details" });
+  await expect(detailsButton).toBeEnabled();
   if (open) {
     await expect(page.getByTestId("details-menu")).toBeHidden();
-    await page.getByTestId("details-button").click();
+    await detailsButton.click();
     await expect(page.getByTestId("details-menu")).toBeVisible();
   } else {
     await expect(page.getByTestId("details-menu")).toBeVisible();
-    await page.getByTestId("details-button").click();
+    await detailsButton.click();
     await expect(page.getByTestId("details-menu")).toBeHidden();
   }
 };

--- a/apps/parsley/playwright/tests/ai.spec.ts
+++ b/apps/parsley/playwright/tests/ai.spec.ts
@@ -6,12 +6,10 @@ const logLink =
 test.describe("Parsley AI", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto(logLink);
+    await expect(page.getByTestId("ansi-row")).not.toHaveCount(0);
   });
 
   test("opens the AI drawer and logs in", async ({ page }) => {
-    await page.locator("[data-cy^='log-row-']").first().waitFor();
-    expect(await page.getByTestId("ansi-row").count()).toBeGreaterThan(0);
-
     const parsleyAIButton = page.getByRole("button", {
       name: "Parsley AI",
     });

--- a/apps/parsley/playwright/tests/ansiLogs/ansi_filtering.spec.ts
+++ b/apps/parsley/playwright/tests/ansiLogs/ansi_filtering.spec.ts
@@ -123,11 +123,13 @@ test.describe("Filtering", () => {
           await expect(page.getByTestId("ansi-row")).not.toHaveCount(0);
           await page
             .getByTestId(`filter-${filter1}`)
-            .getByRole("button", { name: "Hide filter" })
+            .getByTestId("accordion-toggle")
+            .getByRole("switch", { name: "Hide filter" })
             .click();
           await page
             .getByTestId(`filter-${filter2}`)
-            .getByRole("button", { name: "Hide filter" })
+            .getByTestId("accordion-toggle")
+            .getByRole("switch", { name: "Hide filter" })
             .click();
           await expect(page).toHaveURL(
             new RegExp(`filters=010${filter1},001${filter2}`),
@@ -214,11 +216,13 @@ test.describe("Filtering", () => {
           await expect(page.getByTestId("ansi-row")).not.toHaveCount(0);
           await page
             .getByTestId(`filter-${filter1}`)
-            .getByRole("button", { name: "Hide filter" })
+            .getByTestId("accordion-toggle")
+            .getByRole("switch", { name: "Hide filter" })
             .click();
           await page
             .getByTestId(`filter-${filter2}`)
-            .getByRole("button", { name: "Hide filter" })
+            .getByTestId("accordion-toggle")
+            .getByRole("switch", { name: "Hide filter" })
             .click();
           await expect(page).toHaveURL(
             new RegExp(`filters=010${filter1},001${filter2}`),
@@ -243,6 +247,7 @@ test.describe("Filtering", () => {
     test("should be able to edit a filter", async ({ page }) => {
       await page
         .getByTestId(`filter-${filter}`)
+        .getByTestId("accordion-toggle")
         .getByRole("button", { name: "Edit filter" })
         .click();
       await page.getByTestId("edit-filter-name").clear();
@@ -263,6 +268,7 @@ test.describe("Filtering", () => {
     test("should be able to delete a filter", async ({ page }) => {
       await page
         .getByTestId(`filter-${filter}`)
+        .getByTestId("accordion-toggle")
         .getByRole("button", { name: "Delete filter" })
         .click();
       await expect(page).toHaveURL(/^(?!.*filters)/);

--- a/apps/parsley/playwright/tests/ansiLogs/ansi_filtering.spec.ts
+++ b/apps/parsley/playwright/tests/ansiLogs/ansi_filtering.spec.ts
@@ -123,11 +123,11 @@ test.describe("Filtering", () => {
           await expect(page.getByTestId("ansi-row")).not.toHaveCount(0);
           await page
             .getByTestId(`filter-${filter1}`)
-            .locator('[aria-label="Hide filter"]')
+            .getByRole("button", { name: "Hide filter" })
             .click();
           await page
             .getByTestId(`filter-${filter2}`)
-            .locator('[aria-label="Hide filter"]')
+            .getByRole("button", { name: "Hide filter" })
             .click();
           await expect(page).toHaveURL(
             new RegExp(`filters=010${filter1},001${filter2}`),
@@ -214,11 +214,11 @@ test.describe("Filtering", () => {
           await expect(page.getByTestId("ansi-row")).not.toHaveCount(0);
           await page
             .getByTestId(`filter-${filter1}`)
-            .locator('[aria-label="Hide filter"]')
+            .getByRole("button", { name: "Hide filter" })
             .click();
           await page
             .getByTestId(`filter-${filter2}`)
-            .locator('[aria-label="Hide filter"]')
+            .getByRole("button", { name: "Hide filter" })
             .click();
           await expect(page).toHaveURL(
             new RegExp(`filters=010${filter1},001${filter2}`),
@@ -243,7 +243,7 @@ test.describe("Filtering", () => {
     test("should be able to edit a filter", async ({ page }) => {
       await page
         .getByTestId(`filter-${filter}`)
-        .locator('[aria-label="Edit filter"]')
+        .getByRole("button", { name: "Edit filter" })
         .click();
       await page.getByTestId("edit-filter-name").clear();
       await page.getByTestId("edit-filter-name").fill("running");
@@ -263,7 +263,7 @@ test.describe("Filtering", () => {
     test("should be able to delete a filter", async ({ page }) => {
       await page
         .getByTestId(`filter-${filter}`)
-        .locator('[aria-label="Delete filter"]')
+        .getByRole("button", { name: "Delete filter" })
         .click();
       await expect(page).toHaveURL(/^(?!.*filters)/);
       const skippedLines = page.locator("[data-cy^='skipped-lines-row-']");

--- a/apps/parsley/playwright/tests/ansiLogs/ansi_filtering.spec.ts
+++ b/apps/parsley/playwright/tests/ansiLogs/ansi_filtering.spec.ts
@@ -10,6 +10,7 @@ test.describe("Filtering", () => {
       test.beforeEach(async ({ page }) => {
         await page.goto(logLink);
         await expect(page.getByTestId("paginated-virtual-list")).toBeVisible();
+        await expect(page.getByTestId("ansi-row")).not.toHaveCount(0);
       });
 
       test("should not collapse bookmarks and share line", async ({ page }) => {
@@ -18,7 +19,9 @@ test.describe("Filtering", () => {
         await expect(page).toHaveURL(/\?bookmarks=0,6,297&shareLine=5/);
         await helpers.addFilter(page, "doesNotMatchAnything");
 
-        const logRows = await page.locator("[data-cy^='log-row-']").all();
+        const filteredRows = page.locator("[data-cy^='log-row-']");
+        await expect(filteredRows).toHaveCount(4);
+        const logRows = await filteredRows.all();
         for (const row of logRows) {
           const dataCy = await row.getAttribute("data-cy");
           expect(dataCy).toMatch(/log-row-(0|5|6|297)/);
@@ -47,25 +50,21 @@ test.describe("Filtering", () => {
           page,
         }) => {
           await page.goto(`${logLink}?filterLogic=and`);
+          await expect(page.getByTestId("ansi-row")).not.toHaveCount(0);
           await helpers.addFilter(page, filter1);
           await helpers.addFilter(page, filter2);
           await expect(page).toHaveURL(
             new RegExp(`filters=100${filter1},100${filter2}`),
           );
 
-          // Wait for filtered rows to load.
-          await page
-            .locator("[data-cy^='log-row-']:not([data-bookmarked=true])")
-            .first()
-            .waitFor();
-
-          const logRows = await page
-            .locator("[data-cy^='log-row-']:not([data-bookmarked=true])")
-            .all();
+          const filteredRows = page.locator(
+            "[data-cy^='log-row-']:not([data-bookmarked=true])",
+          );
+          await expect(filteredRows).not.toHaveCount(0);
+          const logRows = await filteredRows.all();
           for (const row of logRows) {
-            const text = await row.innerText();
-            expect(text.toLowerCase()).toContain(filter1.toLowerCase());
-            expect(text.toLowerCase()).toContain(filter2.toLowerCase());
+            await expect(row).toContainText(filter1, { ignoreCase: true });
+            await expect(row).toContainText(filter2, { ignoreCase: true });
           }
         });
 
@@ -73,6 +72,7 @@ test.describe("Filtering", () => {
           await page.goto(
             `${logLink}?filterLogic=and&filters=100${filter1},100${filter2}`,
           );
+          await expect(page.getByTestId("ansi-row")).not.toHaveCount(0);
           await page
             .getByTestId(`filter-${filter1}`)
             .getByText("Sensitive", { exact: true })
@@ -81,13 +81,14 @@ test.describe("Filtering", () => {
             new RegExp(`filters=110${filter1},100${filter2}`),
           );
 
-          const logRows = await page
-            .locator("[data-cy^='log-row-']:not([data-bookmarked=true])")
-            .all();
+          const filteredRows = page.locator(
+            "[data-cy^='log-row-']:not([data-bookmarked=true])",
+          );
+          await expect(filteredRows).not.toHaveCount(0);
+          const logRows = await filteredRows.all();
           for (const row of logRows) {
-            const text = await row.innerText();
-            expect(text).toContain(filter1);
-            expect(text.toLowerCase()).toContain(filter2.toLowerCase());
+            await expect(row).toContainText(filter1, { ignoreCase: false });
+            await expect(row).toContainText(filter2, { ignoreCase: true });
           }
         });
 
@@ -95,6 +96,7 @@ test.describe("Filtering", () => {
           await page.goto(
             `${logLink}?filterLogic=and&filters=110${filter1},100${filter2}`,
           );
+          await expect(page.getByTestId("ansi-row")).not.toHaveCount(0);
           await page
             .getByTestId(`filter-${filter2}`)
             .getByText("Inverse", { exact: true })
@@ -103,13 +105,14 @@ test.describe("Filtering", () => {
             new RegExp(`filters=110${filter1},101${filter2}`),
           );
 
-          const logRows = await page
-            .locator("[data-cy^='log-row-']:not([data-bookmarked=true])")
-            .all();
+          const filteredRows = page.locator(
+            "[data-cy^='log-row-']:not([data-bookmarked=true])",
+          );
+          await expect(filteredRows).not.toHaveCount(0);
+          const logRows = await filteredRows.all();
           for (const row of logRows) {
-            const text = await row.innerText();
-            expect(text).toContain(filter1);
-            expect(text).not.toContain(filter2);
+            await expect(row).toContainText(filter1, { ignoreCase: false });
+            await expect(row).not.toContainText(filter2, { ignoreCase: true });
           }
         });
 
@@ -117,6 +120,7 @@ test.describe("Filtering", () => {
           await page.goto(
             `${logLink}?filterLogic=and&filters=110${filter1},101${filter2}`,
           );
+          await expect(page.getByTestId("ansi-row")).not.toHaveCount(0);
           await page
             .getByTestId(`filter-${filter1}`)
             .locator('[aria-label="Hide filter"]')
@@ -128,9 +132,8 @@ test.describe("Filtering", () => {
           await expect(page).toHaveURL(
             new RegExp(`filters=010${filter1},001${filter2}`),
           );
-          await expect(
-            page.locator("[data-cy^='skipped-lines-row-']"),
-          ).toHaveCount(0);
+          const skippedLines = page.locator("[data-cy^='skipped-lines-row-']");
+          await expect(skippedLines).toHaveCount(0);
         });
       });
 
@@ -139,24 +142,20 @@ test.describe("Filtering", () => {
           page,
         }) => {
           await page.goto(`${logLink}?filterLogic=or`);
+          await expect(page.getByTestId("ansi-row")).not.toHaveCount(0);
           await helpers.addFilter(page, filter1);
           await helpers.addFilter(page, filter2);
           await expect(page).toHaveURL(
             new RegExp(`filters=100${filter1},100${filter2}`),
           );
 
-          // Wait for filtered rows to load.
-          await page
-            .locator("[data-cy^='log-row-']:not([data-bookmarked=true])")
-            .first()
-            .waitFor();
-
-          const logRows = await page
-            .locator("[data-cy^='log-row-']:not([data-bookmarked=true])")
-            .all();
+          const filteredRows = page.locator(
+            "[data-cy^='log-row-']:not([data-bookmarked=true])",
+          );
+          await expect(filteredRows).not.toHaveCount(0);
+          const logRows = await filteredRows.all();
           for (const row of logRows) {
-            const text = await row.innerText();
-            expect(text.toLowerCase()).toMatch(/warning|storybook/);
+            await expect(row).toContainText(/warning|storybook/i);
           }
         });
 
@@ -164,6 +163,7 @@ test.describe("Filtering", () => {
           await page.goto(
             `${logLink}?filterLogic=or&filters=100${filter1},100${filter2}`,
           );
+          await expect(page.getByTestId("ansi-row")).not.toHaveCount(0);
           await page
             .getByTestId(`filter-${filter1}`)
             .getByText("Sensitive", { exact: true })
@@ -172,21 +172,22 @@ test.describe("Filtering", () => {
             new RegExp(`filters=110${filter1},100${filter2}`),
           );
 
-          const logRows = await page
-            .locator("[data-cy^='log-row-']:not([data-bookmarked=true])")
-            .all();
-          for (const row of logRows) {
-            const text = await row.innerText();
-            const matchesFilter1 = text.includes("Warning");
-            const matchesFilter2 = text.toLowerCase().includes("storybook");
-            expect(matchesFilter1 || matchesFilter2).toBe(true);
-          }
+          const filteredRows = page.locator(
+            "[data-cy^='log-row-']:not([data-bookmarked=true])",
+          );
+          await expect(filteredRows).not.toHaveCount(0);
+          await expect(
+            filteredRows
+              .filter({ hasNotText: /Warning/ })
+              .filter({ hasNotText: /storybook/i }),
+          ).toHaveCount(0);
         });
 
         test("should be able to toggle inverse matching", async ({ page }) => {
           await page.goto(
             `${logLink}?filterLogic=or&filters=110${filter1},100${filter2}`,
           );
+          await expect(page.getByTestId("ansi-row")).not.toHaveCount(0);
           await page
             .getByTestId(`filter-${filter2}`)
             .getByText("Inverse", { exact: true })
@@ -195,23 +196,22 @@ test.describe("Filtering", () => {
             new RegExp(`filters=110${filter1},101${filter2}`),
           );
 
-          const logRows = await page
-            .locator("[data-cy^='log-row-']:not([data-bookmarked=true])")
-            .all();
-          for (const row of logRows) {
-            const text = await row.innerText();
-            const matchesFilter1 = text.includes("Warning");
-            const doesNotMatchFilter2 = !text
-              .toLowerCase()
-              .includes("storybook");
-            expect(matchesFilter1 || doesNotMatchFilter2).toBe(true);
-          }
+          const filteredRows = page.locator(
+            "[data-cy^='log-row-']:not([data-bookmarked=true])",
+          );
+          await expect(filteredRows).not.toHaveCount(0);
+          await expect(
+            filteredRows
+              .filter({ hasNotText: /Warning/ })
+              .filter({ hasText: /storybook/i }),
+          ).toHaveCount(0);
         });
 
         test("should be able to toggle visibility", async ({ page }) => {
           await page.goto(
             `${logLink}?filterLogic=or&filters=110${filter1},101${filter2}`,
           );
+          await expect(page.getByTestId("ansi-row")).not.toHaveCount(0);
           await page
             .getByTestId(`filter-${filter1}`)
             .locator('[aria-label="Hide filter"]')
@@ -223,9 +223,8 @@ test.describe("Filtering", () => {
           await expect(page).toHaveURL(
             new RegExp(`filters=010${filter1},001${filter2}`),
           );
-          await expect(
-            page.locator("[data-cy^='skipped-lines-row-']"),
-          ).toHaveCount(0);
+          const skippedLines = page.locator("[data-cy^='skipped-lines-row-']");
+          await expect(skippedLines).toHaveCount(0);
         });
       });
     });
@@ -236,10 +235,9 @@ test.describe("Filtering", () => {
 
     test.beforeEach(async ({ page }) => {
       await page.goto(`${logLink}?filters=100${filter}`);
-      await page.locator("[data-cy^='skipped-lines-row-']").first().waitFor();
-      expect(
-        await page.locator("[data-cy^='skipped-lines-row-']").count(),
-      ).toBeGreaterThan(0);
+      await expect(page.getByTestId("ansi-row")).toHaveCount(0);
+      const skippedLines = page.locator("[data-cy^='skipped-lines-row-']");
+      await expect(skippedLines).not.toHaveCount(0);
     });
 
     test("should be able to edit a filter", async ({ page }) => {
@@ -252,12 +250,13 @@ test.describe("Filtering", () => {
       await page.getByRole("button", { name: "Apply" }).click();
       await expect(page).toHaveURL(/filters=100running/);
 
-      const logRows = await page
-        .locator("[data-cy^='log-row-']:not([data-bookmarked=true])")
-        .all();
+      const filteredRows = page.locator(
+        "[data-cy^='log-row-']:not([data-bookmarked=true])",
+      );
+      await expect(filteredRows).not.toHaveCount(0);
+      const logRows = await filteredRows.all();
       for (const row of logRows) {
-        const text = await row.innerText();
-        expect(text.toLowerCase()).toContain("running");
+        await expect(row).toContainText("running", { ignoreCase: true });
       }
     });
 
@@ -267,9 +266,8 @@ test.describe("Filtering", () => {
         .locator('[aria-label="Delete filter"]')
         .click();
       await expect(page).toHaveURL(/^(?!.*filters)/);
-      await expect(page.locator("[data-cy^='skipped-lines-row-']")).toHaveCount(
-        0,
-      );
+      const skippedLines = page.locator("[data-cy^='skipped-lines-row-']");
+      await expect(skippedLines).toHaveCount(0);
     });
   });
 
@@ -279,31 +277,20 @@ test.describe("Filtering", () => {
 
     test("should be able to hide and unhide filters", async ({ page }) => {
       await page.goto(`${logLink}?filters=110${filter1},100${filter2}`);
-      await page.locator("[data-cy^='skipped-lines-row-']").first().waitFor();
-      expect(
-        await page.locator("[data-cy^='skipped-lines-row-']").count(),
-      ).toBeGreaterThan(0);
+      await expect(page.getByTestId("ansi-row")).toHaveCount(0);
+      const skippedLines = page.locator("[data-cy^='skipped-lines-row-']");
+      await expect(skippedLines).not.toHaveCount(0);
 
       await page.getByTestId("all-filters-toggle").click();
-      await expect(page.getByTestId("all-filters-toggle")).toHaveAttribute(
-        "aria-checked",
-        "false",
-      );
-      await expect(page.locator("[data-cy^='skipped-lines-row-']")).toHaveCount(
-        0,
-      );
+      await expect(page.getByTestId("all-filters-toggle")).not.toBeChecked();
+      await expect(skippedLines).toHaveCount(0);
       await expect(page).toHaveURL(
         new RegExp(`filters=010${filter1},000${filter2}`),
       );
 
       await page.getByTestId("all-filters-toggle").click();
-      await expect(page.getByTestId("all-filters-toggle")).toHaveAttribute(
-        "aria-checked",
-        "true",
-      );
-      expect(
-        await page.locator("[data-cy^='skipped-lines-row-']").count(),
-      ).toBeGreaterThan(0);
+      await expect(page.getByTestId("all-filters-toggle")).toBeChecked();
+      await expect(skippedLines).not.toHaveCount(0);
       await expect(page).toHaveURL(
         new RegExp(`filters=110${filter1},100${filter2}`),
       );

--- a/apps/parsley/playwright/tests/ansiLogs/ansi_highlighting.spec.ts
+++ b/apps/parsley/playwright/tests/ansiLogs/ansi_highlighting.spec.ts
@@ -7,6 +7,7 @@ const logLink =
 test.describe("Highlighting", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto(logLink);
+    await expect(page.getByTestId("ansi-row")).not.toHaveCount(0);
   });
 
   test("applying a highlight should highlight the matching words", async ({
@@ -15,7 +16,7 @@ test.describe("Highlighting", () => {
     await helpers.addHighlight(page, "@bugsnag/plugin-react@");
     const highlights = page.getByTestId("highlight");
     await expect(highlights).toHaveCount(1);
-    await expect(highlights.first()).toContainText("@bugsnag/plugin-react@");
+    await expect(highlights).toContainText("@bugsnag/plugin-react@");
   });
 
   test("applying a search to a highlighted line should not overwrite an already highlighted term if the search matches the highlight", async ({
@@ -25,7 +26,7 @@ test.describe("Highlighting", () => {
     await helpers.addSearch(page, "@bugsnag/plugin-react@");
     const highlights = page.getByTestId("highlight");
     await expect(highlights).toHaveCount(1);
-    await expect(highlights.first()).toContainText("@bugsnag/plugin-react");
+    await expect(highlights).toContainText("@bugsnag/plugin-react@");
   });
 
   test("should highlight other terms in the log if the search term does not match the highlight", async ({
@@ -33,12 +34,12 @@ test.describe("Highlighting", () => {
   }) => {
     await helpers.addHighlight(page, "@bugsnag/plugin-react@");
     await helpers.addSearch(page, "info");
+
     const highlights = page.getByTestId("highlight");
     await expect(highlights).toHaveCount(5);
     const highlightElements = await highlights.all();
     for (const element of highlightElements) {
-      const text = await element.innerText();
-      expect(text).toMatch(/@bugsnag\/plugin-react@|info/);
+      await expect(element).toContainText(/@bugsnag\/plugin-react@|info/);
     }
   });
 
@@ -47,7 +48,7 @@ test.describe("Highlighting", () => {
   }) => {
     await helpers.addHighlight(page, "@bugsnag/plugin-react@");
     const highlights = page.getByTestId("highlight");
-    expect(await highlights.count()).toBeGreaterThan(0);
+    await expect(highlights).not.toHaveCount(0);
 
     await expect(page.getByTestId("delete-highlight-button")).toBeVisible();
     await page.getByTestId("delete-highlight-button").click();
@@ -59,13 +60,12 @@ test.describe("Highlighting", () => {
   }) => {
     await helpers.addHighlight(page, "@bugsnag/plugin-react@");
     await helpers.addHighlight(page, "info");
+
     const highlights = page.getByTestId("highlight");
     await expect(highlights).toHaveCount(5);
-
     const highlightElements = await highlights.all();
     for (const element of highlightElements) {
-      const text = await element.innerText();
-      expect(text).toMatch(/@bugsnag\/plugin-react@|info/);
+      await expect(element).toContainText(/@bugsnag\/plugin-react@|info/);
     }
 
     const colors = new Set<string>();
@@ -80,6 +80,7 @@ test.describe("Highlighting", () => {
 
   test("highlights should not corrupt links", async ({ page }) => {
     await page.goto(`${logLink}?shareLine=200`);
+    await expect(page.getByTestId("ansi-row")).not.toHaveCount(0);
     await helpers.addHighlight(page, "github");
     await helpers.addHighlight(page, "storybook");
 
@@ -101,11 +102,11 @@ test.describe("Highlighting", () => {
     );
     await helpers.addFilter(page, "task");
     const highlights = page.getByTestId("highlight");
-    expect(await highlights.count()).toBeGreaterThan(0);
+    await expect(highlights).not.toHaveCount(0);
 
     const sideNavHighlights = page.getByTestId("side-nav-highlight");
     await expect(sideNavHighlights).toHaveCount(1);
-    await expect(sideNavHighlights.first()).toContainText("task");
+    await expect(sideNavHighlights).toContainText("task");
   });
 
   test("should not add a highlight when a filter term is added if `Apply Highlights to Filters` is disabled", async ({

--- a/apps/parsley/playwright/tests/ansiLogs/ansi_highlighting.spec.ts
+++ b/apps/parsley/playwright/tests/ansiLogs/ansi_highlighting.spec.ts
@@ -50,8 +50,11 @@ test.describe("Highlighting", () => {
     const highlights = page.getByTestId("highlight");
     await expect(highlights).not.toHaveCount(0);
 
-    await expect(page.getByTestId("delete-highlight-button")).toBeVisible();
-    await page.getByTestId("delete-highlight-button").click();
+    const deleteHighlightButton = page.getByRole("button", {
+      name: "Delete highlight",
+    });
+    await expect(deleteHighlightButton).toBeVisible();
+    await deleteHighlightButton.click();
     await expect(highlights).toHaveCount(0);
   });
 

--- a/apps/parsley/playwright/tests/ansiLogs/ansi_log_view.spec.ts
+++ b/apps/parsley/playwright/tests/ansiLogs/ansi_log_view.spec.ts
@@ -274,8 +274,11 @@ test.describe("Sharing lines", () => {
     page,
   }) => {
     await page.getByTestId("line-index-1").click();
-    await expect(page.getByTestId("sharing-menu-button")).toBeVisible();
-    await page.getByTestId("sharing-menu-button").click();
+    const sharingMenuButton = page.getByRole("button", {
+      name: "Expand share menu",
+    });
+    await expect(sharingMenuButton).toBeVisible();
+    await sharingMenuButton.click();
     await expect(page.getByTestId("sharing-menu")).toBeVisible();
   });
 

--- a/apps/parsley/playwright/tests/ansiLogs/ansi_log_view.spec.ts
+++ b/apps/parsley/playwright/tests/ansiLogs/ansi_log_view.spec.ts
@@ -9,12 +9,7 @@ test.describe("Basic evergreen log view", () => {
 
   test.beforeEach(async ({ page }) => {
     await page.goto(logLink);
-  });
-
-  test("should render ansi lines", async ({ page }) => {
-    const ansiRows = page.getByTestId("ansi-row");
-    await ansiRows.first().waitFor();
-    expect(await ansiRows.count()).toBeGreaterThan(0);
+    await expect(page.getByTestId("ansi-row")).not.toHaveCount(0);
   });
 
   test("by default should have wrapping turned off and should be able to scroll horizontally", async ({
@@ -80,6 +75,7 @@ test.describe("Basic evergreen log view", () => {
 test.describe("Bookmarking and selecting lines", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto(logLink);
+    await expect(page.getByTestId("ansi-row")).not.toHaveCount(0);
   });
 
   test("should default to bookmarking 0 and the last log line on load", async ({
@@ -100,8 +96,8 @@ test.describe("Bookmarking and selecting lines", () => {
     await expect(page.getByTestId("bookmark-list")).toContainText("297");
     await page.getByTestId("log-row-4").dblclick();
     await expect(page).toHaveURL(/\?bookmarks=0,297/);
-    const bookmarkList = await page.getByTestId("bookmark-list").innerText();
-    expect(bookmarkList).not.toContain("4");
+    const bookmarkList = page.getByTestId("bookmark-list");
+    await expect(bookmarkList).not.toContainText("4");
   });
 
   test("should be able to set and unset the share line", async ({ page }) => {
@@ -112,8 +108,8 @@ test.describe("Bookmarking and selecting lines", () => {
     await expect(page.getByTestId("bookmark-list")).toContainText("297");
     await page.getByTestId("log-link-5").click();
     await expect(page).toHaveURL(/\?bookmarks=0,297/);
-    const bookmarkList = await page.getByTestId("bookmark-list").innerText();
-    expect(bookmarkList).not.toContain("5");
+    const bookmarkList = page.getByTestId("bookmark-list");
+    await expect(bookmarkList).not.toContainText("5");
   });
 
   test("should be able to copy bookmarks as JIRA format", async ({ page }) => {
@@ -175,6 +171,7 @@ test.describe("Jump to line", () => {
     page,
   }) => {
     await page.goto(logLink);
+    await expect(page.locator("[data-cy^='log-row-']")).not.toHaveCount(0);
     await expect(page.getByTestId("log-row-4")).toBeVisible();
     await page.getByTestId("log-row-4").dblclick();
     await expect(page.getByTestId("bookmark-4")).toBeVisible();
@@ -190,6 +187,7 @@ test.describe("Jump to line", () => {
     page,
   }) => {
     await page.goto(`${logLink}?filters=100pass`);
+    await expect(page.locator("[data-cy^='log-row-']")).not.toHaveCount(0);
     await page.getByTestId("log-row-56").dblclick();
     await expect(page.getByTestId("bookmark-56")).toBeVisible();
 
@@ -204,6 +202,7 @@ test.describe("Jump to line", () => {
     page,
   }) => {
     await page.goto(`${logLink}?shareLine=200`);
+    await expect(page.getByTestId("ansi-row")).not.toHaveCount(0);
     await expect(page.getByTestId("log-row-200")).toBeVisible();
   });
 });
@@ -214,6 +213,7 @@ test.describe("expanding collapsed rows", () => {
 
   test.beforeEach(async ({ page }) => {
     await page.goto(logLinkWithFilters);
+    await expect(page.getByTestId("ansi-row")).not.toHaveCount(0);
   });
 
   test("should be able to expand collapsed rows", async ({ page }) => {
@@ -264,6 +264,7 @@ test.describe("expanding collapsed rows", () => {
 test.describe("Sharing lines", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto(logLink);
+    await expect(page.getByTestId("ansi-row")).not.toHaveCount(0);
     await expect(page.getByTestId("line-index-1")).toBeVisible();
   });
 
@@ -336,6 +337,7 @@ test.describe("jump to failing log line", () => {
 
   test.beforeEach(async ({ page }) => {
     await page.goto(failingLogLink);
+    await expect(page.getByTestId("ansi-row")).not.toHaveCount(0);
   });
 
   test("should jump to failing log line based on user setting", async ({
@@ -348,6 +350,7 @@ test.describe("jump to failing log line", () => {
       "log-viewing",
     );
     await page.reload();
+    await expect(page.getByTestId("ansi-row")).not.toHaveCount(0);
     await expect(page.getByTestId("bookmark-list")).toContainText("9614");
     await expect(page.getByTestId("log-row-0")).toBeVisible();
     await expect(page.getByTestId("log-row-9614")).toBeHidden();
@@ -359,6 +362,7 @@ test.describe("jump to failing log line", () => {
       "log-viewing",
     );
     await page.reload();
+    await expect(page.getByTestId("ansi-row")).not.toHaveCount(0);
     await expect(page.getByTestId("bookmark-list")).toContainText("9614");
     await expect(page.getByTestId("log-row-9614")).toBeVisible();
     await expect(page.getByTestId("log-row-0")).toBeHidden();
@@ -368,25 +372,17 @@ test.describe("jump to failing log line", () => {
 test.describe("sections", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto(logLink);
+    await expect(page.getByTestId("ansi-row")).not.toHaveCount(0);
   });
 
   test("Can enable/disable sections", async ({ page }) => {
     await helpers.toggleDetailsPanel(page, true);
     await page.getByTestId("log-viewing-tab").click();
     await expect(page.getByTestId("sections-toggle")).toBeEnabled();
-    await expect(page.getByTestId("sections-toggle")).toHaveAttribute(
-      "aria-checked",
-      "true",
-    );
+    await expect(page.getByTestId("sections-toggle")).toBeChecked();
     await page.getByTestId("sections-toggle").click();
-    await expect(page.getByTestId("sections-toggle")).toHaveAttribute(
-      "aria-checked",
-      "false",
-    );
+    await expect(page.getByTestId("sections-toggle")).not.toBeChecked();
     await page.getByTestId("sections-toggle").click();
-    await expect(page.getByTestId("sections-toggle")).toHaveAttribute(
-      "aria-checked",
-      "true",
-    );
+    await expect(page.getByTestId("sections-toggle")).toBeChecked();
   });
 });

--- a/apps/parsley/playwright/tests/ansiLogs/ansi_log_view.spec.ts
+++ b/apps/parsley/playwright/tests/ansiLogs/ansi_log_view.spec.ts
@@ -148,7 +148,9 @@ test.describe("Bookmarking and selecting lines", () => {
 
     await helpers.toggleDetailsPanel(page, true);
 
-    const moreOptionsButton = page.locator(`[aria-label='More options']`);
+    const moreOptionsButton = page.getByRole("button", {
+      name: "More options",
+    });
     await moreOptionsButton.click();
     await expect(page.getByText("Copy raw")).toBeVisible();
     await page.getByText("Copy raw").click();
@@ -255,7 +257,7 @@ test.describe("expanding collapsed rows", () => {
 
     await page
       .getByTestId("expanded-row-1-to-4")
-      .locator(`[aria-label="Delete range"]`)
+      .getByRole("button", { name: "Delete range" })
       .click();
     await expect(page.getByTestId("skipped-lines-row-1-4")).toBeVisible();
   });

--- a/apps/parsley/playwright/tests/ansiLogs/ansi_searching.spec.ts
+++ b/apps/parsley/playwright/tests/ansiLogs/ansi_searching.spec.ts
@@ -61,28 +61,31 @@ test.describe("Searching", () => {
     await expect(page.getByTestId("search-count")).toBeVisible();
     await expect(page.getByTestId("search-count")).toContainText("1/4");
 
-    await page.getByTestId("next-button").click();
+    const nextButton = page.getByRole("button", { name: "Next" });
+    const previousButton = page.getByRole("button", { name: "Prev" });
+
+    await nextButton.click();
     await expect(page.getByTestId("search-count")).toContainText("2/4");
 
-    await page.getByTestId("next-button").click();
+    await nextButton.click();
     await expect(page.getByTestId("search-count")).toContainText("3/4");
 
-    await page.getByTestId("next-button").click();
+    await nextButton.click();
     await expect(page.getByTestId("search-count")).toContainText("4/4");
 
-    await page.getByTestId("next-button").click();
+    await nextButton.click();
     await expect(page.getByTestId("search-count")).toContainText("1/4");
 
-    await page.getByTestId("previous-button").click();
+    await previousButton.click();
     await expect(page.getByTestId("search-count")).toContainText("4/4");
 
-    await page.getByTestId("previous-button").click();
+    await previousButton.click();
     await expect(page.getByTestId("search-count")).toContainText("3/4");
 
-    await page.getByTestId("previous-button").click();
+    await previousButton.click();
     await expect(page.getByTestId("search-count")).toContainText("2/4");
 
-    await page.getByTestId("previous-button").click();
+    await previousButton.click();
     await expect(page.getByTestId("search-count")).toContainText("1/4");
   });
 
@@ -93,7 +96,8 @@ test.describe("Searching", () => {
     await expect(page.getByTestId("search-count")).toBeVisible();
     await expect(page.getByTestId("search-count")).toContainText("1/4");
 
-    await page.getByTestId("next-button").click();
+    const nextButton = page.getByRole("button", { name: "Next" });
+    await nextButton.click();
     await expect(page.getByTestId("search-count")).toContainText("2/4");
 
     await page.getByTestId("log-row-27").dblclick();
@@ -127,6 +131,7 @@ test.describe("Searching", () => {
 
     await page
       .getByTestId(`filter-${filter}`)
+      .getByTestId("accordion-toggle")
       .getByRole("button", { name: "Delete filter" })
       .click();
 

--- a/apps/parsley/playwright/tests/ansiLogs/ansi_searching.spec.ts
+++ b/apps/parsley/playwright/tests/ansiLogs/ansi_searching.spec.ts
@@ -7,6 +7,7 @@ const logLink =
 test.describe("Searching", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto(logLink);
+    await expect(page.getByTestId("ansi-row")).not.toHaveCount(0);
   });
 
   test("searching for a term should highlight matching words", async ({
@@ -18,7 +19,7 @@ test.describe("Searching", () => {
 
     const highlights = page.getByTestId("highlight");
     await expect(highlights).toHaveCount(1);
-    await expect(highlights.first()).toContainText("Starting");
+    await expect(highlights).toContainText("Starting");
   });
 
   test("searching for a term should snap the matching line to the top of the window", async ({
@@ -102,7 +103,6 @@ test.describe("Searching", () => {
 
   test("should be able to search on filtered content", async ({ page }) => {
     await helpers.addFilter(page, "installation");
-    await page.locator("[data-cy^='skipped-lines-row-']").first().waitFor();
 
     const skippedLines = page.locator("[data-cy^='skipped-lines-row-']");
     await expect(skippedLines).toHaveCount(3);
@@ -117,7 +117,9 @@ test.describe("Searching", () => {
   }) => {
     const filter = "nonexistent-term";
     await helpers.addFilter(page, filter);
-    await page.locator("[data-cy^='skipped-lines-row-']").first().waitFor();
+
+    const skippedLines = page.locator("[data-cy^='skipped-lines-row-']");
+    await expect(skippedLines).toHaveCount(1);
 
     await helpers.addSearch(page, "info");
     await expect(page.getByTestId("search-count")).toBeVisible();
@@ -129,10 +131,7 @@ test.describe("Searching", () => {
       .click();
 
     await expect(page).toHaveURL(/^(?!.*filters)/);
-    await expect(page.locator("[data-cy^='skipped-lines-row-']")).toHaveCount(
-      0,
-    );
-
+    await expect(skippedLines).toHaveCount(0);
     await expect(page.getByTestId("search-count")).toContainText("1/4");
     await expect(page.locator("[data-highlighted='true']")).toContainText(
       "info",

--- a/apps/parsley/playwright/tests/ansiLogs/ansi_searching.spec.ts
+++ b/apps/parsley/playwright/tests/ansiLogs/ansi_searching.spec.ts
@@ -127,7 +127,7 @@ test.describe("Searching", () => {
 
     await page
       .getByTestId(`filter-${filter}`)
-      .locator('[aria-label="Delete filter"]')
+      .getByRole("button", { name: "Delete filter" })
       .click();
 
     await expect(page).toHaveURL(/^(?!.*filters)/);

--- a/apps/parsley/playwright/tests/external_links.spec.ts
+++ b/apps/parsley/playwright/tests/external_links.spec.ts
@@ -7,6 +7,7 @@ test.describe("External Links", () => {
       await page.goto(
         "/evergreen/spruce_ubuntu1604_test_2c9056df66d42fb1908d52eed096750a91f1f089_22_03_02_16_45_12/0/task",
       );
+      await expect(page.getByTestId("ansi-row")).not.toHaveCount(0);
       await helpers.toggleDetailsPanel(page, true);
     });
 
@@ -36,15 +37,16 @@ test.describe("External Links", () => {
   });
 
   test.describe("should render links to external pages when viewing an evergreen test log", () => {
-    const evgTestLogWithoutGroupID =
+    const evergreenTestLogs =
       "/test/spruce_ubuntu1604_check_codegen_d54e2c6ede60e004c48d3c4d996c59579c7bbd1f_22_03_02_15_41_35/0/JustAFakeTestInALonelyWorld";
-    const evgTestLogWithGroupID =
+    const resmokeTestLogs =
       "/test/mongodb_mongo_master_rhel80_debug_v4ubsan_all_feature_flags_experimental_concurrency_sharded_with_stepdowns_and_balancer_4_linux_enterprise_361789ed8a613a2dc0335a821ead0ab6205fbdaa_22_09_21_02_53_24/0/1716e11b4f8a4541c5e2faf70affbfab";
 
     test("should disable the link to the job logs page since when there are no resmoke logs", async ({
       page,
     }) => {
-      await page.goto(evgTestLogWithoutGroupID);
+      await page.goto(evergreenTestLogs);
+      await expect(page.getByTestId("ansi-row")).not.toHaveCount(0);
       await helpers.toggleDetailsPanel(page, true);
       await expect(page.getByTestId("job-logs-button")).toBeDisabled();
     });
@@ -52,7 +54,8 @@ test.describe("External Links", () => {
     test("should enable the link to the job logs page when there are resmoke logs", async ({
       page,
     }) => {
-      await page.goto(evgTestLogWithGroupID);
+      await page.goto(resmokeTestLogs);
+      await expect(page.getByTestId("resmoke-row")).not.toHaveCount(0);
       await helpers.toggleDetailsPanel(page, true);
       const jobLogsButton = page.getByTestId("job-logs-button");
       await expect(jobLogsButton).toBeEnabled();
@@ -63,7 +66,8 @@ test.describe("External Links", () => {
     });
 
     test("should render links to the log files", async ({ page }) => {
-      await page.goto(evgTestLogWithoutGroupID);
+      await page.goto(evergreenTestLogs);
+      await expect(page.getByTestId("ansi-row")).not.toHaveCount(0);
       await helpers.toggleDetailsPanel(page, true);
 
       const rawLogButton = page.getByTestId("raw-log-button");
@@ -89,6 +93,7 @@ test.describe("External Links", () => {
       await page.goto(
         "/taskFile/spruce_ubuntu1604_test_2c9056df66d42fb1908d52eed096750a91f1f089_22_03_02_16_45_12/0/sample%20file",
       );
+      await expect(page.getByTestId("ansi-row")).not.toHaveCount(0);
       await helpers.toggleDetailsPanel(page, true);
     });
 

--- a/apps/parsley/playwright/tests/external_links.spec.ts
+++ b/apps/parsley/playwright/tests/external_links.spec.ts
@@ -14,11 +14,13 @@ test.describe("External Links", () => {
     test("should disable the link to the job logs page since there are no resmoke logs", async ({
       page,
     }) => {
-      await expect(page.getByTestId("job-logs-button")).toBeDisabled();
+      const jobLogsButton = page.getByRole("button", { name: "Job logs" });
+      await expect(jobLogsButton).toBeVisible();
+      await expect(jobLogsButton).toBeDisabled();
     });
 
     test("should render links to the log files", async ({ page }) => {
-      const rawLogButton = page.getByTestId("raw-log-button");
+      const rawLogButton = page.getByRole("link", { name: "Raw" });
       await expect(rawLogButton).toBeVisible();
       await expect(rawLogButton).toBeEnabled();
       await expect(rawLogButton).toHaveAttribute(
@@ -26,7 +28,7 @@ test.describe("External Links", () => {
         "http://localhost:9090/task_log_raw/spruce_ubuntu1604_test_2c9056df66d42fb1908d52eed096750a91f1f089_22_03_02_16_45_12/0?text=true&time=true&type=T",
       );
 
-      const htmlLogButton = page.getByTestId("html-log-button");
+      const htmlLogButton = page.getByRole("link", { name: "HTML" });
       await expect(htmlLogButton).toBeVisible();
       await expect(htmlLogButton).toBeEnabled();
       await expect(htmlLogButton).toHaveAttribute(
@@ -48,7 +50,9 @@ test.describe("External Links", () => {
       await page.goto(evergreenTestLogs);
       await expect(page.getByTestId("ansi-row")).not.toHaveCount(0);
       await helpers.toggleDetailsPanel(page, true);
-      await expect(page.getByTestId("job-logs-button")).toBeDisabled();
+      const jobLogsButton = page.getByRole("button", { name: "Job logs" });
+      await expect(jobLogsButton).toBeVisible();
+      await expect(jobLogsButton).toBeDisabled();
     });
 
     test("should enable the link to the job logs page when there are resmoke logs", async ({
@@ -57,7 +61,8 @@ test.describe("External Links", () => {
       await page.goto(resmokeTestLogs);
       await expect(page.getByTestId("resmoke-row")).not.toHaveCount(0);
       await helpers.toggleDetailsPanel(page, true);
-      const jobLogsButton = page.getByTestId("job-logs-button");
+      const jobLogsButton = page.getByRole("link", { name: "Job logs" });
+      await expect(jobLogsButton).toBeVisible();
       await expect(jobLogsButton).toBeEnabled();
       await expect(jobLogsButton).toHaveAttribute(
         "href",
@@ -70,7 +75,7 @@ test.describe("External Links", () => {
       await expect(page.getByTestId("ansi-row")).not.toHaveCount(0);
       await helpers.toggleDetailsPanel(page, true);
 
-      const rawLogButton = page.getByTestId("raw-log-button");
+      const rawLogButton = page.getByRole("link", { name: "Raw" });
       await expect(rawLogButton).toBeVisible();
       await expect(rawLogButton).toBeEnabled();
       await expect(rawLogButton).toHaveAttribute(
@@ -78,7 +83,7 @@ test.describe("External Links", () => {
         "http://localhost:9090/rest/v2/tasks/spruce_ubuntu1604_check_codegen_d54e2c6ede60e004c48d3c4d996c59579c7bbd1f_22_03_02_15_41_35/build/TestLogs/JustAFakeTestInALonelyWorld?execution=0&print_time=true",
       );
 
-      const htmlLogButton = page.getByTestId("html-log-button");
+      const htmlLogButton = page.getByRole("link", { name: "HTML" });
       await expect(htmlLogButton).toBeVisible();
       await expect(htmlLogButton).toBeEnabled();
       await expect(htmlLogButton).toHaveAttribute(
@@ -98,7 +103,7 @@ test.describe("External Links", () => {
     });
 
     test("should link to the raw file", async ({ page }) => {
-      const rawLogButton = page.getByTestId("raw-log-button");
+      const rawLogButton = page.getByRole("link", { name: "Raw" });
       await expect(rawLogButton).toBeVisible();
       await expect(rawLogButton).toBeEnabled();
       await expect(rawLogButton).toHaveAttribute("href", /s3\.amazonaws\.com/);

--- a/apps/parsley/playwright/tests/project_filters.spec.ts
+++ b/apps/parsley/playwright/tests/project_filters.spec.ts
@@ -9,6 +9,7 @@ const resmokeLogLink =
 test.describe("project filters", () => {
   test("should show a message if there are no filters", async ({ page }) => {
     await page.goto(spruceLogLink);
+    await expect(page.getByTestId("ansi-row")).not.toHaveCount(0);
     await page.getByText("View project filters").click();
     await expect(page.getByTestId("project-filters-modal")).toBeVisible();
     await expect(page.getByTestId("project-filter")).toBeHidden();
@@ -17,6 +18,7 @@ test.describe("project filters", () => {
 
   test("should be able to apply a filter", async ({ page }) => {
     await page.goto(resmokeLogLink);
+    await expect(page.getByTestId("resmoke-row")).not.toHaveCount(0);
     await page.getByText("View project filters").click();
     await expect(page.getByTestId("project-filters-modal")).toBeVisible();
     const row0Checkbox = page.getByRole("checkbox", { name: "Select row 0" });
@@ -26,15 +28,15 @@ test.describe("project filters", () => {
     await expect(page).toHaveURL(
       /111%28NETWORK%257CASIO%257CEXECUTOR%257CCONNPOOL%257CREPL_HB%29/,
     );
-    expect(
-      await page.locator("[data-cy^='skipped-lines-row-']").count(),
-    ).toBeGreaterThan(0);
+    const skippedLines = page.locator("[data-cy^='skipped-lines-row-']");
+    await expect(skippedLines).not.toHaveCount(0);
   });
 
   test("should allow clicking on the filter name to check the checkbox", async ({
     page,
   }) => {
     await page.goto(resmokeLogLink);
+    await expect(page.getByTestId("resmoke-row")).not.toHaveCount(0);
     await page.getByText("View project filters").click();
     await expect(page.getByTestId("project-filters-modal")).toBeVisible();
     const row0Checkbox = page.getByRole("checkbox", { name: "Select row 0" });
@@ -44,6 +46,7 @@ test.describe("project filters", () => {
 
   test("properly processes filters with commas", async ({ page }) => {
     await page.goto(resmokeLogLink);
+    await expect(page.getByTestId("resmoke-row")).not.toHaveCount(0);
     await page.getByText("View project filters").click();
     await expect(page.getByTestId("project-filters-modal")).toBeVisible();
     const row3Checkbox = page.getByRole("checkbox", { name: "Select row 3" });
@@ -53,15 +56,15 @@ test.describe("project filters", () => {
     await expect(page).toHaveURL(
       /110%2522Connection%2520accepted%2522%252C%2522attr%2522/,
     );
-    expect(
-      await page.locator("[data-cy^='skipped-lines-row-']").count(),
-    ).toBeGreaterThan(0);
+    const skippedLines = page.locator("[data-cy^='skipped-lines-row-']");
+    await expect(skippedLines).not.toHaveCount(0);
   });
 
   test("should disable checkbox if filter is already applied", async ({
     page,
   }) => {
     await page.goto(`${resmokeLogLink}?filters=111D%255Cd`);
+    await expect(page.getByTestId("resmoke-row")).not.toHaveCount(0);
     await page.getByText("View project filters").click();
     await expect(page.getByTestId("project-filters-modal")).toBeVisible();
     const row1Checkbox = page.getByRole("checkbox", {

--- a/apps/parsley/playwright/tests/resmokeLogs/resmoke_evg_all_log_view.spec.ts
+++ b/apps/parsley/playwright/tests/resmokeLogs/resmoke_evg_all_log_view.spec.ts
@@ -7,13 +7,7 @@ test.describe("Basic resmoke log view", () => {
 
   test.beforeEach(async ({ page }) => {
     await page.goto(logLink);
-  });
-
-  test("should render resmoke lines", async ({ page }) => {
-    const resmokeRows = page.getByTestId("resmoke-row");
-    await resmokeRows.first().waitFor();
-    expect(await resmokeRows.count()).toBeGreaterThan(0);
-    await expect(page.getByTestId("ansii-row")).toBeHidden();
+    await expect(page.getByTestId("resmoke-row")).not.toHaveCount(0);
   });
 
   test("the HTML log button is disabled", async ({ page }) => {

--- a/apps/parsley/playwright/tests/resmokeLogs/resmoke_evg_all_log_view.spec.ts
+++ b/apps/parsley/playwright/tests/resmokeLogs/resmoke_evg_all_log_view.spec.ts
@@ -12,14 +12,16 @@ test.describe("Basic resmoke log view", () => {
 
   test("the HTML log button is disabled", async ({ page }) => {
     await helpers.toggleDetailsPanel(page, true);
-    await expect(page.getByTestId("html-log-button")).toBeDisabled();
+    const htmlLogButton = page.getByRole("button", { name: "HTML" });
+    await expect(htmlLogButton).toBeDisabled();
   });
 
   test("the job logs button has a link to the job logs page", async ({
     page,
   }) => {
     await helpers.toggleDetailsPanel(page, true);
-    await expect(page.getByTestId("job-logs-button")).toHaveAttribute(
+    const jobLogsButton = page.getByRole("link", { name: "Job logs" });
+    await expect(jobLogsButton).toHaveAttribute(
       "href",
       "http://localhost:3000/job-logs/mongodb_mongo_master_enterprise_amazon_linux2_arm64_all_feature_flags_jsCore_patch_9801cf147ed208ce4c0ff8dff4a97cdb216f4c22_65f06bd09ccd4eaaccca1391_24_03_12_14_51_29/0/job0",
     );

--- a/apps/parsley/playwright/tests/resmokeLogs/resmoke_evg_test_log_view.spec.ts
+++ b/apps/parsley/playwright/tests/resmokeLogs/resmoke_evg_test_log_view.spec.ts
@@ -188,8 +188,8 @@ test.describe("Bookmarking and selecting lines", () => {
       "|ShardedClusterFixture:job0:mongos1        |j0:s1   |20010|73217|";
     const logLine1638 = `[ContinuousStepdown:job0] Pausing the stepdown thread.`;
 
-    await page.getByTestId("details-button").click();
-    await page.getByTestId("copy-text-button").click();
+    await page.getByRole("button", { name: "Details" }).click();
+    await page.getByRole("button", { name: "Copy Jira" }).click();
     await helpers.assertValueCopiedToClipboard(
       page,
       `{noformat}\n${logLine0}\n...\n${logLine10}\n${logLine11}\n...\n${logLine1638}\n{noformat}`,
@@ -334,8 +334,11 @@ test.describe("Sharing lines", () => {
     page,
   }) => {
     await page.getByTestId("line-index-1").click();
-    await expect(page.getByTestId("sharing-menu-button")).toBeVisible();
-    await page.getByTestId("sharing-menu-button").click();
+    const sharingMenuButton = page.getByRole("button", {
+      name: "Expand share menu",
+    });
+    await expect(sharingMenuButton).toBeVisible();
+    await sharingMenuButton.click();
     await expect(page.getByTestId("sharing-menu")).toBeVisible();
   });
 

--- a/apps/parsley/playwright/tests/resmokeLogs/resmoke_evg_test_log_view.spec.ts
+++ b/apps/parsley/playwright/tests/resmokeLogs/resmoke_evg_test_log_view.spec.ts
@@ -295,7 +295,7 @@ test.describe("expanding collapsed rows", () => {
 
     await page
       .getByTestId("expanded-row-1-to-3")
-      .locator(`[aria-label="Delete range"]`)
+      .getByRole("button", { name: "Delete range" })
       .click();
     await expect(page.getByTestId("skipped-lines-row-1-3")).toBeVisible();
   });

--- a/apps/parsley/playwright/tests/resmokeLogs/resmoke_evg_test_log_view.spec.ts
+++ b/apps/parsley/playwright/tests/resmokeLogs/resmoke_evg_test_log_view.spec.ts
@@ -7,12 +7,7 @@ const logLink =
 test.describe("Basic resmoke log view", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto(logLink);
-  });
-
-  test("should render resmoke lines", async ({ page }) => {
-    const resmokeRows = page.getByTestId("resmoke-row");
-    await resmokeRows.first().waitFor();
-    expect(await resmokeRows.count()).toBeGreaterThan(0);
+    await expect(page.getByTestId("resmoke-row")).not.toHaveCount(0);
   });
 
   test("by default should have wrapping turned off and should be able to scroll horizontally", async ({
@@ -87,6 +82,7 @@ test.describe("Resmoke syntax highlighting", () => {
 
   test.beforeEach(async ({ page }) => {
     await page.goto(logLink);
+    await expect(page.getByTestId("resmoke-row")).not.toHaveCount(0);
   });
 
   test("should not color non-resmoke log lines", async ({ page }) => {
@@ -145,6 +141,7 @@ test.describe("Resmoke syntax highlighting", () => {
 test.describe("Bookmarking and selecting lines", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto(logLink);
+    await expect(page.getByTestId("resmoke-row")).not.toHaveCount(0);
   });
 
   test("should default to bookmarking 0 and the last log line on load", async ({
@@ -213,6 +210,7 @@ test.describe("Jump to line", () => {
     page,
   }) => {
     await page.goto(logLink);
+    await expect(page.getByTestId("resmoke-row")).not.toHaveCount(0);
     await expect(page.getByTestId("log-row-4")).toBeVisible();
     await page.getByTestId("log-row-4").dblclick();
     await expect(page.getByTestId("bookmark-4")).toBeVisible();
@@ -229,6 +227,7 @@ test.describe("Jump to line", () => {
     page,
   }) => {
     await page.goto(`${logLink}?filters=100repl_hb`);
+    await expect(page.getByTestId("resmoke-row")).not.toHaveCount(0);
     await expect(page.getByTestId("log-row-30")).toBeVisible();
     await page.getByTestId("log-row-30").dblclick();
     await expect(page).toHaveURL(/bookmarks=0,30,12568/);
@@ -245,6 +244,7 @@ test.describe("Jump to line", () => {
     page,
   }) => {
     await page.goto(`${logLink}?shareLine=200`);
+    await expect(page.getByTestId("resmoke-row")).not.toHaveCount(0);
     await expect(page.getByTestId("log-row-200")).toBeVisible();
   });
 });
@@ -255,6 +255,7 @@ test.describe("expanding collapsed rows", () => {
 
   test.beforeEach(async ({ page }) => {
     await page.goto(logLinkWithFilters);
+    await expect(page.getByTestId("resmoke-row")).not.toHaveCount(0);
   });
 
   test("should be able to expand collapsed rows", async ({ page }) => {
@@ -307,6 +308,7 @@ test.describe("pretty print", () => {
       localStorage.setItem("pretty-print-bookmarks", "true");
     });
     await page.reload();
+    await expect(page.getByTestId("resmoke-row")).not.toHaveCount(0);
   });
 
   test("should pretty print bookmarks if pretty print is enabled", async ({
@@ -315,19 +317,17 @@ test.describe("pretty print", () => {
     const defaultRowHeight = 17.5;
 
     const logRow19 = page.getByTestId("log-row-19");
-
     await expect(logRow19).toBeVisible();
     await logRow19.dblclick();
     await expect(logRow19).toHaveAttribute("data-bookmarked", "true");
-    const box = await logRow19.boundingBox();
-    expect(box).not.toBeNull();
-    expect(box!.height).toBeGreaterThan(defaultRowHeight);
+    await expect(logRow19).not.toHaveCSS("height", `${defaultRowHeight}px`);
   });
 });
 
 test.describe("Sharing lines", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto(logLink);
+    await expect(page.getByTestId("resmoke-row")).not.toHaveCount(0);
   });
 
   test("should present a share button with a menu when a line is selected", async ({
@@ -396,6 +396,7 @@ test.describe("Sharing lines", () => {
 test.describe("Exclude timestamps toggle", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto(logLink);
+    await expect(page.getByTestId("resmoke-row")).not.toHaveCount(0);
   });
 
   test("should disable the exclude timestamps toggle for resmoke logs", async ({

--- a/apps/parsley/playwright/tests/resmokeLogs/resmoke_filtering.spec.ts
+++ b/apps/parsley/playwright/tests/resmokeLogs/resmoke_filtering.spec.ts
@@ -9,6 +9,7 @@ test.describe("Filtering", () => {
     test.describe("Basic filtering", () => {
       test.beforeEach(async ({ page }) => {
         await page.goto(logLink);
+        await expect(page.getByTestId("resmoke-row")).not.toHaveCount(0);
         await expect(page.getByTestId("paginated-virtual-list")).toBeVisible();
       });
 
@@ -18,7 +19,9 @@ test.describe("Filtering", () => {
         await expect(page).toHaveURL(/\?bookmarks=0,6,115&shareLine=5/);
         await helpers.addFilter(page, "doesNotMatchAnything");
 
-        const logRows = await page.locator("[data-cy^='log-row-']").all();
+        const filteredRows = page.locator("[data-cy^='log-row-']");
+        await expect(filteredRows).toHaveCount(4);
+        const logRows = await filteredRows.all();
         for (const row of logRows) {
           const dataCy = await row.getAttribute("data-cy");
           expect(dataCy).toMatch(/log-row-(0|5|6|115)/);
@@ -47,25 +50,21 @@ test.describe("Filtering", () => {
           page,
         }) => {
           await page.goto(`${logLink}?filterLogic=and`);
+          await expect(page.getByTestId("resmoke-row")).not.toHaveCount(0);
           await helpers.addFilter(page, filter1);
           await helpers.addFilter(page, filter2);
           await expect(page).toHaveURL(
             new RegExp(`filters=100${filter1},100${filter2}`),
           );
 
-          // Wait for filtered rows to load.
-          await page
-            .locator("[data-cy^='log-row-']:not([data-bookmarked=true])")
-            .first()
-            .waitFor();
-
-          const logRows = await page
-            .locator("[data-cy^='log-row-']:not([data-bookmarked=true])")
-            .all();
+          const filteredRows = page.locator(
+            "[data-cy^='log-row-']:not([data-bookmarked=true])",
+          );
+          await expect(filteredRows).not.toHaveCount(0);
+          const logRows = await filteredRows.all();
           for (const row of logRows) {
-            const text = await row.innerText();
-            expect(text.toLowerCase()).toContain(filter1.toLowerCase());
-            expect(text.toLowerCase()).toContain(filter2.toLowerCase());
+            await expect(row).toContainText(filter1, { ignoreCase: true });
+            await expect(row).toContainText(filter2, { ignoreCase: true });
           }
         });
 
@@ -73,6 +72,7 @@ test.describe("Filtering", () => {
           await page.goto(
             `${logLink}?filterLogic=and&filters=100${filter1},100${filter2}`,
           );
+          await expect(page.getByTestId("resmoke-row")).not.toHaveCount(0);
           await page
             .getByTestId(`filter-${filter1}`)
             .getByText("Sensitive", { exact: true })
@@ -80,14 +80,14 @@ test.describe("Filtering", () => {
           await expect(page).toHaveURL(
             new RegExp(`filters=110${filter1},100${filter2}`),
           );
-
-          const logRows = await page
-            .locator("[data-cy^='log-row-']:not([data-bookmarked=true])")
-            .all();
+          const filteredRows = page.locator(
+            "[data-cy^='log-row-']:not([data-bookmarked=true])",
+          );
+          await expect(filteredRows).not.toHaveCount(0);
+          const logRows = await filteredRows.all();
           for (const row of logRows) {
-            const text = await row.innerText();
-            expect(text).toContain(filter1);
-            expect(text.toLowerCase()).toContain(filter2.toLowerCase());
+            await expect(row).toContainText(filter1, { ignoreCase: false });
+            await expect(row).toContainText(filter2, { ignoreCase: true });
           }
         });
 
@@ -95,6 +95,7 @@ test.describe("Filtering", () => {
           await page.goto(
             `${logLink}?filterLogic=and&filters=110${filter1},100${filter2}`,
           );
+          await expect(page.getByTestId("resmoke-row")).not.toHaveCount(0);
           await page
             .getByTestId(`filter-${filter2}`)
             .getByText("Inverse", { exact: true })
@@ -103,13 +104,14 @@ test.describe("Filtering", () => {
             new RegExp(`filters=110${filter1},101${filter2}`),
           );
 
-          const logRows = await page
-            .locator("[data-cy^='log-row-']:not([data-bookmarked=true])")
-            .all();
+          const filteredRows = page.locator(
+            "[data-cy^='log-row-']:not([data-bookmarked=true])",
+          );
+          await expect(filteredRows).not.toHaveCount(0);
+          const logRows = await filteredRows.all();
           for (const row of logRows) {
-            const text = await row.innerText();
-            expect(text).toContain(filter1);
-            expect(text).not.toContain(filter2);
+            await expect(row).toContainText(filter1, { ignoreCase: false });
+            await expect(row).not.toContainText(filter2, { ignoreCase: true });
           }
         });
 
@@ -117,6 +119,7 @@ test.describe("Filtering", () => {
           await page.goto(
             `${logLink}?filterLogic=and&filters=110${filter1},101${filter2}`,
           );
+          await expect(page.getByTestId("resmoke-row")).not.toHaveCount(0);
           await page
             .getByTestId(`filter-${filter1}`)
             .locator('[aria-label="Hide filter"]')
@@ -128,9 +131,8 @@ test.describe("Filtering", () => {
           await expect(page).toHaveURL(
             new RegExp(`filters=010${filter1},001${filter2}`),
           );
-          await expect(
-            page.locator("[data-cy^='skipped-lines-row-']"),
-          ).toHaveCount(0);
+          const skippedLines = page.locator("[data-cy^='skipped-lines-row-']");
+          await expect(skippedLines).toHaveCount(0);
         });
       });
 
@@ -139,24 +141,20 @@ test.describe("Filtering", () => {
           page,
         }) => {
           await page.goto(`${logLink}?filterLogic=or`);
+          await expect(page.getByTestId("resmoke-row")).not.toHaveCount(0);
           await helpers.addFilter(page, filter1);
           await helpers.addFilter(page, filter2);
           await expect(page).toHaveURL(
             new RegExp(`filters=100${filter1},100${filter2}`),
           );
 
-          // Wait for filtered rows to load.
-          await page
-            .locator("[data-cy^='log-row-']:not([data-bookmarked=true])")
-            .first()
-            .waitFor();
-
-          const logRows = await page
-            .locator("[data-cy^='log-row-']:not([data-bookmarked=true])")
-            .all();
+          const filteredRows = page.locator(
+            "[data-cy^='log-row-']:not([data-bookmarked=true])",
+          );
+          await expect(filteredRows).not.toHaveCount(0);
+          const logRows = await filteredRows.all();
           for (const row of logRows) {
-            const text = await row.innerText();
-            expect(text.toLowerCase()).toMatch(/deleted|session/);
+            await expect(row).toContainText(/deleted|session/i);
           }
         });
 
@@ -164,6 +162,7 @@ test.describe("Filtering", () => {
           await page.goto(
             `${logLink}?filterLogic=or&filters=100${filter1},100${filter2}`,
           );
+          await expect(page.getByTestId("resmoke-row")).not.toHaveCount(0);
           await page
             .getByTestId(`filter-${filter1}`)
             .getByText("Sensitive", { exact: true })
@@ -172,21 +171,22 @@ test.describe("Filtering", () => {
             new RegExp(`filters=110${filter1},100${filter2}`),
           );
 
-          const logRows = await page
-            .locator("[data-cy^='log-row-']:not([data-bookmarked=true])")
-            .all();
-          for (const row of logRows) {
-            const text = await row.innerText();
-            const matchesFilter1 = text.includes("deleted");
-            const matchesFilter2 = text.toLowerCase().includes("session");
-            expect(matchesFilter1 || matchesFilter2).toBe(true);
-          }
+          const filteredRows = page.locator(
+            "[data-cy^='log-row-']:not([data-bookmarked=true])",
+          );
+          await expect(filteredRows).not.toHaveCount(0);
+          await expect(
+            filteredRows
+              .filter({ hasNotText: /deleted/ })
+              .filter({ hasNotText: /session/i }),
+          ).toHaveCount(0);
         });
 
         test("should be able to toggle inverse matching", async ({ page }) => {
           await page.goto(
             `${logLink}?filterLogic=or&filters=110${filter1},100${filter2}`,
           );
+          await expect(page.getByTestId("resmoke-row")).not.toHaveCount(0);
           await page
             .getByTestId(`filter-${filter2}`)
             .getByText("Inverse", { exact: true })
@@ -195,21 +195,22 @@ test.describe("Filtering", () => {
             new RegExp(`filters=110${filter1},101${filter2}`),
           );
 
-          const logRows = await page
-            .locator("[data-cy^='log-row-']:not([data-bookmarked=true])")
-            .all();
-          for (const row of logRows) {
-            const text = await row.innerText();
-            const matchesFilter1 = text.includes("deleted");
-            const doesNotMatchFilter2 = !text.toLowerCase().includes("session");
-            expect(matchesFilter1 || doesNotMatchFilter2).toBe(true);
-          }
+          const filteredRows = page.locator(
+            "[data-cy^='log-row-']:not([data-bookmarked=true])",
+          );
+          await expect(filteredRows).not.toHaveCount(0);
+          await expect(
+            filteredRows
+              .filter({ hasText: /deleted/ })
+              .filter({ hasNotText: /session/i }),
+          ).toHaveCount(0);
         });
 
         test("should be able to toggle visibility", async ({ page }) => {
           await page.goto(
             `${logLink}?filterLogic=or&filters=110${filter1},101${filter2}`,
           );
+          await expect(page.getByTestId("resmoke-row")).not.toHaveCount(0);
           await page
             .getByTestId(`filter-${filter1}`)
             .locator('[aria-label="Hide filter"]')
@@ -221,9 +222,8 @@ test.describe("Filtering", () => {
           await expect(page).toHaveURL(
             new RegExp(`filters=010${filter1},001${filter2}`),
           );
-          await expect(
-            page.locator("[data-cy^='skipped-lines-row-']"),
-          ).toHaveCount(0);
+          const skippedLines = page.locator("[data-cy^='skipped-lines-row-']");
+          await expect(skippedLines).toHaveCount(0);
         });
       });
     });
@@ -234,10 +234,9 @@ test.describe("Filtering", () => {
 
     test.beforeEach(async ({ page }) => {
       await page.goto(`${logLink}?filters=100${filter}`);
-      await page.locator("[data-cy^='skipped-lines-row-']").first().waitFor();
-      expect(
-        await page.locator("[data-cy^='skipped-lines-row-']").count(),
-      ).toBeGreaterThan(0);
+      await expect(page.getByTestId("resmoke-row")).toHaveCount(0);
+      const skippedLines = page.locator("[data-cy^='skipped-lines-row-']");
+      await expect(skippedLines).not.toHaveCount(0);
     });
 
     test("should be able to edit a filter", async ({ page }) => {
@@ -250,12 +249,13 @@ test.describe("Filtering", () => {
       await page.getByRole("button", { name: "Apply" }).click();
       await expect(page).toHaveURL(/filters=100session/);
 
-      const logRows = await page
-        .locator("[data-cy^='log-row-']:not([data-bookmarked=true])")
-        .all();
+      const filteredRows = page.locator(
+        "[data-cy^='log-row-']:not([data-bookmarked=true])",
+      );
+      await expect(filteredRows).not.toHaveCount(0);
+      const logRows = await filteredRows.all();
       for (const row of logRows) {
-        const text = await row.innerText();
-        expect(text.toLowerCase()).toContain("session");
+        await expect(row).toContainText("session", { ignoreCase: true });
       }
     });
 
@@ -265,9 +265,8 @@ test.describe("Filtering", () => {
         .locator('[aria-label="Delete filter"]')
         .click();
       await expect(page).toHaveURL(/^(?!.*filters)/);
-      await expect(page.locator("[data-cy^='skipped-lines-row-']")).toHaveCount(
-        0,
-      );
+      const skippedLines = page.locator("[data-cy^='skipped-lines-row-']");
+      await expect(skippedLines).toHaveCount(0);
     });
   });
 
@@ -277,31 +276,21 @@ test.describe("Filtering", () => {
 
     test("should be able to hide and unhide filters", async ({ page }) => {
       await page.goto(`${logLink}?filters=110${filter1},100${filter2}`);
-      await page.locator("[data-cy^='skipped-lines-row-']").first().waitFor();
-      expect(
-        await page.locator("[data-cy^='skipped-lines-row-']").count(),
-      ).toBeGreaterThan(0);
+      await expect(page.getByTestId("resmoke-row")).toHaveCount(0);
+      const skippedLines = page.locator("[data-cy^='skipped-lines-row-']");
+      await expect(skippedLines).not.toHaveCount(0);
 
       await page.getByTestId("all-filters-toggle").click();
-      await expect(page.getByTestId("all-filters-toggle")).toHaveAttribute(
-        "aria-checked",
-        "false",
-      );
-      await expect(page.locator("[data-cy^='skipped-lines-row-']")).toHaveCount(
-        0,
-      );
+      await expect(page.getByTestId("all-filters-toggle")).not.toBeChecked();
+
+      await expect(skippedLines).toHaveCount(0);
       await expect(page).toHaveURL(
         new RegExp(`filters=010${filter1},000${filter2}`),
       );
 
       await page.getByTestId("all-filters-toggle").click();
-      await expect(page.getByTestId("all-filters-toggle")).toHaveAttribute(
-        "aria-checked",
-        "true",
-      );
-      expect(
-        await page.locator("[data-cy^='skipped-lines-row-']").count(),
-      ).toBeGreaterThan(0);
+      await expect(page.getByTestId("all-filters-toggle")).toBeChecked();
+      await expect(skippedLines).not.toHaveCount(0);
       await expect(page).toHaveURL(
         new RegExp(`filters=110${filter1},100${filter2}`),
       );

--- a/apps/parsley/playwright/tests/resmokeLogs/resmoke_filtering.spec.ts
+++ b/apps/parsley/playwright/tests/resmokeLogs/resmoke_filtering.spec.ts
@@ -122,11 +122,11 @@ test.describe("Filtering", () => {
           await expect(page.getByTestId("resmoke-row")).not.toHaveCount(0);
           await page
             .getByTestId(`filter-${filter1}`)
-            .locator('[aria-label="Hide filter"]')
+            .getByRole("button", { name: "Hide" })
             .click();
           await page
             .getByTestId(`filter-${filter2}`)
-            .locator('[aria-label="Hide filter"]')
+            .getByRole("button", { name: "Hide" })
             .click();
           await expect(page).toHaveURL(
             new RegExp(`filters=010${filter1},001${filter2}`),
@@ -213,11 +213,11 @@ test.describe("Filtering", () => {
           await expect(page.getByTestId("resmoke-row")).not.toHaveCount(0);
           await page
             .getByTestId(`filter-${filter1}`)
-            .locator('[aria-label="Hide filter"]')
+            .getByRole("button", { name: "Hide" })
             .click();
           await page
             .getByTestId(`filter-${filter2}`)
-            .locator('[aria-label="Hide filter"]')
+            .getByRole("button", { name: "Hide" })
             .click();
           await expect(page).toHaveURL(
             new RegExp(`filters=010${filter1},001${filter2}`),
@@ -242,7 +242,7 @@ test.describe("Filtering", () => {
     test("should be able to edit a filter", async ({ page }) => {
       await page
         .getByTestId(`filter-${filter}`)
-        .locator('[aria-label="Edit filter"]')
+        .getByRole("button", { name: "Edit filter" })
         .click();
       await page.getByTestId("edit-filter-name").clear();
       await page.getByTestId("edit-filter-name").fill("session");
@@ -262,7 +262,7 @@ test.describe("Filtering", () => {
     test("should be able to delete a filter", async ({ page }) => {
       await page
         .getByTestId(`filter-${filter}`)
-        .locator('[aria-label="Delete filter"]')
+        .getByRole("button", { name: "Delete filter" })
         .click();
       await expect(page).toHaveURL(/^(?!.*filters)/);
       const skippedLines = page.locator("[data-cy^='skipped-lines-row-']");

--- a/apps/parsley/playwright/tests/resmokeLogs/resmoke_filtering.spec.ts
+++ b/apps/parsley/playwright/tests/resmokeLogs/resmoke_filtering.spec.ts
@@ -122,11 +122,13 @@ test.describe("Filtering", () => {
           await expect(page.getByTestId("resmoke-row")).not.toHaveCount(0);
           await page
             .getByTestId(`filter-${filter1}`)
-            .getByRole("button", { name: "Hide" })
+            .getByTestId("accordion-toggle")
+            .getByRole("switch", { name: "Hide filter" })
             .click();
           await page
             .getByTestId(`filter-${filter2}`)
-            .getByRole("button", { name: "Hide" })
+            .getByTestId("accordion-toggle")
+            .getByRole("switch", { name: "Hide filter" })
             .click();
           await expect(page).toHaveURL(
             new RegExp(`filters=010${filter1},001${filter2}`),
@@ -201,8 +203,8 @@ test.describe("Filtering", () => {
           await expect(filteredRows).not.toHaveCount(0);
           await expect(
             filteredRows
-              .filter({ hasText: /deleted/ })
-              .filter({ hasNotText: /session/i }),
+              .filter({ hasNotText: /deleted/ })
+              .filter({ hasText: /session/i }),
           ).toHaveCount(0);
         });
 
@@ -213,11 +215,13 @@ test.describe("Filtering", () => {
           await expect(page.getByTestId("resmoke-row")).not.toHaveCount(0);
           await page
             .getByTestId(`filter-${filter1}`)
-            .getByRole("button", { name: "Hide" })
+            .getByTestId("accordion-toggle")
+            .getByRole("switch", { name: "Hide filter" })
             .click();
           await page
             .getByTestId(`filter-${filter2}`)
-            .getByRole("button", { name: "Hide" })
+            .getByTestId("accordion-toggle")
+            .getByRole("switch", { name: "Hide filter" })
             .click();
           await expect(page).toHaveURL(
             new RegExp(`filters=010${filter1},001${filter2}`),
@@ -242,6 +246,7 @@ test.describe("Filtering", () => {
     test("should be able to edit a filter", async ({ page }) => {
       await page
         .getByTestId(`filter-${filter}`)
+        .getByTestId("accordion-toggle")
         .getByRole("button", { name: "Edit filter" })
         .click();
       await page.getByTestId("edit-filter-name").clear();
@@ -262,6 +267,7 @@ test.describe("Filtering", () => {
     test("should be able to delete a filter", async ({ page }) => {
       await page
         .getByTestId(`filter-${filter}`)
+        .getByTestId("accordion-toggle")
         .getByRole("button", { name: "Delete filter" })
         .click();
       await expect(page).toHaveURL(/^(?!.*filters)/);

--- a/apps/parsley/playwright/tests/resmokeLogs/resmoke_highlighting.spec.ts
+++ b/apps/parsley/playwright/tests/resmokeLogs/resmoke_highlighting.spec.ts
@@ -7,6 +7,7 @@ const logLink =
 test.describe("Highlighting", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto(logLink);
+    await expect(page.getByTestId("resmoke-row")).not.toHaveCount(0);
   });
 
   test("applying a highlight should highlight matching words", async ({
@@ -15,7 +16,7 @@ test.describe("Highlighting", () => {
     await helpers.addHighlight(page, "ShardedClusterFixture:job0:mongos0 ");
     const highlights = page.getByTestId("highlight");
     await expect(highlights).toHaveCount(1);
-    await expect(highlights.first()).toContainText(
+    await expect(highlights).toContainText(
       "ShardedClusterFixture:job0:mongos0 ",
     );
   });
@@ -27,7 +28,7 @@ test.describe("Highlighting", () => {
     await helpers.addSearch(page, "ShardedClusterFixture:job0:mongos0 ");
     const highlights = page.getByTestId("highlight");
     await expect(highlights).toHaveCount(1);
-    await expect(highlights.first()).toContainText(
+    await expect(highlights).toContainText(
       "ShardedClusterFixture:job0:mongos0 ",
     );
   });
@@ -37,13 +38,12 @@ test.describe("Highlighting", () => {
   }) => {
     await helpers.addHighlight(page, "ShardedClusterFixture:job0:mongos0 ");
     await helpers.addSearch(page, "ShardedClusterFixture:job0:shard0:node1");
+
     const highlights = page.getByTestId("highlight");
     await expect(highlights).toHaveCount(2);
-
     const highlightElements = await highlights.all();
     for (const element of highlightElements) {
-      const text = await element.innerText();
-      expect(text).toMatch(
+      await expect(element).toContainText(
         /ShardedClusterFixture:job0:mongos0|ShardedClusterFixture:job0:shard0:node1/,
       );
     }
@@ -54,7 +54,7 @@ test.describe("Highlighting", () => {
   }) => {
     await helpers.addHighlight(page, "ShardedClusterFixture:job0:shard0:node1");
     const highlights = page.getByTestId("highlight");
-    expect(await highlights.count()).toBeGreaterThan(0);
+    await expect(highlights).not.toHaveCount(0);
 
     await expect(page.getByTestId("delete-highlight-button")).toBeVisible();
     await page.getByTestId("delete-highlight-button").click();
@@ -66,13 +66,12 @@ test.describe("Highlighting", () => {
   }) => {
     await helpers.addHighlight(page, "ShardedClusterFixture:job0:mongos0 ");
     await helpers.addHighlight(page, "ShardedClusterFixture:job0:shard0:node1");
+
     const highlights = page.getByTestId("highlight");
     await expect(highlights).toHaveCount(2);
-
     const highlightElements = await highlights.all();
     for (const element of highlightElements) {
-      const text = await element.innerText();
-      expect(text).toMatch(
+      await expect(element).toContainText(
         /ShardedClusterFixture:job0:mongos0|ShardedClusterFixture:job0:shard0:node1/,
       );
     }
@@ -98,11 +97,11 @@ test.describe("Highlighting", () => {
     );
     await helpers.addFilter(page, "job0");
     const highlights = page.getByTestId("highlight");
-    expect(await highlights.count()).toBeGreaterThan(0);
+    await expect(highlights).not.toHaveCount(0);
 
     const sideNavHighlights = page.getByTestId("side-nav-highlight");
     await expect(sideNavHighlights).toHaveCount(1);
-    await expect(sideNavHighlights.first()).toContainText("job0");
+    await expect(sideNavHighlights).toContainText("job0");
   });
 
   test("should not add a highlight when a filter term is added if `Apply Highlights to Filters` is disabled", async ({

--- a/apps/parsley/playwright/tests/resmokeLogs/resmoke_highlighting.spec.ts
+++ b/apps/parsley/playwright/tests/resmokeLogs/resmoke_highlighting.spec.ts
@@ -56,8 +56,11 @@ test.describe("Highlighting", () => {
     const highlights = page.getByTestId("highlight");
     await expect(highlights).not.toHaveCount(0);
 
-    await expect(page.getByTestId("delete-highlight-button")).toBeVisible();
-    await page.getByTestId("delete-highlight-button").click();
+    const deleteHighlightButton = page.getByRole("button", {
+      name: "Delete highlight",
+    });
+    await expect(deleteHighlightButton).toBeVisible();
+    await deleteHighlightButton.click();
     await expect(highlights).toHaveCount(0);
   });
 

--- a/apps/parsley/playwright/tests/resmokeLogs/resmoke_searching.spec.ts
+++ b/apps/parsley/playwright/tests/resmokeLogs/resmoke_searching.spec.ts
@@ -63,19 +63,22 @@ test.describe("Searching", () => {
     await expect(page.getByTestId("search-count")).toBeVisible();
     await expect(page.getByTestId("search-count")).toContainText("1/8");
 
+    const nextButton = page.getByRole("button", { name: "Next" });
+    const previousButton = page.getByRole("button", { name: "Prev" });
+
     // Click the button 8 times
     for (let i = 1; i <= 7; i++) {
-      await page.getByTestId("next-button").click();
+      await nextButton.click();
       await expect(page.getByTestId("search-count")).toContainText(
         `${i + 1}/8`,
       );
     }
 
-    await page.getByTestId("next-button").click();
+    await nextButton.click();
     await expect(page.getByTestId("search-count")).toContainText("1/8");
 
     for (let i = 7; i >= 0; i--) {
-      await page.getByTestId("previous-button").click();
+      await previousButton.click();
       await expect(page.getByTestId("search-count")).toContainText(
         `${i + 1}/8`,
       );
@@ -89,7 +92,8 @@ test.describe("Searching", () => {
     await expect(page.getByTestId("search-count")).toBeVisible();
     await expect(page.getByTestId("search-count")).toContainText("1/8");
 
-    await page.getByTestId("next-button").click();
+    const nextButton = page.getByRole("button", { name: "Next" });
+    await nextButton.click();
     await expect(page.getByTestId("search-count")).toContainText("2/8");
 
     await page.getByTestId("log-row-112").dblclick();
@@ -123,6 +127,7 @@ test.describe("Searching", () => {
 
     await page
       .getByTestId(`filter-${filter}`)
+      .getByTestId("accordion-toggle")
       .getByRole("button", { name: "Delete filter" })
       .click();
 

--- a/apps/parsley/playwright/tests/resmokeLogs/resmoke_searching.spec.ts
+++ b/apps/parsley/playwright/tests/resmokeLogs/resmoke_searching.spec.ts
@@ -7,6 +7,7 @@ const logLink =
 test.describe("Searching", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto(logLink);
+    await expect(page.getByTestId("resmoke-row")).not.toHaveCount(0);
   });
 
   test("searching for a term should highlight matching words", async ({
@@ -18,7 +19,7 @@ test.describe("Searching", () => {
 
     const highlights = page.getByTestId("highlight");
     await expect(highlights).toHaveCount(1);
-    await expect(highlights.first()).toContainText(
+    await expect(highlights).toContainText(
       "ShardedClusterFixture:job0:mongos0 ",
     );
   });
@@ -98,7 +99,6 @@ test.describe("Searching", () => {
 
   test("should be able to search on filtered content", async ({ page }) => {
     await helpers.addFilter(page, "conn49");
-    await page.locator("[data-cy^='skipped-lines-row-']").first().waitFor();
 
     const skippedLines = page.locator("[data-cy^='skipped-lines-row-']");
     await expect(skippedLines).toHaveCount(7);
@@ -113,7 +113,9 @@ test.describe("Searching", () => {
   }) => {
     const filter = "nonexistent-term";
     await helpers.addFilter(page, filter);
-    await page.locator("[data-cy^='skipped-lines-row-']").first().waitFor();
+
+    const skippedLines = page.locator("[data-cy^='skipped-lines-row-']");
+    await expect(skippedLines).toHaveCount(1);
 
     await helpers.addSearch(page, "conn49");
     await expect(page.getByTestId("search-count")).toBeVisible();
@@ -125,9 +127,7 @@ test.describe("Searching", () => {
       .click();
 
     await expect(page).toHaveURL(/^(?!.*filters)/);
-    await expect(page.locator("[data-cy^='skipped-lines-row-']")).toHaveCount(
-      0,
-    );
+    await expect(skippedLines).toHaveCount(0);
 
     await expect(page.getByTestId("search-count")).toContainText("1/8");
     await expect(page.locator("[data-highlighted='true']")).toContainText(

--- a/apps/parsley/playwright/tests/resmokeLogs/resmoke_searching.spec.ts
+++ b/apps/parsley/playwright/tests/resmokeLogs/resmoke_searching.spec.ts
@@ -123,7 +123,7 @@ test.describe("Searching", () => {
 
     await page
       .getByTestId(`filter-${filter}`)
-      .locator('[aria-label="Delete filter"]')
+      .getByRole("button", { name: "Delete filter" })
       .click();
 
     await expect(page).toHaveURL(/^(?!.*filters)/);

--- a/apps/parsley/playwright/tests/routes.spec.ts
+++ b/apps/parsley/playwright/tests/routes.spec.ts
@@ -17,12 +17,8 @@ test.describe("Parsley Routes", () => {
     const logLink =
       "/evergreen/spruce_ubuntu1604_test_2c9056df66d42fb1908d52eed096750a91f1f089_22_03_02_16_45_12/0/task";
     await page.goto(logLink);
-    await page.locator("[data-cy^='log-row-']").first().waitFor();
-    expect(await page.locator("[data-cy^='log-row-']").count()).toBeGreaterThan(
-      0,
-    );
-    await page.getByTestId("ansi-row").first().waitFor();
-    expect(await page.getByTestId("ansi-row").count()).toBeGreaterThan(0);
+    await expect(page.locator("[data-cy^='log-row-']")).not.toHaveCount(0);
+    await expect(page.getByTestId("ansi-row")).not.toHaveCount(0);
     await expect(page.getByTestId("resmoke-row")).toBeHidden();
     await expect(page.getByText("Task logger initialized")).toBeVisible();
   });
@@ -47,12 +43,8 @@ test.describe("Parsley Routes", () => {
     const testLogLine =
       "AssertionError: Timed out retrying after 4000ms: Too many elements found. Found '1', expected '0'";
     await page.goto(logLink);
-    await page.locator("[data-cy^='log-row-']").first().waitFor();
-    expect(await page.locator("[data-cy^='log-row-']").count()).toBeGreaterThan(
-      0,
-    );
-    await page.getByTestId("ansi-row").first().waitFor();
-    expect(await page.getByTestId("ansi-row").count()).toBeGreaterThan(0);
+    await expect(page.locator("[data-cy^='log-row-']")).not.toHaveCount(0);
+    await expect(page.getByTestId("ansi-row")).not.toHaveCount(0);
     await expect(page.getByTestId("resmoke-row")).toBeHidden();
     await expect(page.getByText(testLogLine)).toBeVisible();
   });
@@ -63,12 +55,8 @@ test.describe("Parsley Routes", () => {
     const logLink =
       "/taskFile/spruce_ubuntu1604_test_2c9056df66d42fb1908d52eed096750a91f1f089_22_03_02_16_45_12/0/sample%20file";
     await page.goto(logLink);
-    await page.locator("[data-cy^='log-row-']").first().waitFor();
-    expect(await page.locator("[data-cy^='log-row-']").count()).toBeGreaterThan(
-      0,
-    );
-    await page.getByTestId("ansi-row").first().waitFor();
-    expect(await page.getByTestId("ansi-row").count()).toBeGreaterThan(0);
+    await expect(page.locator("[data-cy^='log-row-']")).not.toHaveCount(0);
+    await expect(page.getByTestId("ansi-row")).not.toHaveCount(0);
   });
 
   test("should show 404 when visiting a nonexistent page", async ({ page }) => {

--- a/apps/parsley/playwright/tests/sectioning.spec.ts
+++ b/apps/parsley/playwright/tests/sectioning.spec.ts
@@ -29,18 +29,17 @@ test.describe("Sectioning", () => {
     await expect(page.getByTestId("section-header")).toHaveCount(0);
   });
 
-  test("Clicking 'Open all subsections' opens all subsections", async ({
-    page,
-  }) => {
-    await page.getByTestId("open-all-sections-btn").click();
+  test("Clicking 'Open all sections' opens all sections", async ({ page }) => {
+    const openAllSectionsButton = page.getByRole("button", {
+      name: "Open all sections",
+    });
+    await openAllSectionsButton.click();
 
     const carets = page.getByTestId("caret-toggle");
     await expect(carets).not.toHaveCount(0);
     const caretToggles = await carets.all();
     for (const toggle of caretToggles) {
-      await expect(
-        toggle.getByRole("button", { name: "Close section" }),
-      ).toBeVisible();
+      await expect(toggle).toHaveAttribute("aria-label", "Close section");
     }
 
     const headers = page.getByTestId("section-header");
@@ -51,22 +50,18 @@ test.describe("Sectioning", () => {
     }
   });
 
-  test("Clicking 'Close all subsections' opens all subsections", async ({
-    page,
-  }) => {
-    await page.getByTestId("close-all-sections-btn").click();
+  test("Clicking 'Close all sections' opens all sections", async ({ page }) => {
+    const closeAllSectionsButton = page.getByRole("button", {
+      name: "Close all sections",
+    });
+    await closeAllSectionsButton.click();
 
     // Wait for the first caret toggle to update before checking all of them.
     const carets = page.getByTestId("caret-toggle");
     await expect(carets).not.toHaveCount(0);
-    await expect(
-      carets.nth(0).getByRole("button", { name: "Open section" }),
-    ).toBeVisible();
     const caretToggles = await carets.all();
     for (const toggle of caretToggles) {
-      await expect(
-        toggle.getByRole("button", { name: "Open section" }),
-      ).toBeVisible();
+      await expect(toggle).toHaveAttribute("aria-label", "Open section");
     }
 
     const openLineNumbers = [0, 1, 2, 8, 9, 9616, 9617, 9618, 9619];
@@ -140,7 +135,10 @@ test.describe("Sectioning", () => {
       true,
       "log-viewing",
     );
-    await page.getByTestId("open-all-sections-btn").click();
+    const openAllSectionsButton = page.getByRole("button", {
+      name: "Open all sections",
+    });
+    await openAllSectionsButton.click();
     await page.getByTestId("bookmark-9614").click();
     await expect(page.locator("[data-cy='line-index-9614']")).toBeVisible();
     await expect(page.getByTestId("sticky-headers")).toBeVisible();

--- a/apps/parsley/playwright/tests/sectioning.spec.ts
+++ b/apps/parsley/playwright/tests/sectioning.spec.ts
@@ -10,7 +10,8 @@ const getTargetSelector = (rowIndex: number) =>
 test.describe("Sectioning", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto(`${logLink}?shareLine=0`);
-    await page.getByTestId("section-header").first().waitFor();
+    await expect(page.getByTestId("ansi-row")).not.toHaveCount(0);
+    await expect(page.getByTestId("section-header")).not.toHaveCount(0);
   });
 
   test("Toggling the sections options displays and hides sections", async ({
@@ -19,13 +20,10 @@ test.describe("Sectioning", () => {
     // Check that sections is toggled.
     await helpers.toggleDetailsPanel(page, true);
     await page.locator("button[data-cy='log-viewing-tab']").click();
-    await expect(page.getByTestId("sections-toggle")).toHaveAttribute(
-      "aria-checked",
-      "true",
-    );
+    await expect(page.getByTestId("sections-toggle")).toBeChecked();
     await helpers.toggleDetailsPanel(page, false);
     // Assert sections are visible.
-    expect(await page.getByTestId("section-header").count()).toBeGreaterThan(0);
+    await expect(page.getByTestId("section-header")).not.toHaveCount(0);
     // Untoggle sections and assert they are hidden.
     await helpers.clickToggle(page, "sections-toggle", false, "log-viewing");
     await expect(page.getByTestId("section-header")).toHaveCount(0);
@@ -35,21 +33,19 @@ test.describe("Sectioning", () => {
     page,
   }) => {
     await page.getByTestId("open-all-sections-btn").click();
-    const caretToggles = await page.getByTestId("caret-toggle").all();
+
+    const carets = page.getByTestId("caret-toggle");
+    await expect(carets).not.toHaveCount(0);
+    const caretToggles = await carets.all();
     for (const toggle of caretToggles) {
       await expect(toggle).toHaveAttribute("aria-label", "Close section");
     }
 
-    const headers = await page.getByTestId("section-header").all();
-    for (const header of headers) {
+    const headers = page.getByTestId("section-header");
+    await expect(headers).not.toHaveCount(0);
+    const sectionHeaders = await headers.all();
+    for (const header of sectionHeaders) {
       await expect(header).toHaveAttribute("aria-expanded", "true");
-    }
-
-    const sections = await page
-      .locator("[title='Use shift+click to select multiple lines']")
-      .all();
-    for (let i = 0; i < sections.length; i++) {
-      await expect(sections[i]).toHaveAttribute("data-cy", `line-index-${i}`);
     }
   });
 
@@ -59,30 +55,25 @@ test.describe("Sectioning", () => {
     await page.getByTestId("close-all-sections-btn").click();
 
     // Wait for the first caret toggle to update before checking all of them.
-    await expect(page.getByTestId("caret-toggle").first()).toHaveAttribute(
+    await expect(page.getByTestId("caret-toggle").nth(0)).toHaveAttribute(
       "aria-label",
       "Open section",
     );
 
-    const caretToggles = await page.getByTestId("caret-toggle").all();
+    const carets = page.getByTestId("caret-toggle");
+    await expect(carets).not.toHaveCount(0);
+    const caretToggles = await carets.all();
     for (const toggle of caretToggles) {
       await expect(toggle).toHaveAttribute("aria-label", "Open section");
     }
 
-    const sectionsCount = page.locator(
-      "[title='Use shift+click to select multiple lines']",
-    );
-    await expect(sectionsCount).toHaveCount(9);
-
     const openLineNumbers = [0, 1, 2, 8, 9, 9616, 9617, 9618, 9619];
-    const sections = await page
-      .locator("[title='Use shift+click to select multiple lines']")
-      .all();
-    for (let i = 0; i < sections.length; i++) {
-      await expect(sections[i]).toHaveAttribute(
-        "data-cy",
-        `line-index-${openLineNumbers[i]}`,
-      );
+    const visibleRows = page.locator("[data-cy^='log-row-']");
+    await expect(visibleRows).toHaveCount(openLineNumbers.length);
+    const logRows = await visibleRows.all();
+    for (const row of logRows) {
+      const dataCy = await row.getAttribute("data-cy");
+      expect(dataCy).toMatch(/log-row-(0|1|2|8|9|9616|9617|9618|9619)/);
     }
   });
 
@@ -118,6 +109,7 @@ test.describe("Sectioning", () => {
     page,
   }) => {
     await page.goto(logLink);
+    await expect(page.getByTestId("ansi-row")).not.toHaveCount(0);
     await expect(
       page.getByText(
         "[2024/03/12 11:18:36.034] Command 'subprocess.exec' ('check resmoke failure') in function 'run tests' (step 2.20 of 2) failed: process encountered problem: exit code 1.",
@@ -129,6 +121,7 @@ test.describe("Sectioning", () => {
     page,
   }) => {
     await page.goto(`${logLink}?shareLine=19`);
+    await expect(page.getByTestId("ansi-row")).not.toHaveCount(0);
     await expect(
       page.getByText(
         "[2024/03/12 11:01:53.831] rm -rf /data/db/* mongo-diskstats* mongo-*.tgz ~/.aws ~/.boto venv",

--- a/apps/parsley/playwright/tests/sectioning.spec.ts
+++ b/apps/parsley/playwright/tests/sectioning.spec.ts
@@ -38,7 +38,9 @@ test.describe("Sectioning", () => {
     await expect(carets).not.toHaveCount(0);
     const caretToggles = await carets.all();
     for (const toggle of caretToggles) {
-      await expect(toggle).toHaveAttribute("aria-label", "Close section");
+      await expect(
+        toggle.getByRole("button", { name: "Close section" }),
+      ).toBeVisible();
     }
 
     const headers = page.getByTestId("section-header");
@@ -55,16 +57,16 @@ test.describe("Sectioning", () => {
     await page.getByTestId("close-all-sections-btn").click();
 
     // Wait for the first caret toggle to update before checking all of them.
-    await expect(page.getByTestId("caret-toggle").nth(0)).toHaveAttribute(
-      "aria-label",
-      "Open section",
-    );
-
     const carets = page.getByTestId("caret-toggle");
     await expect(carets).not.toHaveCount(0);
+    await expect(
+      carets.nth(0).getByRole("button", { name: "Open section" }),
+    ).toBeVisible();
     const caretToggles = await carets.all();
     for (const toggle of caretToggles) {
-      await expect(toggle).toHaveAttribute("aria-label", "Open section");
+      await expect(
+        toggle.getByRole("button", { name: "Open section" }),
+      ).toBeVisible();
     }
 
     const openLineNumbers = [0, 1, 2, 8, 9, 9616, 9617, 9618, 9619];

--- a/apps/parsley/playwright/tests/shortcuts.spec.ts
+++ b/apps/parsley/playwright/tests/shortcuts.spec.ts
@@ -3,6 +3,7 @@ import { test, expect } from "@playwright/test";
 test.describe("Shortcuts", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto("/");
+    await expect(page.getByTestId("upload-zone")).toBeVisible();
   });
 
   test("should be able to open the modal using keyboard shortcut", async ({

--- a/apps/parsley/playwright/tests/uploadedLogs/upload.spec.ts
+++ b/apps/parsley/playwright/tests/uploadedLogs/upload.spec.ts
@@ -36,13 +36,12 @@ test.describe("Upload page", () => {
       await page.getByTestId("process-log-button").click();
 
       await expect(page.getByTestId("log-window")).toBeVisible();
-      expect(await page.getByTestId("resmoke-row").count()).toBeGreaterThan(0);
+      await expect(page.getByTestId("resmoke-row")).not.toHaveCount(0);
     });
   });
 
   test.describe("uploading logs via clipboard", () => {
     test.beforeEach(async ({ page }) => {
-      // Set up clipboard mock before navigation.
       await page.goto("/upload");
     });
 
@@ -83,8 +82,8 @@ test.describe("Upload page", () => {
 
       await expect(page.getByTestId("log-window")).toBeVisible();
       const resmokeRows = page.getByTestId("resmoke-row");
-      expect(await resmokeRows.count()).toBeGreaterThan(0);
-      await expect(resmokeRows.first()).toContainText(
+      await expect(resmokeRows).not.toHaveCount(0);
+      await expect(resmokeRows.nth(0)).toContainText(
         "[js_test:group_pushdown] Fixture status:",
       );
     });
@@ -105,6 +104,7 @@ test.describe("Upload page", () => {
       await page.getByTestId("upload-link").click();
       await expect(page.getByTestId("confirmation-modal")).toBeVisible();
       await page.getByRole("button", { name: "Confirm" }).click();
+      await expect(page).toHaveURL("/upload");
       await expect(page.getByTestId("upload-zone")).toBeVisible();
     });
   });

--- a/apps/parsley/playwright/tests/uploadedLogs/upload.spec.ts
+++ b/apps/parsley/playwright/tests/uploadedLogs/upload.spec.ts
@@ -33,7 +33,7 @@ test.describe("Upload page", () => {
       await expect(page.getByTestId("parse-log-select")).toBeVisible();
       await page.getByTestId("parse-log-select").click();
       await page.getByRole("option", { name: "Resmoke" }).click();
-      await page.getByTestId("process-log-button").click();
+      await page.getByRole("button", { name: "Process log" }).click();
 
       await expect(page.getByTestId("log-window")).toBeVisible();
       await expect(page.getByTestId("resmoke-row")).not.toHaveCount(0);
@@ -76,7 +76,7 @@ test.describe("Upload page", () => {
       await expect(resmokeOption).toBeVisible();
       await resmokeOption.click();
 
-      const processButton = page.getByTestId("process-log-button");
+      const processButton = page.getByRole("button", { name: "Process log" });
       await expect(processButton).toBeVisible();
       await processButton.click();
 

--- a/apps/parsley/src/components/DetailsMenu/DetailsMenuCard/ButtonRow/index.tsx
+++ b/apps/parsley/src/components/DetailsMenu/DetailsMenuCard/ButtonRow/index.tsx
@@ -20,7 +20,6 @@ const ButtonRow: React.FC = () => {
         justify="middle"
         trigger={
           <Button
-            data-cy="job-logs-button"
             disabled={!jobLogsURL}
             href={jobLogsURL}
             leftGlyph={<Icon glyph="Export" />}
@@ -37,7 +36,6 @@ const ButtonRow: React.FC = () => {
         justify="middle"
         trigger={
           <Button
-            data-cy="raw-log-button"
             disabled={!rawLogURL}
             href={rawLogURL}
             leftGlyph={<Icon glyph="Export" />}
@@ -54,7 +52,6 @@ const ButtonRow: React.FC = () => {
         justify="middle"
         trigger={
           <Button
-            data-cy="html-log-button"
             disabled={!htmlLogURL}
             href={htmlLogURL}
             leftGlyph={<Icon glyph="Export" />}

--- a/apps/parsley/src/components/LogRow/BaseRow/SharingMenu/index.tsx
+++ b/apps/parsley/src/components/LogRow/BaseRow/SharingMenu/index.tsx
@@ -134,11 +134,7 @@ const SharingMenu: React.FC = () => {
       open={open}
       setOpen={setMenuOpen}
       trigger={
-        <MenuIcon
-          aria-label="Expand share menu"
-          data-cy="sharing-menu-button"
-          onClick={setMenuOpen}
-        >
+        <MenuIcon aria-label="Expand share menu" onClick={setMenuOpen}>
           <Icon glyph="Ellipsis" />
         </MenuIcon>
       }

--- a/apps/parsley/src/components/NavBar/index.tsx
+++ b/apps/parsley/src/components/NavBar/index.tsx
@@ -41,7 +41,7 @@ const NavBar: React.FC = () => {
         >
           <Icon glyph="InfoWithCircle" />
         </IconButton>
-        <StyledDetailsMenu data-cy="details-button" disabled={!hasLogs} />
+        <StyledDetailsMenu disabled={!hasLogs} />
         {isDevelopmentBuild() && (
           <Button
             onClick={logoutAndRedirect}

--- a/apps/parsley/src/components/Search/SearchResults/index.tsx
+++ b/apps/parsley/src/components/Search/SearchResults/index.tsx
@@ -1,5 +1,5 @@
 import styled from "@emotion/styled";
-import { Button } from "@leafygreen-ui/button";
+import { Button, Size } from "@leafygreen-ui/button";
 import { CharKey, ModifierKey } from "@evg-ui/lib/constants/keys";
 import { size } from "@evg-ui/lib/constants/tokens";
 import { useKeyboardShortcut } from "@evg-ui/lib/hooks/useKeyboardShortcut";
@@ -40,17 +40,12 @@ const SearchResults: React.FC<SearchResultsProps> = ({
       {searchState.searchRange !== undefined && (
         <>
           <Button
-            data-cy="previous-button"
             onClick={() => paginate(DIRECTION.PREVIOUS)}
-            size="small"
+            size={Size.Small}
           >
             Prev
           </Button>
-          <Button
-            data-cy="next-button"
-            onClick={() => paginate(DIRECTION.NEXT)}
-            size="small"
-          >
+          <Button onClick={() => paginate(DIRECTION.NEXT)} size={Size.Small}>
             Next
           </Button>
         </>

--- a/apps/parsley/src/components/SidePanel/NavGroup/FilterNavGroup/FilterGroup/index.tsx
+++ b/apps/parsley/src/components/SidePanel/NavGroup/FilterNavGroup/FilterGroup/index.tsx
@@ -105,7 +105,6 @@ const FilterGroup: React.FC<FilterGroupProps> = ({
           <IconButtonContainer>
             <Toggle
               aria-label={visible ? "Hide filter" : "Show filter"}
-              aria-labelledby={id}
               checked={visible}
               disabled={!isValid}
               onChange={() => editFilter("visible", !visible, filter)}

--- a/apps/parsley/src/components/SidePanel/NavGroup/HighlightNavGroup/index.tsx
+++ b/apps/parsley/src/components/SidePanel/NavGroup/HighlightNavGroup/index.tsx
@@ -32,7 +32,6 @@ const HighlightNavGroup: React.FC = () => {
         <HighlightedTerm key={`highlight-${highlight}`}>
           <IconButton
             aria-label="Delete highlight"
-            data-cy="delete-highlight-button"
             onClick={() => deleteHighlight(highlight)}
           >
             <Icon glyph="X" />

--- a/apps/parsley/src/components/SubHeader/SectionControls.test.tsx
+++ b/apps/parsley/src/components/SubHeader/SectionControls.test.tsx
@@ -97,14 +97,21 @@ describe("SectionControls", () => {
       },
     }));
     renderWithRouterMatch(<SectionControls />, { wrapper });
-    expect(screen.getByDataCy("open-all-sections-btn")).toBeVisible();
-    await user.click(screen.getByDataCy("open-all-sections-btn"));
+
+    const openAllSectionsButton = screen.getByRole("button", {
+      name: "Open all sections",
+    });
+    expect(openAllSectionsButton).toBeVisible();
+    await user.click(openAllSectionsButton);
     expect(sendEventMock).toHaveBeenCalledOnce();
     expect(sendEventMock).toHaveBeenCalledWith({
       name: "Clicked open all sections button",
     });
     expect(toggleAllSectionsMock).toHaveBeenCalledOnce();
-    await user.click(screen.getByDataCy("close-all-sections-btn"));
+    const closeAllSectionsButton = screen.getByRole("button", {
+      name: "Close all sections",
+    });
+    await user.click(closeAllSectionsButton);
     await waitFor(() =>
       expect(toggleAllSectionsMock).toHaveBeenCalledWith(false),
     );

--- a/apps/parsley/src/components/SubHeader/SectionControls.tsx
+++ b/apps/parsley/src/components/SubHeader/SectionControls.tsx
@@ -28,7 +28,6 @@ const SectionControls = () => {
     <>
       {!allOpen && (
         <Button
-          data-cy="open-all-sections-btn"
           onClick={() => {
             toggleAllSections(true);
             sendEvent({ name: "Clicked open all sections button" });
@@ -40,7 +39,6 @@ const SectionControls = () => {
       )}
       {!allClosed && (
         <Button
-          data-cy="close-all-sections-btn"
           onClick={() => {
             toggleAllSections(false);
             sendEvent({ name: "Clicked close all sections button" });

--- a/apps/parsley/src/pages/LogDrop/FileDropper.test.tsx
+++ b/apps/parsley/src/pages/LogDrop/FileDropper.test.tsx
@@ -235,7 +235,9 @@ describe("FileDropper", () => {
       defaultOption.click();
     });
 
-    const processLogButton = screen.getByText("Process Log");
+    const processLogButton = screen.getByRole("button", {
+      name: "Process log",
+    });
     expect(processLogButton).toBeInTheDocument();
 
     act(() => {

--- a/apps/parsley/src/pages/LogDrop/ParseLogSelect/ParseLogSelect.test.tsx
+++ b/apps/parsley/src/pages/LogDrop/ParseLogSelect/ParseLogSelect.test.tsx
@@ -21,7 +21,7 @@ describe("parse log select", () => {
       />,
     );
     expect(screen.getByText("Select...")).toBeInTheDocument();
-    expect(screen.getByDataCy("process-log-button")).toHaveAttribute(
+    expect(screen.getByRole("button", { name: "Process log" })).toHaveAttribute(
       "aria-disabled",
       "true",
     );
@@ -37,7 +37,7 @@ describe("parse log select", () => {
       />,
     );
     expect(screen.getByText("Raw")).toBeInTheDocument();
-    expect(screen.getByDataCy("process-log-button")).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Process log" })).toBeEnabled();
   });
 
   it("defaults to 'Resmoke' option if stored value is set to resmoke logs", () => {
@@ -50,7 +50,7 @@ describe("parse log select", () => {
       />,
     );
     expect(screen.getByText("Resmoke")).toBeInTheDocument();
-    expect(screen.getByDataCy("process-log-button")).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Process log" })).toBeEnabled();
   });
 
   it("clicking the 'Process Log' button calls the onParse function", async () => {
@@ -64,7 +64,7 @@ describe("parse log select", () => {
         onParse={onParse}
       />,
     );
-    await user.click(screen.getByDataCy("process-log-button"));
+    await user.click(screen.getByRole("button", { name: "Process log" }));
     expect(onParse).toHaveBeenCalledTimes(1);
   });
 

--- a/apps/parsley/src/pages/LogDrop/ParseLogSelect/index.tsx
+++ b/apps/parsley/src/pages/LogDrop/ParseLogSelect/index.tsx
@@ -53,12 +53,11 @@ const ParseLogSelect: React.FC<ParseLogSelectProps> = ({
       <ButtonContainer>
         <Button onClick={onCancel}>Cancel</Button>
         <Button
-          data-cy="process-log-button"
           disabled={!logType}
           onClick={() => onParse(logType)}
           variant="primary"
         >
-          Process Log
+          Process log
         </Button>
       </ButtonContainer>
     </ProcessLogsContainer>


### PR DESCRIPTION
DEVPROD-32887

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->

<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
Things like `count()`, `innerText()`, `all()` are not retryable in Playwright, so we can replace these statements with `toHaveCount` and `toContainText`, or add additional guards. Also cleans up general test logic.