### PR TITLE
DEVPROD-34037 Spotlight task debugger in the UI

### DIFF
--- a/apps/parsley/src/gql/generated/types.ts
+++ b/apps/parsley/src/gql/generated/types.ts
@@ -3064,6 +3064,7 @@ export type ProjectTasksPair = {
   __typename?: "ProjectTasksPair";
   allowedBVs: Array<Scalars["String"]["output"]>;
   allowedTasks: Array<Scalars["String"]["output"]>;
+  displayName: Scalars["String"]["output"];
   projectId: Scalars["String"]["output"];
 };
 

--- a/apps/spruce/src/analytics/task/useTaskAnalytics.ts
+++ b/apps/spruce/src/analytics/task/useTaskAnalytics.ts
@@ -100,7 +100,7 @@ type Action =
       reviewed: boolean;
     }
   | { name: "Clicked cost details button" }
-  | { name: "Clicked debug spawn host guide cue dismiss" };
+  | { name: "Clicked to dismiss debug spawn host guide cue" };
 
 export const useTaskAnalytics = () => {
   const { [slugs.taskId]: taskId } = useParams();

--- a/apps/spruce/src/analytics/task/useTaskAnalytics.ts
+++ b/apps/spruce/src/analytics/task/useTaskAnalytics.ts
@@ -99,7 +99,8 @@ type Action =
       name: "Clicked review task";
       reviewed: boolean;
     }
