### PR TITLE
DEVPROD-32499: Show repo-level subscriptions on project pages

### DIFF
--- a/apps/spruce/playwright/tests/projectAndRepoSettings/repoSettings/notifications.spec.ts
+++ b/apps/spruce/playwright/tests/projectAndRepoSettings/repoSettings/notifications.spec.ts
@@ -1,0 +1,40 @@
+import { test, expect } from "../../../fixtures";
+import { validateToast, selectOption } from "../../../helpers";
+import {
+  getProjectSettingsRoute,
+  getRepoSettingsRoute,
+  ProjectSettingsTabRoutes,
+  projectUseRepoEnabled,
+  repo,
+} from "../constants";
+import { save } from "../utils";
+
+test.describe("Repo Notifications", () => {
+  const repoNotificationsRoute = getRepoSettingsRoute(
+    repo,
+    ProjectSettingsTabRoutes.Notifications,
+  );
+  const projectNotificationsRoute = getProjectSettingsRoute(
+    projectUseRepoEnabled,
+    ProjectSettingsTabRoutes.Notifications,
+  );
+
+  test("adding a subscription to a repo causes it to appear on a branch project's notifications page", async ({
+    authenticatedPage: page,
+  }) => {
+    await page.goto(repoNotificationsRoute);
+    await page.getByRole("button", { name: "Add Subscription" }).click();
+    await selectOption(page, "Event", "Any version finishes");
+    await selectOption(page, "Notification Method", "Email");
+    await page.getByTestId("email-input").fill("test@example.com");
+    await save(page);
+    await validateToast(page, "success", "Successfully updated repo", true);
+
+    await page.goto(projectNotificationsRoute);
+    await expect(
+      page.getByTestId("expandable-card").filter({
+        hasText: "Version outcome",
+      }),
+    ).toBeVisible();
+  });
+});

