### PR TITLE
DEVPROD-32420: Fix taskhistory background polling

### DIFF
--- a/apps/spruce/src/gql/client/link/pausePollingLink.test.ts
+++ b/apps/spruce/src/gql/client/link/pausePollingLink.test.ts
@@ -154,6 +154,33 @@ describe("pausePollingLink", () => {
     });
   });
 
+  it("delays a TaskHistory request when tab is inactive", async () => {
+    documentHiddenSpy.mockReturnValue(true);
+    navigatorOnlineSpy.mockReturnValue(true);
+
+    const observer = { next: vi.fn(), error: vi.fn(), complete: vi.fn() };
+
+    execute(
+      ApolloLink.from([pausePollingLink, mockHttpLink]),
+      {
+        query: gql`
+          query TaskHistory {
+            someData {
+              id
+              name
+            }
+          }
+        `,
+      },
+      { client: mockClient },
+    ).subscribe(observer);
+
+    expect(mockForward).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(observer.next).not.toHaveBeenCalled();
+    });
+  });
+
   it("ignores queries that are not in pauseableQueries", async () => {
     documentHiddenSpy.mockReturnValue(true);
     navigatorOnlineSpy.mockReturnValue(true);

--- a/apps/spruce/src/gql/client/link/pausePollingLink.ts
+++ b/apps/spruce/src/gql/client/link/pausePollingLink.ts
@@ -41,4 +41,4 @@ export const pausePollingLink = new ApolloLink((operation, forward) => {
   return forward(operation);
 });
 
-const pauseableQueries = ["Waterfall"];
+const pauseableQueries = ["Waterfall", "TaskHistory"];


### PR DESCRIPTION
DEVPROD-32420

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->

<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
<!-- add description, context, thought process, etc -->
Prevent TaskHistory query from polling when the tab is inactive via `pausePollingLink`

### Testing
<!-- add a description of how you tested it -->
- Tested locally
- Added unit test