### PR TITLE
DEVPROD-34789: Surface TSS quarantine skipped tests in Spruce

### DIFF
--- a/apps/parsley/src/gql/generated/types.ts
+++ b/apps/parsley/src/gql/generated/types.ts
@@ -3139,6 +3139,13 @@ export type QuarantineVariantInput = {
   projectIdentifier: Scalars["String"]["input"];
 };
 
+/** QuarantinedTest represents a test skipped because it was quarantined in TSS at execution time. */
+export type QuarantinedTest = {
+  __typename?: "QuarantinedTest";
+  displayTestName?: Maybe<Scalars["String"]["output"]>;
+  testName: Scalars["String"]["output"];
+};
+
 export type Query = {
   __typename?: "Query";
   adminEvents: AdminEventsPayload;
@@ -3180,6 +3187,7 @@ export type Query = {
   taskHistory: TaskHistory;
   taskHistoryByCreateTime: TaskHistoryByCreateTime;
   taskNamesForBuildVariant?: Maybe<Array<Scalars["String"]["output"]>>;
+  taskQuarantinedTestsSample?: Maybe<Array<TaskQuarantinedTestsSample>>;
   taskQueueDistros: Array<TaskQueueDistro>;
   taskTestSample?: Maybe<Array<TaskTestResultSample>>;
   user: User;
@@ -3318,6 +3326,12 @@ export type QueryTaskHistoryByCreateTimeArgs = {
 export type QueryTaskNamesForBuildVariantArgs = {
   buildVariant: Scalars["String"]["input"];
   projectIdentifier: Scalars["String"]["input"];
+};
+
+export type QueryTaskQuarantinedTestsSampleArgs = {
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  taskIds: Array<Scalars["String"]["input"]>;
+  versionId: Scalars["String"]["input"];
 };
 
 export type QueryTaskTestSampleArgs = {
@@ -4173,6 +4187,8 @@ export type Task = {
   prevTaskPassing?: Maybe<Task>;
   priority?: Maybe<Scalars["Int"]["output"]>;
   project?: Maybe<Project>;
+  /** quarantinedTestsSkippedCount is the number of tests this execution skipped because they were quarantined in TSS at execution time. */
+  quarantinedTestsSkippedCount: Scalars["Int"]["output"];
   requester: Scalars["String"]["output"];
   resetWhenFinished: Scalars["Boolean"]["output"];
   revision?: Maybe<Scalars["String"]["output"]>;
@@ -4436,6 +4452,18 @@ export type TaskQuarantineEntry = {
   __typename?: "TaskQuarantineEntry";
   taskName: Scalars["String"]["output"];
   tests: Array<TestQuarantineEntry>;
+};
+
+/**
+ * TaskQuarantinedTestsSample is the return value for the taskQuarantinedTestsSample query.
+ * It contains the execution-time snapshot of tests skipped because they were quarantined in TSS.
+ */
+export type TaskQuarantinedTestsSample = {
+  __typename?: "TaskQuarantinedTestsSample";
+  execution: Scalars["Int"]["output"];
+  quarantinedTests: Array<QuarantinedTest>;
+  quarantinedTestsSkippedCount: Scalars["Int"]["output"];
+  taskId: Scalars["String"]["output"];
 };
 
 /**
@@ -4957,6 +4985,8 @@ export type Version = {
   predictedCost?: Maybe<Cost>;
   previousVersion?: Maybe<Version>;
   projectMetadata?: Maybe<Project>;
+  /** quarantinedTestsSkippedCount is the number of tests skipped across the version's tasks because they were quarantined in TSS at execution time. */
+  quarantinedTestsSkippedCount: Scalars["Int"]["output"];
   repo: Scalars["String"]["output"];
   requester: Scalars["String"]["output"];
   revision: Scalars["String"]["output"];

--- a/apps/spruce/src/analytics/task/useTaskAnalytics.ts
+++ b/apps/spruce/src/analytics/task/useTaskAnalytics.ts
@@ -66,6 +66,15 @@ type Action =
       "test.name": string;
       "test.task_id": string;
     }
+  | {
+      name: "Viewed quarantined tests modal";
+      "tests.skipped_count": number;
+    }
+  | {
+      name: "Clicked download quarantined tests JSON button";
+      "tests.skipped_count": number;
+    }
+  | { name: "Clicked quarantined test skips metadata link" }
   | { name: "Clicked annotation link"; "link.text": string }
   | { name: "Changed log preview type"; "log.type": LogTypes }
   | { name: "Viewed notification modal" }

--- a/apps/spruce/src/components/QuarantinedTestsModal/QuarantinedTestsModal.stories.tsx
+++ b/apps/spruce/src/components/QuarantinedTestsModal/QuarantinedTestsModal.stories.tsx
@@ -1,0 +1,60 @@
+import { WordBreak } from "@evg-ui/lib/components/styles";
+import { LGColumnDef } from "@evg-ui/lib/components/Table";
+import { CustomMeta, CustomStoryObj } from "@evg-ui/lib/test_utils/types";
+import { QuarantinedTestsModal } from ".";
+
+type StoryRow = {
+  testName: string;
+};
+
+const columns: LGColumnDef<StoryRow>[] = [
+  {
+    id: "testName",
+    header: "Test Name",
+    accessorKey: "testName",
+    cell: ({ getValue }) => <WordBreak>{getValue() as string}</WordBreak>,
+  },
+];
+
+const getRows = (count: number): StoryRow[] =>
+  Array.from({ length: count }, (_, i) => ({
+    testName: `tests/unit/quarantined_test_${i}.js`,
+  }));
+
+export default {
+  component: QuarantinedTestsModal,
+} satisfies CustomMeta<typeof QuarantinedTestsModal>;
+
+export const Default: CustomStoryObj<typeof QuarantinedTestsModal> = {
+  render: () => (
+    <QuarantinedTestsModal
+      columns={columns}
+      dataCyPrefix="story-quarantined-tests"
+      getSearchText={({ testName }) => testName}
+      onClickDownload={() => {}}
+      open
+      rows={getRows(8)}
+      searchPlaceholder="Search test names"
+      setOpen={() => {}}
+      subtitle="8 tests were quarantined in TSS when this task ran. This snapshot may not match the current quarantine state."
+      totalCount={8}
+    />
+  ),
+};
+
+export const Truncated: CustomStoryObj<typeof QuarantinedTestsModal> = {
+  render: () => (
+    <QuarantinedTestsModal
+      columns={columns}
+      dataCyPrefix="story-quarantined-tests"
+      getSearchText={({ testName }) => testName}
+      onClickDownload={() => {}}
+      open
+      rows={getRows(50)}
+      searchPlaceholder="Search test names"
+      setOpen={() => {}}
+      subtitle="120 tests were quarantined in TSS when this task ran. This snapshot may not match the current quarantine state."
+      totalCount={120}
+    />
+  ),
+};

--- a/apps/spruce/src/components/QuarantinedTestsModal/index.tsx
+++ b/apps/spruce/src/components/QuarantinedTestsModal/index.tsx
@@ -1,0 +1,123 @@
+import { useMemo, useState } from "react";
+import styled from "@emotion/styled";
+import { Button } from "@leafygreen-ui/button";
+import {
+  SearchInput,
+  Size as SearchInputSize,
+} from "@leafygreen-ui/search-input";
+import { LGTableDataType } from "@leafygreen-ui/table";
+import { Disclaimer } from "@leafygreen-ui/typography";
+import Icon from "@evg-ui/lib/components/Icon";
+import {
+  BaseTable,
+  LGColumnDef,
+  LGRowData,
+  TablePlaceholder,
+  useLeafyGreenTable,
+} from "@evg-ui/lib/components/Table";
+import { size } from "@evg-ui/lib/constants/tokens";
+import { DisplayModal } from "components/DisplayModal";
+
+interface QuarantinedTestsModalProps<T extends LGRowData> {
+  columns: LGColumnDef<T>[];
+  dataCyPrefix: string;
+  getSearchText: (row: T) => string;
+  loading?: boolean;
+  onClickDownload: () => void;
+  open: boolean;
+  rows: LGTableDataType<T>[];
+  searchPlaceholder: string;
+  setOpen: (open: boolean) => void;
+  subtitle: string;
+  totalCount: number;
+}
+
+export const QuarantinedTestsModal = <T extends LGRowData>({
+  columns,
+  dataCyPrefix,
+  getSearchText,
+  loading = false,
+  onClickDownload,
+  open,
+  rows,
+  searchPlaceholder,
+  setOpen,
+  subtitle,
+  totalCount,
+}: QuarantinedTestsModalProps<T>) => {
+  const [search, setSearch] = useState("");
+
+  const visibleRows = useMemo(
+    () =>
+      rows.filter((row) =>
+        getSearchText(row).toLowerCase().includes(search.toLowerCase()),
+      ),
+    [rows, getSearchText, search],
+  );
+
+  const table = useLeafyGreenTable<T>({
+    columns,
+    data: visibleRows,
+    enableColumnFilters: false,
+  });
+
+  return (
+    <DisplayModal
+      data-cy={`${dataCyPrefix}-modal`}
+      open={open}
+      setOpen={setOpen}
+      size="large"
+      subtitle={subtitle}
+      title="Tests skipped due to TSS quarantine"
+    >
+      <HeaderRow>
+        <SearchInput
+          aria-label={searchPlaceholder}
+          data-cy={`${dataCyPrefix}-search`}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder={searchPlaceholder}
+          size={SearchInputSize.Small}
+          value={search}
+        />
+        <Button
+          data-cy={`${dataCyPrefix}-download`}
+          leftGlyph={<Icon glyph="Download" />}
+          onClick={onClickDownload}
+          size="small"
+        >
+          Download JSON
+        </Button>
+      </HeaderRow>
+      {!loading && rows.length < totalCount && (
+        <Disclaimer data-cy={`${dataCyPrefix}-truncation-note`}>
+          Showing the first {rows.length} of {totalCount} tests. Download the
+          JSON for the full list.
+        </Disclaimer>
+      )}
+      <OverflowContainer>
+        <BaseTable
+          data-cy={`${dataCyPrefix}-table`}
+          emptyComponent={<TablePlaceholder message="No matching tests." />}
+          loading={loading}
+          loadingRows={5}
+          shouldAlternateRowColor
+          table={table}
+        />
+      </OverflowContainer>
+    </DisplayModal>
+  );
+};
+
+const HeaderRow = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: ${size.xs};
+  margin-bottom: ${size.xs};
+`;
+
+const OverflowContainer = styled.div`
+  max-height: 600px;
+  overflow-y: scroll;
+  margin-top: ${size.xs};
+`;

--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -3136,6 +3136,13 @@ export type QuarantineVariantInput = {
   projectIdentifier: Scalars["String"]["input"];
 };
 
+/** QuarantinedTest represents a test skipped because it was quarantined in TSS at execution time. */
+export type QuarantinedTest = {
+  __typename?: "QuarantinedTest";
+  displayTestName?: Maybe<Scalars["String"]["output"]>;
+  testName: Scalars["String"]["output"];
+};
+
 export type Query = {
   __typename?: "Query";
   adminEvents: AdminEventsPayload;
@@ -3177,6 +3184,7 @@ export type Query = {
   taskHistory: TaskHistory;
   taskHistoryByCreateTime: TaskHistoryByCreateTime;
   taskNamesForBuildVariant?: Maybe<Array<Scalars["String"]["output"]>>;
+  taskQuarantinedTestsSample?: Maybe<Array<TaskQuarantinedTestsSample>>;
   taskQueueDistros: Array<TaskQueueDistro>;
   taskTestSample?: Maybe<Array<TaskTestResultSample>>;
   user: User;
@@ -3315,6 +3323,12 @@ export type QueryTaskHistoryByCreateTimeArgs = {
 export type QueryTaskNamesForBuildVariantArgs = {
   buildVariant: Scalars["String"]["input"];
   projectIdentifier: Scalars["String"]["input"];
+};
+
+export type QueryTaskQuarantinedTestsSampleArgs = {
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  taskIds: Array<Scalars["String"]["input"]>;
+  versionId: Scalars["String"]["input"];
 };
 
 export type QueryTaskTestSampleArgs = {
@@ -4170,6 +4184,8 @@ export type Task = {
   prevTaskPassing?: Maybe<Task>;
   priority?: Maybe<Scalars["Int"]["output"]>;
   project?: Maybe<Project>;
+  /** quarantinedTestsSkippedCount is the number of tests this execution skipped because they were quarantined in TSS at execution time. */
+  quarantinedTestsSkippedCount: Scalars["Int"]["output"];
   requester: Scalars["String"]["output"];
   resetWhenFinished: Scalars["Boolean"]["output"];
   reviewed?: Maybe<Scalars["Boolean"]["output"]>;
@@ -4434,6 +4450,18 @@ export type TaskQuarantineEntry = {
   __typename?: "TaskQuarantineEntry";
   taskName: Scalars["String"]["output"];
   tests: Array<TestQuarantineEntry>;
+};
+
+/**
+ * TaskQuarantinedTestsSample is the return value for the taskQuarantinedTestsSample query.
+ * It contains the execution-time snapshot of tests skipped because they were quarantined in TSS.
+ */
+export type TaskQuarantinedTestsSample = {
+  __typename?: "TaskQuarantinedTestsSample";
+  execution: Scalars["Int"]["output"];
+  quarantinedTests: Array<QuarantinedTest>;
+  quarantinedTestsSkippedCount: Scalars["Int"]["output"];
+  taskId: Scalars["String"]["output"];
 };
 
 /**
@@ -11292,6 +11320,27 @@ export type TaskPerfPluginEnabledQuery = {
   } | null;
 };
 
+export type TaskQuarantinedTestsSampleQueryVariables = Exact<{
+  versionId: Scalars["String"]["input"];
+  taskIds: Array<Scalars["String"]["input"]>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+}>;
+
+export type TaskQuarantinedTestsSampleQuery = {
+  __typename?: "Query";
+  taskQuarantinedTestsSample?: Array<{
+    __typename?: "TaskQuarantinedTestsSample";
+    execution: number;
+    quarantinedTestsSkippedCount: number;
+    taskId: string;
+    quarantinedTests: Array<{
+      __typename?: "QuarantinedTest";
+      displayTestName?: string | null;
+      testName: string;
+    }>;
+  }> | null;
+};
+
 export type TaskQueueDistrosQueryVariables = Exact<{ [key: string]: never }>;
 
 export type TaskQueueDistrosQuery = {
@@ -11467,6 +11516,7 @@ export type TaskQuery = {
     order: number;
     patchNumber?: number | null;
     priority?: number | null;
+    quarantinedTestsSkippedCount: number;
     requester: string;
     resetWhenFinished: boolean;
     reviewed?: boolean | null;

--- a/apps/spruce/src/gql/mocks/taskData.ts
+++ b/apps/spruce/src/gql/mocks/taskData.ts
@@ -9,6 +9,7 @@ export const taskQuery: TaskQueryType = {
   task: {
     __typename: "Task",
     id: "someTaskId",
+    quarantinedTestsSkippedCount: 0,
     generatedByName: null,
     generatedBy: null,
     activatedTime: null,

--- a/apps/spruce/src/gql/queries/index.ts
+++ b/apps/spruce/src/gql/queries/index.ts
@@ -68,6 +68,7 @@ export { TASK_NAMES_FOR_BUILD_VARIANT } from "./task-names-for-build-variant";
 export { TASK_OVERVIEW_POPUP } from "./task-overview-popup";
 export { TASK_OWNER_TEAM } from "./task-owner-team";
 export { TASK_PERF_PLUGIN_ENABLED } from "./task-perf-plugin-enabled";
+export { TASK_QUARANTINED_TESTS_SAMPLE } from "./task-quarantined-tests-sample";
 export { TASK_QUEUE_DISTROS } from "./task-queue-distros";
 export { TASK_STATUSES } from "./task-statuses";
 export { TASK_TEST_COUNT } from "./task-test-count";

--- a/apps/spruce/src/gql/queries/task-quarantined-tests-sample.ts
+++ b/apps/spruce/src/gql/queries/task-quarantined-tests-sample.ts
@@ -1,0 +1,23 @@
+import { gql } from "@apollo/client";
+
+export const TASK_QUARANTINED_TESTS_SAMPLE = gql`
+  query TaskQuarantinedTestsSample(
+    $versionId: String!
+    $taskIds: [String!]!
+    $limit: Int
+  ) {
+    taskQuarantinedTestsSample(
+      versionId: $versionId
+      taskIds: $taskIds
+      limit: $limit
+    ) {
+      execution
+      quarantinedTests {
+        displayTestName
+        testName
+      }
+      quarantinedTestsSkippedCount
+      taskId
+    }
+  }
+`;

--- a/apps/spruce/src/gql/queries/task.ts
+++ b/apps/spruce/src/gql/queries/task.ts
@@ -125,6 +125,7 @@ export const TASK = gql`
           allowed
         }
       }
+      quarantinedTestsSkippedCount
       requester
       resetWhenFinished
       reviewed @client

--- a/apps/spruce/src/pages/task/ActionButtons/MarkReviewed/taskData.ts
+++ b/apps/spruce/src/pages/task/ActionButtons/MarkReviewed/taskData.ts
@@ -165,6 +165,7 @@ export const taskData: NonNullable<TaskQuery["task"]> = {
     revision: "da7ae2020c5af16fdc5daf95a6420b36ec742a06",
     __typename: "VersionLite",
   },
+  quarantinedTestsSkippedCount: 0,
   testSelectionEnabled: false,
 };
 
@@ -357,5 +358,6 @@ export const displayTaskData: NonNullable<TaskQuery["task"]> &
     revision: "da7ae2020c5af16fdc5daf95a6420b36ec742a06",
     __typename: "VersionLite",
   },
