### PR TITLE
DEVPROD-32552: Preserve trailing zeros on cost values on Task and Version Metadata Panel

### DIFF
--- a/apps/spruce/src/components/CostModal/CostModal.test.tsx
+++ b/apps/spruce/src/components/CostModal/CostModal.test.tsx
@@ -41,7 +41,7 @@ describe("CostModal", () => {
       />,
     );
     expect(screen.getByText("$0.52")).toBeInTheDocument();
-    expect(screen.getByText("$0.5")).toBeInTheDocument();
+    expect(screen.getByText("$0.50")).toBeInTheDocument();
     expect(screen.getByText("$0.01")).toBeInTheDocument();
     expect(screen.getByText("$0.02")).toBeInTheDocument();
     expect(screen.getByText("$0.001")).toBeInTheDocument();

--- a/apps/spruce/src/components/CostModal/index.tsx
+++ b/apps/spruce/src/components/CostModal/index.tsx
@@ -14,6 +14,7 @@ import {
   getHoneycombVersionCostUrl,
 } from "constants/externalResources/honeycomb";
 import { Cost } from "gql/generated/types";
+import { formatCost } from "utils/numbers";
 
 interface CostRow {
   category: string;
@@ -52,7 +53,11 @@ const columns: LGColumnDef<CostRow>[] = [
     header: "Cost",
     cell: ({ getValue }) => {
       const cost = getValue() as number | null | undefined;
-      return <TabularNum>{cost && cost > 0 ? `$${cost}` : "N/A"}</TabularNum>;
+      return (
+        <TabularNum>
+          {cost != null && cost > 0 ? `$${formatCost(cost)}` : "N/A"}
+        </TabularNum>
+      );
     },
   },
 ];

--- a/apps/spruce/src/pages/task/metadata/index.tsx
+++ b/apps/spruce/src/pages/task/metadata/index.tsx
@@ -32,6 +32,7 @@ import {
 } from "constants/routes";
 import { TaskQuery } from "gql/generated/types";
 import { useDateFormat } from "hooks/useDateFormat";
+import { formatCost } from "utils/numbers";
 import { isInStepback } from "utils/stepback";
 import { msToDuration } from "utils/string";
 import { AbortMessage } from "./AbortMessage";
@@ -334,7 +335,7 @@ export const Metadata: React.FC<Props> = ({ error, loading, task }) => {
         )}
         {finishTime && taskCost?.total != null && (
           <MetadataItem data-cy="task-metadata-cost">
-            <MetadataLabel>Cost:</MetadataLabel> ${taskCost.total}
+            <MetadataLabel>Cost:</MetadataLabel> ${formatCost(taskCost.total)}
             {taskCost.total > 0 && (
               <>
                 {" "}

--- a/apps/spruce/src/pages/version/Metadata/index.tsx
+++ b/apps/spruce/src/pages/version/Metadata/index.tsx
@@ -27,6 +27,7 @@ import {
 } from "constants/routes";
 import { VersionQuery } from "gql/generated/types";
 import { useDateFormat } from "hooks";
+import { formatCost } from "utils/numbers";
 import { msToDuration } from "utils/string";
 import { ParametersModal } from "../ParametersModal";
 import IncludedLocalModules from "./IncludedLocalModules";
@@ -231,7 +232,7 @@ export const Metadata: React.FC<MetadataProps> = ({ version }) => {
             data-cy="version-metadata-cost"
             tooltipDescription={costTooltip}
           >
-            <MetadataLabel>Cost:</MetadataLabel> ${totalCost}
+            <MetadataLabel>Cost:</MetadataLabel> ${formatCost(totalCost)}
             {cost != null && isVersionComplete && (
               <>
                 {" "}

--- a/apps/spruce/src/utils/numbers/index.ts
+++ b/apps/spruce/src/utils/numbers/index.ts
@@ -89,6 +89,20 @@ const roundMax = (max: number) => {
   return Math.ceil(max / 1000) * 1000;
 };
 
+/**
+ * `formatCost` formats a cost value for display, preserving trailing zeros to 2 decimal places.
+ * Values with more precision (e.g. sub-cent costs) are displayed with their full precision.
+ * @param value - the numeric cost value
+ * @returns a formatted string with at least 2 decimal places
+ * @example formatCost(0.1) // => "0.10"
+ * @example formatCost(0.0058) // => "0.0058"
+ */
+const formatCost = (value: number): string =>
+  new Intl.NumberFormat("en-US", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 20,
+  }).format(value);
+
 export {
   toDecimal,
   toPercent,
@@ -96,4 +110,5 @@ export {
   roundDecimal,
   cryptoRandom,
   roundMax,
+  formatCost,
 };

--- a/apps/spruce/src/utils/numbers/numbers.test.ts
+++ b/apps/spruce/src/utils/numbers/numbers.test.ts
@@ -1,4 +1,4 @@
-import { roundDecimal, cryptoRandom, roundMax } from ".";
+import { roundDecimal, cryptoRandom, roundMax, formatCost } from ".";
 
 describe("roundDecimal", () => {
   it("correctly rounds a decimal to the specified number of places", () => {
@@ -17,6 +17,21 @@ describe("cryptoRandom", () => {
     const randomNumber = cryptoRandom();
     expect(randomNumber).toBeGreaterThanOrEqual(0);
     expect(randomNumber).toBeLessThan(1);
+  });
+});
+
+describe("formatCost", () => {
+  it("PreservesTrailingZero", () => {
+    expect(formatCost(0.1)).toBe("0.10");
+  });
+  it("PadsWholeNumberToTwoDecimalPlaces", () => {
+    expect(formatCost(5)).toBe("5.00");
+  });
+  it("LeavesValueWithTwoDecimalsUnchanged", () => {
+    expect(formatCost(0.52)).toBe("0.52");
+  });
+  it("PassesThroughSubCentPrecision", () => {
+    expect(formatCost(0.0058)).toBe("0.0058");
   });
 });
 


### PR DESCRIPTION
DEVPROD-32552

### Description
This PR addresses a user reported issue where the Task/Patch/Version Cost value in the Metadata panel as well as the cost modal does not preserve trailing zero i.e if the cost is $0.10 the UI shows $0.1. 

Adding a custom formatter as for the cost we need higher precision than the `toFixedCost` function.
Ex: .1 --> .10
Ex: .000055 --> .000055

This function was added to apps/spruce/src/utils/numbers/index.ts and is for the cost value display in the task/version and modal places

### Screenshots

Task Page:
<img width="397" height="87" alt="image" src="https://github.com/user-attachments/assets/06bbec02-aab3-4f8c-a4ca-a0c08c14803e" />
<img width="284" height="440" alt="image" src="https://github.com/user-attachments/assets/0a10bbc2-fb46-4599-acb2-1f2f862409e2" />
<img width="472" height="224" alt="image" src="https://github.com/user-attachments/assets/ad0626f4-7669-411b-b13a-940110b70801" />

Patch/Version Page:
<img width="422" height="89" alt="image" src="https://github.com/user-attachments/assets/6811fc23-6004-4037-9951-293a20ff631a" />
<img width="290" height="373" alt="image" src="https://github.com/user-attachments/assets/98b62b3e-2c6e-4501-a73c-aa3c5ad53166" />
<img width="557" height="230" alt="image" src="https://github.com/user-attachments/assets/4ee95e75-c07d-4097-ae88-5a15727d7cd6" />

Patch Page with more Precision
<img width="302" height="358" alt="image" src="https://github.com/user-attachments/assets/a9afc914-c008-460c-ae44-7ae0d5faaf22" />
<img width="511" height="286" alt="image" src="https://github.com/user-attachments/assets/737bb4e4-20f5-4d90-8261-7b1a66dfb5da" />


### Testing
Tested in staging using this [Patch](https://spruce-local.corp.mongodb.com:8443/version/6a0c78bdb1b0c100077151f3/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)

### Evergreen PR
None

CC: @malikchaya2 