--- a/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/NotificationsTab/NotificationsTab.tsx
+++ b/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/NotificationsTab/NotificationsTab.tsx
@@ -13,8 +13,7 @@ const tab = ProjectSettingsTabRoutes.Notifications;
 const getInitialFormState = (
   projectData: TabProps["projectData"],
   repoData: TabProps["repoData"],
-): NotificationsFormState => {
-  // @ts-expect-error: FIXME. This comment was added by an automated script.
+): NotificationsFormState | undefined => {
   if (!projectData) return repoData;
   if (repoData) return { ...projectData, repoData };
   return projectData;

--- a/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/NotificationsTab/NotificationsTab.tsx
+++ b/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/NotificationsTab/NotificationsTab.tsx
@@ -25,7 +25,10 @@ export const NotificationsTab: React.FC<TabProps> = ({
   projectType,
   repoData,
 }) => {
-  const initialFormState = getInitialFormState(projectData, repoData);
+  const initialFormState = useMemo(
+    () => getInitialFormState(projectData, repoData),
+    [projectData, repoData],
+  );
 
   const formSchema = useMemo(
     () =>

--- a/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/NotificationsTab/NotificationsTab.tsx
+++ b/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/NotificationsTab/NotificationsTab.tsx
@@ -10,12 +10,22 @@ import { NotificationsFormState, TabProps } from "./types";
 
 const tab = ProjectSettingsTabRoutes.Notifications;
 
+const getInitialFormState = (
+  projectData: TabProps["projectData"],
+  repoData: TabProps["repoData"],
+): NotificationsFormState => {
+  // @ts-expect-error: FIXME. This comment was added by an automated script.
+  if (!projectData) return repoData;
+  if (repoData) return { ...projectData, repoData };
+  return projectData;
+};
+
 export const NotificationsTab: React.FC<TabProps> = ({
   projectData,
   projectType,
   repoData,
 }) => {
-  const initialFormState = projectData || repoData;
+  const initialFormState = getInitialFormState(projectData, repoData);
 
   const formSchema = useMemo(
     () =>

--- a/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/NotificationsTab/getFormSchema.tsx
+++ b/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/NotificationsTab/getFormSchema.tsx
@@ -195,8 +195,11 @@ const HelpText: React.FC<HelpTextProps> = ({ isAttachedToRepo }) => {
       )}
       {isAttachedToRepo && (
         <NoteText>
-          Note: Project notifications are <b>merged with repo notifications</b>,
-          meaning that users will receive duplicate notifications if the repo
+          Project notifications are{" "}
+          <i>
+            <b>merged with repo notifications</b>
+          </i>
+          , meaning that users will receive duplicate notifications if the repo
           and project are subscribed to the same event.
         </NoteText>
       )}
@@ -206,5 +209,4 @@ const HelpText: React.FC<HelpTextProps> = ({ isAttachedToRepo }) => {
 
 const NoteText = styled.div`
   margin-top: ${size.xxs};
-  font-style: italic;
 `;

--- a/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/NotificationsTab/getFormSchema.tsx
+++ b/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/NotificationsTab/getFormSchema.tsx
@@ -138,7 +138,11 @@ export const getFormSchema = (
       }),
       subscriptions: {
         "ui:placeholder": "No subscriptions are defined.",
-        "ui:descriptionNode": <HelpText />,
+        "ui:descriptionNode": (
+          <HelpText
+            isAttachedToRepo={projectType === ProjectType.AttachedProject}
+          />
+        ),
         "ui:addButtonText": "Add subscription",
         "ui:orderable": false,
         "ui:useExpandableCard": true,
@@ -172,7 +176,11 @@ export const getFormSchema = (
   };
 };
 
-const HelpText: React.FC = () => {
+interface HelpTextProps {
+  isAttachedToRepo: boolean;
+}
+
+const HelpText: React.FC<HelpTextProps> = ({ isAttachedToRepo }) => {
   const spruceConfig = useSpruceConfig();
   const slackName = spruceConfig?.slack?.name;
 
@@ -185,11 +193,13 @@ const HelpText: React.FC = () => {
           <InlineCode>invite {slackName}</InlineCode> in the channel.
         </>
       )}
-      <NoteText>
-        Note: Project notifications are <b>merged with repo notifications</b>,
-        meaning that users will receive duplicate notifications if the repo and
-        project are subscribed to the same event.
-      </NoteText>
+      {isAttachedToRepo && (
+        <NoteText>
+          Note: Project notifications are <b>merged with repo notifications</b>,
+          meaning that users will receive duplicate notifications if the repo
+          and project are subscribed to the same event.
+        </NoteText>
+      )}
     </Description>
   );
 };

--- a/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/NotificationsTab/getFormSchema.tsx
+++ b/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/NotificationsTab/getFormSchema.tsx
@@ -1,4 +1,6 @@
 import { InlineCode, Description } from "@leafygreen-ui/typography";
+import { styled } from "storybook/theming";
+import { size } from "@evg-ui/lib/constants/tokens";
 import { bannerThemeToLabelMap } from "components/Banners";
 import {
   getEventSchema,
@@ -176,13 +178,23 @@ const HelpText: React.FC = () => {
 
   return (
     <Description>
-      Private slack channels may require further Slack configuration.
+      Private Slack channels may require further Slack configuration.{" "}
       {slackName && (
-        <div>
+        <>
           Invite evergreen to your private Slack channels by running{" "}
           <InlineCode>invite {slackName}</InlineCode> in the channel.
-        </div>
+        </>
       )}
+      <NoteText>
+        Note: Project notifications are <b>merged with repo notifications</b>,
+        meaning that users will receive duplicate notifications if the repo and
+        project are both subscribed to the same event.
+      </NoteText>
     </Description>
   );
 };
+
+const NoteText = styled.div`
+  margin-top: ${size.xxs};
+  font-style: italic;
+`;

--- a/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/NotificationsTab/getFormSchema.tsx
+++ b/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/NotificationsTab/getFormSchema.tsx
@@ -29,6 +29,26 @@ export const getFormSchema = (
   return {
     fields: {},
     schema: {
+      definitions: {
+        subscriptionArray: {
+          title: "Subscriptions",
+          type: "array" as const,
+          default: [],
+          items: {
+            type: "object" as const,
+            properties: {
+              subscriptionData: {
+                type: "object" as const,
+                title: "",
+                properties: {
+                  event: eventSchema,
+                  notification: notificationSchema,
+                },
+              },
+            },
+          },
+        },
+      },
       type: "object" as const,
       properties: {
         buildBreakSettings: {
@@ -75,23 +95,16 @@ export const getFormSchema = (
             },
           },
         }),
-        subscriptions: {
-          type: "array" as const,
-          title: "Subscriptions",
-          items: {
+        subscriptions: { $ref: "#/definitions/subscriptionArray" },
+        ...(projectType === ProjectType.AttachedProject && {
+          repoData: {
             type: "object" as const,
+            title: "Repo Subscriptions",
             properties: {
-              subscriptionData: {
-                type: "object" as const,
-                title: "",
-                properties: {
-                  event: eventSchema,
-                  notification: notificationSchema,
-                },
-              },
+              subscriptions: { $ref: "#/definitions/subscriptionArray" },
             },
           },
-        },
+        }),
       },
     },
     uiSchema: {
@@ -133,6 +146,23 @@ export const getFormSchema = (
           subscriptionData: {
             event: eventUiSchema,
             notification: notificationUiSchema,
+          },
+        },
+      },
+      repoData: {
+        subscriptions: {
+          "ui:placeholder": "Repo has no subscriptions defined.",
+          "ui:addable": false,
+          "ui:orderable": false,
+          "ui:readonly": true,
+          "ui:showLabel": false,
+          "ui:useExpandableCard": true,
+          items: {
+            "ui:label": false,
+            subscriptionData: {
+              event: eventUiSchema,
+              notification: notificationUiSchema,
+            },
           },
         },
       },

--- a/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/NotificationsTab/getFormSchema.tsx
+++ b/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/NotificationsTab/getFormSchema.tsx
@@ -1,5 +1,5 @@
+import styled from "@emotion/styled";
 import { InlineCode, Description } from "@leafygreen-ui/typography";
-import { styled } from "storybook/theming";
 import { size } from "@evg-ui/lib/constants/tokens";
 import { bannerThemeToLabelMap } from "components/Banners";
 import {

--- a/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/NotificationsTab/getFormSchema.tsx
+++ b/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/NotificationsTab/getFormSchema.tsx
@@ -188,7 +188,7 @@ const HelpText: React.FC = () => {
       <NoteText>
         Note: Project notifications are <b>merged with repo notifications</b>,
         meaning that users will receive duplicate notifications if the repo and
-        project are both subscribed to the same event.
+        project are subscribed to the same event.
       </NoteText>
     </Description>
   );

--- a/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/NotificationsTab/transformers.test.ts
+++ b/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/NotificationsTab/transformers.test.ts
@@ -1,10 +1,84 @@
-import { BannerTheme, ProjectSettingsInput } from "gql/generated/types";
+import {
+  BannerTheme,
+  ProjectSettingsInput,
+  RepoSettingsInput,
+} from "gql/generated/types";
 import { data } from "../testData";
 import { ProjectType } from "../utils";
 import { formToGql, gqlToForm } from "./transformers";
 import { NotificationsFormState } from "./types";
 
-const { projectBase } = data;
+const { projectBase, repoBase } = data;
+
+describe("repo data", () => {
+  it("correctly converts from GQL to a form", () => {
+    expect(
+      gqlToForm(repoBase, { projectType: ProjectType.Repo }),
+    ).toStrictEqual(repoFormBase);
+  });
+
+  it("correctly converts from a form to GQL when the subscriptions field is empty", () => {
+    expect(formToGql(repoFormBase, true, "repo123")).toStrictEqual(
+      repoResultBase,
+    );
+  });
+
+  it("correctly converts from a form to GQL when the subscriptions field is populated", () => {
+    const repoForm = {
+      ...repoFormBase,
+      subscriptions: [
+        {
+          subscriptionData: {
+            id: "xyz",
+            event: {
+              extraFields: {
+                requester: "gitter_request",
+              },
+              eventSelect: "any-version-finishes",
+            },
+            notification: {
+              notificationSelect: "jira-comment",
+              jiraCommentInput: "evg-123",
+            },
+          },
+        },
+      ],
+    };
+    const repoResult = {
+      ...repoResultBase,
+      subscriptions: [
+        {
+          id: "xyz",
+          owner_type: "project",
+          regex_selectors: [],
+          resource_type: "VERSION",
+          selectors: [
+            {
+              type: "project",
+              data: "repo123",
+            },
+            {
+              type: "requester",
+              data: "gitter_request",
+            },
+          ],
+          subscriber: {
+            type: "jira-comment",
+            target: "evg-123",
+            jiraIssueSubscriber: undefined,
+            webhookSubscriber: undefined,
+          },
+          trigger: "outcome",
+          trigger_data: {
+            requester: "gitter_request",
+          },
+        },
+      ],
+    };
+
+    expect(formToGql(repoForm, true, "repo123")).toStrictEqual(repoResult);
+  });
+});
 
 describe("project data", () => {
   it("correctly converts from GQL to a form for project type", () => {
@@ -259,3 +333,19 @@ const projectResultBase: ProjectSettingsInput = {
 };
 
 const banner = { bannerData: { text: "", theme: BannerTheme.Announcement } };
+
+const repoFormBase: NotificationsFormState = {
+  buildBreakSettings: {
+    notifyOnBuildFailure: false,
+  },
+  subscriptions: [],
+};
+
+const repoResultBase: RepoSettingsInput = {
+  repoId: "repo123",
+  projectRef: {
+    id: "repo123",
+    notifyOnBuildFailure: false,
+  },
+  subscriptions: [],
+};

--- a/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/NotificationsTab/types.ts
+++ b/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/NotificationsTab/types.ts
@@ -20,21 +20,26 @@ export type Notification = Partial<{
   };
 }>;
 
+interface Subscription {
+  subscriptionData: {
+    id: string;
+    event: {
+      eventSelect: string;
+      extraFields: FormExtraFields;
+      regexSelector?: FormRegexSelector[];
+    };
+    notification: Notification;
+  };
+}
+
 export interface NotificationsFormState {
   buildBreakSettings: {
     notifyOnBuildFailure: boolean | null;
   };
-  subscriptions: Array<{
-    subscriptionData: {
-      id: string;
-      event: {
-        eventSelect: string;
-        extraFields: FormExtraFields;
-        regexSelector?: FormRegexSelector[];
-      };
-      notification: Notification;
-    };
-  }> | null;
+  subscriptions: Subscription[] | null;
+  repoData?: {
+    subscriptions: Subscription[] | null;
+  };
   banner?: {
     bannerData: {
       text: string;


### PR DESCRIPTION
DEVPROD-32499

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->

<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
Since repo subscriptions now also apply to branch projects, show these subscriptions on the page.

### Screenshots
<kbd>
<img  height="859" alt="Screenshot 2026-05-13 at 4 49 34 PM" src="https://github.com/user-attachments/assets/393d1146-332c-4aad-9065-3920f02949a8" /></kbd>

<!-- add screenshots of visible changes -->

### Testing
* Integration test