### PR TITLE
DEVPROD-33350: Show correct total cost values for patches with child patches

### DIFF
--- a/apps/spruce/src/pages/version/Metadata/Metadata.test.tsx
+++ b/apps/spruce/src/pages/version/Metadata/Metadata.test.tsx
@@ -245,8 +245,10 @@ describe("version metadata cost display", () => {
             cost: { __typename: "Cost", total: 3.75 },
             childPatches: null,
             githubPatchData: null,
-            includedLocalModules: null,
-          } as unknown as Version["patch"],
+            includedLocalModules: [],
+            id: "child-patch",
+            patchNumber: 123,
+          },
           finishTime: new Date("2024-01-02"),
         }}
       />,

--- a/apps/spruce/src/pages/version/Metadata/Metadata.test.tsx
+++ b/apps/spruce/src/pages/version/Metadata/Metadata.test.tsx
@@ -232,6 +232,36 @@ describe("version metadata cost display", () => {
     ).toBeInTheDocument();
   });
 
+  it("ShowsPatchCostTotalInModalForPatches", async () => {
+    const user = userEvent.setup();
+    render(
+      <Metadata
+        version={{
+          ...baseVersion,
+          isPatch: true,
+          cost: { __typename: "Cost", total: 1.5 },
+          patch: {
+            __typename: "Patch",
+            cost: { __typename: "Cost", total: 3.75 },
+            childPatches: null,
+            githubPatchData: null,
+            includedLocalModules: null,
+          } as unknown as Version["patch"],
+          finishTime: new Date("2024-01-02"),
+        }}
+      />,
+      {
+        route: "/version/version123",
+        path: "/version/:id",
+        wrapper,
+      },
+    );
+    await user.click(screen.getByDataCy("version-cost-details-button"));
+    // Total row in the modal uses patch.cost.total (3.75), not cost.total (1.5).
+    const modal = screen.getByDataCy("cost-modal");
+    expect(within(modal).getByText("$3.75")).toBeInTheDocument();
+  });
+
   it("CanReopenCostModalAfterClosing", async () => {
     const user = userEvent.setup();
     render(

--- a/apps/spruce/src/pages/version/Metadata/index.tsx
+++ b/apps/spruce/src/pages/version/Metadata/index.tsx
@@ -279,6 +279,7 @@ export const Metadata: React.FC<MetadataProps> = ({ version }) => {
           open={costModalOpen}
           setOpen={setCostModalOpen}
           startTs={startTime ?? undefined}
+          total={totalCost ?? cost.total}
           versionId={id}
         />
       )}


### PR DESCRIPTION
DEVPROD-33350

### Description
This PR fixes a bug where the patch total cost shown in the metadata panel did not match the cost shown in the cost modal.

Two issues fixed:
- The cost modal was not including child patch cost in the total.
- The child patch cost value was not being rounded correctly.

### Screenshots
Without the change:
<img width="313" height="384" alt="image" src="https://github.com/user-attachments/assets/06c7de98-19be-47e1-aadf-392fb76ab839" />
<img width="699" height="729" alt="image" src="https://github.com/user-attachments/assets/746903cf-c65d-461f-b448-67322969546f" />


With the Change:
<img width="330" height="392" alt="image" src="https://github.com/user-attachments/assets/126d4071-d9cf-4bb9-bb66-a06f4ead0144" />

<img width="717" height="727" alt="image" src="https://github.com/user-attachments/assets/7e9de57d-1022-48fd-b718-4867a024b4c6" />


### Testing
Testing in staging

### Evergreen PR
[Evergreen-App PR](https://github.com/evergreen-ci/evergreen/pull/10303)