### PR TITLE
DEVPROD-35252: Don't poll if someone paginates on the "Task History Overview"

### DIFF
--- a/apps/spruce/src/pages/task/taskTabs/TaskHistory/index.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/TaskHistory/index.tsx
@@ -71,9 +71,10 @@ const TaskHistory: React.FC<TaskHistoryProps> = ({ baseTaskId, task }) => {
     "",
   );
 
+  const defaultCursorId = isPatch ? baseTaskId : task.id;
   const [cursorId] = useQueryParam<string>(
     TaskHistoryOptions.CursorID,
-    isPatch ? baseTaskId : task.id,
+    defaultCursorId,
   );
   const [direction] = useQueryParam<TaskHistoryDirection>(
     TaskHistoryOptions.Direction,
@@ -87,6 +88,14 @@ const TaskHistory: React.FC<TaskHistoryProps> = ({ baseTaskId, task }) => {
   const [date] = useQueryParam<string>(TaskHistoryOptions.Date, "");
   const timezone = useUserTimeZone();
   const utcDate = getUTCEndOfDay(date, timezone);
+
+  // Polling refetches the timeline on an interval, which yanks the user around
+  // once they've paginated into history. Only poll on the default, most-recent
+  // view (cursor still at its default and no date filter applied).
+  const isFirstPage =
+    cursorId === defaultCursorId &&
+    direction === TaskHistoryDirection.Before &&
+    !date;
 
   const { data, error, loading } = useQuery<
     TaskHistoryQuery,
@@ -108,7 +117,7 @@ const TaskHistory: React.FC<TaskHistoryProps> = ({ baseTaskId, task }) => {
       includeGenerator: !!task.generatedBy,
     },
     fetchPolicy: "cache-first",
-    pollInterval: DEFAULT_POLL_INTERVAL,
+    pollInterval: isFirstPage ? DEFAULT_POLL_INTERVAL : 0,
   });
   useErrorToast(error, "Unable to get task history");
 


### PR DESCRIPTION
[DEVPROD-35252](https://jira.mongodb.org/browse/DEVPROD-35252)

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->

<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
Adding a simple block to not poll and refresh the task history page if someone is paginating through it. If we do we risk shifting the history while they're looking through it and/or refreshing it which would be disruptive