+  quarantinedTestsSkippedCount: 0,
   testSelectionEnabled: false,
 };

--- a/apps/spruce/src/pages/task/metadata/ExecutionSection/QuarantinedTestsSkipped/QuarantinedTestsSkipped.stories.tsx
+++ b/apps/spruce/src/pages/task/metadata/ExecutionSection/QuarantinedTestsSkipped/QuarantinedTestsSkipped.stories.tsx
@@ -1,0 +1,28 @@
+import { CustomMeta, CustomStoryObj } from "@evg-ui/lib/test_utils/types";
+import { QuarantinedTestsSkipped } from ".";
+
+export default {
+  component: QuarantinedTestsSkipped,
+} satisfies CustomMeta<typeof QuarantinedTestsSkipped>;
+
+export const ZeroSkipped: CustomStoryObj<typeof QuarantinedTestsSkipped> = {
+  render: () => (
+    <QuarantinedTestsSkipped
+      count={0}
+      execution={0}
+      taskId="t1"
+      testSelectionEnabled
+    />
+  ),
+};
+
+export const SomeSkipped: CustomStoryObj<typeof QuarantinedTestsSkipped> = {
+  render: () => (
+    <QuarantinedTestsSkipped
+      count={12}
+      execution={0}
+      taskId="t1"
+      testSelectionEnabled
+    />
+  ),
+};

