### PR TITLE
DEVPROD-35061: Add analytics for diff viewer

### DIFF
--- a/apps/spruce/src/analytics/version/useVersionAnalytics.ts
+++ b/apps/spruce/src/analytics/version/useVersionAnalytics.ts
@@ -71,6 +71,11 @@ type Action =
       num_reoccurring_tests: number;
       num_tests: number;
       num_failed_tasks: number;
+    }
+  | {
+      name: "Clicked code changes diff link";
+      "diff.type": "file" | "patch";
+      "diff.format"?: "html" | "raw";
     };
 
 export const useVersionAnalytics = (id: string) => {

--- a/apps/spruce/src/components/CodeChanges/CodeChanges.test.tsx
+++ b/apps/spruce/src/components/CodeChanges/CodeChanges.test.tsx
@@ -14,6 +14,10 @@ import {
 import { CODE_CHANGES } from "gql/queries";
 import { CodeChanges } from ".";
 
+vi.mock("analytics", () => ({
+  useVersionAnalytics: () => ({ sendEvent: vi.fn() }),
+}));
+
 vi.mock("constants/routes", () => ({
   getVersionDiffRoute: vi.fn(
     (versionId: string, moduleIndex: number) =>

--- a/apps/spruce/src/components/CodeChanges/Table.tsx
+++ b/apps/spruce/src/components/CodeChanges/Table.tsx
@@ -4,6 +4,7 @@ import {
   BaseTable,
   LGColumnDef,
 } from "@evg-ui/lib/components/Table";
+import { useVersionAnalytics } from "analytics";
 import { getFileDiffRoute } from "constants/routes";
 import { FileDiffsFragment } from "gql/generated/types";
 import { FileDiffText } from "./Badge";
@@ -20,8 +21,9 @@ export const Table: React.FC<TableProps> = ({
   moduleIndex,
   patchId,
 }) => {
+  const { sendEvent } = useVersionAnalytics(patchId);
   const table = useLeafyGreenTable<FileDiffsFragment>({
-    columns: getColumns(patchId, moduleIndex, disableDiffLinks),
+    columns: getColumns(patchId, moduleIndex, disableDiffLinks, sendEvent),
     data: fileDiffs ?? [],
     enableColumnFilters: false,
     enableSorting: false,
@@ -41,6 +43,7 @@ const getColumns = (
   patchId: string,
   moduleIndex: number,
   disableDiffLinks: boolean,
+  sendEvent: ReturnType<typeof useVersionAnalytics>["sendEvent"],
 ): LGColumnDef<FileDiffsFragment>[] => [
   {
     accessorKey: "fileName",
@@ -61,7 +64,16 @@ const getColumns = (
       }
       const fileDiffRoute = getFileDiffRoute(patchId, fileName, moduleIndex);
       return (
-        <StyledLink data-cy="file-link" href={fileDiffRoute}>
+        <StyledLink
+          data-cy="file-link"
+          href={fileDiffRoute}
+          onClick={() =>
+            sendEvent({
+              name: "Clicked code changes diff link",
+              "diff.type": "file",
+            })
+          }
+        >
           <WordBreak>{getValue() as string}</WordBreak>
         </StyledLink>
       );

--- a/apps/spruce/src/components/CodeChanges/Table.tsx
+++ b/apps/spruce/src/components/CodeChanges/Table.tsx
@@ -23,7 +23,7 @@ export const Table: React.FC<TableProps> = ({
 }) => {
   const { sendEvent } = useVersionAnalytics(patchId);
   const table = useLeafyGreenTable<FileDiffsFragment>({
-    columns: getColumns(patchId, moduleIndex, disableDiffLinks, sendEvent),
+    columns: getColumns({ patchId, moduleIndex, disableDiffLinks, sendEvent }),
     data: fileDiffs ?? [],
     enableColumnFilters: false,
     enableSorting: false,
@@ -39,12 +39,17 @@ export const Table: React.FC<TableProps> = ({
   );
 };
 
-const getColumns = (
-  patchId: string,
-  moduleIndex: number,
-  disableDiffLinks: boolean,
-  sendEvent: ReturnType<typeof useVersionAnalytics>["sendEvent"],
-): LGColumnDef<FileDiffsFragment>[] => [
+const getColumns = ({
+  disableDiffLinks,
+  moduleIndex,
+  patchId,
+  sendEvent,
+}: {
+  patchId: string;
+  moduleIndex: number;
+  disableDiffLinks: boolean;
+  sendEvent: ReturnType<typeof useVersionAnalytics>["sendEvent"];
+}): LGColumnDef<FileDiffsFragment>[] => [
   {
     accessorKey: "fileName",
     header: "File Name",

--- a/apps/spruce/src/components/CodeChanges/index.tsx
+++ b/apps/spruce/src/components/CodeChanges/index.tsx
@@ -4,6 +4,7 @@ import { Button } from "@leafygreen-ui/button";
 import { Skeleton, TableSkeleton } from "@leafygreen-ui/skeleton-loader";
 import { Body } from "@leafygreen-ui/typography";
 import { size } from "@evg-ui/lib/constants/tokens";
+import { useVersionAnalytics } from "analytics";
 import { getVersionDiffRoute } from "constants/routes";
 import {
   CodeChangesQuery,
@@ -21,6 +22,7 @@ export const CodeChanges: React.FC<CodeChangesProps> = ({
   disableDiffLinks = false,
   patchId,
 }) => {
+  const { sendEvent } = useVersionAnalytics(patchId);
   const { data, error, loading } = useQuery<
     CodeChangesQuery,
     CodeChangesQueryVariables
@@ -81,6 +83,13 @@ export const CodeChanges: React.FC<CodeChangesProps> = ({
                   <Button
                     data-cy="html-diff-btn"
                     href={getVersionDiffRoute(patchId, index)}
+                    onClick={() =>
+                      sendEvent({
+                        name: "Clicked code changes diff link",
+                        "diff.type": "patch",
+                        "diff.format": "html",
+                      })
+                    }
                     size="small"
                     title="Open diff as html file"
                   >
@@ -89,6 +98,13 @@ export const CodeChanges: React.FC<CodeChangesProps> = ({
                   <Button
                     data-cy="raw-diff-btn"
                     href={rawLink}
+                    onClick={() =>
+                      sendEvent({
+                        name: "Clicked code changes diff link",
+                        "diff.type": "patch",
+                        "diff.format": "raw",
+                      })
+                    }
                     size="small"
                     title="Open diff as raw file"
                   >


### PR DESCRIPTION
DEVPROD-35061

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->

<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
I was curious about usage of the diff buttons on a patch's changes tab and noticed we didn't have analytics events.