### PR TITLE
DEVPROD-34802: Reduce waterfall renders

### DIFF
--- a/apps/spruce/package.json
+++ b/apps/spruce/package.json
@@ -52,6 +52,7 @@
   },
   "dependencies": {
     "@apollo/client": "^4.1.3",
+    "@emotion/css": "11.13.5",
     "@emotion/react": "11.14.0",
     "@emotion/styled": "11.14.1",
     "@evg-ui/analytics-visualizer": "workspace:*",
@@ -128,7 +129,6 @@
     "react-virtuoso": "^4.18.3"
   },
   "devDependencies": {
-    "@emotion/css": "11.13.5",
     "@eslint/compat": "^2.0.1",
     "@evg-ui/eslint-config": "workspace:*",
     "@evg-ui/lint-staged": "workspace:*",

--- a/apps/spruce/src/components/TaskBox/index.tsx
+++ b/apps/spruce/src/components/TaskBox/index.tsx
@@ -1,4 +1,7 @@
 import { forwardRef } from "react";
+// Using non-React Emotion generates a static class, avoiding runtime performance impacts on pages like the waterfall.
+// eslint-disable-next-line @emotion/no-vanilla
+import { css as classNameCss } from "@emotion/css";
 import { css } from "@emotion/react";
 import styled from "@emotion/styled";
 import { palette } from "@leafygreen-ui/palette";
@@ -34,7 +37,7 @@ const statusStyles = Object.entries(statusColorMap)
   })
   .join("\n");
 
-export const taskBoxStyles = css`
+const taskBoxStyles = css`
   width: ${DEFAULT_SQUARE_SIZE}px;
   height: ${DEFAULT_SQUARE_SIZE}px;
   border: ${SQUARE_BORDER}px solid ${white};
@@ -84,6 +87,8 @@ export const taskBoxStyles = css`
     border-color: ${black} transparent transparent transparent;
   }
 `;
