### PR TITLE
DEVPROD-34996: Use UserLite field instead of User

### DIFF
--- a/apps/parsley/src/gql/generated/types.ts
+++ b/apps/parsley/src/gql/generated/types.ts
@@ -2545,7 +2545,9 @@ export type Patch = {
   taskStatuses: Array<Scalars["String"]["output"]>;
   tasks: Array<Scalars["String"]["output"]>;
   time?: Maybe<PatchTime>;
+  /** @deprecated Use userLite instead. */
   user: User;
+  userLite: UserLite;
   variants: Array<Scalars["String"]["output"]>;
   variantsTasks: Array<VariantTask>;
   version?: Maybe<VersionLite>;
@@ -3178,6 +3180,7 @@ export type Query = {
   taskTestSample?: Maybe<Array<TaskTestResultSample>>;
   user: User;
   userConfig?: Maybe<UserConfig>;
+  userLite: UserLite;
   variantQuarantineStatus: VariantQuarantineStatus;
   version: Version;
   viewableProjectRefs: Array<GroupedProjects>;
@@ -3320,6 +3323,10 @@ export type QueryTaskTestSampleArgs = {
 };
 
 export type QueryUserArgs = {
+  userId?: InputMaybe<Scalars["String"]["input"]>;
+};
+
+export type QueryUserLiteArgs = {
   userId?: InputMaybe<Scalars["String"]["input"]>;
 };
 
@@ -4825,12 +4832,31 @@ export type UserConfig = {
   user: Scalars["String"]["output"];
 };
 
-/** UserLite replaces User by sidestepping the APIUser field. It does not contain all fields at this time. */
+/**
+ * UserLite replaces User by sidestepping the APIDBUser API model and binding directly to the
+ * service-layer user model. New clients should query UserLite instead of User.
+ */
 export type UserLite = {
   __typename?: "UserLite";
+  betaFeatures?: Maybe<BetaFeatures>;
   displayName?: Maybe<Scalars["String"]["output"]>;
   emailAddress?: Maybe<Scalars["String"]["output"]>;
+  hasTokenExchangePending: Scalars["Boolean"]["output"];
   id: Scalars["String"]["output"];
+  parsleyFilters?: Maybe<Array<ParsleyFilter>>;
+  patches?: Maybe<Patches>;
+  permissions?: Maybe<Permissions>;
+  settings?: Maybe<UserSettings>;
+  subscriptions?: Maybe<Array<GeneralSubscription>>;
+  tokenAccessTokenExpiresAt?: Maybe<Scalars["Time"]["output"]>;
+};
+
+/**
+ * UserLite replaces User by sidestepping the APIDBUser API model and binding directly to the
+ * service-layer user model. New clients should query UserLite instead of User.
+ */
+export type UserLitePatchesArgs = {
+  patchesInput: PatchesInput;
 };
 
 export type UserServiceFlags = {
@@ -4939,7 +4965,9 @@ export type Version = {
   taskStatuses: Array<Scalars["String"]["output"]>;
   tasks: VersionTasks;
   upstreamProject?: Maybe<UpstreamProject>;
+  /** @deprecated Use userLite instead. */
   user: User;
+  userLite: UserLite;
   versionTiming?: Maybe<VersionTiming>;
   warnings: Array<Scalars["String"]["output"]>;
   waterfallBuilds?: Maybe<Array<WaterfallBuild>>;
@@ -5261,7 +5289,7 @@ export type UserQueryVariables = Exact<{ [key: string]: never }>;
 
 export type UserQuery = {
   __typename?: "Query";
-  user: { __typename?: "User"; userId: string };
+  user: { __typename?: "UserLite"; userId: string };
 };
 
 export type ProjectFiltersQueryVariables = Exact<{

--- a/apps/parsley/src/gql/queries/get-user.ts
+++ b/apps/parsley/src/gql/queries/get-user.ts
@@ -2,8 +2,8 @@ import { gql } from "@apollo/client";
 
 export const GET_USER = gql`
   query User {
-    user {
-      userId
+    user: userLite {
+      userId: id
     }
   }
 `;

--- a/apps/spruce/src/components/Banners/RepotrackerBanner/RepotrackerBanner.test.tsx
+++ b/apps/spruce/src/components/Banners/RepotrackerBanner/RepotrackerBanner.test.tsx
@@ -189,7 +189,7 @@ const adminUser: ApolloMock<
   result: {
     data: {
       user: {
-        __typename: "User",
+        __typename: "UserLite",
         userId: "admin",
         permissions: {
           __typename: "Permissions",
@@ -216,7 +216,7 @@ const basicUser: ApolloMock<
   result: {
     data: {
       user: {
-        __typename: "User",
+        __typename: "UserLite",
         userId: "basic",
         permissions: {
           __typename: "Permissions",

--- a/apps/spruce/src/components/Header/Navbar.stories.tsx
+++ b/apps/spruce/src/components/Header/Navbar.stories.tsx
@@ -18,7 +18,7 @@ const userMock: ApolloMock<UserQuery, UserQueryVariables> = {
   result: {
     data: {
       user: {
-        __typename: "User",
+        __typename: "UserLite",
         displayName: "Mohamed Khelif",
         emailAddress: "mohamed.khelif@mongodb.com",
         userId: "mohamed.khelif",

--- a/apps/spruce/src/gql/client/cache.ts
+++ b/apps/spruce/src/gql/client/cache.ts
@@ -153,6 +153,23 @@ export const cache = new InMemoryCache({
         },
       },
     },
+    UserLite: {
+      keyFields: ["id"],
+      fields: {
+        displayName: {
+          read(existing, { readField }) {
+            // Return id if displayName is not set so that displayName is always populated
+            return existing || readField("id");
+          },
+        },
+        id: {
+          read(existing, { readField }) {
+            // Service users don't have ids, just displayNames. Make sure both fields are set.
+            return existing || readField("displayName");
+          },
+        },
+      },
+    },
     UserConfig: {
       keyFields: ["user"],
     },

--- a/apps/spruce/src/gql/fragments/basePatch.ts
+++ b/apps/spruce/src/gql/fragments/basePatch.ts
@@ -14,9 +14,9 @@ export const BASE_PATCH = gql`
       id
     }
     status
-    user {
+    user: userLite {
       displayName
-      userId
+      userId: id
     }
     variantsTasks {
       name

--- a/apps/spruce/src/gql/fragments/patchesPage.ts
+++ b/apps/spruce/src/gql/fragments/patchesPage.ts
@@ -18,9 +18,9 @@ export const PATCHES_PAGE_PATCHES = gql`
         repo
       }
       status
-      user {
+      user: userLite {
         displayName
-        userId
+        userId: id
       }
       versionFull {
         id

--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -2542,7 +2542,9 @@ export type Patch = {
   taskStatuses: Array<Scalars["String"]["output"]>;
   tasks: Array<Scalars["String"]["output"]>;
   time?: Maybe<PatchTime>;
+  /** @deprecated Use userLite instead. */
   user: User;
+  userLite: UserLite;
   variants: Array<Scalars["String"]["output"]>;
   variantsTasks: Array<VariantTask>;
   version?: Maybe<VersionLite>;
@@ -3175,6 +3177,7 @@ export type Query = {
   taskTestSample?: Maybe<Array<TaskTestResultSample>>;
   user: User;
   userConfig?: Maybe<UserConfig>;
+  userLite: UserLite;
   variantQuarantineStatus: VariantQuarantineStatus;
   version: Version;
   viewableProjectRefs: Array<GroupedProjects>;
@@ -3317,6 +3320,10 @@ export type QueryTaskTestSampleArgs = {
 };
 
 export type QueryUserArgs = {
+  userId?: InputMaybe<Scalars["String"]["input"]>;
+};
+
+export type QueryUserLiteArgs = {
   userId?: InputMaybe<Scalars["String"]["input"]>;
 };
 
@@ -4823,12 +4830,31 @@ export type UserConfig = {
   user: Scalars["String"]["output"];
 };
 
-/** UserLite replaces User by sidestepping the APIUser field. It does not contain all fields at this time. */
+/**
+ * UserLite replaces User by sidestepping the APIDBUser API model and binding directly to the
+ * service-layer user model. New clients should query UserLite instead of User.
+ */
 export type UserLite = {
   __typename?: "UserLite";
+  betaFeatures?: Maybe<BetaFeatures>;
   displayName?: Maybe<Scalars["String"]["output"]>;
   emailAddress?: Maybe<Scalars["String"]["output"]>;
+  hasTokenExchangePending: Scalars["Boolean"]["output"];
   id: Scalars["String"]["output"];
+  parsleyFilters?: Maybe<Array<ParsleyFilter>>;
+  patches?: Maybe<Patches>;
+  permissions?: Maybe<Permissions>;
+  settings?: Maybe<UserSettings>;
+  subscriptions?: Maybe<Array<GeneralSubscription>>;
+  tokenAccessTokenExpiresAt?: Maybe<Scalars["Time"]["output"]>;
+};
+
+/**
+ * UserLite replaces User by sidestepping the APIDBUser API model and binding directly to the
+ * service-layer user model. New clients should query UserLite instead of User.
+ */
+export type UserLitePatchesArgs = {
+  patchesInput: PatchesInput;
 };
 
 export type UserServiceFlags = {
@@ -4937,7 +4963,9 @@ export type Version = {
   taskStatuses: Array<Scalars["String"]["output"]>;
   tasks: VersionTasks;
   upstreamProject?: Maybe<UpstreamProject>;
+  /** @deprecated Use userLite instead. */
   user: User;
+  userLite: UserLite;
   versionTiming?: Maybe<VersionTiming>;
   warnings: Array<Scalars["String"]["output"]>;
   waterfallBuilds?: Maybe<Array<WaterfallBuild>>;
@@ -5280,7 +5308,11 @@ export type BasePatchFragment = {
   status: string;
   parameters: Array<{ __typename?: "Parameter"; key: string; value: string }>;
   projectMetadata?: { __typename?: "Project"; id: string } | null;
-  user: { __typename?: "User"; displayName?: string | null; userId: string };
+  user: {
+    __typename?: "UserLite";
+    displayName?: string | null;
+    userId: string;
+  };
   variantsTasks: Array<{
     __typename?: "VariantTask";
     name: string;
@@ -5391,7 +5423,11 @@ export type PatchesPagePatchesFragment = {
       owner: string;
       repo: string;
     } | null;
-    user: { __typename?: "User"; displayName?: string | null; userId: string };
+    user: {
+      __typename?: "UserLite";
+      displayName?: string | null;
+      userId: string;
+    };
     versionFull?: {
       __typename?: "Version";
       id: string;
@@ -7292,7 +7328,11 @@ export type SchedulePatchMutation = {
     } | null;
     parameters: Array<{ __typename?: "Parameter"; key: string; value: string }>;
     projectMetadata?: { __typename?: "Project"; id: string } | null;
-    user: { __typename?: "User"; displayName?: string | null; userId: string };
+    user: {
+      __typename?: "UserLite";
+      displayName?: string | null;
+      userId: string;
+    };
     variantsTasks: Array<{
       __typename?: "VariantTask";
       name: string;
@@ -7502,7 +7542,11 @@ export type UpdatePatchDescriptionMutation = {
     status: string;
     parameters: Array<{ __typename?: "Parameter"; key: string; value: string }>;
     projectMetadata?: { __typename?: "Project"; id: string } | null;
-    user: { __typename?: "User"; displayName?: string | null; userId: string };
+    user: {
+      __typename?: "UserLite";
+      displayName?: string | null;
+      userId: string;
+    };
     variantsTasks: Array<{
       __typename?: "VariantTask";
       name: string;
@@ -8990,7 +9034,7 @@ export type MainlineCommitsForHistoryQuery = {
           tag: string;
         }> | null;
         user: {
-          __typename?: "User";
+          __typename?: "UserLite";
           displayName?: string | null;
           userId: string;
         };
@@ -9020,7 +9064,7 @@ export type MainlineCommitsForHistoryQuery = {
           tag: string;
         }> | null;
         user: {
-          __typename?: "User";
+          __typename?: "UserLite";
           displayName?: string | null;
           userId: string;
         };
@@ -9210,7 +9254,11 @@ export type ConfigurePatchQuery = {
     time?: { __typename?: "PatchTime"; submittedAt: string } | null;
     versionFull?: { __typename?: "Version"; id: string } | null;
     parameters: Array<{ __typename?: "Parameter"; key: string; value: string }>;
-    user: { __typename?: "User"; displayName?: string | null; userId: string };
+    user: {
+      __typename?: "UserLite";
+      displayName?: string | null;
+      userId: string;
+    };
     variantsTasks: Array<{
       __typename?: "VariantTask";
       name: string;
@@ -9241,7 +9289,11 @@ export type PatchQuery = {
     } | null;
     versionFull?: { __typename?: "Version"; id: string } | null;
     parameters: Array<{ __typename?: "Parameter"; key: string; value: string }>;
-    user: { __typename?: "User"; displayName?: string | null; userId: string };
+    user: {
+      __typename?: "UserLite";
+      displayName?: string | null;
+      userId: string;
+    };
     variantsTasks: Array<{
       __typename?: "VariantTask";
       name: string;
@@ -9764,7 +9816,7 @@ export type ProjectPatchesQuery = {
           repo: string;
         } | null;
         user: {
-          __typename?: "User";
+          __typename?: "UserLite";
           displayName?: string | null;
           userId: string;
         };
@@ -11687,7 +11739,7 @@ export type UserDistroSettingsPermissionsQueryVariables = Exact<{
 export type UserDistroSettingsPermissionsQuery = {
   __typename?: "Query";
   user: {
-    __typename?: "User";
+    __typename?: "UserLite";
     userId: string;
     permissions?: {
       __typename?: "Permissions";
@@ -11710,7 +11762,7 @@ export type UserPatchesQueryVariables = Exact<{
 export type UserPatchesQuery = {
   __typename?: "Query";
   user: {
-    __typename?: "User";
+    __typename?: "UserLite";
     displayName?: string | null;
     userId: string;
     patches?: {
@@ -11734,7 +11786,7 @@ export type UserPatchesQuery = {
           repo: string;
         } | null;
         user: {
-          __typename?: "User";
+          __typename?: "UserLite";
           displayName?: string | null;
           userId: string;
         };
@@ -11764,7 +11816,7 @@ export type UserProjectSettingsPermissionsQueryVariables = Exact<{
 export type UserProjectSettingsPermissionsQuery = {
   __typename?: "Query";
   user: {
-    __typename?: "User";
+    __typename?: "UserLite";
     userId: string;
     permissions?: {
       __typename?: "Permissions";
@@ -11785,7 +11837,7 @@ export type UserRepoSettingsPermissionsQueryVariables = Exact<{
 export type UserRepoSettingsPermissionsQuery = {
   __typename?: "Query";
   user: {
-    __typename?: "User";
+    __typename?: "UserLite";
     userId: string;
     permissions?: {
       __typename?: "Permissions";
@@ -11803,7 +11855,7 @@ export type UserSettingsQueryVariables = Exact<{ [key: string]: never }>;
 export type UserSettingsQuery = {
   __typename?: "Query";
   user: {
-    __typename?: "User";
+    __typename?: "UserLite";
     userId: string;
     settings?: {
       __typename?: "UserSettings";
@@ -11834,7 +11886,7 @@ export type UserSubscriptionsQueryVariables = Exact<{ [key: string]: never }>;
 export type UserSubscriptionsQuery = {
   __typename?: "Query";
   user: {
-    __typename?: "User";
+    __typename?: "UserLite";
     userId: string;
     settings?: {
       __typename?: "UserSettings";
@@ -11879,7 +11931,7 @@ export type UserTokenExchangeQueryVariables = Exact<{ [key: string]: never }>;
 export type UserTokenExchangeQuery = {
   __typename?: "Query";
   user: {
-    __typename?: "User";
+    __typename?: "UserLite";
     hasTokenExchangePending: boolean;
     tokenAccessTokenExpiresAt?: Date | null;
     userId: string;
@@ -11891,7 +11943,7 @@ export type UserQueryVariables = Exact<{ [key: string]: never }>;
 export type UserQuery = {
   __typename?: "Query";
   user: {
-    __typename?: "User";
+    __typename?: "UserLite";
     displayName?: string | null;
     emailAddress?: string | null;
     userId: string;
@@ -12142,7 +12194,11 @@ export type VersionQuery = {
       owner: string;
       repo: string;
     } | null;
-    user: { __typename?: "User"; displayName?: string | null; userId: string };
+    user: {
+      __typename?: "UserLite";
+      displayName?: string | null;
+      userId: string;
+    };
     versionTiming?: {
       __typename?: "VersionTiming";
       makespan?: number | null;
@@ -12223,7 +12279,7 @@ export type WaterfallQuery = {
       revision: string;
       gitTags?: Array<{ __typename?: "GitTag"; tag: string }> | null;
       user: {
-        __typename?: "User";
+        __typename?: "UserLite";
         displayName?: string | null;
         userId: string;
       };

--- a/apps/spruce/src/gql/mocks/getSpruceConfig.ts
+++ b/apps/spruce/src/gql/mocks/getSpruceConfig.ts
@@ -75,7 +75,7 @@ export const getUserSettingsMock: ApolloMock<
   result: {
     data: {
       user: {
-        __typename: "User",
+        __typename: "UserLite",
         userId: "user.id",
         settings: {
           __typename: "UserSettings",

--- a/apps/spruce/src/gql/mocks/getUser.ts
+++ b/apps/spruce/src/gql/mocks/getUser.ts
@@ -10,7 +10,7 @@ export const getUserMock: ApolloMock<UserQuery, UserQueryVariables> = {
   result: {
     data: {
       user: {
-        __typename: "User",
+        __typename: "UserLite",
         userId: "admin",
         displayName: "Evergreen Admin",
         emailAddress: "admin@evergreen.com",

--- a/apps/spruce/src/gql/queries/mainline-commits-for-history.ts
+++ b/apps/spruce/src/gql/queries/mainline-commits-for-history.ts
@@ -23,9 +23,9 @@ export const MAINLINE_COMMITS_FOR_HISTORY = gql`
           message
           order
           revision
-          user {
+          user: userLite {
             displayName
-            userId
+            userId: id
           }
         }
         version {
@@ -49,9 +49,9 @@ export const MAINLINE_COMMITS_FOR_HISTORY = gql`
           message
           order
           revision
-          user {
+          user: userLite {
             displayName
-            userId
+            userId: id
           }
         }
       }

--- a/apps/spruce/src/gql/queries/user-distro-settings-permissions.ts
+++ b/apps/spruce/src/gql/queries/user-distro-settings-permissions.ts
@@ -2,7 +2,7 @@ import { gql } from "@apollo/client";
 
 export const USER_DISTRO_SETTINGS_PERMISSIONS = gql`
   query UserDistroSettingsPermissions($distroId: String!) {
-    user {
+    user: userLite {
       permissions {
         canCreateDistro
         distroPermissions(options: { distroId: $distroId }) {
@@ -11,7 +11,7 @@ export const USER_DISTRO_SETTINGS_PERMISSIONS = gql`
           edit
         }
       }
-      userId
+      userId: id
     }
   }
 `;

--- a/apps/spruce/src/gql/queries/user-patches.ts
+++ b/apps/spruce/src/gql/queries/user-patches.ts
@@ -3,12 +3,12 @@ import { PATCHES_PAGE_PATCHES } from "../fragments/patchesPage";
 
 export const USER_PATCHES = gql`
   query UserPatches($userId: String, $patchesInput: PatchesInput!) {
-    user(userId: $userId) {
+    user: userLite(userId: $userId) {
       displayName
       patches(patchesInput: $patchesInput) {
         ...PatchesPagePatches
       }
-      userId
+      userId: id
     }
   }
   ${PATCHES_PAGE_PATCHES}

--- a/apps/spruce/src/gql/queries/user-project-settings-permissions.ts
+++ b/apps/spruce/src/gql/queries/user-project-settings-permissions.ts
@@ -2,7 +2,7 @@ import { gql } from "@apollo/client";
 
 export const USER_PROJECT_SETTINGS_PERMISSIONS = gql`
   query UserProjectSettingsPermissions($projectIdentifier: String!) {
-    user {
+    user: userLite {
       permissions {
         canCreateProject
         projectPermissions(options: { projectIdentifier: $projectIdentifier }) {
@@ -10,7 +10,7 @@ export const USER_PROJECT_SETTINGS_PERMISSIONS = gql`
           edit
         }
       }
-      userId
+      userId: id
     }
   }
 `;

--- a/apps/spruce/src/gql/queries/user-repo-settings-permissions.ts
+++ b/apps/spruce/src/gql/queries/user-repo-settings-permissions.ts
@@ -2,14 +2,14 @@ import { gql } from "@apollo/client";
 
 export const USER_REPO_SETTINGS_PERMISSIONS = gql`
   query UserRepoSettingsPermissions($repoId: String!) {
-    user {
+    user: userLite {
       permissions {
         repoPermissions(options: { repoId: $repoId }) {
           id: repoId
           edit
         }
       }
-      userId
+      userId: id
     }
   }
 `;

--- a/apps/spruce/src/gql/queries/user-settings.ts
+++ b/apps/spruce/src/gql/queries/user-settings.ts
@@ -2,7 +2,7 @@ import { gql } from "@apollo/client";
 
 export const USER_SETTINGS = gql`
   query UserSettings {
-    user {
+    user: userLite {
       settings {
         dateFormat
         githubUser {
@@ -21,7 +21,7 @@ export const USER_SETTINGS = gql`
         timeFormat
         timezone
       }
-      userId
+      userId: id
     }
   }
 `;

--- a/apps/spruce/src/gql/queries/user-subscriptions.ts
+++ b/apps/spruce/src/gql/queries/user-subscriptions.ts
@@ -2,7 +2,7 @@ import { gql } from "@apollo/client";
 
 export const USER_SUBSCRIPTIONS = gql`
   query UserSubscriptions {
-    user {
+    user: userLite {
       settings {
         notifications {
           buildBreakId
@@ -35,7 +35,7 @@ export const USER_SUBSCRIPTIONS = gql`
         trigger
         triggerData
       }
-      userId
+      userId: id
     }
   }
 `;

--- a/apps/spruce/src/gql/queries/user-token-exchange.ts
+++ b/apps/spruce/src/gql/queries/user-token-exchange.ts
@@ -2,10 +2,10 @@ import { gql } from "@apollo/client";
 
 export const USER_TOKEN_EXCHANGE = gql`
   query UserTokenExchange {
-    user {
+    user: userLite {
       hasTokenExchangePending
       tokenAccessTokenExpiresAt
-      userId
+      userId: id
     }
   }
 `;

--- a/apps/spruce/src/gql/queries/user.ts
+++ b/apps/spruce/src/gql/queries/user.ts
@@ -2,13 +2,13 @@ import { gql } from "@apollo/client";
 
 export const USER = gql`
   query User {
-    user {
+    user: userLite {
       displayName
       emailAddress
       permissions {
         canEditAdminSettings
       }
-      userId
+      userId: id
     }
   }
 `;

--- a/apps/spruce/src/gql/queries/version.ts
+++ b/apps/spruce/src/gql/queries/version.ts
@@ -104,9 +104,9 @@ export const VERSION = gql`
       taskCount(
         options: { includeNeverActivatedTasks: $includeNeverActivatedTasks }
       )
-      user {
+      user: userLite {
         displayName
-        userId
+        userId: id
       }
       versionTiming {
         makespan

--- a/apps/spruce/src/gql/queries/waterfall.ts
+++ b/apps/spruce/src/gql/queries/waterfall.ts
@@ -15,9 +15,9 @@ export const WATERFALL = gql`
         order
         requester
         revision
-        user {
+        user: userLite {
           displayName
-          userId
+          userId: id
         }
         waterfallBuilds {
           id

--- a/apps/spruce/src/hooks/useBreadcrumbRoot/useBreadcrumbRoot.test.tsx
+++ b/apps/spruce/src/hooks/useBreadcrumbRoot/useBreadcrumbRoot.test.tsx
@@ -10,7 +10,7 @@ const createCacheWithUser = (currentUserId: string = "admin") => {
     query: USER,
     data: {
       user: {
-        __typename: "User",
+        __typename: "UserLite",
         userId: currentUserId,
         displayName: "Evergreen Admin",
         emailAddress: "admin@example.com",

--- a/apps/spruce/src/hooks/useGetUserPatchesPageTitleAndLink/useGetUserPatchesPageTitleAndLink.test.tsx
+++ b/apps/spruce/src/hooks/useGetUserPatchesPageTitleAndLink/useGetUserPatchesPageTitleAndLink.test.tsx
@@ -10,7 +10,7 @@ const createCacheWithUser = (currentUserId: string = "admin") => {
     query: USER,
     data: {
       user: {
-        __typename: "User",
+        __typename: "UserLite",
         userId: currentUserId,
         displayName: "Evergreen Admin",
         emailAddress: "admin@example.com",

--- a/apps/spruce/src/hooks/useHasProjectOrRepoEditPermission/useHasProjectOrRepoPermissions.test.tsx
+++ b/apps/spruce/src/hooks/useHasProjectOrRepoEditPermission/useHasProjectOrRepoPermissions.test.tsx
@@ -109,7 +109,7 @@ const userHasProjectPermissions: ApolloMock<
   result: {
     data: {
       user: {
-        __typename: "User",
+        __typename: "UserLite",
         userId: "evergreen.user",
         permissions: {
           __typename: "Permissions",
@@ -136,7 +136,7 @@ const userNoProjectPermissions: ApolloMock<
   result: {
     data: {
       user: {
-        __typename: "User",
+        __typename: "UserLite",
         userId: "evergreen.user",
         permissions: {
           __typename: "Permissions",
@@ -163,7 +163,7 @@ const userHasRepoPermissions: ApolloMock<
   result: {
     data: {
       user: {
-        __typename: "User",
+        __typename: "UserLite",
         userId: "evergreen.user",
         permissions: {
           __typename: "Permissions",
@@ -189,7 +189,7 @@ const userNoRepoPermissions: ApolloMock<
   result: {
     data: {
       user: {
-        __typename: "User",
+        __typename: "UserLite",
         userId: "evergreen.user",
         permissions: {
           __typename: "Permissions",

--- a/apps/spruce/src/pages/distroSettings/DeleteDistro/DeleteDistro.test.tsx
+++ b/apps/spruce/src/pages/distroSettings/DeleteDistro/DeleteDistro.test.tsx
@@ -128,7 +128,7 @@ const isAdminMock: ApolloMock<
   result: {
     data: {
       user: {
-        __typename: "User",
+        __typename: "UserLite",
         userId: "me",
         permissions: {
           __typename: "Permissions",
@@ -158,7 +158,7 @@ const notAdminMock: ApolloMock<
   result: {
     data: {
       user: {
-        __typename: "User",
+        __typename: "UserLite",
         userId: "me",
         permissions: {
           __typename: "Permissions",

--- a/apps/spruce/src/pages/distroSettings/NewDistro/NewDistroButton.test.tsx
+++ b/apps/spruce/src/pages/distroSettings/NewDistro/NewDistroButton.test.tsx
@@ -34,7 +34,7 @@ describe("new distro button", () => {
       result: {
         data: {
           user: {
-            __typename: "User",
+            __typename: "UserLite",
             userId: "string",
             permissions: {
               __typename: "Permissions",
@@ -132,7 +132,7 @@ const hasPermissionsMock: ApolloMock<
   result: {
     data: {
       user: {
-        __typename: "User",
+        __typename: "UserLite",
         userId: "string",
         permissions: {
           __typename: "Permissions",

--- a/apps/spruce/src/pages/projectAndRepoSettings/shared/CreateDuplicateProjectButton.test.tsx
+++ b/apps/spruce/src/pages/projectAndRepoSettings/shared/CreateDuplicateProjectButton.test.tsx
@@ -58,7 +58,7 @@ describe("createDuplicateProjectField", () => {
       result: {
         data: {
           user: {
-            __typename: "User",
+            __typename: "UserLite",
             userId: "string",
             permissions: {
               __typename: "Permissions",
@@ -203,7 +203,7 @@ const permissionsMock: ApolloMock<
   result: {
     data: {
       user: {
-        __typename: "User",
+        __typename: "UserLite",
         userId: "string",
         permissions: {
           __typename: "Permissions",

--- a/apps/spruce/src/pages/spawn/spawnHost/spawnHostButton/useUserTokenExchange.test.ts
+++ b/apps/spruce/src/pages/spawn/spawnHost/spawnHostButton/useUserTokenExchange.test.ts
@@ -31,7 +31,7 @@ const userTokenExchangeMock = (
   result: {
     data: {
       user: {
-        __typename: "User" as const,
+        __typename: "UserLite" as const,
         hasTokenExchangePending: false,
         tokenAccessTokenExpiresAt: null,
         ...overrides,

--- a/apps/spruce/src/pages/version/Metadata/Metadata.test.tsx
+++ b/apps/spruce/src/pages/version/Metadata/Metadata.test.tsx
@@ -56,7 +56,11 @@ const baseVersion: Version = {
     repo: "evergreen",
   },
   upstreamProject: null,
-  user: { __typename: "User", displayName: "Test User", userId: "testuser" },
+  user: {
+    __typename: "UserLite",
+    displayName: "Test User",
+    userId: "testuser",
+  },
   versionTiming: null,
 };
 

--- a/packages/lib/src/context/AuthProvider/index.tsx
+++ b/packages/lib/src/context/AuthProvider/index.tsx
@@ -190,7 +190,7 @@ const AuthProvider: React.FC<{
         "content-type": "application/json",
       },
       body: JSON.stringify({
-        query: "{\n  user {\n    userId\n  }\n}",
+        query: "{\n  userLite {\n    id\n  }\n}",
         variables: {},
       }),
       method: "POST",

--- a/packages/lib/src/gql/generated/types.ts
+++ b/packages/lib/src/gql/generated/types.ts
@@ -2545,7 +2545,9 @@ export type Patch = {
   taskStatuses: Array<Scalars["String"]["output"]>;
   tasks: Array<Scalars["String"]["output"]>;
   time?: Maybe<PatchTime>;
+  /** @deprecated Use userLite instead. */
   user: User;
+  userLite: UserLite;
   variants: Array<Scalars["String"]["output"]>;
   variantsTasks: Array<VariantTask>;
   version?: Maybe<VersionLite>;
@@ -3178,6 +3180,7 @@ export type Query = {
   taskTestSample?: Maybe<Array<TaskTestResultSample>>;
   user: User;
   userConfig?: Maybe<UserConfig>;
+  userLite: UserLite;
   variantQuarantineStatus: VariantQuarantineStatus;
   version: Version;
   viewableProjectRefs: Array<GroupedProjects>;
@@ -3320,6 +3323,10 @@ export type QueryTaskTestSampleArgs = {
 };
 
 export type QueryUserArgs = {
+  userId?: InputMaybe<Scalars["String"]["input"]>;
+};
+
+export type QueryUserLiteArgs = {
   userId?: InputMaybe<Scalars["String"]["input"]>;
 };
 
@@ -4825,12 +4832,31 @@ export type UserConfig = {
   user: Scalars["String"]["output"];
 };
 
-/** UserLite replaces User by sidestepping the APIUser field. It does not contain all fields at this time. */
+/**
+ * UserLite replaces User by sidestepping the APIDBUser API model and binding directly to the
+ * service-layer user model. New clients should query UserLite instead of User.
+ */
 export type UserLite = {
   __typename?: "UserLite";
+  betaFeatures?: Maybe<BetaFeatures>;
   displayName?: Maybe<Scalars["String"]["output"]>;
   emailAddress?: Maybe<Scalars["String"]["output"]>;
+  hasTokenExchangePending: Scalars["Boolean"]["output"];
   id: Scalars["String"]["output"];
+  parsleyFilters?: Maybe<Array<ParsleyFilter>>;
+  patches?: Maybe<Patches>;
+  permissions?: Maybe<Permissions>;
+  settings?: Maybe<UserSettings>;
+  subscriptions?: Maybe<Array<GeneralSubscription>>;
+  tokenAccessTokenExpiresAt?: Maybe<Scalars["Time"]["output"]>;
+};
+
+/**
+ * UserLite replaces User by sidestepping the APIDBUser API model and binding directly to the
+ * service-layer user model. New clients should query UserLite instead of User.
+ */
+export type UserLitePatchesArgs = {
+  patchesInput: PatchesInput;
 };
 
 export type UserServiceFlags = {
@@ -4939,7 +4965,9 @@ export type Version = {
   taskStatuses: Array<Scalars["String"]["output"]>;
   tasks: VersionTasks;
   upstreamProject?: Maybe<UpstreamProject>;
+  /** @deprecated Use userLite instead. */
   user: User;
+  userLite: UserLite;
   versionTiming?: Maybe<VersionTiming>;
   warnings: Array<Scalars["String"]["output"]>;
   waterfallBuilds?: Maybe<Array<WaterfallBuild>>;
@@ -5192,7 +5220,7 @@ export type UserBetaFeaturesQueryVariables = Exact<{ [key: string]: never }>;
 export type UserBetaFeaturesQuery = {
   __typename?: "Query";
   user: {
-    __typename?: "User";
+    __typename?: "UserLite";
     userId: string;
     betaFeatures?: { __typename: "BetaFeatures" } | null;
   };

--- a/packages/lib/src/gql/queries/user-beta-features.ts
+++ b/packages/lib/src/gql/queries/user-beta-features.ts
@@ -2,11 +2,11 @@ import { gql } from "@apollo/client";
 
 export const USER_BETA_FEATURES = gql`
   query UserBetaFeatures {
-    user {
+    user: userLite {
       betaFeatures {
         __typename
       }
-      userId
+      userId: id
     }
   }
 `;

--- a/packages/lib/src/hooks/useBetaFeatures/useBetaFeatures.test.tsx
+++ b/packages/lib/src/hooks/useBetaFeatures/useBetaFeatures.test.tsx
@@ -106,7 +106,7 @@ const userBetaFeatures: ApolloMock<
   result: {
     data: {
       user: {
-        __typename: "User",
+        __typename: "UserLite",
         userId: "me",
         betaFeatures: {
           __typename: "BetaFeatures",


### PR DESCRIPTION
DEVPROD-34996

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->

<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
<!-- add description, context, thought process, etc -->
Replace all instances of `User` type with `UserLite` to utilize the non-REST based type.
- Use GraphQL aliases when possible to minimize the number of application code changes
- Followup app PR will rename `UserLite to `User` so that we can deprecate the REST-based type
- Duplicate `User` cache policy for now

### Screenshots
<!-- add screenshots of visible changes -->

### Testing
<!-- add a description of how you tested it -->
- Update mock data to use the right `__typename`

### Evergreen PR
<!-- link to a corresponding Evergreen PR if applicable -->
https://github.com/evergreen-ci/evergreen/pull/10335