--- a/apps/spruce/src/pages/task/metadata/ExecutionSection/QuarantinedTestsSkipped/QuarantinedTestsSkipped.test.tsx
+++ b/apps/spruce/src/pages/task/metadata/ExecutionSection/QuarantinedTestsSkipped/QuarantinedTestsSkipped.test.tsx
@@ -1,0 +1,62 @@
+import {
+  MockedProvider,
+  renderWithRouterMatch as render,
+  screen,
+} from "@evg-ui/lib/test_utils";
+import { QuarantinedTestsSkipped } from ".";
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <MockedProvider>{children}</MockedProvider>
+);
+
+describe("QuarantinedTestsSkipped", () => {
+  it("renders nothing when test selection is disabled and no tests were skipped", () => {
+    render(
+      <QuarantinedTestsSkipped
+        count={0}
+        execution={0}
+        taskId="t1"
+        testSelectionEnabled={false}
+      />,
+      { wrapper },
+    );
+    expect(screen.queryByDataCy("quarantined-test-skips")).toBeNull();
+  });
+
+  it("shows an unlinked zero badge when test selection ran and skipped nothing", () => {
+    render(
+      <QuarantinedTestsSkipped
+        count={0}
+        execution={0}
+        taskId="t1"
+        testSelectionEnabled
+      />,
+      { wrapper },
+    );
+    expect(
+      screen.getByDataCy("quarantined-test-skips-badge"),
+    ).toHaveTextContent("0");
+    expect(screen.queryByDataCy("quarantined-test-skips-link")).toBeNull();
+  });
+
+  it("links a nonzero count to the Tests tab with the modal deep link", () => {
+    render(
+      <QuarantinedTestsSkipped
+        count={4}
+        execution={2}
+        taskId="t1"
+        testSelectionEnabled
+      />,
+      { wrapper },
+    );
+    expect(
+      screen.getByDataCy("quarantined-test-skips-badge"),
+    ).toHaveTextContent("4");
+    const href = screen
+      .getByDataCy("quarantined-test-skips-link")
+      .getAttribute("href");
+    expect(href).toContain("/task/t1/tests");
+    expect(href).toContain("execution=2");
+    expect(href).toContain("quarantinedTests=true");
+  });
+});