+
+export const taskBoxClassName = classNameCss(taskBoxStyles.styles);
 
 const PolymorphicTaskBox = styled.div`
   ${taskBoxStyles}

--- a/apps/spruce/src/components/VisibilityContainer/index.tsx
+++ b/apps/spruce/src/components/VisibilityContainer/index.tsx
@@ -1,27 +1,31 @@
 import { useCallback, useMemo, useRef, useState } from "react";
-import { SerializedStyles } from "@emotion/react";
 import useIntersectionObserver from "hooks/useIntersectionObserver";
 
 interface VisibilityContainerProps {
   children: React.ReactNode;
+  className?: string;
   "data-cy"?: string;
-  containerCss?: SerializedStyles;
   offset?: number;
+  style?: React.CSSProperties;
 }
 /**
  * `VisibilityContainer` is a component that will only render its children when it is visible in the viewport.
+ * Styling is accepted via className/style rather than Emotion's css prop so that pages rendering many
+ * instances (e.g. the waterfall) avoid the css prop's per-element runtime.
  * @param props - VisibilityContainerProps
  * @param props.children - The children to render when the component is visible
- * @param props.containerCss - Styles to apply to the outer div element
+ * @param props.className - Class name to apply to the outer div element
  * @param props."data-cy" - Optional data-cy property
  * @param props.offset - An offset in px which defines when to make component visible
+ * @param props.style - Inline styles to apply to the outer div element
  * @returns The VisibilityContainer component
  */
 const VisibilityContainer: React.FC<VisibilityContainerProps> = ({
   children,
-  containerCss,
+  className,
   "data-cy": dataCy,
   offset = 0,
+  style,
 }) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const [isVisible, setIsVisible] = useState(false);
@@ -43,9 +47,10 @@ const VisibilityContainer: React.FC<VisibilityContainerProps> = ({
   return (
     <div
       ref={containerRef}
-      css={containerCss}
+      className={className}
       data-cy={dataCy}
       data-visible={isVisible}
+      style={style}
     >
       {isVisible ? children : null}
     </div>

--- a/apps/spruce/src/pages/waterfall/BuildRow.tsx
+++ b/apps/spruce/src/pages/waterfall/BuildRow.tsx
@@ -1,4 +1,7 @@
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
+// Using non-React Emotion generates a static class, avoiding runtime performance impacts on pages like the waterfall.
+// eslint-disable-next-line @emotion/no-vanilla
+import { css as classNameCss } from "@emotion/css";
 import { css } from "@emotion/react";
 import styled from "@emotion/styled";
 import { IconButton } from "@leafygreen-ui/icon-button";
@@ -80,7 +83,6 @@ const BuildRowInner: React.FC<Props> = ({
   );
 
   const { builds, displayName } = build;
-  let buildIndex = 0;
 
   const { columnWidth } = useBuildVariantContext();
 
@@ -90,14 +92,6 @@ const BuildRowInner: React.FC<Props> = ({
         ? calculateBVContainerHeight({ builds, columnWidth })
         : 0,
     [builds, columnWidth],
-  );
-
-  const containerStyles = useMemo(
-    () => css`
-      ${buildGroupCss};
-      height: ${containerHeight}px;
-    `,
-    [containerHeight],
   );
 
   const iconButtonProps = isFirstBuild
@@ -111,6 +105,37 @@ const BuildRowInner: React.FC<Props> = ({
         firstActiveTaskId = builds[i].tasks[0].id;
         break;
       }
+    }
+  }
+
+  const buildColumns: React.ReactNode[] = [];
+  let buildIndex = 0;
+  for (const { inactiveVersions, version } of versions) {
+    if (inactiveVersions?.length) {
+      buildColumns.push(
+        <InactiveVersion
+          key={inactiveVersions[0].id}
+          data-cy="inactive-column"
+        />,
+      );
+    } else if (version && version.id === builds?.[buildIndex]?.version) {
+      /* The list of builds returned does not include a placeholder for inactive builds, so we need to check whether the build matches the version in the current column.
+      Builds are sorted in descending revision order and so match the versions' sort order. */
+      const b = builds[buildIndex];
+      buildIndex += 1;
+      buildColumns.push(
+        <BuildGrid
+          key={b.id}
+          build={b}
+          firstActiveTaskId={firstActiveTaskId}
+          handleTaskClick={handleTaskClick}
+          isRightmostBuild={b.version === lastActiveVersionId}
+          openTaskId={openTaskId}
+          setOpenTaskId={setOpenTaskId}
+        />,
+      );
+    } else {
+      buildColumns.push(<BuildContainer key={version?.id} />);
     }
   }
 
@@ -135,38 +160,12 @@ const BuildRowInner: React.FC<Props> = ({
         </StyledLink>
       </BuildVariantTitle>
       <VisibilityContainer
-        containerCss={containerStyles}
+        className={buildGroupClassName}
         data-cy="build-group"
         offset={1000}
+        style={{ height: containerHeight }}
       >
-        {versions.map(({ inactiveVersions, version }) => {
-          if (inactiveVersions?.length) {
-            return (
-              <InactiveVersion
-                key={inactiveVersions[0].id}
-                data-cy="inactive-column"
-              />
-            );
-          }
-          /* The list of builds returned does not include a placeholder for inactive builds, so we need to check whether the build matches the version in the current column.
-        Builds are sorted in descending revision order and so match the versions' sort order. */
-          if (version && version.id === builds?.[buildIndex]?.version) {
-            const b = builds[buildIndex];
-            buildIndex += 1;
-            return (
-              <BuildGrid
-                key={b.id}
-                build={b}
-                firstActiveTaskId={firstActiveTaskId}
-                handleTaskClick={handleTaskClick}
-                isRightmostBuild={b.version === lastActiveVersionId}
-                openTaskId={openTaskId}
-                setOpenTaskId={setOpenTaskId}
-              />
-            );
-          }
-          return <BuildContainer key={version?.id} />;
-        })}
+        {buildColumns}
       </VisibilityContainer>
     </Row>
   );
@@ -249,6 +248,8 @@ const buildGroupCss = css`
   border-radius: ${size.xs};
   padding: ${padding}px;
 `;
+
+const buildGroupClassName = classNameCss(buildGroupCss.styles);
 
 const BuildContainer = styled.div`
   ${columnBasis}

--- a/apps/spruce/src/pages/waterfall/WaterfallTask.tsx
+++ b/apps/spruce/src/pages/waterfall/WaterfallTask.tsx
@@ -3,7 +3,7 @@ import { Link } from "react-router-dom";
 import { taskStatusToCopy } from "@evg-ui/lib/constants/task";
 import { TaskStatus } from "@evg-ui/lib/types/task";
 import { Unpacked } from "@evg-ui/lib/types/utils";
-import { taskBoxStyles } from "components/TaskBox";
+import { taskBoxClassName } from "components/TaskBox";
 import { getTaskRoute } from "constants/routes";
 import { walkthroughSteps, waterfallGuideId } from "./constants";
 import { TaskOverviewPopup } from "./TaskOverviewPopup";
