### PR TITLE
DEVPROD-33503: Allow quarantining passing tests and non-patch variants

### DIFF
--- a/apps/spruce/src/pages/task/taskTabs/testsTable/ActionMenu/ActionMenu.test.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/testsTable/ActionMenu/ActionMenu.test.tsx
@@ -42,7 +42,7 @@ describe("action menu for tests table", () => {
     });
     expect(
       screen.getByText(
-        "Test selection did not run for this task, so its tests cannot be quarantined. Test selection is only available on patch builds for build variants and tasks configured for it.",
+        "Test selection did not run for this task, so its tests cannot be quarantined.",
       ),
     ).toBeVisible();
   });
@@ -68,10 +68,10 @@ describe("action menu for tests table", () => {
     });
   });
 
-  it("disables quarantine option when test is passing and not quarantined", async () => {
+  it("quarantines a passing test", async () => {
     const user = userEvent.setup();
-    const { Component } = RenderFakeToastContext(
-      <MockedProvider mocks={[]}>
+    const { Component, dispatchToast } = RenderFakeToastContext(
+      <MockedProvider mocks={[quarantinePassingTestMock]}>
         <ActionMenu task={taskWithTestSelection} test={passingTest} />
       </MockedProvider>,
     );
@@ -80,10 +80,14 @@ describe("action menu for tests table", () => {
     await waitFor(() => {
       expect(screen.getByDataCy("quarantine-test")).toBeVisible();
     });
-    expect(screen.getByDataCy("quarantine-test")).toHaveAttribute(
+    expect(screen.getByDataCy("quarantine-test")).not.toHaveAttribute(
       "aria-disabled",
       "true",
     );
+    await user.click(screen.getByDataCy("quarantine-test"));
+    await waitFor(() => {
+      expect(dispatchToast.success).toHaveBeenCalledTimes(1);
+    });
   });
 
   it("quarantines a failing test on a non-display task", async () => {
@@ -159,49 +163,47 @@ const failingTestOnDisplayTask: TestResult = {
   logs: {},
 };
 
-const quarantineTestMock: ApolloMock<
-  QuarantineTestMutation,
-  QuarantineTestMutationVariables
-> = {
+const quarantineMock = ({
+  id,
+  taskId,
+  testName,
+}: {
+  id: string;
+  taskId: string;
+  testName: string;
+}): ApolloMock<QuarantineTestMutation, QuarantineTestMutationVariables> => ({
   request: {
     query: QUARANTINE_TEST,
-    variables: {
-      taskId: taskQuery.task.id,
-      testName: "test_1",
-    },
+    variables: { taskId, testName },
   },
   result: {
     data: {
       quarantineTest: {
         __typename: "TestResult",
-        id: "1",
+        id,
         isManuallyQuarantined: true,
       },
     },
   },
-};
+});
 
-const quarantineDisplayTaskTestMock: ApolloMock<
-  QuarantineTestMutation,
-  QuarantineTestMutationVariables
-> = {
-  request: {
-    query: QUARANTINE_TEST,
-    variables: {
-      taskId: "execTaskId",
-      testName: "test_4",
-    },
-  },
-  result: {
-    data: {
-      quarantineTest: {
-        __typename: "TestResult",
-        id: "4",
-        isManuallyQuarantined: true,
-      },
-    },
-  },
-};
+const quarantineTestMock = quarantineMock({
+  id: "1",
+  taskId: taskQuery.task.id,
+  testName: "test_1",
+});
+
+const quarantinePassingTestMock = quarantineMock({
+  id: "2",
+  taskId: taskQuery.task.id,
+  testName: "test_2",
+});
+
+const quarantineDisplayTaskTestMock = quarantineMock({
+  id: "4",
+  taskId: "execTaskId",
+  testName: "test_4",
+});
 
 const unquarantineTestMock: ApolloMock<
   UnquarantineTestMutation,

--- a/apps/spruce/src/pages/task/taskTabs/testsTable/ActionMenu/index.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/testsTable/ActionMenu/index.tsx
@@ -2,7 +2,6 @@ import { useState } from "react";
 import { useMutation } from "@apollo/client/react";
 import { Size as ButtonSize } from "@leafygreen-ui/button";
 import { useToastContext } from "@evg-ui/lib/context/toast";
-import { TestStatus } from "@evg-ui/lib/types/test";
 import { useTaskAnalytics } from "analytics";
 import { ButtonDropdown, DropdownItem } from "components/ButtonDropdown";
 import {
@@ -85,8 +84,7 @@ export const ActionMenu: React.FC<ActionMenuProps> = ({ task, test }) => {
     dropdownItems = [
       <DropdownItem key="disabled" disabled>
         Test selection did not run for this task, so its tests cannot be
-        quarantined. Test selection is only available on patch builds for build
-        variants and tasks configured for it.
+        quarantined.
       </DropdownItem>,
     ];
   } else if (test.isManuallyQuarantined) {
@@ -101,17 +99,11 @@ export const ActionMenu: React.FC<ActionMenuProps> = ({ task, test }) => {
       </DropdownItem>,
     ];
   } else {
-    const canQuarantine = test.status === TestStatus.Fail;
     dropdownItems = [
       <DropdownItem
         key="quarantine"
         data-cy="quarantine-test"
-        description={
-          canQuarantine
-            ? "Quarantine test so that it does not run in future task runs."
-            : "Passing tests cannot be quarantined."
-        }
-        disabled={!canQuarantine}
+        description="Quarantine test so that it does not run in future task runs."
         onClick={onQuarantineTest}
       >
         Quarantine


### PR DESCRIPTION
DEVPROD-33503

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->

<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
Work done:
  - **Quarantine passing tests**: drop the FE-side gate that required `test.status === Fail`. Users can now quarantine a flaky test from a run where it happened to pass for example
  - **Non-patch variants**:  removing "test selection is only available on patch builds" copy from the ActionMenu's disabled-state message. BE is also allowing non-patched variants to be quarantined as previously they were returning false. No other FE work needed

### Screenshots
https://github.com/user-attachments/assets/595858f1-ff1f-4daf-ba53-2c0de1755477


### Testing
* Smoke tested locally
* Added tests

### Evergreen PR
https://github.com/evergreen-ci/evergreen/pull/10240