### PR TITLE
DEVPROD-34043: Include user in Jira event creation log

### DIFF
--- a/apps/spruce/src/pages/task/taskTabs/logs/logTypes/TaskEventLogLine.stories.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/logs/logTypes/TaskEventLogLine.stories.tsx
@@ -69,14 +69,6 @@ export const TaskJiraAlertCreated = buildStory(
   },
 );
 
-export const TaskJiraAlertCreatedNoUser = buildStory(
-  TaskEventType.TaskJiraAlertCreated,
-  {
-    jiraIssue: "EVG-1234",
-    jiraLink: "https://jira.mongodb.org/browse/EVG-1234",
-  },
-);
-
 export const TaskDeactivated = buildStory(TaskEventType.TaskDeactivated, {
   userId: "mohamed.khelif",
 });

--- a/apps/spruce/src/pages/task/taskTabs/logs/logTypes/TaskEventLogLine.stories.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/logs/logTypes/TaskEventLogLine.stories.tsx
@@ -1,0 +1,112 @@
+import { CustomMeta, CustomStoryObj } from "@evg-ui/lib/test_utils/types";
+import { TaskEventLogData } from "gql/generated/types";
+import { getUserSettingsMock } from "gql/mocks/getSpruceConfig";
+import { TaskEventType } from "types/task";
+import { TaskEventLogLine } from "./TaskEventLogLine";
+
+export default {
+  component: TaskEventLogLine,
+} satisfies CustomMeta<typeof TaskEventLogLine>;
+
+const timestamp = new Date("2026-05-29T12:00:00.000Z");
+
+const apolloMocks = {
+  apolloClient: {
+    mocks: [getUserSettingsMock],
+  },
+};
+
+const buildStory = (
+  eventType: TaskEventType,
+  data: Partial<TaskEventLogData> = {},
+): CustomStoryObj<typeof TaskEventLogLine> => ({
+  render: (args) => <TaskEventLogLine {...args} />,
+  args: {
+    id: "event-id",
+    resourceId: "task-id",
+    resourceType: "TASK",
+    timestamp,
+    eventType,
+    data: { timestamp, ...data },
+  },
+  parameters: apolloMocks,
+});
+
+export const TaskBlocked = buildStory(TaskEventType.TaskBlocked, {
+  blockedOn: "blocking-task-id",
+});
+
+export const TaskFinished = buildStory(TaskEventType.TaskFinished, {
+  status: "success",
+});
+
+export const TaskStarted = buildStory(TaskEventType.TaskStarted);
+
+export const TaskDispatched = buildStory(TaskEventType.TaskDispatched, {
+  hostId: "host-1",
+});
+
+export const TaskUndispatched = buildStory(TaskEventType.TaskUndispatched, {
+  hostId: "host-1",
+});
+
+export const TaskCreated = buildStory(TaskEventType.TaskCreated);
+
+export const TaskRestarted = buildStory(TaskEventType.TaskRestarted, {
+  userId: "mohamed.khelif",
+});
+
+export const TaskActivated = buildStory(TaskEventType.TaskActivated, {
+  userId: "mohamed.khelif",
+});
+
+export const TaskJiraAlertCreated = buildStory(
+  TaskEventType.TaskJiraAlertCreated,
+  {
+    jiraIssue: "EVG-1234",
+    jiraLink: "https://jira.mongodb.org/browse/EVG-1234",
+    userId: "mohamed.khelif",
+  },
+);
+
+export const TaskJiraAlertCreatedNoUser = buildStory(
+  TaskEventType.TaskJiraAlertCreated,
+  {
+    jiraIssue: "EVG-1234",
+    jiraLink: "https://jira.mongodb.org/browse/EVG-1234",
+  },
+);
+
+export const TaskDeactivated = buildStory(TaskEventType.TaskDeactivated, {
+  userId: "mohamed.khelif",
+});
+
+export const TaskAbortRequest = buildStory(TaskEventType.TaskAbortRequest, {
+  userId: "mohamed.khelif",
+});
+
+export const TaskScheduled = buildStory(TaskEventType.TaskScheduled);
+
+export const TaskPriorityChanged = buildStory(
+  TaskEventType.TaskPriorityChanged,
+  {
+    priority: 50,
+    userId: "mohamed.khelif",
+  },
+);
+
+export const TaskDependenciesOverridden = buildStory(
+  TaskEventType.TaskDependenciesOverridden,
+  {
+    userId: "mohamed.khelif",
+  },
+);
+
+export const MergeTaskUnscheduled = buildStory(
+  TaskEventType.MergeTaskUnscheduled,
+  {
+    userId: "mohamed.khelif",
+  },
+);
+
+export const ContainerAllocated = buildStory(TaskEventType.ContainerAllocated);

--- a/apps/spruce/src/pages/task/taskTabs/logs/logTypes/TaskEventLogLine.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/logs/logTypes/TaskEventLogLine.tsx
@@ -77,7 +77,7 @@ export const TaskEventLogLine: React.FC<TaskEventLogEntry> = ({
           <StyledLink href={jiraLink ?? ""}>
             <strong>{jiraIssue}</strong>
           </StyledLink>
-          {userId && <> by {userId}</>}
+          {userId && ` by ${userId}`}
         </>
       );
       break;

--- a/apps/spruce/src/pages/task/taskTabs/logs/logTypes/TaskEventLogLine.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/logs/logTypes/TaskEventLogLine.tsx
@@ -77,6 +77,7 @@ export const TaskEventLogLine: React.FC<TaskEventLogEntry> = ({
           <StyledLink href={jiraLink ?? ""}>
             <strong>{jiraIssue}</strong>
           </StyledLink>
+          {userId && <> by {userId}</>}
         </>
       );
       break;


### PR DESCRIPTION
DEVPROD-34043

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->

<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
Adding user who created the Jira ticket to the event log.

### Screenshots
<img width="659" height="203" alt="Screenshot 2026-05-29 at 1 57 57 PM" src="https://github.com/user-attachments/assets/20fdcc7d-5fec-4894-a30c-2b34ed1267bc" />

### Testing
* Story book tests