--- a/apps/spruce/src/pages/task/metadata/ExecutionSection/QuarantinedTestsSkipped/index.tsx
+++ b/apps/spruce/src/pages/task/metadata/ExecutionSection/QuarantinedTestsSkipped/index.tsx
@@ -1,0 +1,80 @@
+import styled from "@emotion/styled";
+import { Badge, Variant as BadgeVariant } from "@leafygreen-ui/badge";
+import { InfoSprinkle } from "@leafygreen-ui/info-sprinkle";
+import { BaseFontSize } from "@leafygreen-ui/tokens";
+import { StyledRouterLink } from "@evg-ui/lib/components/styles";
+import { size } from "@evg-ui/lib/constants/tokens";
+import { useTaskAnalytics } from "analytics";
+import { MetadataItem } from "components/MetadataCard";
+import { getTaskRoute } from "constants/routes";
+import { QueryParams, TaskTab } from "types/task";
+
+type Props = {
+  count: number;
+  execution: number;
+  taskId: string;
+  testSelectionEnabled: boolean;
+};
+
+export const QuarantinedTestsSkipped: React.FC<Props> = ({
+  count,
+  execution,
+  taskId,
+  testSelectionEnabled,
+}) => {
+  const { sendEvent } = useTaskAnalytics();
+
+  // A zero count is only meaningful as a trust signal when test selection
+  // actually ran on this task.
+  if (count === 0 && !testSelectionEnabled) {
+    return null;
+  }
+
+  return (
+    <MetadataItem as="div" label="Quarantined test skips">
+      <BadgeWrapper data-cy="quarantined-test-skips">
+        <InfoSprinkle baseFontSize={BaseFontSize.Body1}>
+          Tests skipped on this execution because they were quarantined in TSS
+          when it ran. This is an execution-time snapshot, not the live
+          quarantine state.
+        </InfoSprinkle>
+        {count === 0 ? (
+          <Badge
+            data-cy="quarantined-test-skips-badge"
+            variant={BadgeVariant.Green}
+          >
+            0
+          </Badge>
+        ) : (
+          <StyledRouterLink
+            data-cy="quarantined-test-skips-link"
+            onClick={() =>
+              sendEvent({
+                name: "Clicked quarantined test skips metadata link",
+              })
+            }
+            to={getTaskRoute(taskId, {
+              execution,
+              tab: TaskTab.Tests,
+              [QueryParams.QuarantinedTests]: true,
+            })}
+          >
+            <Badge
+              data-cy="quarantined-test-skips-badge"
+              variant={BadgeVariant.Yellow}
+            >
+              {count}
+            </Badge>
+          </StyledRouterLink>
+        )}
+      </BadgeWrapper>
+    </MetadataItem>
+  );
+};
+
+const BadgeWrapper = styled.div`
+  display: inline-flex;
+  align-items: center;
+  gap: ${size.xxs};
+  vertical-align: middle;
+`;

