### PR TITLE
DEVPROD-33381: Add retryFailedLogMoveLookbackMonths and retryFailedLogMoveMaxJobsPerRun to admin settings

### DIFF
--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -7663,6 +7663,8 @@ export type AdminSettingsQuery = {
     buckets?: {
       __typename?: "BucketsConfig";
       longRetentionProjects?: Array<string> | null;
+      retryFailedLogMoveLookbackMonths?: number | null;
+      retryFailedLogMoveMaxJobsPerRun?: number | null;
       credentials?: {
         __typename?: "S3Credentials";
         key?: string | null;

--- a/apps/spruce/src/gql/queries/admin-settings.ts
+++ b/apps/spruce/src/gql/queries/admin-settings.ts
@@ -103,6 +103,8 @@ export const ADMIN_SETTINGS = gql`
           name
         }
         longRetentionProjects
+        retryFailedLogMoveLookbackMonths
+        retryFailedLogMoveMaxJobsPerRun
         testResultsBucket {
           name
           roleARN

--- a/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/OtherTab/schemaFields.ts
+++ b/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/OtherTab/schemaFields.ts
@@ -389,6 +389,14 @@ export const bucketConfig = {
       type: "string" as const,
       title: "Failed Tasks Log Bucket",
     },
+    retryFailedLogMoveLookbackMonths: {
+      type: "number" as const,
+      title: "Retry Failed Log Move Lookback Months",
+    },
+    retryFailedLogMoveMaxJobsPerRun: {
+      type: "number" as const,
+      title: "Retry Failed Log Move Max Jobs Per Run",
+    },
   },
   uiSchema: {
     "ui:ObjectFieldTemplate": CardFieldTemplate,

--- a/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/OtherTab/transformers.test.ts
+++ b/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/OtherTab/transformers.test.ts
@@ -367,6 +367,8 @@ const expectedGql: AdminSettingsInput = {
       name: "logBucketLongRetention",
     },
     longRetentionProjects: ["project1", "project2"],
+    retryFailedLogMoveLookbackMonths: undefined,
+    retryFailedLogMoveMaxJobsPerRun: undefined,
     testResultsBucket: {
       name: "evergreen-test-results",
       testResultsPrefix: "results/",

--- a/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/OtherTab/transformers.test.ts
+++ b/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/OtherTab/transformers.test.ts
@@ -244,6 +244,8 @@ const expectedForm: OtherFormState = {
       credentialsKey: "cred-key",
       credentialsSecret: "cred-secret",
       failedTasksLogBucketName: "evergreen-failed-tasks",
+      retryFailedLogMoveLookbackMonths: 0,
+      retryFailedLogMoveMaxJobsPerRun: 0,
     },
     sshPairs: {
       taskHostKey: {

--- a/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/OtherTab/transformers.ts
+++ b/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/OtherTab/transformers.ts
@@ -122,6 +122,10 @@ export const gqlToForm = ((data) => {
         credentialsKey: buckets?.credentials?.key ?? "",
         credentialsSecret: buckets?.credentials?.secret ?? "",
         failedTasksLogBucketName: buckets?.logBucketFailedTasks?.name ?? "",
+        retryFailedLogMoveLookbackMonths:
+          buckets?.retryFailedLogMoveLookbackMonths ?? 0,
+        retryFailedLogMoveMaxJobsPerRun:
+          buckets?.retryFailedLogMoveMaxJobsPerRun ?? 0,
       },
 
       sshPairs: {
@@ -338,6 +342,10 @@ export const formToGql = ((form: OtherFormState) => {
         key: bucketConfig.credentialsKey || undefined,
         secret: bucketConfig.credentialsSecret || undefined,
       },
+      retryFailedLogMoveLookbackMonths:
+        bucketConfig.retryFailedLogMoveLookbackMonths || undefined,
+      retryFailedLogMoveMaxJobsPerRun:
+        bucketConfig.retryFailedLogMoveMaxJobsPerRun || undefined,
     },
 
     ssh: {

--- a/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/OtherTab/types.ts
+++ b/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/OtherTab/types.ts
@@ -59,6 +59,8 @@ export interface OtherFormState {
       credentialsKey: string;
       credentialsSecret: string;
       failedTasksLogBucketName: string;
+      retryFailedLogMoveLookbackMonths: number;
+      retryFailedLogMoveMaxJobsPerRun: number;
     };
 
     sshPairs: {


### PR DESCRIPTION
DEVPROD-33381

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->

<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
 Adds two new integer fields from BucketsConfig to the Spruce Admin Settings UI under the General tab's bucket configuration section:
  - retryFailedLogMoveLookbackMonths
  - retryFailedLogMoveMaxJobsPerRun

### Screenshots
<img width="816" height="303" alt="image" src="https://github.com/user-attachments/assets/ebebdeb4-0738-47c3-b883-689a7f5a174c" />
### Testing
Added to existing tests 

### Evergreen PR
<!-- link to a corresponding Evergreen PR if applicable -->
