### PR TITLE
DEVPROD-33342: Add better messaging and UI around TSS action button

### DIFF
--- a/apps/spruce/src/pages/task/taskTabs/testsTable/ActionMenu/ActionMenu.test.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/testsTable/ActionMenu/ActionMenu.test.tsx
@@ -64,7 +64,7 @@ describe("action menu for tests table", () => {
     });
     expect(
       screen.getByText(
-        "Quarantine status can only be managed from an execution task. Open an execution task from this display task to quarantine a test.",
+        "Quarantine is not available on display tasks. Open one of this task's execution tasks to quarantine a test.",
       ),
     ).toBeVisible();
   });

--- a/apps/spruce/src/pages/task/taskTabs/testsTable/ActionMenu/ActionMenu.test.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/testsTable/ActionMenu/ActionMenu.test.tsx
@@ -25,7 +25,7 @@ const taskWithTestSelection = {
 };
 
 describe("action menu for tests table", () => {
-  it("shows disabled message when test selection is not enabled", async () => {
+  it("shows disabled message when test selection did not run for the task", async () => {
     const user = userEvent.setup();
     const { Component } = RenderFakeToastContext(
       <MockedProvider mocks={[]}>
@@ -41,7 +41,9 @@ describe("action menu for tests table", () => {
       expect(screen.getByDataCy("card-dropdown")).toBeVisible();
     });
     expect(
-      screen.getByText("Test selection is disabled for this task."),
+      screen.getByText(
+        "Test selection did not run for this task, so its tests cannot be quarantined. Test selection is only available on patch builds for build variants and tasks configured for it.",
+      ),
     ).toBeVisible();
   });
 
@@ -62,7 +64,7 @@ describe("action menu for tests table", () => {
     });
     expect(
       screen.getByText(
-        "Cannot manage test quarantine status from display status. Click on an execution task instead.",
+        "Quarantine status can only be managed from an execution task. Open an execution task from this display task to quarantine a test.",
       ),
     ).toBeVisible();
   });

--- a/apps/spruce/src/pages/task/taskTabs/testsTable/ActionMenu/index.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/testsTable/ActionMenu/index.tsx
@@ -85,8 +85,8 @@ export const ActionMenu: React.FC<ActionMenuProps> = ({ task, test }) => {
   } else if (task.displayOnly) {
     dropdownItems = [
       <DropdownItem key="display-task" disabled>
-        Quarantine status can only be managed from an execution task. Open an
-        execution task from this display task to quarantine a test.
+        Quarantine is not available on display tasks. Open one of this
+        task&apos;s execution tasks to quarantine a test.
       </DropdownItem>,
     ];
   } else if (test.isManuallyQuarantined) {

--- a/apps/spruce/src/pages/task/taskTabs/testsTable/ActionMenu/index.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/testsTable/ActionMenu/index.tsx
@@ -77,14 +77,16 @@ export const ActionMenu: React.FC<ActionMenuProps> = ({ task, test }) => {
   if (!task.testSelectionEnabled) {
     dropdownItems = [
       <DropdownItem key="disabled" disabled>
-        Test selection is disabled for this task.
+        Test selection did not run for this task, so its tests cannot be
+        quarantined. Test selection is only available on patch builds for build
+        variants and tasks configured for it.
       </DropdownItem>,
     ];
   } else if (task.displayOnly) {
     dropdownItems = [
       <DropdownItem key="display-task" disabled>
-        Cannot manage test quarantine status from display status. Click on an
-        execution task instead.
+        Quarantine status can only be managed from an execution task. Open an
+        execution task from this display task to quarantine a test.
       </DropdownItem>,
     ];
   } else if (test.isManuallyQuarantined) {


### PR DESCRIPTION
DEVPROD-33342

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->

<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
<!-- add description, context, thought process, etc -->

Before the TSS action item would always show up and not give helpful information on why it would be there or disabled leading to confusing and not a great UX. Some of the copy is a bit length but also it shouldn't really show that much unless TSS is enabled.

**Behavior Table:**
  | Condition | Behavior | Message |
  |---|---|---|
  | Project's `testSelection.allowed` is false | Actions column hidden | — |
  | Project allows TSS, but task's `testSelectionEnabled` is false (non-patch requester, excluded build variant, or excluded task name) | Disabled dropdown item | "Test selection did not run for this task, so its tests cannot be quarantined. Test selection is only available on patch builds for build variants and tasks configured for it." |
  | Display task | Disabled dropdown item | "Quarantine status can only be managed from an execution task. Open an execution task from this display task to quarantine a test." |
  | Test is already quarantined | Enabled "Unquarantine" | "Allow this test to run in future task runs." |
  | Test is passing (and not quarantined) | Disabled "Quarantine" | "Passing tests cannot be quarantined." |
  | Test is failing (and not quarantined) | Enabled "Quarantine" | "Quarantine test so that it does not run in future task runs." |



### Screenshots
New message.
<img width="493" height="400" alt="Screenshot 2026-05-15 at 4 04 54 PM" src="https://github.com/user-attachments/assets/acf1f3e6-29b5-421d-9743-9d89ce48fc30" />

No longer showing action button.
<img width="1196" height="502" alt="Screenshot 2026-05-15 at 4 05 15 PM" src="https://github.com/user-attachments/assets/c48fff11-717e-4b09-b015-16d0bd2b61f1" />

### Testing
* Updated tests
* Smoke tested in staging