--- a/apps/spruce/src/pages/task/metadata/ExecutionSection/index.tsx
+++ b/apps/spruce/src/pages/task/metadata/ExecutionSection/index.tsx
@@ -10,6 +10,7 @@ import { TaskQuery } from "gql/generated/types";
 import { isInStepback } from "utils/stepback";
 import { AbortMessage } from "./AbortMessage";
 import { DetailsDescription } from "./DetailsDescription";
+import { QuarantinedTestsSkipped } from "./QuarantinedTestsSkipped";
 import { TestSelection } from "./TestSelection";
 
 const { red } = palette;
@@ -88,6 +89,12 @@ export const ExecutionSection: React.FC<ExecutionSectionProps> = ({ task }) => {
       {testSelectionEnabledForProject && (
         <TestSelection testSelectionEnabled={testSelectionEnabled} />
       )}
+      <QuarantinedTestsSkipped
+        count={task.quarantinedTestsSkippedCount}
+        execution={execution}
+        taskId={task.id}
+        testSelectionEnabled={testSelectionEnabled}
+      />
       {hasCost && (
         <CostSummary
           onClickDetailsButton={() =>

--- a/apps/spruce/src/pages/task/taskTabs/testsTable/QuarantinedTests/QuarantinedTests.test.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/testsTable/QuarantinedTests/QuarantinedTests.test.tsx
@@ -1,0 +1,189 @@
+import { RenderFakeToastContext } from "@evg-ui/lib/context/toast/__mocks__";
+import {
+  MockedProvider,
+  renderWithRouterMatch as render,
+  screen,
+  stubGetClientRects,
+  userEvent,
+  waitFor,
+} from "@evg-ui/lib/test_utils";
+import { ApolloMock } from "@evg-ui/lib/test_utils/types";
+import {
+  TaskQuarantinedTestsSampleQuery,
+  TaskQuarantinedTestsSampleQueryVariables,
+  TaskQuery,
+} from "gql/generated/types";
+import { taskQuery } from "gql/mocks/taskData";
+import { TASK_QUARANTINED_TESTS_SAMPLE } from "gql/queries";
+import {
+  FULL_LIST_LIMIT,
+  MODAL_DISPLAY_LIMIT,
+  QuarantinedTestsSample,
+} from "./utils";
+import { QuarantinedTests } from ".";
+
+const quarantinedTask: NonNullable<TaskQuery["task"]> = {
+  ...taskQuery.task,
+  id: "t1",
+  execution: 0,
+  quarantinedTestsSkippedCount: 3,
+  versionMetadata: {
+    ...taskQuery.task.versionMetadata,
+    id: "v1",
+  },
+};
+
+const sample: QuarantinedTestsSample = {
+  __typename: "TaskQuarantinedTestsSample",
+  execution: 0,
+  quarantinedTests: [
+    {
+      __typename: "QuarantinedTest",
+      displayTestName: "Display One",
+      testName: "test_one",
+    },
+    {
+      __typename: "QuarantinedTest",
+      displayTestName: null,
+      testName: "test_two",
+    },
+    {
+      __typename: "QuarantinedTest",
+      displayTestName: null,
+      testName: "test_three",
+    },
+  ],
+  quarantinedTestsSkippedCount: 3,
+  taskId: "t1",
+};
+
+const getSampleMock = (
+  limit: number,
+  sampleOverrides: Partial<QuarantinedTestsSample> = {},
+): ApolloMock<
+  TaskQuarantinedTestsSampleQuery,
+  TaskQuarantinedTestsSampleQueryVariables
+> => ({
+  request: {
+    query: TASK_QUARANTINED_TESTS_SAMPLE,
+    variables: { versionId: "v1", taskIds: ["t1"], limit },
+  },
+  result: {
+    data: {
+      taskQuarantinedTestsSample: [{ ...sample, ...sampleOverrides }],
+    },
+  },
+});
+
+const Wrapper = ({
+  mocks = [getSampleMock(MODAL_DISPLAY_LIMIT)],
+  task = quarantinedTask,
+}: {
+  mocks?: ApolloMock<
+    TaskQuarantinedTestsSampleQuery,
+    TaskQuarantinedTestsSampleQueryVariables
+  >[];
+  task?: NonNullable<TaskQuery["task"]>;
+}) => (
+  <MockedProvider mocks={mocks}>
+    <QuarantinedTests task={task} />
+  </MockedProvider>
+);
+
+// Deliberately avoids the :taskId slug so that useTaskAnalytics' queries stay
+// skipped, mirroring Metadata.test.tsx.
+const routerOptions = {
+  path: "/task/:id/:tab",
+  route: "/task/t1/tests?execution=0",
+};
+const deepLinkOptions = {
+  ...routerOptions,
+  route: "/task/t1/tests?execution=0&quarantinedTests=true",
+};
+
+describe("QuarantinedTests", () => {
+  beforeAll(() => {
+    stubGetClientRects();
+    Object.defineProperty(URL, "createObjectURL", {
+      value: vi.fn(() => "blob:mock"),
+      writable: true,
+    });
+    Object.defineProperty(URL, "revokeObjectURL", {
+      value: vi.fn(),
+      writable: true,
+    });
+    vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {});
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders nothing when no tests were skipped", () => {
+    const { Component } = RenderFakeToastContext(
+      <Wrapper
+        mocks={[]}
+        task={{ ...quarantinedTask, quarantinedTestsSkippedCount: 0 }}
+      />,
+    );
+    render(<Component />, deepLinkOptions);
+    expect(screen.queryByDataCy("quarantined-tests-modal")).toBeNull();
+  });
+
+  it("auto-opens the modal from the deep-link param and clears the param on close", async () => {
+    const user = userEvent.setup();
+    const { Component } = RenderFakeToastContext(<Wrapper />);
+    const { router } = render(<Component />, deepLinkOptions);
+    expect(await screen.findByDataCy("quarantined-tests-modal")).toBeVisible();
+    expect(screen.getByText("Display One")).toBeVisible();
+    await user.click(screen.getByRole("button", { name: "Close modal" }));
+    await waitFor(() => {
+      expect(screen.getByDataCy("quarantined-tests-modal")).not.toBeVisible();
+    });
+    expect(router.state.location.search).not.toContain("quarantinedTests");
+  });
+
+  it("does not open when the sample is for a newer execution", async () => {
+    const { Component } = RenderFakeToastContext(
+      <Wrapper
+        mocks={[getSampleMock(MODAL_DISPLAY_LIMIT, { execution: 1 })]}
+      />,
+    );
+    render(<Component />, deepLinkOptions);
+    await expect(
+      screen.findByDataCy("quarantined-tests-modal", undefined, {
+        timeout: 250,
+      }),
+    ).rejects.toThrow();
+  });
+
+  it("downloads the full list as JSON from the modal", async () => {
+    const user = userEvent.setup();
+    const { Component } = RenderFakeToastContext(
+      <Wrapper
+        mocks={[
+          getSampleMock(MODAL_DISPLAY_LIMIT),
+          getSampleMock(FULL_LIST_LIMIT),
+        ]}
+      />,
+    );
+    render(<Component />, deepLinkOptions);
+    expect(await screen.findByDataCy("quarantined-tests-modal")).toBeVisible();
+    await user.click(screen.getByDataCy("quarantined-tests-download"));
+    await waitFor(() => {
+      expect(URL.createObjectURL).toHaveBeenCalledTimes(1);
+    });
+    const blob = vi.mocked(URL.createObjectURL).mock.calls[0][0] as Blob;
+    expect(JSON.parse(await blob.text())).toStrictEqual({
+      taskId: "t1",
+      execution: 0,
+      quarantinedTestsSkippedCount: 3,
+      truncated: false,
+      quarantinedTests: [
+        { testName: "test_one", displayTestName: "Display One" },
+        { testName: "test_two" },
+        { testName: "test_three" },
+      ],
+    });
+  });
+});

--- a/apps/spruce/src/pages/task/taskTabs/testsTable/QuarantinedTests/index.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/testsTable/QuarantinedTests/index.tsx
@@ -1,0 +1,150 @@
+import { useEffect, useState } from "react";
+import { skipToken, useLazyQuery, useQuery } from "@apollo/client/react";
+import pluralize from "pluralize";
+import { WordBreak } from "@evg-ui/lib/components/styles";
+import { LGColumnDef } from "@evg-ui/lib/components/Table";
+import { useToastContext } from "@evg-ui/lib/context/toast";
+import { useQueryParams } from "@evg-ui/lib/hooks";
+import { useTaskAnalytics } from "analytics";
+import { QuarantinedTestsModal } from "components/QuarantinedTestsModal";
+import {
+  TaskQuarantinedTestsSampleQuery,
+  TaskQuarantinedTestsSampleQueryVariables,
+  TaskQuery,
+} from "gql/generated/types";
+import { TASK_QUARANTINED_TESTS_SAMPLE } from "gql/queries";
+import { QueryParams } from "types/task";
+import { formatZeroIndexForDisplay } from "utils/numbers";
+import {
+  buildQuarantinedTestsJson,
+  downloadJsonBlob,
+  FULL_LIST_LIMIT,
+  MODAL_DISPLAY_LIMIT,
+  QuarantinedTestsSample,
+} from "./utils";
+
+type QuarantinedTestEntry = QuarantinedTestsSample["quarantinedTests"][number];
+
+interface QuarantinedTestsProps {
+  task: NonNullable<TaskQuery["task"]>;
+}
+
+export const QuarantinedTests: React.FC<QuarantinedTestsProps> = ({ task }) => {
+  const { execution, id: taskId, quarantinedTestsSkippedCount: count } = task;
+  const versionId = task.versionMetadata.id;
+  const dispatchToast = useToastContext();
+  const { sendEvent } = useTaskAnalytics();
+  const [showModal, setShowModal] = useState(false);
+  const [queryParams, setQueryParams] = useQueryParams();
+
+  const { data } = useQuery<
+    TaskQuarantinedTestsSampleQuery,
+    TaskQuarantinedTestsSampleQueryVariables
+  >(
+    TASK_QUARANTINED_TESTS_SAMPLE,
+    count > 0
+      ? {
+          variables: {
+            versionId,
+            taskIds: [taskId],
+            limit: MODAL_DISPLAY_LIMIT,
+          },
+          errorPolicy: "all",
+        }
+      : skipToken,
+  );
+  const sample = data?.taskQuarantinedTestsSample?.[0];
+
+  // The sample query always reflects the latest execution, while the count is
+  // accurate for the selected one; suppress the modal when they disagree.
+  const listAvailable = sample !== undefined && sample.execution === execution;
+
+  const [fetchFullList] = useLazyQuery<
+    TaskQuarantinedTestsSampleQuery,
+    TaskQuarantinedTestsSampleQueryVariables
+  >(TASK_QUARANTINED_TESTS_SAMPLE);
+
+  const setModalOpen = (open: boolean) => {
+    setShowModal(open);
+    if (!open && queryParams[QueryParams.QuarantinedTests] !== undefined) {
+      setQueryParams({
+        ...queryParams,
+        [QueryParams.QuarantinedTests]: undefined,
+      });
+    }
+  };
+
+  const shouldAutoOpen = queryParams[QueryParams.QuarantinedTests] === true;
+  useEffect(() => {
+    if (shouldAutoOpen && listAvailable) {
+      sendEvent({
+        name: "Viewed quarantined tests modal",
+        "tests.skipped_count": count,
+      });
+      setShowModal(true);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [shouldAutoOpen, listAvailable]);
+
+  const handleDownload = async () => {
+    sendEvent({
+      name: "Clicked download quarantined tests JSON button",
+      "tests.skipped_count": count,
+    });
+    try {
+      const { data: fullData } = await fetchFullList({
+        variables: { versionId, taskIds: [taskId], limit: FULL_LIST_LIMIT },
+      });
+      const fullSample = fullData?.taskQuarantinedTestsSample?.[0];
+      if (!fullSample) {
+        throw new Error("no quarantined test sample returned");
+      }
+      downloadJsonBlob(
+        buildQuarantinedTestsJson(fullSample),
+        `quarantined-tests-${taskId}-${execution}.json`,
+      );
+    } catch {
+      dispatchToast.error(
+        "There was an error downloading the quarantined test list.",
+      );
+    }
+  };
+
+  if (!listAvailable) {
+    return null;
+  }
+
+  return (
+    <QuarantinedTestsModal
+      columns={columns}
+      dataCyPrefix="quarantined-tests"
+      getSearchText={getEntryName}
+      onClickDownload={handleDownload}
+      open={showModal}
+      rows={sample.quarantinedTests}
+      searchPlaceholder="Search test names"
+      setOpen={setModalOpen}
+      subtitle={`${sample.quarantinedTestsSkippedCount} ${pluralize(
+        "test",
+        sample.quarantinedTestsSkippedCount,
+      )} ${
+        sample.quarantinedTestsSkippedCount === 1 ? "was" : "were"
+      } quarantined in TSS when execution ${formatZeroIndexForDisplay(
+        sample.execution,
+      )} of this task ran. This snapshot may not match the current quarantine state.`}
+      totalCount={sample.quarantinedTestsSkippedCount}
+    />
+  );
+};
+
+const getEntryName = ({ displayTestName, testName }: QuarantinedTestEntry) =>
+  displayTestName || testName;
+
+const columns: LGColumnDef<QuarantinedTestEntry>[] = [
+  {
+    id: "testName",
+    header: "Test Name",
+    accessorFn: getEntryName,
+    cell: ({ getValue }) => <WordBreak>{getValue() as string}</WordBreak>,
+  },
+];

--- a/apps/spruce/src/pages/task/taskTabs/testsTable/QuarantinedTests/utils.ts
+++ b/apps/spruce/src/pages/task/taskTabs/testsTable/QuarantinedTests/utils.ts
@@ -1,0 +1,40 @@
+import { TaskQuarantinedTestsSampleQuery } from "gql/generated/types";
+
+export type QuarantinedTestsSample = NonNullable<
+  TaskQuarantinedTestsSampleQuery["taskQuarantinedTestsSample"]
+>[number];
+
+// Matches the backend's default sample size; the modal points to the JSON
+// download for anything beyond it.
+export const MODAL_DISPLAY_LIMIT = 50;
+
+// The backend caps stored entries well below this, so fetching with this
+// limit returns the entire stored list.
+export const FULL_LIST_LIMIT = 100000;
+
+export const buildQuarantinedTestsJson = (sample: QuarantinedTestsSample) => ({
+  taskId: sample.taskId,
+  execution: sample.execution,
+  quarantinedTestsSkippedCount: sample.quarantinedTestsSkippedCount,
+  truncated:
+    sample.quarantinedTests.length < sample.quarantinedTestsSkippedCount,
+  quarantinedTests: sample.quarantinedTests.map(
+    ({ displayTestName, testName }) => ({
+      testName,
+      ...(displayTestName && { displayTestName }),
+    }),
+  ),
+});
+
+export const downloadJsonBlob = (payload: object, filename: string) => {
+  const element = document.createElement("a");
+  const file = new Blob([JSON.stringify(payload, null, 2)], {
+    type: "application/json",
+  });
+  element.href = URL.createObjectURL(file);
+  element.download = filename;
+  document.body.appendChild(element);
+  element.click();
+  URL.revokeObjectURL(element.href);
+  document.body.removeChild(element);
+};

--- a/apps/spruce/src/pages/task/taskTabs/testsTable/TestsTable.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/testsTable/TestsTable.tsx
@@ -35,6 +35,7 @@ import {
 } from "types/task";
 import { queryString } from "utils";
 import { getColumnsTemplate } from "./getColumnsTemplate";
+import { QuarantinedTests } from "./QuarantinedTests";
 
 const { getLimit, getPage, getString, parseSortString, queryParamAsNumber } =
   queryString;
@@ -178,34 +179,37 @@ const TestsTable: React.FC<TestsTableProps> = ({ task }) => {
   });
 
   return (
-    <TableWrapper
-      controls={
-        <TableControl
-          filteredCount={filteredTestCount}
-          label="tests"
+    <>
+      <QuarantinedTests task={task} />
+      <TableWrapper
+        controls={
+          <TableControl
+            filteredCount={filteredTestCount}
+            label="tests"
+            // @ts-expect-error: FIXME. This comment was added by an automated script.
+            limit={limitNum}
+            onClear={clearQueryParams}
+            onPageSizeChange={() => {
+              sendEvent({ name: "Changed page size" });
+            }}
+            // @ts-expect-error: FIXME. This comment was added by an automated script.
+            page={pageNum}
+            totalCount={totalTestCount}
+          />
+        }
+        shouldShowBottomTableControl={filteredTestCount > 10}
+      >
+        <BaseTable
+          data-cy="tests-table"
+          data-loading={isLoading}
+          loading={isLoading}
           // @ts-expect-error: FIXME. This comment was added by an automated script.
-          limit={limitNum}
-          onClear={clearQueryParams}
-          onPageSizeChange={() => {
-            sendEvent({ name: "Changed page size" });
-          }}
-          // @ts-expect-error: FIXME. This comment was added by an automated script.
-          page={pageNum}
-          totalCount={totalTestCount}
+          loadingRows={limitNum}
+          shouldAlternateRowColor
+          table={table}
         />
-      }
-      shouldShowBottomTableControl={filteredTestCount > 10}
-    >
-      <BaseTable
-        data-cy="tests-table"
-        data-loading={isLoading}
-        loading={isLoading}
-        // @ts-expect-error: FIXME. This comment was added by an automated script.
-        loadingRows={limitNum}
-        shouldAlternateRowColor
-        table={table}
-      />
-    </TableWrapper>
+      </TableWrapper>
+    </>
   );
 };
 

--- a/apps/spruce/src/types/task.ts
+++ b/apps/spruce/src/types/task.ts
@@ -63,6 +63,7 @@ export enum LogTypes {
 
 export enum QueryParams {
   LogType = "logtype",
+  QuarantinedTests = "quarantinedTests",
   TaskId = "taskId",
 }
 

--- a/packages/lib/src/gql/generated/types.ts
+++ b/packages/lib/src/gql/generated/types.ts
@@ -3139,6 +3139,13 @@ export type QuarantineVariantInput = {
   projectIdentifier: Scalars["String"]["input"];
 };
 
+/** QuarantinedTest represents a test skipped because it was quarantined in TSS at execution time. */
+export type QuarantinedTest = {
+  __typename?: "QuarantinedTest";
+  displayTestName?: Maybe<Scalars["String"]["output"]>;
+  testName: Scalars["String"]["output"];
+};
+
 export type Query = {
   __typename?: "Query";
   adminEvents: AdminEventsPayload;
@@ -3180,6 +3187,7 @@ export type Query = {
   taskHistory: TaskHistory;
   taskHistoryByCreateTime: TaskHistoryByCreateTime;
   taskNamesForBuildVariant?: Maybe<Array<Scalars["String"]["output"]>>;
+  taskQuarantinedTestsSample?: Maybe<Array<TaskQuarantinedTestsSample>>;
   taskQueueDistros: Array<TaskQueueDistro>;
   taskTestSample?: Maybe<Array<TaskTestResultSample>>;
   user: User;
@@ -3318,6 +3326,12 @@ export type QueryTaskHistoryByCreateTimeArgs = {
 export type QueryTaskNamesForBuildVariantArgs = {
   buildVariant: Scalars["String"]["input"];
   projectIdentifier: Scalars["String"]["input"];
+};
+
+export type QueryTaskQuarantinedTestsSampleArgs = {
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  taskIds: Array<Scalars["String"]["input"]>;
+  versionId: Scalars["String"]["input"];
 };
 
 export type QueryTaskTestSampleArgs = {
@@ -4173,6 +4187,8 @@ export type Task = {
   prevTaskPassing?: Maybe<Task>;
   priority?: Maybe<Scalars["Int"]["output"]>;
   project?: Maybe<Project>;
+  /** quarantinedTestsSkippedCount is the number of tests this execution skipped because they were quarantined in TSS at execution time. */
+  quarantinedTestsSkippedCount: Scalars["Int"]["output"];
   requester: Scalars["String"]["output"];
   resetWhenFinished: Scalars["Boolean"]["output"];
   revision?: Maybe<Scalars["String"]["output"]>;
@@ -4436,6 +4452,18 @@ export type TaskQuarantineEntry = {
   __typename?: "TaskQuarantineEntry";
   taskName: Scalars["String"]["output"];
   tests: Array<TestQuarantineEntry>;
+};
+
+/**
+ * TaskQuarantinedTestsSample is the return value for the taskQuarantinedTestsSample query.
+ * It contains the execution-time snapshot of tests skipped because they were quarantined in TSS.
+ */
+export type TaskQuarantinedTestsSample = {
+  __typename?: "TaskQuarantinedTestsSample";
+  execution: Scalars["Int"]["output"];
+  quarantinedTests: Array<QuarantinedTest>;
+  quarantinedTestsSkippedCount: Scalars["Int"]["output"];
+  taskId: Scalars["String"]["output"];
 };
 
 /**
@@ -4957,6 +4985,8 @@ export type Version = {
   predictedCost?: Maybe<Cost>;
   previousVersion?: Maybe<Version>;
   projectMetadata?: Maybe<Project>;
+  /** quarantinedTestsSkippedCount is the number of tests skipped across the version's tasks because they were quarantined in TSS at execution time. */
+  quarantinedTestsSkippedCount: Scalars["Int"]["output"];
   repo: Scalars["String"]["output"];
   requester: Scalars["String"]["output"];
   revision: Scalars["String"]["output"];


### PR DESCRIPTION
DEVPROD-34789

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->

<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
Adding visibility to skipped tests due to TSS on the task level.

- Added TSS skipped count on the Task's metadata UI
- Added skipped TSS tests modal where you can search and download the skipped tests.
- Added unit tests and storybooks


### Screenshots
From storybook

Inlined on Task metadata section
<img width="441" height="215" alt="Screenshot 2026-07-13 at 3 54 27 PM" src="https://github.com/user-attachments/assets/e3664f38-d1bd-424d-a801-5a08e34b7345" />

Modal when you click on the above text.
<img width="1016" height="826" alt="Screenshot 2026-07-13 at 3 53 39 PM" src="https://github.com/user-attachments/assets/7d1237ac-bd48-4640-b5f1-2934d55b312d" />

### Testing
* Unit tests
* Story tests/local smoke tests