### PR TITLE
DEVPROD-33572: Allow quarantining display task's execution tests

### DIFF
--- a/apps/spruce/src/analytics/task/useTaskAnalytics.ts
+++ b/apps/spruce/src/analytics/task/useTaskAnalytics.ts
@@ -56,10 +56,12 @@ type Action =
   | {
       name: "Clicked quarantine test button";
       "test.name": string;
+      "test.task_id": string;
     }
   | {
       name: "Clicked unquarantine test button";
       "test.name": string;
+      "test.task_id": string;
     }
   | { name: "Clicked annotation link"; "link.text": string }
   | { name: "Changed log preview type"; "log.type": LogTypes }

--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -11291,6 +11291,7 @@ export type TaskTestsQuery = {
         duration?: number | null;
         isManuallyQuarantined: boolean;
         status: string;
+        taskId?: string | null;
         testFile: string;
         logs: {
           __typename?: "TestLog";

--- a/apps/spruce/src/gql/queries/task-tests.ts
+++ b/apps/spruce/src/gql/queries/task-tests.ts
@@ -36,6 +36,7 @@ export const TASK_TESTS = gql`
             urlRaw
           }
           status
+          taskId
           testFile
         }
         totalTestCount

--- a/apps/spruce/src/pages/task/taskTabs/testsTable/ActionMenu/ActionMenu.stories.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/testsTable/ActionMenu/ActionMenu.stories.tsx
@@ -48,6 +48,15 @@ const quarantinedTest: TestResult = {
   logs: {},
 };
 
+const failingTestOnDisplayTask: TestResult = {
+  id: "4",
+  taskId: "execTaskId",
+  testFile: "test_4",
+  status: TestStatus.Fail,
+  isManuallyQuarantined: false,
+  logs: {},
+};
+
 export const TestSelectionDisabled: CustomStoryObj<typeof ActionMenu> = {
   render: () => (
     <ActionMenu
@@ -61,7 +70,7 @@ export const DisplayTask: CustomStoryObj<typeof ActionMenu> = {
   render: () => (
     <ActionMenu
       task={{ ...taskWithTestSelection, displayOnly: true }}
-      test={failingTest}
+      test={failingTestOnDisplayTask}
     />
   ),
 };

--- a/apps/spruce/src/pages/task/taskTabs/testsTable/ActionMenu/ActionMenu.test.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/testsTable/ActionMenu/ActionMenu.test.tsx
@@ -86,7 +86,7 @@ describe("action menu for tests table", () => {
     );
   });
 
-  it("quarantines a failing test", async () => {
+  it("quarantines a failing test on a non-display task", async () => {
     const user = userEvent.setup();
     const { Component, dispatchToast } = RenderFakeToastContext(
       <MockedProvider mocks={[quarantineTestMock]}>

--- a/apps/spruce/src/pages/task/taskTabs/testsTable/ActionMenu/ActionMenu.test.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/testsTable/ActionMenu/ActionMenu.test.tsx
@@ -47,26 +47,25 @@ describe("action menu for tests table", () => {
     ).toBeVisible();
   });
 
-  it("shows disabled message on display tasks", async () => {
+  it("quarantines a failing test on a display task using its execution task ID", async () => {
     const user = userEvent.setup();
-    const { Component } = RenderFakeToastContext(
-      <MockedProvider mocks={[]}>
+    const { Component, dispatchToast } = RenderFakeToastContext(
+      <MockedProvider mocks={[quarantineDisplayTaskTestMock]}>
         <ActionMenu
           task={{ ...taskWithTestSelection, displayOnly: true }}
-          test={failingTest}
+          test={failingTestOnDisplayTask}
         />
       </MockedProvider>,
     );
     render(<Component />);
     await user.click(screen.getByDataCy("ellipsis-btn"));
     await waitFor(() => {
-      expect(screen.getByDataCy("card-dropdown")).toBeVisible();
+      expect(screen.getByDataCy("quarantine-test")).toBeVisible();
     });
-    expect(
-      screen.getByText(
-        "Quarantine is not available on display tasks. Open one of this task's execution tasks to quarantine a test.",
-      ),
-    ).toBeVisible();
+    await user.click(screen.getByDataCy("quarantine-test"));
+    await waitFor(() => {
+      expect(dispatchToast.success).toHaveBeenCalledTimes(1);
+    });
   });
 
   it("disables quarantine option when test is passing and not quarantined", async () => {
@@ -126,6 +125,7 @@ describe("action menu for tests table", () => {
 
 const failingTest: TestResult = {
   id: "1",
+  taskId: taskQuery.task.id,
   testFile: "test_1",
   status: TestStatus.Fail,
   isManuallyQuarantined: false,
@@ -134,6 +134,7 @@ const failingTest: TestResult = {
 
 const passingTest: TestResult = {
   id: "2",
+  taskId: taskQuery.task.id,
   testFile: "test_2",
   status: TestStatus.Pass,
   isManuallyQuarantined: false,
@@ -142,9 +143,19 @@ const passingTest: TestResult = {
 
 const quarantinedTest: TestResult = {
   id: "3",
+  taskId: taskQuery.task.id,
   testFile: "test_3",
   status: TestStatus.Pass,
   isManuallyQuarantined: true,
+  logs: {},
+};
+
+const failingTestOnDisplayTask: TestResult = {
+  id: "4",
+  taskId: "execTaskId",
+  testFile: "test_4",
+  status: TestStatus.Fail,
+  isManuallyQuarantined: false,
   logs: {},
 };
 
@@ -164,6 +175,28 @@ const quarantineTestMock: ApolloMock<
       quarantineTest: {
         __typename: "TestResult",
         id: "1",
+        isManuallyQuarantined: true,
+      },
+    },
+  },
+};
+
+const quarantineDisplayTaskTestMock: ApolloMock<
+  QuarantineTestMutation,
+  QuarantineTestMutationVariables
+> = {
+  request: {
+    query: QUARANTINE_TEST,
+    variables: {
+      taskId: "execTaskId",
+      testName: "test_4",
+    },
+  },
+  result: {
+    data: {
+      quarantineTest: {
+        __typename: "TestResult",
+        id: "4",
         isManuallyQuarantined: true,
       },
     },

--- a/apps/spruce/src/pages/task/taskTabs/testsTable/ActionMenu/index.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/testsTable/ActionMenu/index.tsx
@@ -55,6 +55,7 @@ export const ActionMenu: React.FC<ActionMenuProps> = ({ task, test }) => {
 
   const onQuarantineTest = () => {
     setOpen(false);
+    // Fall back to task.id since the field is nullable in the schema; for non-display tasks the two IDs are equal.
     const taskId = test.taskId ?? task.id;
     sendEvent({
       name: "Clicked quarantine test button",

--- a/apps/spruce/src/pages/task/taskTabs/testsTable/ActionMenu/index.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/testsTable/ActionMenu/index.tsx
@@ -59,7 +59,9 @@ export const ActionMenu: React.FC<ActionMenuProps> = ({ task, test }) => {
       name: "Clicked quarantine test button",
       "test.name": test.testFile,
     });
-    quarantineTest({ variables: { taskId: task.id, testName: test.testFile } });
+    quarantineTest({
+      variables: { taskId: test.taskId ?? task.id, testName: test.testFile },
+    });
   };
 
   const onUnquarantineTest = () => {
@@ -69,7 +71,7 @@ export const ActionMenu: React.FC<ActionMenuProps> = ({ task, test }) => {
       "test.name": test.testFile,
     });
     unquarantineTest({
-      variables: { taskId: task.id, testName: test.testFile },
+      variables: { taskId: test.taskId ?? task.id, testName: test.testFile },
     });
   };
 
@@ -80,13 +82,6 @@ export const ActionMenu: React.FC<ActionMenuProps> = ({ task, test }) => {
         Test selection did not run for this task, so its tests cannot be
         quarantined. Test selection is only available on patch builds for build
         variants and tasks configured for it.
-      </DropdownItem>,
-    ];
-  } else if (task.displayOnly) {
-    dropdownItems = [
-      <DropdownItem key="display-task" disabled>
-        Quarantine is not available on display tasks. Open one of this
-        task&apos;s execution tasks to quarantine a test.
       </DropdownItem>,
     ];
   } else if (test.isManuallyQuarantined) {

--- a/apps/spruce/src/pages/task/taskTabs/testsTable/ActionMenu/index.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/testsTable/ActionMenu/index.tsx
@@ -55,23 +55,27 @@ export const ActionMenu: React.FC<ActionMenuProps> = ({ task, test }) => {
 
   const onQuarantineTest = () => {
     setOpen(false);
+    const taskId = test.taskId ?? task.id;
     sendEvent({
       name: "Clicked quarantine test button",
       "test.name": test.testFile,
+      "test.task_id": taskId,
     });
     quarantineTest({
-      variables: { taskId: test.taskId ?? task.id, testName: test.testFile },
+      variables: { taskId, testName: test.testFile },
     });
   };
 
   const onUnquarantineTest = () => {
     setOpen(false);
+    const taskId = test.taskId ?? task.id;
     sendEvent({
       name: "Clicked unquarantine test button",
       "test.name": test.testFile,
+      "test.task_id": taskId,
     });
     unquarantineTest({
-      variables: { taskId: test.taskId ?? task.id, testName: test.testFile },
+      variables: { taskId, testName: test.testFile },
     });
   };
 


### PR DESCRIPTION
DEVPROD-33572

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->

<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
Before we disallowed quaranting display task's tests. This will enable them to be quarantined.

### Screenshots
https://github.com/user-attachments/assets/d786aaed-0e0a-4808-adad-bc3ec261c1e1

https://github.com/user-attachments/assets/4cce0491-abd2-41f2-8406-a843dc9a2356



### Testing
* Added and updated UI tests 
* Updated storybook
* Smoke tested locally

### Evergreen PR:
https://github.com/evergreen-ci/evergreen/pull/10233