-  | { name: "Clicked cost details button" };
+  | { name: "Clicked cost details button" }
+  | { name: "Clicked debug spawn host guide cue dismiss" };
 
 export const useTaskAnalytics = () => {
   const { [slugs.taskId]: taskId } = useParams();

--- a/apps/spruce/src/constants/cookies.ts
+++ b/apps/spruce/src/constants/cookies.ts
@@ -10,6 +10,8 @@ export const INCLUDE_HIDDEN_PATCHES = "include-hidden-patches";
 export const INCLUDE_NEVER_ACTIVATED_TASKS = "include-never-activated-tasks";
 export const SLACK_NOTIFICATION_BANNER = "has-closed-slack-banner";
 export const SUBSCRIPTION_METHOD = "subscription-method";
+export const SEEN_DEBUG_SPAWN_HOST_GUIDE_CUE =
+  "seen-debug-spawn-host-guide-cue";
 export const SEEN_WATERFALL_ONBOARDING_TUTORIAL =
   "seen-waterfall-onboarding-tutorial";
 export const SEEN_TASK_HISTORY_ONBOARDING_TUTORIAL =

--- a/apps/spruce/src/constants/externalResources/index.ts
+++ b/apps/spruce/src/constants/externalResources/index.ts
@@ -20,6 +20,8 @@ export const taskSpawnHostDocumentationUrl = `${hostsDocumentationUrl}/Spawn-Hos
 
 export const debugSpawnHostsDocumentationUrl = `${hostsDocumentationUrl}/Debug-Spawn-Hosts`;
 
+export const debugSpawnHostsAdminDocumentationUrl = `${hostsDocumentationUrl}/Debug-Spawn-Hosts#for-project-admins`;
+
 export const projectDistroSettingsDocumentationUrl = `${projectSettingsDocumentationUrl}/Project-and-Distro-Settings`;
 
 export const projectSettingsRepoSettingsDocumentationUrl = `${projectSettingsDocumentationUrl}/Repo-Level-Settings`;

--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -3061,6 +3061,7 @@ export type ProjectTasksPair = {
   __typename?: "ProjectTasksPair";
   allowedBVs: Array<Scalars["String"]["output"]>;
   allowedTasks: Array<Scalars["String"]["output"]>;
+  displayName: Scalars["String"]["output"];
   projectId: Scalars["String"]["output"];
 };
 

--- a/apps/spruce/src/pages/task/metadata/DebugSpawnHostGuideCue.tsx
+++ b/apps/spruce/src/pages/task/metadata/DebugSpawnHostGuideCue.tsx
@@ -1,11 +1,15 @@
 import { useEffect, useRef, useState } from "react";
+import styled from "@emotion/styled";
 import { GuideCue } from "@leafygreen-ui/guide-cue";
+import { palette } from "@leafygreen-ui/palette";
 import Cookies from "js-cookie";
 import { StyledLink, StyledRouterLink } from "@evg-ui/lib/components/styles";
 import { useTaskAnalytics } from "analytics";
 import { MetadataItem } from "components/MetadataCard";
 import { SEEN_DEBUG_SPAWN_HOST_GUIDE_CUE } from "constants/cookies";
 import { getSpawnHostRoute } from "constants/routes";
+
+const { green } = palette;
 
 const debugSpawnHostDocsUrl =
   "https://docs.devprod.prod.corp.mongodb.com/evergreen/Hosts/Debug-Spawn-Hosts";
@@ -67,13 +71,12 @@ export const DebugSpawnHostGuideCue: React.FC<DebugSpawnHostGuideCueProps> = ({
         open={open && isVisible}
         refEl={refEl}
         setOpen={setOpen}
-        title="Debug your failed task"
+        title="New: Debug Spawn Hosts"
       >
-        Spawn a host with debug mode to interactively re-run and inspect failed
-        commands.{" "}
-        <StyledLink hideExternalIcon={false} href={debugSpawnHostDocsUrl}>
-          Learn more
-        </StyledLink>
+        This task can be debugged using <GreenText>debug spawn hosts</GreenText>
+        , which allows you to interactively re-run and inspect failed commands.
+        Read more in{" "}
+        <StyledLink href={debugSpawnHostDocsUrl}>the docs</StyledLink>.
       </GuideCue>
       <span ref={refEl}>
         <StyledRouterLink
@@ -97,3 +100,7 @@ export const DebugSpawnHostGuideCue: React.FC<DebugSpawnHostGuideCueProps> = ({
     </MetadataItem>
   );
 };
+
+const GreenText = styled.span`
+  color: ${green.base};
+`;

--- a/apps/spruce/src/pages/task/metadata/DebugSpawnHostGuideCue.tsx
+++ b/apps/spruce/src/pages/task/metadata/DebugSpawnHostGuideCue.tsx
@@ -7,7 +7,10 @@ import { StyledLink, StyledRouterLink } from "@evg-ui/lib/components/styles";
 import { useTaskAnalytics } from "analytics";
 import { MetadataItem } from "components/MetadataCard";
 import { SEEN_DEBUG_SPAWN_HOST_GUIDE_CUE } from "constants/cookies";
-import { debugSpawnHostsDocumentationUrl } from "constants/externalResources";
+import {
+  debugSpawnHostsAdminDocumentationUrl,
+  debugSpawnHostsDocumentationUrl,
+} from "constants/externalResources";
 import { getSpawnHostRoute } from "constants/routes";
 import useIntersectionObserver from "hooks/useIntersectionObserver";
 
@@ -68,6 +71,13 @@ export const DebugSpawnHostGuideCue: React.FC<DebugSpawnHostGuideCueProps> = ({
         , which allows you to interactively re-run and inspect failed commands.
         Read more in{" "}
         <StyledLink href={debugSpawnHostsDocumentationUrl}>the docs</StyledLink>
+        .
+        <br />
+        <br />
+        If not yet enabled, reach out to your{" "}
+        <StyledLink href={debugSpawnHostsAdminDocumentationUrl}>
+          project admin
+        </StyledLink>
         .
       </GuideCue>
       <span ref={refEl}>

--- a/apps/spruce/src/pages/task/metadata/DebugSpawnHostGuideCue.tsx
+++ b/apps/spruce/src/pages/task/metadata/DebugSpawnHostGuideCue.tsx
@@ -1,0 +1,99 @@
+import { useEffect, useRef, useState } from "react";
+import { GuideCue } from "@leafygreen-ui/guide-cue";
+import Cookies from "js-cookie";
+import { StyledLink, StyledRouterLink } from "@evg-ui/lib/components/styles";
+import { useTaskAnalytics } from "analytics";
+import { MetadataItem } from "components/MetadataCard";
+import { SEEN_DEBUG_SPAWN_HOST_GUIDE_CUE } from "constants/cookies";
+import { getSpawnHostRoute } from "constants/routes";
+
+const debugSpawnHostDocsUrl =
+  "https://docs.devprod.prod.corp.mongodb.com/evergreen/Hosts/Debug-Spawn-Hosts";
+
+interface DebugSpawnHostGuideCueProps {
+  enabled: boolean;
+  distroId: string;
+  taskId: string;
+}
+
+export const DebugSpawnHostGuideCue: React.FC<DebugSpawnHostGuideCueProps> = ({
+  distroId,
+  enabled,
+  taskId,
+}) => {
+  const taskAnalytics = useTaskAnalytics();
+  const refEl = useRef<HTMLSpanElement>(null);
+
+  const [open, setOpen] = useState(
+    Cookies.get(SEEN_DEBUG_SPAWN_HOST_GUIDE_CUE) !== "true",
+  );
+  const [isVisible, setIsVisible] = useState(false);
+
+  useEffect(() => {
+    if (!open || !refEl.current) {
+      return;
+    }
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setIsVisible(true);
+          observer.disconnect();
+        }
+      },
+      { threshold: 0.5 },
+    );
+    observer.observe(refEl.current);
+    return () => observer.disconnect();
+  }, [open]);
+
+  const closeGuideCue = () => {
+    Cookies.set(SEEN_DEBUG_SPAWN_HOST_GUIDE_CUE, "true", { expires: 365 });
+    setOpen(false);
+  };
+
+  return (
+    <MetadataItem>
+      <GuideCue
+        currentStep={1}
+        data-cy="debug-spawn-host-guide-cue"
+        enabled={enabled}
+        numberOfSteps={1}
+        onPrimaryButtonClick={() => {
+          closeGuideCue();
+          taskAnalytics.sendEvent({
+            name: "Clicked debug spawn host guide cue dismiss",
+          });
+        }}
+        open={open && isVisible}
+        refEl={refEl}
+        setOpen={setOpen}
+        title="Debug your failed task"
+      >
+        Spawn a host with debug mode to interactively re-run and inspect failed
+        commands.{" "}
+        <StyledLink hideExternalIcon={false} href={debugSpawnHostDocsUrl}>
+          Learn more
+        </StyledLink>
+      </GuideCue>
+      <span ref={refEl}>
+        <StyledRouterLink
+          data-cy="task-spawn-host-link"
+          onClick={() => {
+            closeGuideCue();
+            taskAnalytics.sendEvent({
+              name: "Clicked metadata link",
+              "link.type": "spawn host link",
+            });
+          }}
+          to={getSpawnHostRoute({
+            distroId,
+            spawnHost: true,
+            taskId,
+          })}
+        >
+          Spawn host
+        </StyledRouterLink>
+      </span>
+    </MetadataItem>
+  );
+};

--- a/apps/spruce/src/pages/task/metadata/DebugSpawnHostGuideCue.tsx
+++ b/apps/spruce/src/pages/task/metadata/DebugSpawnHostGuideCue.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import styled from "@emotion/styled";
 import { GuideCue } from "@leafygreen-ui/guide-cue";
 import { palette } from "@leafygreen-ui/palette";
@@ -7,12 +7,11 @@ import { StyledLink, StyledRouterLink } from "@evg-ui/lib/components/styles";
 import { useTaskAnalytics } from "analytics";
 import { MetadataItem } from "components/MetadataCard";
 import { SEEN_DEBUG_SPAWN_HOST_GUIDE_CUE } from "constants/cookies";
+import { debugSpawnHostsDocumentationUrl } from "constants/externalResources";
 import { getSpawnHostRoute } from "constants/routes";
+import useIntersectionObserver from "hooks/useIntersectionObserver";
 
 const { green } = palette;
-
-const debugSpawnHostDocsUrl =
-  "https://docs.devprod.prod.corp.mongodb.com/evergreen/Hosts/Debug-Spawn-Hosts";
 
 interface DebugSpawnHostGuideCueProps {
   enabled: boolean;
@@ -25,7 +24,7 @@ export const DebugSpawnHostGuideCue: React.FC<DebugSpawnHostGuideCueProps> = ({
   enabled,
   taskId,
 }) => {
-  const taskAnalytics = useTaskAnalytics();
+  const { sendEvent } = useTaskAnalytics();
   const refEl = useRef<HTMLSpanElement>(null);
 
   const [open, setOpen] = useState(
@@ -33,22 +32,15 @@ export const DebugSpawnHostGuideCue: React.FC<DebugSpawnHostGuideCueProps> = ({
   );
   const [isVisible, setIsVisible] = useState(false);
 
-  useEffect(() => {
-    if (!open || !refEl.current) {
-      return;
-    }
-    const observer = new IntersectionObserver(
-      ([entry]) => {
-        if (entry.isIntersecting) {
-          setIsVisible(true);
-          observer.disconnect();
-        }
-      },
-      { threshold: 0.5 },
-    );
-    observer.observe(refEl.current);
-    return () => observer.disconnect();
-  }, [open]);
+  useIntersectionObserver(
+    refEl,
+    useCallback(([entry]) => {
+      if (entry.isIntersecting) {
+        setIsVisible(true);
+      }
+    }, []),
+    { threshold: 0.5 },
+  );
 
   const closeGuideCue = () => {
     Cookies.set(SEEN_DEBUG_SPAWN_HOST_GUIDE_CUE, "true", { expires: 365 });
@@ -59,13 +51,12 @@ export const DebugSpawnHostGuideCue: React.FC<DebugSpawnHostGuideCueProps> = ({
     <MetadataItem>
       <GuideCue
         currentStep={1}
-        data-cy="debug-spawn-host-guide-cue"
         enabled={enabled}
         numberOfSteps={1}
         onPrimaryButtonClick={() => {
           closeGuideCue();
-          taskAnalytics.sendEvent({
-            name: "Clicked debug spawn host guide cue dismiss",
+          sendEvent({
+            name: "Clicked to dismiss debug spawn host guide cue",
           });
         }}
         open={open && isVisible}
@@ -76,14 +67,15 @@ export const DebugSpawnHostGuideCue: React.FC<DebugSpawnHostGuideCueProps> = ({
         This task can be debugged using <GreenText>debug spawn hosts</GreenText>
         , which allows you to interactively re-run and inspect failed commands.
         Read more in{" "}
-        <StyledLink href={debugSpawnHostDocsUrl}>the docs</StyledLink>.
+        <StyledLink href={debugSpawnHostsDocumentationUrl}>the docs</StyledLink>
+        .
       </GuideCue>
       <span ref={refEl}>
         <StyledRouterLink
           data-cy="task-spawn-host-link"
           onClick={() => {
             closeGuideCue();
-            taskAnalytics.sendEvent({
+            sendEvent({
               name: "Clicked metadata link",
               "link.type": "spawn host link",
             });

--- a/apps/spruce/src/pages/task/metadata/index.tsx
+++ b/apps/spruce/src/pages/task/metadata/index.tsx
@@ -26,17 +26,18 @@ import {
   getTaskQueueRoute,
   getTaskRoute,
   getHostRoute,
-  getSpawnHostRoute,
   getProjectPatchesRoute,
   getImageRoute,
 } from "constants/routes";
 import { TaskQuery } from "gql/generated/types";
 import { useDateFormat } from "hooks/useDateFormat";
 import { formatCost } from "utils/numbers";
+import { isFailedTaskStatus } from "utils/statuses";
 import { isInStepback } from "utils/stepback";
 import { msToDuration } from "utils/string";
 import { AbortMessage } from "./AbortMessage";
 import { BuildVariantCard } from "./BuildVariant";
+import { DebugSpawnHostGuideCue } from "./DebugSpawnHostGuideCue";
 import { DependsOn } from "./DependsOn";
 import DetailsDescription from "./DetailsDescription";
 import ETATimer from "./ETATimer";
@@ -481,24 +482,11 @@ export const Metadata: React.FC<Props> = ({ error, loading, task }) => {
             </MetadataItem>
           )}
           {spawnHostLink && (
-            <MetadataItem>
-              <StyledRouterLink
-                data-cy="task-spawn-host-link"
-                onClick={() =>
-                  taskAnalytics.sendEvent({
-                    name: "Clicked metadata link",
-                    "link.type": "spawn host link",
-                  })
-                }
-                to={getSpawnHostRoute({
-                  distroId,
-                  spawnHost: true,
-                  taskId,
-                })}
-              >
-                Spawn host
-              </StyledRouterLink>
-            </MetadataItem>
+            <DebugSpawnHostGuideCue
+              distroId={distroId}
+              enabled={isFailedTaskStatus(displayStatus)}
+              taskId={taskId}
+            />
           )}
         </MetadataCard>
       )}

--- a/packages/lib/src/gql/generated/types.ts
+++ b/packages/lib/src/gql/generated/types.ts
@@ -3064,6 +3064,7 @@ export type ProjectTasksPair = {
   __typename?: "ProjectTasksPair";
   allowedBVs: Array<Scalars["String"]["output"]>;
   allowedTasks: Array<Scalars["String"]["output"]>;
+  displayName: Scalars["String"]["output"];
   projectId: Scalars["String"]["output"];
 };
 


### PR DESCRIPTION
DEVPROD-34037

### Description
Adds a spotlight to the spawn host button describing the new debuggable spawn hosts feature when visiting a failed task for the first time.
### Screenshots
<img width="411" height="336" alt="image" src="https://github.com/user-attachments/assets/7699957d-da37-483a-b522-246666a7449f" />

### Testing
Tested manually in staging