@@ -47,7 +47,7 @@ const WaterfallTaskInner: React.FC<{
       <Link
         key={taskId}
         ref={taskBoxRef}
-        css={taskBoxStyles}
+        className={taskBoxClassName}
         data-status={taskStatus}
         data-tooltip={`${displayName} - ${taskStatusToCopy[taskStatus]}`}
         onClick={onClick}

--- a/apps/spruce/src/pages/waterfall/useFilters.ts
+++ b/apps/spruce/src/pages/waterfall/useFilters.ts
@@ -59,17 +59,6 @@ export const useFilters = ({
   const filteredBuildVariants = useMemo(() => {
     const bvs: BuildVariant[] = [];
 
-    let pinIndex = 0;
-    const pushVariant = (variant: BuildVariant) => {
-      if (pins.includes(variant.id)) {
-        // If build variant is pinned, insert it at the end of the list of pinned variants
-        bvs.splice(pinIndex, 0, variant);
-        pinIndex += 1;
-      } else {
-        bvs.push(variant);
-      }
-    };
-
     const activeVersions = flattenedVersions.filter(
       (v) =>
         activeVersionIds.includes(v.id) && matchesRequesters(v, requesters),
@@ -112,7 +101,7 @@ export const useFilters = ({
         }
       });
       if (activeBuilds.length) {
-        pushVariant({ ...bv, builds: activeBuilds });
+        bvs.push({ ...bv, builds: activeBuilds });
       }
     });
     return bvs;
@@ -122,11 +111,22 @@ export const useFilters = ({
     buildVariants,
     flattenedVersions,
     omitInactiveBuilds,
-    pins,
     requesters,
     statuses,
     taskFilterRegex,
   ]);
+
+  const orderedBuildVariants = useMemo(() => {
+    if (!pins.length) {
+      return filteredBuildVariants;
+    }
+    const pinned: BuildVariant[] = [];
+    const unpinned: BuildVariant[] = [];
+    filteredBuildVariants.forEach((bv) => {
+      (pins.includes(bv.id) ? pinned : unpinned).push(bv);
+    });
+    return [...pinned, ...unpinned];
+  }, [filteredBuildVariants, pins]);
 
   const groupedVersions = useMemo(() => {
     const hasActiveBuild = (version: Version) =>
@@ -154,7 +154,7 @@ export const useFilters = ({
 
   return {
     activeVersionIds: filteredVersionIds,
-    buildVariants: filteredBuildVariants,
+    buildVariants: orderedBuildVariants,
     versions: groupedVersions,
   };
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -439,6 +439,9 @@ importers:
       '@apollo/client':
         specifier: ^4.1.3
         version: 4.1.7(graphql-ws@6.0.8(@types/ws@8.18.1)(graphql@16.12.0)(ws@8.20.0))(graphql@16.12.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rxjs@7.8.2)
+      '@emotion/css':
+        specifier: 11.13.5
+        version: 11.13.5
       '@emotion/react':
         specifier: 11.14.0
         version: 11.14.0(@types/react@18.3.12)(react@18.3.1)
@@ -680,9 +683,6 @@ importers:
         specifier: ^4.18.3
         version: 4.18.3(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     devDependencies:
-      '@emotion/css':
-        specifier: 11.13.5
-        version: 11.13.5
       '@eslint/compat':
         specifier: ^2.0.1
         version: 2.0.5(eslint@9.39.4(@types/eslint@9.6.1)(jiti@2.6.1))


### PR DESCRIPTION
DEVPROD-34802

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->

<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
<!-- add description, context, thought process, etc -->
So random but this is kinda followup to #1429... I just learned that `@emotion/css` and `@emotion/react` have different runtime behaviors, so the changes in that PR were not as impactful as desired. By using the vanilla version of Emotion, we can create one static class that's applied to all waterfall boxes.

Also reduce the impacts of pins on render, and apply the same Emotion changes to build rows!

### Testing
<!-- add a description of how you tested it -->
Improvements Claude measured by using [react-scan](https://react-scan.com) (great tool btw) on the waterfall page:

| Action | Before | After |
|---|---|---|
| Status filter: select 2 | 358ms | 278ms |
| Status filter: clear | 286ms | 148ms |
| Task filter: clear all | 395ms | 202ms |
| Pagination: next page | 370ms | 136ms |
| Pagination: next page (again) | 361ms | 148ms |
| Pagination: prev page | 363ms | 150ms |