### PR TITLE
DEVPROD-34197: Update Spruce logo for Pride Month

### DIFF
--- a/apps/spruce/src/components/Header/Navbar.stories.tsx
+++ b/apps/spruce/src/components/Header/Navbar.stories.tsx
@@ -1,0 +1,92 @@
+import { AuthStateContext } from "@evg-ui/lib/context/AuthProvider";
+import {
+  ApolloMock,
+  CustomStoryObj,
+  CustomMeta,
+} from "@evg-ui/lib/test_utils/types";
+import {
+  SpruceConfigQuery,
+  SpruceConfigQueryVariables,
+  UserQuery,
+  UserQueryVariables,
+} from "gql/generated/types";
+import { USER, SPRUCE_CONFIG } from "gql/queries";
+import { Navbar } from "./Navbar";
+
+const userMock: ApolloMock<UserQuery, UserQueryVariables> = {
+  request: { query: USER },
+  result: {
+    data: {
+      user: {
+        __typename: "User",
+        displayName: "Mohamed Khelif",
+        emailAddress: "mohamed.khelif@mongodb.com",
+        userId: "mohamed.khelif",
+        permissions: {
+          __typename: "Permissions",
+          canEditAdminSettings: false,
+        },
+      },
+    },
+  },
+};
+
+const spruceConfigMock: ApolloMock<
+  SpruceConfigQuery,
+  SpruceConfigQueryVariables
+> = {
+  request: { query: SPRUCE_CONFIG },
+  result: {
+    data: {
+      spruceConfig: {
+        __typename: "SpruceConfig",
+        banner: null,
+        bannerTheme: null,
+        containerPools: null,
+        jira: null,
+        providers: null,
+        serviceFlags: {
+          __typename: "UserServiceFlags",
+          debugSpawnHostDisabled: false,
+          jwtTokenForCLIDisabled: false,
+        },
+        slack: null,
+        spawnHost: {
+          __typename: "SpawnHostConfig",
+          spawnHostsPerUser: 5,
+          unexpirableHostsPerUser: 2,
+          unexpirableVolumesPerUser: 2,
+        },
+        ui: {
+          __typename: "UIConfig",
+          defaultProject: "mongodb-mongo-master",
+        },
+      },
+    },
+  },
+};
+
+const mocks = [userMock, spruceConfigMock];
+
+export default {
+  component: Navbar,
+  parameters: {
+    apolloClient: { mocks },
+  },
+} satisfies CustomMeta<typeof Navbar>;
+
+export const Default: CustomStoryObj<typeof Navbar> = {
+  render: () => (
+    <AuthStateContext.Provider
+      value={{
+        isAuthenticated: true,
+        hasCheckedAuth: true,
+        localLogin: () => {},
+        logoutAndRedirect: () => {},
+        dispatchAuthenticated: () => {},
+      }}
+    >
+      <Navbar />
+    </AuthStateContext.Provider>
+  ),
+};

--- a/apps/spruce/src/components/Header/Navbar.tsx
+++ b/apps/spruce/src/components/Header/Navbar.tsx
@@ -5,7 +5,7 @@ import styled from "@emotion/styled";
 import { palette } from "@leafygreen-ui/palette";
 import Cookies from "js-cookie";
 import { Link, useParams } from "react-router-dom";
-import Icon, { AnimatedIcon, SpringLogo } from "@evg-ui/lib/components/Icon";
+import Icon, { AnimatedIcon, PrideLogo } from "@evg-ui/lib/components/Icon";
 import { size } from "@evg-ui/lib/constants/tokens";
 import { useAuthProviderContext } from "@evg-ui/lib/context/AuthProvider";
 import { useNavbarAnalytics } from "analytics";
@@ -70,7 +70,7 @@ export const Navbar: React.FC = () => {
           onClick={() => sendEvent({ name: "Clicked logo link" })}
           to={routes.myPatches}
         >
-          <AnimatedIcon alwaysAnimate icon={SpringLogo} />
+          <AnimatedIcon icon={PrideLogo} />
         </LogoLink>
         <PrimaryLink
           data-cy="waterfall-link"

--- a/packages/lib/src/context/AuthProvider/index.tsx
+++ b/packages/lib/src/context/AuthProvider/index.tsx
@@ -231,4 +231,4 @@ const useAuthProviderContext = (): AuthState & AuthProviderDispatchMethods => {
   return authState;
 };
 
-export { AuthProvider, useAuthProviderContext };
+export { AuthProvider, AuthStateContext, useAuthProviderContext };


### PR DESCRIPTION
## Description
Swaps the Spruce navbar logo from the spring leaf to the Pride Month animated rainbow logo for June.

## Screenshots
The navbar logo now cycles through rainbow pride flag colors continuously.

## Testing
Verified the `PrideLogo` component renders correctly via `AnimatedIcon` — animations pause on mount and play on hover (matching the behavior of the other seasonal logos).

## Evergreen PR
N/A