### PR TITLE
DEVPROD-34692 Support searching for more commits when we run out on waterfall

### DIFF
--- a/apps/spruce/playwright/tests/waterfall/filters.spec.ts
+++ b/apps/spruce/playwright/tests/waterfall/filters.spec.ts
@@ -34,6 +34,10 @@ test.describe("requester filtering", () => {
     await page.getByTestId("requester-filter").click();
     await page.getByTestId("ad_hoc-option").click();
     await expect(page.getByText("No Results Found")).toBeVisible();
+    await expect(
+      page.getByText("Evergreen found no builds matching the applied filters."),
+    ).toBeVisible();
+    await expect(page.getByTestId("search-older-commits-button")).toBeHidden();
   });
 
   test("filters on git tags and fetches more from the server", async ({

--- a/apps/spruce/src/analytics/waterfall/useWaterfallAnalytics.ts
+++ b/apps/spruce/src/analytics/waterfall/useWaterfallAnalytics.ts
@@ -16,6 +16,7 @@ type Action =
   | { name: "Clicked task box"; "task.status": string }
   | { name: "Clicked jump to most recent commit button" }
   | { name: "Clicked clear all filters button" }
+  | { name: "Clicked search older commits button" }
   | {
       name: "Clicked pin build variant";
       action: "pinned" | "unpinned";

--- a/apps/spruce/src/pages/waterfall/EmptyState/EmptyState.test.tsx
+++ b/apps/spruce/src/pages/waterfall/EmptyState/EmptyState.test.tsx
@@ -71,7 +71,7 @@ describe("EmptyState", () => {
     );
   });
 
-  it("indicates the searched history is exhausted when there is no next page", () => {
+  it("does not offer to search older commits when there is no next page", () => {
     renderEmptyState({
       ...basePagination,
       hasNextPage: false,
@@ -79,7 +79,7 @@ describe("EmptyState", () => {
     });
     expect(
       screen.getByText(
-        "Evergreen found no builds matching the applied filters in the searched commit history.",
+        "Evergreen found no builds matching the applied filters.",
       ),
     ).toBeVisible();
     expect(

--- a/apps/spruce/src/pages/waterfall/EmptyState/EmptyState.test.tsx
+++ b/apps/spruce/src/pages/waterfall/EmptyState/EmptyState.test.tsx
@@ -1,0 +1,104 @@
+import { MemoryRouter, useLocation } from "react-router-dom";
+import { render, screen, userEvent } from "@evg-ui/lib/test_utils";
+import { Pagination } from "../types";
+import { EmptyState } from ".";
+
+const LocationDisplay: React.FC = () => {
+  const location = useLocation();
+  return <div data-cy="location-search">{location.search}</div>;
+};
+
+const basePagination: Pagination = {
+  activeVersionIds: [],
+  hasNextPage: true,
+  hasPrevPage: false,
+  mostRecentVersionOrder: 1000,
+  nextPageOrder: 700,
+  prevPageOrder: 0,
+};
+
+const renderEmptyState = (
+  pagination: Pagination,
+  initialEntry: string = "/project/spruce/waterfall?tasks=initialsync",
+) =>
+  render(
+    <>
+      <EmptyState pagination={pagination} />
+      <LocationDisplay />
+    </>,
+    {
+      wrapper: ({ children }) => (
+        <MemoryRouter initialEntries={[initialEntry]}>{children}</MemoryRouter>
+      ),
+    },
+  );
+
+describe("EmptyState", () => {
+  it("shows a search older commits button when a task filter has more commits to search", () => {
+    renderEmptyState(basePagination);
+    expect(
+      screen.getByText(
+        /Evergreen found no builds matching the applied filters in the 300 commits searched/,
+      ),
+    ).toBeVisible();
+    expect(screen.getByDataCy("search-older-commits-button")).toBeVisible();
+  });
+
+  it("clicking the button searches older commits and clears other pagination params", async () => {
+    const user = userEvent.setup();
+    renderEmptyState(
+      basePagination,
+      "/project/spruce/waterfall?tasks=initialsync&date=2026-06-01&minOrder=5",
+    );
+
+    await user.click(screen.getByDataCy("search-older-commits-button"));
+
+    const search = screen.getByDataCy("location-search");
+    expect(search).toHaveTextContent("maxOrder=700");
+    expect(search).toHaveTextContent("tasks=initialsync");
+    expect(search).not.toHaveTextContent("date");
+    expect(search).not.toHaveTextContent("minOrder");
+  });
+
+  it("disables the button while the next page is being fetched", () => {
+    renderEmptyState(
+      basePagination,
+      "/project/spruce/waterfall?tasks=initialsync&maxOrder=700",
+    );
+    expect(screen.getByDataCy("search-older-commits-button")).toHaveAttribute(
+      "aria-disabled",
+      "true",
+    );
+  });
+
+  it("indicates the searched history is exhausted when there is no next page", () => {
+    renderEmptyState({
+      ...basePagination,
+      hasNextPage: false,
+      nextPageOrder: 0,
+    });
+    expect(
+      screen.getByText(
+        "Evergreen found no builds matching the applied filters in the searched commit history.",
+      ),
+    ).toBeVisible();
+    expect(
+      screen.queryByDataCy("search-older-commits-button"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not offer to search older commits when only filters that search the full history are applied", () => {
+    renderEmptyState(
+      basePagination,
+      "/project/spruce/waterfall?requesters=ad_hoc",
+    );
+    expect(
+      screen.getByText(
+        "Evergreen found no builds matching the applied filters.",
+      ),
+    ).toBeVisible();
+    expect(
+      screen.queryByDataCy("search-older-commits-button"),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/apps/spruce/src/pages/waterfall/EmptyState/index.tsx
+++ b/apps/spruce/src/pages/waterfall/EmptyState/index.tsx
@@ -1,11 +1,61 @@
+import { Button } from "@leafygreen-ui/button";
 import { BasicEmptyState } from "@leafygreen-ui/empty-state";
+import { useQueryParam } from "@evg-ui/lib/hooks";
+import { useWaterfallAnalytics } from "analytics";
 import { VERSION_SEARCH_LIMIT } from "../constants";
+import { Pagination, WaterfallFilterOptions } from "../types";
+import { usePaginationNavigation } from "../usePaginationNavigation";
 import { EmptyGraphic } from "./EmptyGraphic";
 
-export const EmptyState: React.FC = () => (
-  <BasicEmptyState
-    description={`Evergreen found no builds matching the applied filters in the ${VERSION_SEARCH_LIMIT} most recent commits.`}
-    graphic={<EmptyGraphic />}
-    title="No Results Found"
-  />
-);
+interface EmptyStateProps {
+  pagination: Pagination;
+}
+
+export const EmptyState: React.FC<EmptyStateProps> = ({ pagination }) => {
+  const { sendEvent } = useWaterfallAnalytics();
+  const { goToNextPage, hasNextPage, isNavigatingToPage } =
+    usePaginationNavigation(pagination);
+
+  const [tasks] = useQueryParam<string[]>(WaterfallFilterOptions.Task, []);
+  const [statuses] = useQueryParam<string[]>(
+    WaterfallFilterOptions.Statuses,
+    [],
+  );
+  // Task and status filters are only searched within a limited window of commits;
+  // other filters search the project's entire history in one query.
+  const searchIsWindowLimited = tasks.length > 0 || statuses.length > 0;
+
+  if (searchIsWindowLimited && hasNextPage) {
+    return (
+      <BasicEmptyState
+        description={`Evergreen found no builds matching the applied filters in the ${VERSION_SEARCH_LIMIT} commits searched. Older commits may still contain matching builds.`}
+        graphic={<EmptyGraphic />}
+        primaryButton={
+          <Button
+            data-cy="search-older-commits-button"
+            disabled={isNavigatingToPage}
+            onClick={() => {
+              sendEvent({ name: "Clicked search older commits button" });
+              goToNextPage();
+            }}
+          >
+            Search older commits
+          </Button>
+        }
+        title="No Results Found"
+      />
+    );
+  }
+
+  return (
+    <BasicEmptyState
+      description={
+        searchIsWindowLimited
+          ? "Evergreen found no builds matching the applied filters in the searched commit history."
+          : "Evergreen found no builds matching the applied filters."
+      }
+      graphic={<EmptyGraphic />}
+      title="No Results Found"
+    />
+  );
+};

--- a/apps/spruce/src/pages/waterfall/EmptyState/index.tsx
+++ b/apps/spruce/src/pages/waterfall/EmptyState/index.tsx
@@ -49,11 +49,7 @@ export const EmptyState: React.FC<EmptyStateProps> = ({ pagination }) => {
 
   return (
     <BasicEmptyState
-      description={
-        searchIsWindowLimited
-          ? "Evergreen found no builds matching the applied filters in the searched commit history."
-          : "Evergreen found no builds matching the applied filters."
-      }
+      description="Evergreen found no builds matching the applied filters."
       graphic={<EmptyGraphic />}
       title="No Results Found"
     />

--- a/apps/spruce/src/pages/waterfall/PaginationButtons/index.tsx
+++ b/apps/spruce/src/pages/waterfall/PaginationButtons/index.tsx
@@ -2,9 +2,9 @@ import styled from "@emotion/styled";
 import { Button } from "@leafygreen-ui/button";
 import Icon from "@evg-ui/lib/components/Icon";
 import { size } from "@evg-ui/lib/constants/tokens";
-import { useQueryParam, useQueryParams } from "@evg-ui/lib/hooks";
 import { useWaterfallAnalytics } from "analytics";
-import { Pagination, WaterfallFilterOptions } from "../types";
+import { Pagination } from "../types";
+import { usePaginationNavigation } from "../usePaginationNavigation";
 
 interface PaginationButtonsProps {
   pagination: Pagination | undefined;
@@ -14,20 +14,17 @@ export const PaginationButtons: React.FC<PaginationButtonsProps> = ({
   pagination,
 }) => {
   const { sendEvent } = useWaterfallAnalytics();
-  const [queryParams, setQueryParams] = useQueryParams();
-
-  const { hasNextPage, hasPrevPage, nextPageOrder, prevPageOrder } =
-    pagination ?? {};
+  const {
+    goToNextPage,
+    goToPrevPage,
+    hasNextPage,
+    hasPrevPage,
+    isNavigatingToPage,
+  } = usePaginationNavigation(pagination);
 
   const onNextClick = () => {
     sendEvent({ name: "Changed page", direction: "next" });
-    setQueryParams({
-      ...queryParams,
-      [WaterfallFilterOptions.Date]: undefined,
-      [WaterfallFilterOptions.MaxOrder]: nextPageOrder,
-      [WaterfallFilterOptions.MinOrder]: undefined,
-      [WaterfallFilterOptions.Revision]: undefined,
-    });
+    goToNextPage();
   };
 
   const onPrevClick = () => {
@@ -35,41 +32,20 @@ export const PaginationButtons: React.FC<PaginationButtonsProps> = ({
       name: "Changed page",
       direction: "previous",
     });
-    setQueryParams({
-      ...queryParams,
-      [WaterfallFilterOptions.Date]: undefined,
-      [WaterfallFilterOptions.MaxOrder]: undefined,
-      [WaterfallFilterOptions.MinOrder]: prevPageOrder,
-      [WaterfallFilterOptions.Revision]: undefined,
-    });
+    goToPrevPage();
   };
-
-  // Use nullable types here so that we can accurately disable buttons during navigation
-  const [maxOrder] = useQueryParam<number | null>(
-    WaterfallFilterOptions.MaxOrder,
-    null,
-  );
-  const [minOrder] = useQueryParam<number | null>(
-    WaterfallFilterOptions.MinOrder,
-    null,
-  );
-
-  // If the query param is equivalent to the current pagination value, this means we are fetching and the new pagination data hasn't yet been returned.
-  // During this time, disable pagination buttons.
-  const navigatingToPage =
-    prevPageOrder === minOrder || nextPageOrder === maxOrder;
 
   return (
     <ButtonContainer>
       <Button
         data-cy="prev-page-button"
-        disabled={!hasPrevPage || navigatingToPage}
+        disabled={!hasPrevPage || isNavigatingToPage}
         leftGlyph={<Icon glyph="ChevronLeft" />}
         onClick={onPrevClick}
       />
       <Button
         data-cy="next-page-button"
-        disabled={!hasNextPage || navigatingToPage}
+        disabled={!hasNextPage || isNavigatingToPage}
         leftGlyph={<Icon glyph="ChevronRight" />}
         onClick={onNextClick}
       />

--- a/apps/spruce/src/pages/waterfall/WaterfallGrid.tsx
+++ b/apps/spruce/src/pages/waterfall/WaterfallGrid.tsx
@@ -227,7 +227,7 @@ export const WaterfallGrid: React.FC<WaterfallGridProps> = ({
     dataIsComplete &&
     data?.waterfall?.pagination?.activeVersionIds?.length === 0
   ) {
-    return <EmptyState />;
+    return <EmptyState pagination={data.waterfall.pagination} />;
   }
 
   return (

--- a/apps/spruce/src/pages/waterfall/usePaginationNavigation.ts
+++ b/apps/spruce/src/pages/waterfall/usePaginationNavigation.ts
@@ -1,0 +1,52 @@
+import { useQueryParam, useQueryParams } from "@evg-ui/lib/hooks";
+import { Pagination, WaterfallFilterOptions } from "./types";
+
+export const usePaginationNavigation = (pagination: Pagination | undefined) => {
+  const [queryParams, setQueryParams] = useQueryParams();
+
+  const { hasNextPage, hasPrevPage, nextPageOrder, prevPageOrder } =
+    pagination ?? {};
+
+  // Use nullable types here so that we can accurately disable buttons during navigation
+  const [maxOrder] = useQueryParam<number | null>(
+    WaterfallFilterOptions.MaxOrder,
+    null,
+  );
+  const [minOrder] = useQueryParam<number | null>(
+    WaterfallFilterOptions.MinOrder,
+    null,
+  );
+
+  // If the query param is equivalent to the current pagination value, this means we are fetching and the new pagination data hasn't yet been returned.
+  // During this time, disable pagination buttons.
+  const isNavigatingToPage =
+    prevPageOrder === minOrder || nextPageOrder === maxOrder;
+
+  const goToNextPage = () => {
+    setQueryParams({
+      ...queryParams,
+      [WaterfallFilterOptions.Date]: undefined,
+      [WaterfallFilterOptions.MaxOrder]: nextPageOrder,
+      [WaterfallFilterOptions.MinOrder]: undefined,
+      [WaterfallFilterOptions.Revision]: undefined,
+    });
+  };
+
+  const goToPrevPage = () => {
+    setQueryParams({
+      ...queryParams,
+      [WaterfallFilterOptions.Date]: undefined,
+      [WaterfallFilterOptions.MaxOrder]: undefined,
+      [WaterfallFilterOptions.MinOrder]: prevPageOrder,
+      [WaterfallFilterOptions.Revision]: undefined,
+    });
+  };
+
+  return {
+    goToNextPage,
+    goToPrevPage,
+    hasNextPage,
+    hasPrevPage,
+    isNavigatingToPage,
+  };
+};

--- a/apps/spruce/src/pages/waterfall/usePaginationNavigation.ts
+++ b/apps/spruce/src/pages/waterfall/usePaginationNavigation.ts
@@ -1,8 +1,9 @@
+import { useCallback } from "react";
 import { useQueryParam, useQueryParams } from "@evg-ui/lib/hooks";
 import { Pagination, WaterfallFilterOptions } from "./types";
 
 export const usePaginationNavigation = (pagination: Pagination | undefined) => {
-  const [queryParams, setQueryParams] = useQueryParams();
+  const [, setQueryParams] = useQueryParams();
 
   const { hasNextPage, hasPrevPage, nextPageOrder, prevPageOrder } =
     pagination ?? {};
@@ -22,25 +23,25 @@ export const usePaginationNavigation = (pagination: Pagination | undefined) => {
   const isNavigatingToPage =
     prevPageOrder === minOrder || nextPageOrder === maxOrder;
 
-  const goToNextPage = () => {
-    setQueryParams({
+  const goToNextPage = useCallback(() => {
+    setQueryParams((queryParams) => ({
       ...queryParams,
       [WaterfallFilterOptions.Date]: undefined,
       [WaterfallFilterOptions.MaxOrder]: nextPageOrder,
       [WaterfallFilterOptions.MinOrder]: undefined,
       [WaterfallFilterOptions.Revision]: undefined,
-    });
-  };
+    }));
+  }, [setQueryParams, nextPageOrder]);
 
-  const goToPrevPage = () => {
-    setQueryParams({
+  const goToPrevPage = useCallback(() => {
+    setQueryParams((queryParams) => ({
       ...queryParams,
       [WaterfallFilterOptions.Date]: undefined,
       [WaterfallFilterOptions.MaxOrder]: undefined,
       [WaterfallFilterOptions.MinOrder]: prevPageOrder,
       [WaterfallFilterOptions.Revision]: undefined,
-    });
-  };
+    }));
+  }, [setQueryParams, prevPageOrder]);
 
   return {
     goToNextPage,


### PR DESCRIPTION
DEVPROD-34692

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->

<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
A user was concerned that some sparsely ran tasks are not findable on the waterfall page since they run less frequently then our lookback limit. This PR adds a "Search more" button so users can manually trigger a secondary search.


### Screenshots
<!-- add screenshots of visible changes -->
<img width="1194" height="463" alt="image" src="https://github.com/user-attachments/assets/6179c6fb-e701-42ae-aea3-abef902ab697" />

### Testing
<!-- add a description of how you tested it -->

### Evergreen PR
<!-- link to a corresponding Evergreen PR if applicable -->
