### PR TITLE
DEVPROD-35138: Allow display tasks to have event logs

### DIFF
--- a/apps/spruce/playwright/tests/shortcuts/tabs.spec.ts
+++ b/apps/spruce/playwright/tests/shortcuts/tabs.spec.ts
@@ -89,6 +89,7 @@ test.describe("Tab shortcut", () => {
       "/task/mci_ubuntu1604_display_asdf_patch_a1d2c8f70bf5c543de8b9641ac1ec08def1ddb26_5f74d99ab2373627c047c5e5_20_09_30_19_16_47/execution-tasks",
     );
 
+    const taskLogsTab = page.getByTestId("task-logs-tab");
     const taskExecutionTab = page.getByTestId("task-execution-tab");
     const taskTestsTab = page.getByTestId("task-tests-tab");
     const taskFilesTab = page.getByTestId("task-files-tab");
@@ -115,13 +116,13 @@ test.describe("Tab shortcut", () => {
     );
     await page.locator("body").press("j");
 
-    await expect(taskExecutionTab).toHaveAttribute("aria-selected", "true");
+    await expect(taskLogsTab).toHaveAttribute("aria-selected", "true");
     await page.locator("body").press("j");
 
-    await expect(taskTestsTab).toHaveAttribute("aria-selected", "true");
+    await expect(taskExecutionTab).toHaveAttribute("aria-selected", "true");
     await page.locator("body").press("k");
 
-    await expect(taskExecutionTab).toHaveAttribute("aria-selected", "true");
+    await expect(taskLogsTab).toHaveAttribute("aria-selected", "true");
     await page.locator("body").press("k");
 
     await expect(executionTasksTimingTab).toHaveAttribute(
@@ -137,5 +138,8 @@ test.describe("Tab shortcut", () => {
     await page.locator("body").press("k");
 
     await expect(taskTestsTab).toHaveAttribute("aria-selected", "true");
+    await page.locator("body").press("k");
+
+    await expect(taskExecutionTab).toHaveAttribute("aria-selected", "true");
   });
 });

--- a/apps/spruce/src/pages/task/taskTabs/index.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/index.tsx
@@ -78,7 +78,9 @@ const useTabConfig = (
   });
 
   const tabIsActive: Record<TaskTab, boolean> = {
-    [TaskTab.Logs]: !isDisplayTask,
+    // Display tasks have no execution logs, but the Logs tab still surfaces
+    // their event log (e.g. created Jira tickets, restarts).
+    [TaskTab.Logs]: true,
     [TaskTab.ExecutionTasks]: isDisplayTask,
     [TaskTab.Tests]: true,
     [TaskTab.Files]: true,
@@ -92,7 +94,12 @@ const useTabConfig = (
   const tabMap: Record<TaskTab, React.JSX.Element> = {
     [TaskTab.Logs]: (
       <Tab key="task-logs-tab" data-cy="task-logs-tab" name="Logs">
-        <Logs execution={execution} logLinks={logLinks} taskId={id} />
+        <Logs
+          execution={execution}
+          isDisplayTask={isDisplayTask}
+          logLinks={logLinks}
+          taskId={id}
+        />
       </Tab>
     ),
     [TaskTab.Tests]: (

--- a/apps/spruce/src/pages/task/taskTabs/logs/index.test.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/logs/index.test.tsx
@@ -1,0 +1,77 @@
+import { RenderFakeToastContext } from "@evg-ui/lib/context/toast/__mocks__";
+import {
+  renderWithRouterMatch as render,
+  screen,
+} from "@evg-ui/lib/test_utils";
+import { ApolloMock } from "@evg-ui/lib/test_utils/types";
+import {
+  TaskEventLogsQuery,
+  TaskEventLogsQueryVariables,
+  TaskLogLinks,
+} from "gql/generated/types";
+import { TASK_EVENT_LOGS } from "gql/queries";
+import { MockedProvider } from "test_utils/graphql";
+import Logs from ".";
+
+const taskId = "task-id";
+const execution = 0;
+
+const taskEventLogsMock: ApolloMock<
+  TaskEventLogsQuery,
+  TaskEventLogsQueryVariables
+> = {
+  request: {
+    query: TASK_EVENT_LOGS,
+    variables: { id: taskId, execution },
+  },
+  result: {
+    data: {
+      task: {
+        __typename: "Task",
+        id: taskId,
+        execution,
+        taskLogs: {
+          __typename: "TaskLogs",
+          eventLogs: [],
+        },
+      },
+    },
+  },
+};
+
+const renderLogs = (isDisplayTask: boolean) => {
+  const { Component } = RenderFakeToastContext(
+    <MockedProvider mocks={[taskEventLogsMock]}>
+      <Logs
+        execution={execution}
+        isDisplayTask={isDisplayTask}
+        logLinks={{} as TaskLogLinks}
+        taskId={taskId}
+      />
+    </MockedProvider>,
+  );
+  render(<Component />, {
+    route: `/task/${taskId}/logs?logtype=event`,
+    path: "/task/:id/:tab",
+  });
+};
+
+describe("logs", () => {
+  it("renders every log type option for a regular task", () => {
+    renderLogs(false);
+    expect(screen.getByText("Task Logs")).toBeInTheDocument();
+    expect(screen.getByText("Agent Logs")).toBeInTheDocument();
+    expect(screen.getByText("System Logs")).toBeInTheDocument();
+    expect(screen.getByText("Event Logs")).toBeInTheDocument();
+    expect(screen.getByText("Combined")).toBeInTheDocument();
+  });
+
+  it("only offers the event logs option for a display task, since display tasks have no execution logs", () => {
+    renderLogs(true);
+    expect(screen.getByText("Event Logs")).toBeInTheDocument();
+    expect(screen.queryByText("Task Logs")).toBeNull();
+    expect(screen.queryByText("Agent Logs")).toBeNull();
+    expect(screen.queryByText("System Logs")).toBeNull();
+    expect(screen.queryByText("Combined")).toBeNull();
+  });
+});

--- a/apps/spruce/src/pages/task/taskTabs/logs/index.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/logs/index.tsx
@@ -32,12 +32,26 @@ const options = {
   [LogTypes.All]: AllLog,
 };
 
+const logTypeOptions: { id: string; label: string; value: LogTypes }[] = [
+  { id: "cy-task-option", label: "Task Logs", value: LogTypes.Task },
+  { id: "cy-agent-option", label: "Agent Logs", value: LogTypes.Agent },
+  { id: "cy-system-option", label: "System Logs", value: LogTypes.System },
+  { id: "cy-event-option", label: "Event Logs", value: LogTypes.Event },
+  { id: "cy-all-option", label: "Combined", value: LogTypes.All },
+];
+
 interface Props {
   logLinks: TaskLogLinks;
   taskId: string;
   execution: number;
+  isDisplayTask: boolean;
 }
-const Logs: React.FC<Props> = ({ execution, logLinks, taskId }) => {
+const Logs: React.FC<Props> = ({
+  execution,
+  isDisplayTask,
+  logLinks,
+  taskId,
+}) => {
   const { sendEvent } = useTaskAnalytics();
   const updateQueryParams = useUpdateURLQueryParams();
   const { search } = useLocation();
@@ -46,10 +60,11 @@ const Logs: React.FC<Props> = ({ execution, logLinks, taskId }) => {
     .toString()
     .toLowerCase() as LogTypes;
 
+  const validatedLogType = Object.values(LogTypes).includes(logTypeParam)
+    ? logTypeParam
+    : DEFAULT_LOG_TYPE;
   const [currentLog, setCurrentLog] = useState<LogTypes>(
-    Object.values(LogTypes).includes(logTypeParam)
-      ? logTypeParam
-      : DEFAULT_LOG_TYPE,
+    isDisplayTask ? LogTypes.Event : validatedLogType,
   );
   const [noLogs, setNoLogs] = useState(false);
   const [showFade, setShowFade] = useState(false);
@@ -98,21 +113,13 @@ const Logs: React.FC<Props> = ({ execution, logLinks, taskId }) => {
           onChange={onChangeLog}
           value={currentLog}
         >
-          <SegmentedControlOption id="cy-task-option" value={LogTypes.Task}>
-            Task Logs
-          </SegmentedControlOption>
-          <SegmentedControlOption id="cy-agent-option" value={LogTypes.Agent}>
-            Agent Logs
-          </SegmentedControlOption>
-          <SegmentedControlOption id="cy-system-option" value={LogTypes.System}>
-            System Logs
-          </SegmentedControlOption>
-          <SegmentedControlOption id="cy-event-option" value={LogTypes.Event}>
-            Event Logs
-          </SegmentedControlOption>
-          <SegmentedControlOption id="cy-all-option" value={LogTypes.All}>
-            Combined
-          </SegmentedControlOption>
+          {logTypeOptions
+            .filter(({ value }) => !isDisplayTask || value === LogTypes.Event)
+            .map(({ id, label, value }) => (
+              <SegmentedControlOption key={value} id={id} value={value}>
+                {label}
+              </SegmentedControlOption>
+            ))}
         </SegmentedControl>
       </LogHeader>
       <LogContentWrapper>


### PR DESCRIPTION
DEVPROD-35138

### Description
Display tasks don't have logs, so when we get event logs such as when someone files a ticket at the display task level we are not able to see them. This exposes event logs only for display tasks.

### Screenshots
<img width="1273" height="559" alt="Screenshot 2026-06-16 at 12 17 15 PM" src="https://github.com/user-attachments/assets/2033bd3b-7a49-4e9c-88ff-97107f5dc709" />

### Testing
* Added tests
* Tested on prod with Chrome overrides (screen shot)
