### PR TITLE
DEVPROD-32825 Add project setting to disable waterfall

### DIFF
--- a/apps/parsley/src/gql/generated/types.ts
+++ b/apps/parsley/src/gql/generated/types.ts
@@ -2815,6 +2815,7 @@ export type Project = {
   testSelection?: Maybe<TestSelectionSettings>;
   triggers?: Maybe<Array<TriggerAlias>>;
   versionControlEnabled?: Maybe<Scalars["Boolean"]["output"]>;
+  waterfallDisabled?: Maybe<Scalars["Boolean"]["output"]>;
   workstationConfig: WorkstationConfig;
 };
 
@@ -2965,6 +2966,7 @@ export type ProjectInput = {
   testSelection?: InputMaybe<TestSelectionSettingsInput>;
   triggers?: InputMaybe<Array<TriggerAliasInput>>;
   versionControlEnabled?: InputMaybe<Scalars["Boolean"]["input"]>;
+  waterfallDisabled?: InputMaybe<Scalars["Boolean"]["input"]>;
   workstationConfig?: InputMaybe<WorkstationConfigInput>;
 };
 
@@ -3008,6 +3010,7 @@ export type ProjectLite = {
   stepbackBisect?: Maybe<Scalars["Boolean"]["output"]>;
   stepbackDisabled?: Maybe<Scalars["Boolean"]["output"]>;
   versionControlEnabled?: Maybe<Scalars["Boolean"]["output"]>;
+  waterfallDisabled?: Maybe<Scalars["Boolean"]["output"]>;
 };
 
 export enum ProjectPermission {

--- a/apps/parsley/src/gql/generated/types.ts
+++ b/apps/parsley/src/gql/generated/types.ts
@@ -1025,8 +1025,6 @@ export type EditSpawnHostInput = {
   savePublicKey?: InputMaybe<Scalars["Boolean"]["input"]>;
   servicePassword?: InputMaybe<Scalars["String"]["input"]>;
   sleepSchedule?: InputMaybe<SleepScheduleInput>;
-  /** @deprecated Use volumeId instead of volume. */
-  volume?: InputMaybe<Scalars["String"]["input"]>;
   volumeId?: InputMaybe<Scalars["String"]["input"]>;
 };
 
@@ -3155,8 +3153,6 @@ export type Query = {
   githubProjectConflicts: GithubProjectConflicts;
   hasVersion: Scalars["Boolean"]["output"];
   host?: Maybe<Host>;
-  /** @deprecated Use host.events instead. */
-  hostEvents: HostEvents;
   hosts: HostsResponse;
   image?: Maybe<Image>;
   images: Array<Scalars["String"]["output"]>;
@@ -3238,13 +3234,6 @@ export type QueryHasVersionArgs = {
 
 export type QueryHostArgs = {
   hostId: Scalars["String"]["input"];
-};
-
-export type QueryHostEventsArgs = {
-  hostId: Scalars["String"]["input"];
-  hostTag?: InputMaybe<Scalars["String"]["input"]>;
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  page?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type QueryHostsArgs = {
@@ -3958,8 +3947,6 @@ export enum SpawnHostStatusActions {
 export type SpawnVolumeInput = {
   availabilityZone: Scalars["String"]["input"];
   expiration?: InputMaybe<Scalars["Time"]["input"]>;
-  /** @deprecated Use hostId instead of host. */
-  host?: InputMaybe<Scalars["String"]["input"]>;
   hostId?: InputMaybe<Scalars["String"]["input"]>;
   noExpiration?: InputMaybe<Scalars["Boolean"]["input"]>;
   size: Scalars["Int"]["input"];

--- a/apps/parsley/src/gql/generated/types.ts
+++ b/apps/parsley/src/gql/generated/types.ts
@@ -3437,6 +3437,7 @@ export type RepoRef = {
   testSelection?: Maybe<RepoTestSelectionSettings>;
   triggers: Array<TriggerAlias>;
   versionControlEnabled: Scalars["Boolean"]["output"];
+  waterfallDisabled: Scalars["Boolean"]["output"];
   workstationConfig: RepoWorkstationConfig;
 };
 
@@ -3485,6 +3486,7 @@ export type RepoRefInput = {
   testSelection?: InputMaybe<TestSelectionSettingsInput>;
   triggers?: InputMaybe<Array<TriggerAliasInput>>;
   versionControlEnabled?: InputMaybe<Scalars["Boolean"]["input"]>;
+  waterfallDisabled?: InputMaybe<Scalars["Boolean"]["input"]>;
   workstationConfig?: InputMaybe<WorkstationConfigInput>;
 };
 

--- a/apps/spruce/src/gql/fragments/projectSettings/general.ts
+++ b/apps/spruce/src/gql/fragments/projectSettings/general.ts
@@ -45,5 +45,6 @@ export const REPO_GENERAL_SETTINGS = gql`
     stepbackBisect
     stepbackDisabled
     versionControlEnabled
+    waterfallDisabled
   }
 `;

--- a/apps/spruce/src/gql/fragments/projectSettings/general.ts
+++ b/apps/spruce/src/gql/fragments/projectSettings/general.ts
@@ -22,6 +22,7 @@ export const PROJECT_GENERAL_SETTINGS = gql`
     stepbackBisect
     stepbackDisabled
     versionControlEnabled
+    waterfallDisabled
   }
 `;
 

--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -5426,7 +5426,6 @@ export type RepoGeneralSettingsFragment = {
   debugSpawnHostsDisabled: boolean;
   disabledStatsCache: boolean;
   dispatchingDisabled: boolean;
-  waterfallDisabled: boolean;
   displayName: string;
   owner: string;
   patchingDisabled: boolean;
@@ -5438,6 +5437,7 @@ export type RepoGeneralSettingsFragment = {
   stepbackBisect?: boolean | null;
   stepbackDisabled: boolean;
   versionControlEnabled: boolean;
+  waterfallDisabled: boolean;
 };
 
 export type ProjectGithubSettingsFragment = {

--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -1022,8 +1022,6 @@ export type EditSpawnHostInput = {
   savePublicKey?: InputMaybe<Scalars["Boolean"]["input"]>;
   servicePassword?: InputMaybe<Scalars["String"]["input"]>;
   sleepSchedule?: InputMaybe<SleepScheduleInput>;
-  /** @deprecated Use volumeId instead of volume. */
-  volume?: InputMaybe<Scalars["String"]["input"]>;
   volumeId?: InputMaybe<Scalars["String"]["input"]>;
 };
 
@@ -3152,8 +3150,6 @@ export type Query = {
   githubProjectConflicts: GithubProjectConflicts;
   hasVersion: Scalars["Boolean"]["output"];
   host?: Maybe<Host>;
-  /** @deprecated Use host.events instead. */
-  hostEvents: HostEvents;
   hosts: HostsResponse;
   image?: Maybe<Image>;
   images: Array<Scalars["String"]["output"]>;
@@ -3235,13 +3231,6 @@ export type QueryHasVersionArgs = {
 
 export type QueryHostArgs = {
   hostId: Scalars["String"]["input"];
-};
-
-export type QueryHostEventsArgs = {
-  hostId: Scalars["String"]["input"];
-  hostTag?: InputMaybe<Scalars["String"]["input"]>;
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  page?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type QueryHostsArgs = {
@@ -3955,8 +3944,6 @@ export enum SpawnHostStatusActions {
 export type SpawnVolumeInput = {
   availabilityZone: Scalars["String"]["input"];
   expiration?: InputMaybe<Scalars["Time"]["input"]>;
-  /** @deprecated Use hostId instead of host. */
-  host?: InputMaybe<Scalars["String"]["input"]>;
   hostId?: InputMaybe<Scalars["String"]["input"]>;
   noExpiration?: InputMaybe<Scalars["Boolean"]["input"]>;
   size: Scalars["Int"]["input"];

--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -5426,6 +5426,7 @@ export type RepoGeneralSettingsFragment = {
   debugSpawnHostsDisabled: boolean;
   disabledStatsCache: boolean;
   dispatchingDisabled: boolean;
+  waterfallDisabled: boolean;
   displayName: string;
   owner: string;
   patchingDisabled: boolean;
@@ -5812,6 +5813,7 @@ export type RepoSettingsFieldsFragment = {
     debugSpawnHostsDisabled: boolean;
     disabledStatsCache: boolean;
     dispatchingDisabled: boolean;
+    waterfallDisabled: boolean;
     owner: string;
     patchingDisabled: boolean;
     remotePath: string;
@@ -10529,6 +10531,7 @@ export type RepoSettingsQuery = {
       debugSpawnHostsDisabled: boolean;
       disabledStatsCache: boolean;
       dispatchingDisabled: boolean;
+      waterfallDisabled: boolean;
       owner: string;
       patchingDisabled: boolean;
       remotePath: string;

--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -3434,6 +3434,7 @@ export type RepoRef = {
   testSelection?: Maybe<RepoTestSelectionSettings>;
   triggers: Array<TriggerAlias>;
   versionControlEnabled: Scalars["Boolean"]["output"];
+  waterfallDisabled: Scalars["Boolean"]["output"];
   workstationConfig: RepoWorkstationConfig;
 };
 
@@ -3482,6 +3483,7 @@ export type RepoRefInput = {
   testSelection?: InputMaybe<TestSelectionSettingsInput>;
   triggers?: InputMaybe<Array<TriggerAliasInput>>;
   versionControlEnabled?: InputMaybe<Scalars["Boolean"]["input"]>;
+  waterfallDisabled?: InputMaybe<Scalars["Boolean"]["input"]>;
   workstationConfig?: InputMaybe<WorkstationConfigInput>;
 };
 

--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -5813,7 +5813,6 @@ export type RepoSettingsFieldsFragment = {
     debugSpawnHostsDisabled: boolean;
     disabledStatsCache: boolean;
     dispatchingDisabled: boolean;
-    waterfallDisabled: boolean;
     owner: string;
     patchingDisabled: boolean;
     remotePath: string;
@@ -5824,6 +5823,7 @@ export type RepoSettingsFieldsFragment = {
     stepbackBisect?: boolean | null;
     stepbackDisabled: boolean;
     versionControlEnabled: boolean;
+    waterfallDisabled: boolean;
     notifyOnBuildFailure: boolean;
     githubMQTriggerAliases?: Array<string> | null;
     githubPRTriggerAliases?: Array<string> | null;
@@ -10531,7 +10531,6 @@ export type RepoSettingsQuery = {
       debugSpawnHostsDisabled: boolean;
       disabledStatsCache: boolean;
       dispatchingDisabled: boolean;
-      waterfallDisabled: boolean;
       owner: string;
       patchingDisabled: boolean;
       remotePath: string;
@@ -10542,6 +10541,7 @@ export type RepoSettingsQuery = {
       stepbackBisect?: boolean | null;
       stepbackDisabled: boolean;
       versionControlEnabled: boolean;
+      waterfallDisabled: boolean;
       notifyOnBuildFailure: boolean;
       githubMQTriggerAliases?: Array<string> | null;
       githubPRTriggerAliases?: Array<string> | null;

--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -2812,6 +2812,7 @@ export type Project = {
   testSelection?: Maybe<TestSelectionSettings>;
   triggers?: Maybe<Array<TriggerAlias>>;
   versionControlEnabled?: Maybe<Scalars["Boolean"]["output"]>;
+  waterfallDisabled?: Maybe<Scalars["Boolean"]["output"]>;
   workstationConfig: WorkstationConfig;
 };
 
@@ -2962,6 +2963,7 @@ export type ProjectInput = {
   testSelection?: InputMaybe<TestSelectionSettingsInput>;
   triggers?: InputMaybe<Array<TriggerAliasInput>>;
   versionControlEnabled?: InputMaybe<Scalars["Boolean"]["input"]>;
+  waterfallDisabled?: InputMaybe<Scalars["Boolean"]["input"]>;
   workstationConfig?: InputMaybe<WorkstationConfigInput>;
 };
 
@@ -3005,6 +3007,7 @@ export type ProjectLite = {
   stepbackBisect?: Maybe<Scalars["Boolean"]["output"]>;
   stepbackDisabled?: Maybe<Scalars["Boolean"]["output"]>;
   versionControlEnabled?: Maybe<Scalars["Boolean"]["output"]>;
+  waterfallDisabled?: Maybe<Scalars["Boolean"]["output"]>;
 };
 
 export enum ProjectPermission {
@@ -5410,6 +5413,7 @@ export type ProjectGeneralSettingsFragment = {
   stepbackBisect?: boolean | null;
   stepbackDisabled?: boolean | null;
   versionControlEnabled?: boolean | null;
+  waterfallDisabled?: boolean | null;
 };
 
 export type RepoGeneralSettingsFragment = {
@@ -5607,6 +5611,7 @@ export type ProjectSettingsFieldsFragment = {
     stepbackBisect?: boolean | null;
     stepbackDisabled?: boolean | null;
     versionControlEnabled?: boolean | null;
+    waterfallDisabled?: boolean | null;
     notifyOnBuildFailure?: boolean | null;
     githubMQTriggerAliases?: Array<string> | null;
     githubPRTriggerAliases?: Array<string> | null;
@@ -6218,6 +6223,7 @@ export type ProjectEventSettingsFragment = {
     stepbackBisect?: boolean | null;
     stepbackDisabled?: boolean | null;
     versionControlEnabled?: boolean | null;
+    waterfallDisabled?: boolean | null;
     notifyOnBuildFailure?: boolean | null;
     githubMQTriggerAliases?: Array<string> | null;
     githubPRTriggerAliases?: Array<string> | null;
@@ -9297,6 +9303,7 @@ export type ProjectEventLogsQuery = {
           stepbackBisect?: boolean | null;
           stepbackDisabled?: boolean | null;
           versionControlEnabled?: boolean | null;
+          waterfallDisabled?: boolean | null;
           notifyOnBuildFailure?: boolean | null;
           githubMQTriggerAliases?: Array<string> | null;
           githubPRTriggerAliases?: Array<string> | null;
@@ -9519,6 +9526,7 @@ export type ProjectEventLogsQuery = {
           stepbackBisect?: boolean | null;
           stepbackDisabled?: boolean | null;
           versionControlEnabled?: boolean | null;
+          waterfallDisabled?: boolean | null;
           notifyOnBuildFailure?: boolean | null;
           githubMQTriggerAliases?: Array<string> | null;
           githubPRTriggerAliases?: Array<string> | null;
@@ -9806,6 +9814,7 @@ export type ProjectSettingsQuery = {
       stepbackBisect?: boolean | null;
       stepbackDisabled?: boolean | null;
       versionControlEnabled?: boolean | null;
+      waterfallDisabled?: boolean | null;
       notifyOnBuildFailure?: boolean | null;
       githubMQTriggerAliases?: Array<string> | null;
       githubPRTriggerAliases?: Array<string> | null;
@@ -10076,6 +10085,7 @@ export type RepoEventLogsQuery = {
           stepbackBisect?: boolean | null;
           stepbackDisabled?: boolean | null;
           versionControlEnabled?: boolean | null;
+          waterfallDisabled?: boolean | null;
           notifyOnBuildFailure?: boolean | null;
           githubMQTriggerAliases?: Array<string> | null;
           githubPRTriggerAliases?: Array<string> | null;
@@ -10298,6 +10308,7 @@ export type RepoEventLogsQuery = {
           stepbackBisect?: boolean | null;
           stepbackDisabled?: boolean | null;
           versionControlEnabled?: boolean | null;
+          waterfallDisabled?: boolean | null;
           notifyOnBuildFailure?: boolean | null;
           githubMQTriggerAliases?: Array<string> | null;
           githubPRTriggerAliases?: Array<string> | null;

--- a/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/GeneralTab/getFormSchema.tsx
+++ b/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/GeneralTab/getFormSchema.tsx
@@ -142,16 +142,6 @@ export const getFormSchema = (
               true,
             ),
           },
-          waterfallDisabled: {
-            type: ["boolean", "null"],
-            title: "Waterfall",
-            oneOf: radioBoxOptions(
-              ["Enabled", "Disabled"],
-              // @ts-expect-error: FIXME. This comment was added by an automated script.
-              repoData?.projectFlags?.waterfallDisabled,
-              true,
-            ),
-          },
           repotracker: {
             type: "object" as const,
             title: "Repotracker Settings",
@@ -178,6 +168,16 @@ export const getFormSchema = (
                   ["Enabled", "Disabled"],
                   // @ts-expect-error: FIXME. This comment was added by an automated script.
                   repoData?.projectFlags?.repotracker?.runEveryMainlineCommit,
+                ),
+              },
+              waterfallDisabled: {
+                type: ["boolean", "null"],
+                title: "Waterfall",
+                oneOf: radioBoxOptions(
+                  ["Enabled", "Disabled"],
+                  // @ts-expect-error: FIXME. This comment was added by an automated script.
+                  repoData?.projectFlags?.repotracker?.waterfallDisabled,
+                  true,
                 ),
               },
             },
@@ -372,11 +372,6 @@ export const getFormSchema = (
         "ui:widget": widgets.RadioBoxWidget,
         "ui:description": "Sets if any tasks can be dispatched.",
       },
-      waterfallDisabled: {
-        "ui:widget": widgets.RadioBoxWidget,
-        "ui:description":
-          "Disables automatic task activation on the waterfall. Tasks will still appear but will be unscheduled by default.",
-      },
       debug: {
         debugSpawnHostsDisabled: {
           "ui:widget": widgets.RadioBoxWidget,
@@ -400,7 +395,7 @@ export const getFormSchema = (
       repotracker: {
         repotrackerDisabled: {
           "ui:widget": widgets.RadioBoxWidget,
-          "ui:description": `The repotracker will be triggered from GitHub push events sent via webhook. 
+          "ui:description": `The repotracker will be triggered from GitHub push events sent via webhook.
             This creates mainline builds for merged commits.`,
         },
         forceRun: {
@@ -412,6 +407,11 @@ export const getFormSchema = (
           "ui:data-cy": "run-every-mainline-commit-radio-box",
           "ui:widget": widgets.RadioBoxWidget,
           "ui:description": RunEveryMainlineCommitDescription,
+        },
+        waterfallDisabled: {
+          "ui:widget": widgets.RadioBoxWidget,
+          "ui:description":
+            "Disables automatic task activation on the waterfall. Tasks will still appear but will be unscheduled by default.",
         },
       },
       scheduling: {

--- a/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/GeneralTab/getFormSchema.tsx
+++ b/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/GeneralTab/getFormSchema.tsx
@@ -142,6 +142,16 @@ export const getFormSchema = (
               true,
             ),
           },
+          waterfallDisabled: {
+            type: ["boolean", "null"],
+            title: "Waterfall",
+            oneOf: radioBoxOptions(
+              ["Enabled", "Disabled"],
+              // @ts-expect-error: FIXME. This comment was added by an automated script.
+              repoData?.projectFlags?.waterfallDisabled,
+              true,
+            ),
+          },
           repotracker: {
             type: "object" as const,
             title: "Repotracker Settings",
@@ -361,6 +371,11 @@ export const getFormSchema = (
       dispatchingDisabled: {
         "ui:widget": widgets.RadioBoxWidget,
         "ui:description": "Sets if any tasks can be dispatched.",
+      },
+      waterfallDisabled: {
+        "ui:widget": widgets.RadioBoxWidget,
+        "ui:description":
+          "Disables automatic task activation on the waterfall. Tasks will still appear but will be unscheduled by default.",
       },
       debug: {
         debugSpawnHostsDisabled: {

--- a/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/GeneralTab/transformers.test.ts
+++ b/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/GeneralTab/transformers.test.ts
@@ -46,7 +46,7 @@ const repoForm: GeneralFormState = {
   },
   projectFlags: {
     dispatchingDisabled: true,
-    waterfallDisabled: null,
+    waterfallDisabled: false,
     debug: {
       debugSpawnHostsDisabled: false,
     },
@@ -82,7 +82,7 @@ const repoResult: Pick<RepoSettingsInput, "repoId" | "projectRef"> = {
     spawnHostScriptPath: "/test/path",
     versionControlEnabled: false,
     dispatchingDisabled: true,
-    waterfallDisabled: null,
+    waterfallDisabled: false,
     deactivatePrevious: true,
     repotrackerDisabled: false,
     runEveryMainlineCommit: false,

--- a/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/GeneralTab/transformers.test.ts
+++ b/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/GeneralTab/transformers.test.ts
@@ -46,6 +46,7 @@ const repoForm: GeneralFormState = {
   },
   projectFlags: {
     dispatchingDisabled: true,
+    waterfallDisabled: null,
     debug: {
       debugSpawnHostsDisabled: false,
     },
@@ -81,6 +82,8 @@ const repoResult: Pick<RepoSettingsInput, "repoId" | "projectRef"> = {
     spawnHostScriptPath: "/test/path",
     versionControlEnabled: false,
     dispatchingDisabled: true,
+    // @ts-expect-error: waterfallDisabled is on ProjectInput but not RepoRefInput
+    waterfallDisabled: null,
     deactivatePrevious: true,
     repotrackerDisabled: false,
     runEveryMainlineCommit: false,
@@ -116,6 +119,7 @@ const projectForm: GeneralFormState = {
   },
   projectFlags: {
     dispatchingDisabled: null,
+    waterfallDisabled: null,
     debug: {
       debugSpawnHostsDisabled: null,
     },
@@ -154,6 +158,7 @@ const projectResult: Pick<ProjectSettingsInput, "projectId" | "projectRef"> = {
     spawnHostScriptPath: null,
     versionControlEnabled: true,
     dispatchingDisabled: null,
+    waterfallDisabled: null,
     deactivatePrevious: null,
     repotrackerDisabled: null,
     runEveryMainlineCommit: null,

--- a/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/GeneralTab/transformers.test.ts
+++ b/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/GeneralTab/transformers.test.ts
@@ -82,7 +82,6 @@ const repoResult: Pick<RepoSettingsInput, "repoId" | "projectRef"> = {
     spawnHostScriptPath: "/test/path",
     versionControlEnabled: false,
     dispatchingDisabled: true,
-    // @ts-expect-error: waterfallDisabled is on ProjectInput but not RepoRefInput
     waterfallDisabled: null,
     deactivatePrevious: true,
     repotrackerDisabled: false,

--- a/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/GeneralTab/transformers.test.ts
+++ b/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/GeneralTab/transformers.test.ts
@@ -46,7 +46,6 @@ const repoForm: GeneralFormState = {
   },
   projectFlags: {
     dispatchingDisabled: true,
-    waterfallDisabled: false,
     debug: {
       debugSpawnHostsDisabled: false,
     },
@@ -59,6 +58,7 @@ const repoForm: GeneralFormState = {
     repotracker: {
       repotrackerDisabled: false,
       runEveryMainlineCommit: false,
+      waterfallDisabled: false,
       forceRun: null,
     },
     patch: {
@@ -118,7 +118,6 @@ const projectForm: GeneralFormState = {
   },
   projectFlags: {
     dispatchingDisabled: null,
-    waterfallDisabled: null,
     debug: {
       debugSpawnHostsDisabled: null,
     },
@@ -131,6 +130,7 @@ const projectForm: GeneralFormState = {
     repotracker: {
       repotrackerDisabled: null,
       runEveryMainlineCommit: null,
+      waterfallDisabled: null,
       forceRun: null,
     },
     patch: {

--- a/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/GeneralTab/transformers.ts
+++ b/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/GeneralTab/transformers.ts
@@ -44,10 +44,7 @@ export const gqlToForm = ((data, options = {}) => {
     },
     projectFlags: {
       dispatchingDisabled: projectRef.dispatchingDisabled,
-      waterfallDisabled:
-        "waterfallDisabled" in projectRef
-          ? (projectRef.waterfallDisabled ?? null)
-          : null,
+      waterfallDisabled: projectRef.waterfallDisabled,
       debug: {
         debugSpawnHostsDisabled: projectRef.debugSpawnHostsDisabled,
       },

--- a/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/GeneralTab/transformers.ts
+++ b/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/GeneralTab/transformers.ts
@@ -44,6 +44,10 @@ export const gqlToForm = ((data, options = {}) => {
     },
     projectFlags: {
       dispatchingDisabled: projectRef.dispatchingDisabled,
+      waterfallDisabled:
+        "waterfallDisabled" in projectRef
+          ? (projectRef.waterfallDisabled ?? null)
+          : null,
       debug: {
         debugSpawnHostsDisabled: projectRef.debugSpawnHostsDisabled,
       },
@@ -97,6 +101,7 @@ export const formToGql = ((
     spawnHostScriptPath: generalConfiguration.other.spawnHostScriptPath,
     versionControlEnabled: generalConfiguration.other.versionControlEnabled,
     dispatchingDisabled: projectFlags.dispatchingDisabled,
+    waterfallDisabled: projectFlags.waterfallDisabled,
     deactivatePrevious: projectFlags.scheduling.deactivatePrevious,
     repotrackerDisabled: projectFlags.repotracker.repotrackerDisabled,
     debugSpawnHostsDisabled: projectFlags.debug.debugSpawnHostsDisabled,

--- a/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/GeneralTab/transformers.ts
+++ b/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/GeneralTab/transformers.ts
@@ -44,7 +44,6 @@ export const gqlToForm = ((data, options = {}) => {
     },
     projectFlags: {
       dispatchingDisabled: projectRef.dispatchingDisabled,
-      waterfallDisabled: projectRef.waterfallDisabled,
       debug: {
         debugSpawnHostsDisabled: projectRef.debugSpawnHostsDisabled,
       },
@@ -57,6 +56,7 @@ export const gqlToForm = ((data, options = {}) => {
       repotracker: {
         repotrackerDisabled: projectRef.repotrackerDisabled,
         runEveryMainlineCommit: projectRef.runEveryMainlineCommit,
+        waterfallDisabled: projectRef.waterfallDisabled,
         forceRun: null,
       },
       patch: {
@@ -98,9 +98,9 @@ export const formToGql = ((
     spawnHostScriptPath: generalConfiguration.other.spawnHostScriptPath,
     versionControlEnabled: generalConfiguration.other.versionControlEnabled,
     dispatchingDisabled: projectFlags.dispatchingDisabled,
-    waterfallDisabled: projectFlags.waterfallDisabled,
     deactivatePrevious: projectFlags.scheduling.deactivatePrevious,
     repotrackerDisabled: projectFlags.repotracker.repotrackerDisabled,
+    waterfallDisabled: projectFlags.repotracker.waterfallDisabled,
     debugSpawnHostsDisabled: projectFlags.debug.debugSpawnHostsDisabled,
     stepbackDisabled: projectFlags.scheduling.stepbackDisabled,
     stepbackBisect: projectFlags.scheduling.stepbackBisection,

--- a/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/GeneralTab/types.ts
+++ b/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/GeneralTab/types.ts
@@ -20,6 +20,7 @@ export interface GeneralFormState {
   };
   projectFlags: {
     dispatchingDisabled: boolean | null;
+    waterfallDisabled: boolean | null;
     debug: {
       debugSpawnHostsDisabled: boolean | null;
     };

--- a/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/GeneralTab/types.ts
+++ b/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/GeneralTab/types.ts
@@ -20,7 +20,6 @@ export interface GeneralFormState {
   };
   projectFlags: {
     dispatchingDisabled: boolean | null;
-    waterfallDisabled: boolean | null;
     debug: {
       debugSpawnHostsDisabled: boolean | null;
     };
@@ -33,6 +32,7 @@ export interface GeneralFormState {
     repotracker: {
       repotrackerDisabled: boolean | null;
       runEveryMainlineCommit: boolean | null;
+      waterfallDisabled: boolean | null;
       forceRun: null;
     };
     patch: {

--- a/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/testData.ts
+++ b/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/testData.ts
@@ -53,6 +53,7 @@ const projectBase: ProjectSettingsQuery["projectSettings"] = {
     // @ts-expect-error: FIXME. This comment was added by an automated script.
     spawnHostScriptPath: null,
     dispatchingDisabled: null,
+    waterfallDisabled: null,
     versionControlEnabled: true,
     deactivatePrevious: null,
     repotrackerDisabled: null,

--- a/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/testData.ts
+++ b/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/testData.ts
@@ -215,6 +215,7 @@ const repoBase: RepoSettingsQuery["repoSettings"] = {
     spawnHostScriptPath: "/test/path",
     oldestAllowedMergeBase: "abc",
     dispatchingDisabled: true,
+    waterfallDisabled: false,
     versionControlEnabled: false,
     deactivatePrevious: true,
     repotrackerDisabled: false,

--- a/packages/lib/src/gql/generated/types.ts
+++ b/packages/lib/src/gql/generated/types.ts
@@ -2815,6 +2815,7 @@ export type Project = {
   testSelection?: Maybe<TestSelectionSettings>;
   triggers?: Maybe<Array<TriggerAlias>>;
   versionControlEnabled?: Maybe<Scalars["Boolean"]["output"]>;
+  waterfallDisabled?: Maybe<Scalars["Boolean"]["output"]>;
   workstationConfig: WorkstationConfig;
 };
 
@@ -2965,6 +2966,7 @@ export type ProjectInput = {
   testSelection?: InputMaybe<TestSelectionSettingsInput>;
   triggers?: InputMaybe<Array<TriggerAliasInput>>;
   versionControlEnabled?: InputMaybe<Scalars["Boolean"]["input"]>;
+  waterfallDisabled?: InputMaybe<Scalars["Boolean"]["input"]>;
   workstationConfig?: InputMaybe<WorkstationConfigInput>;
 };
 
@@ -3008,6 +3010,7 @@ export type ProjectLite = {
   stepbackBisect?: Maybe<Scalars["Boolean"]["output"]>;
   stepbackDisabled?: Maybe<Scalars["Boolean"]["output"]>;
   versionControlEnabled?: Maybe<Scalars["Boolean"]["output"]>;
+  waterfallDisabled?: Maybe<Scalars["Boolean"]["output"]>;
 };
 
 export enum ProjectPermission {

--- a/packages/lib/src/gql/generated/types.ts
+++ b/packages/lib/src/gql/generated/types.ts
@@ -1025,8 +1025,6 @@ export type EditSpawnHostInput = {
   savePublicKey?: InputMaybe<Scalars["Boolean"]["input"]>;
   servicePassword?: InputMaybe<Scalars["String"]["input"]>;
   sleepSchedule?: InputMaybe<SleepScheduleInput>;
-  /** @deprecated Use volumeId instead of volume. */
-  volume?: InputMaybe<Scalars["String"]["input"]>;
   volumeId?: InputMaybe<Scalars["String"]["input"]>;
 };
 
@@ -3155,8 +3153,6 @@ export type Query = {
   githubProjectConflicts: GithubProjectConflicts;
   hasVersion: Scalars["Boolean"]["output"];
   host?: Maybe<Host>;
-  /** @deprecated Use host.events instead. */
-  hostEvents: HostEvents;
   hosts: HostsResponse;
   image?: Maybe<Image>;
   images: Array<Scalars["String"]["output"]>;
@@ -3238,13 +3234,6 @@ export type QueryHasVersionArgs = {
 
 export type QueryHostArgs = {
   hostId: Scalars["String"]["input"];
-};
-
-export type QueryHostEventsArgs = {
-  hostId: Scalars["String"]["input"];
-  hostTag?: InputMaybe<Scalars["String"]["input"]>;
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  page?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type QueryHostsArgs = {
@@ -3958,8 +3947,6 @@ export enum SpawnHostStatusActions {
 export type SpawnVolumeInput = {
   availabilityZone: Scalars["String"]["input"];
   expiration?: InputMaybe<Scalars["Time"]["input"]>;
-  /** @deprecated Use hostId instead of host. */
-  host?: InputMaybe<Scalars["String"]["input"]>;
   hostId?: InputMaybe<Scalars["String"]["input"]>;
   noExpiration?: InputMaybe<Scalars["Boolean"]["input"]>;
   size: Scalars["Int"]["input"];

--- a/packages/lib/src/gql/generated/types.ts
+++ b/packages/lib/src/gql/generated/types.ts
@@ -3437,6 +3437,7 @@ export type RepoRef = {
   testSelection?: Maybe<RepoTestSelectionSettings>;
   triggers: Array<TriggerAlias>;
   versionControlEnabled: Scalars["Boolean"]["output"];
+  waterfallDisabled: Scalars["Boolean"]["output"];
   workstationConfig: RepoWorkstationConfig;
 };
 
@@ -3485,6 +3486,7 @@ export type RepoRefInput = {
   testSelection?: InputMaybe<TestSelectionSettingsInput>;
   triggers?: InputMaybe<Array<TriggerAliasInput>>;
   versionControlEnabled?: InputMaybe<Scalars["Boolean"]["input"]>;
+  waterfallDisabled?: InputMaybe<Scalars["Boolean"]["input"]>;
   workstationConfig?: InputMaybe<WorkstationConfigInput>;
 };
 


### PR DESCRIPTION
DEVPROD-32825

### Description
From Evergreen PR:

> Adds a new waterfallDisabled project setting that prevents automatic task activation on the waterfall while still allowing the repotracker to create versions and tasks. Commits will still appear on the waterfall but will be unscheduled, but can be manually scheduled.

### Testing
Verified behavior in staging
### Evergreen PR
https://github.com/evergreen-ci/evergreen/pull/10228