### PR TITLE
DEVPROD-36765: Fix TypeError by ensuring logBucket lifecycleLastSyncedAt is Date object

### DIFF
--- a/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/OtherTab/transformers.test.ts
+++ b/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/OtherTab/transformers.test.ts
@@ -12,6 +12,25 @@ describe("other tab transformers", () => {
     expect(formToGql(expectedForm)).toStrictEqual(expectedGql);
   });
 
+  it("converts lifecycleLastSyncedAt values arriving as ISO strings", () => {
+    const isoString = "2026-07-06T12:00:00.000Z";
+    const adminSettingsWithSyncTime: AdminSettingsData = {
+      ...mockAdminSettings,
+      buckets: {
+        ...mockAdminSettings.buckets,
+        logBucket: {
+          ...mockAdminSettings.buckets?.logBucket,
+          lifecycleLastSyncedAt: isoString as unknown as Date,
+        },
+      },
+    };
+
+    const loaded = gqlToForm(adminSettingsWithSyncTime);
+    expect(loaded?.other.bucketConfig.logBucketLifecycleLastSyncedAt).toBe(
+      isoString,
+    );
+  });
+
   it("round-trips S3 storage account ID lists from admin settings", () => {
     const adminSettingsWithS3Lists: AdminSettingsData = {
       ...mockAdminSettings,

--- a/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/OtherTab/transformers.ts
+++ b/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/OtherTab/transformers.ts
@@ -117,8 +117,10 @@ export const gqlToForm = ((data) => {
           buckets?.logBucket?.transitionToIADays ?? 0,
         logBucketTransitionToGlacierDays:
           buckets?.logBucket?.transitionToGlacierDays ?? 0,
-        logBucketLifecycleLastSyncedAt:
-          buckets?.logBucket?.lifecycleLastSyncedAt?.toISOString() ?? "",
+        logBucketLifecycleLastSyncedAt: buckets?.logBucket
+          ?.lifecycleLastSyncedAt
+          ? new Date(buckets.logBucket.lifecycleLastSyncedAt).toISOString()
+          : "",
         logBucketLifecycleSyncError:
           buckets?.logBucket?.lifecycleSyncError ?? "",
         logBucketLongRetentionName: buckets?.logBucketLongRetention?.name ?? "",
@@ -128,9 +130,12 @@ export const gqlToForm = ((data) => {
           buckets?.logBucketLongRetention?.transitionToIADays ?? 0,
         logBucketLongRetentionTransitionToGlacierDays:
           buckets?.logBucketLongRetention?.transitionToGlacierDays ?? 0,
-        logBucketLongRetentionLifecycleLastSyncedAt:
-          buckets?.logBucketLongRetention?.lifecycleLastSyncedAt?.toISOString() ??
-          "",
+        logBucketLongRetentionLifecycleLastSyncedAt: buckets
+          ?.logBucketLongRetention?.lifecycleLastSyncedAt
+          ? new Date(
+              buckets.logBucketLongRetention.lifecycleLastSyncedAt,
+            ).toISOString()
+          : "",
         logBucketLongRetentionLifecycleSyncError:
           buckets?.logBucketLongRetention?.lifecycleSyncError ?? "",
         longRetentionProjects: buckets?.longRetentionProjects ?? [],
@@ -148,9 +153,12 @@ export const gqlToForm = ((data) => {
           buckets?.logBucketFailedTasks?.transitionToIADays ?? 0,
         failedTasksLogBucketTransitionToGlacierDays:
           buckets?.logBucketFailedTasks?.transitionToGlacierDays ?? 0,
-        failedTasksLogBucketLifecycleLastSyncedAt:
-          buckets?.logBucketFailedTasks?.lifecycleLastSyncedAt?.toISOString() ??
-          "",
+        failedTasksLogBucketLifecycleLastSyncedAt: buckets?.logBucketFailedTasks
+          ?.lifecycleLastSyncedAt
+          ? new Date(
+              buckets.logBucketFailedTasks.lifecycleLastSyncedAt,
+            ).toISOString()
+          : "",
         failedTasksLogBucketLifecycleSyncError:
           buckets?.logBucketFailedTasks?.lifecycleSyncError ?? "",
         retryFailedLogMoveLookbackDays:


### PR DESCRIPTION
DEVPROD-36765

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->

<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
The GraphQL Time scalar is mapped to Date in codegen, so TypeScript thought lifecycleLastSyncedAt was a Date. But that mapping is compile-time only. At runtime Apollo hands back the raw JSON string, so .toISOString() threw TypeError whenever the field was actually populated in the DB. When it was null/undefined, optional chaining short-circuited and hid the bug.

Fixed by wrapping all three lifecycleLastSyncedAt values in new Date(...) before calling .toISOString() — for logBucket,
  logBucketLongRetention, and logBucketFailedTasks.

### Testing
Added a case in transformers.test.ts that feeds a populated ISO-string value and asserts it converts correctly.


