### PR TITLE
DEVPROD-36871: Add translate project cache bytes limit to admin settings

### DIFF
--- a/apps/parsley/src/gql/generated/types.ts
+++ b/apps/parsley/src/gql/generated/types.ts
@@ -3736,6 +3736,7 @@ export type SchedulerConfig = {
   stepbackTaskFactor?: Maybe<Scalars["Int"]["output"]>;
   targetTimeSeconds?: Maybe<Scalars["Int"]["output"]>;
   taskFinder?: Maybe<FinderVersion>;
+  translateProjectCacheBytesLimit?: Maybe<Scalars["Int"]["output"]>;
   translateProjectConcurrencyLimit?: Maybe<Scalars["Int"]["output"]>;
 };
 
@@ -3758,6 +3759,7 @@ export type SchedulerConfigInput = {
   stepbackTaskFactor: Scalars["Int"]["input"];
   targetTimeSeconds: Scalars["Int"]["input"];
   taskFinder: FinderVersion;
+  translateProjectCacheBytesLimit?: InputMaybe<Scalars["Int"]["input"]>;
   translateProjectConcurrencyLimit?: InputMaybe<Scalars["Int"]["input"]>;
 };
 

--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -3733,6 +3733,7 @@ export type SchedulerConfig = {
   stepbackTaskFactor?: Maybe<Scalars["Int"]["output"]>;
   targetTimeSeconds?: Maybe<Scalars["Int"]["output"]>;
   taskFinder?: Maybe<FinderVersion>;
+  translateProjectCacheBytesLimit?: Maybe<Scalars["Int"]["output"]>;
   translateProjectConcurrencyLimit?: Maybe<Scalars["Int"]["output"]>;
 };
 
@@ -3755,6 +3756,7 @@ export type SchedulerConfigInput = {
   stepbackTaskFactor: Scalars["Int"]["input"];
   targetTimeSeconds: Scalars["Int"]["input"];
   taskFinder: FinderVersion;
+  translateProjectCacheBytesLimit?: InputMaybe<Scalars["Int"]["input"]>;
   translateProjectConcurrencyLimit?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
@@ -7181,6 +7183,7 @@ export type SaveAdminSettingsMutation = {
       targetTimeSeconds?: number | null;
       taskFinder?: FinderVersion | null;
       translateProjectConcurrencyLimit?: number | null;
+      translateProjectCacheBytesLimit?: number | null;
     } | null;
     taskLimits?: {
       __typename?: "TaskLimitsConfig";
@@ -7971,6 +7974,7 @@ export type AdminSettingsQuery = {
       targetTimeSeconds?: number | null;
       taskFinder?: FinderVersion | null;
       translateProjectConcurrencyLimit?: number | null;
+      translateProjectCacheBytesLimit?: number | null;
     } | null;
     singleTaskDistro?: {
       __typename?: "SingleTaskDistroConfig";

--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -7182,8 +7182,8 @@ export type SaveAdminSettingsMutation = {
       stepbackTaskFactor?: number | null;
       targetTimeSeconds?: number | null;
       taskFinder?: FinderVersion | null;
-      translateProjectConcurrencyLimit?: number | null;
       translateProjectCacheBytesLimit?: number | null;
+      translateProjectConcurrencyLimit?: number | null;
     } | null;
     taskLimits?: {
       __typename?: "TaskLimitsConfig";
@@ -7973,8 +7973,8 @@ export type AdminSettingsQuery = {
       stepbackTaskFactor?: number | null;
       targetTimeSeconds?: number | null;
       taskFinder?: FinderVersion | null;
-      translateProjectConcurrencyLimit?: number | null;
       translateProjectCacheBytesLimit?: number | null;
+      translateProjectConcurrencyLimit?: number | null;
     } | null;
     singleTaskDistro?: {
       __typename?: "SingleTaskDistroConfig";

--- a/apps/spruce/src/gql/mutations/save-admin-settings.ts
+++ b/apps/spruce/src/gql/mutations/save-admin-settings.ts
@@ -74,6 +74,7 @@ export const SAVE_ADMIN_SETTINGS = gql`
         stepbackTaskFactor
         targetTimeSeconds
         taskFinder
+        translateProjectCacheBytesLimit
         translateProjectConcurrencyLimit
       }
       taskLimits {

--- a/apps/spruce/src/gql/queries/admin-settings.ts
+++ b/apps/spruce/src/gql/queries/admin-settings.ts
@@ -340,6 +340,7 @@ export const ADMIN_SETTINGS = gql`
         stepbackTaskFactor
         targetTimeSeconds
         taskFinder
+        translateProjectCacheBytesLimit
         translateProjectConcurrencyLimit
       }
 

--- a/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/RunnersTab/schemaFields.ts
+++ b/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/RunnersTab/schemaFields.ts
@@ -279,6 +279,12 @@ export const scheduler = {
       default: 0,
       minimum: 0,
     },
+    translateProjectCacheBytesLimit: {
+      type: "number" as const,
+      title: "Translate Project Cache Bytes Limit",
+      default: 0,
+      minimum: 0,
+    },
     groupVersions: {
       type: "boolean" as const,
       title: "Group Versions",
@@ -332,6 +338,10 @@ export const scheduler = {
     translateProjectConcurrencyLimit: {
       "ui:description":
         "Maximum number of project configs translated concurrently. 0 means unlimited.",
+    },
+    translateProjectCacheBytesLimit: {
+      "ui:description":
+        "Byte budget for the project translation cache, measured against each entry's serialized size. 0 uses the built-in default.",
     },
     groupVersions: {
       "ui:fieldCss": fullWidthCss,

--- a/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/RunnersTab/transformers.test.ts
+++ b/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/RunnersTab/transformers.test.ts
@@ -66,6 +66,7 @@ const form: RunnersFormState = {
       numDependentsFactor: 1,
       stepbackTaskFactor: 1,
       translateProjectConcurrencyLimit: 1,
+      translateProjectCacheBytesLimit: 1,
     },
     repotracker: {
       numNewRepoRevisionsToFetch: 1,
@@ -124,6 +125,7 @@ const gql: AdminSettingsInput = {
     numDependentsFactor: 1,
     stepbackTaskFactor: 1,
     translateProjectConcurrencyLimit: 1,
+    translateProjectCacheBytesLimit: 1,
   },
   repotracker: {
     numNewRepoRevisionsToFetch: 1,

--- a/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/RunnersTab/transformers.ts
+++ b/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/RunnersTab/transformers.ts
@@ -57,6 +57,7 @@ export const gqlToForm = ((data) => {
     stepbackTaskFactor,
     targetTimeSeconds,
     taskFinder,
+    translateProjectCacheBytesLimit,
     translateProjectConcurrencyLimit,
   } = scheduler ?? {};
 
@@ -117,6 +118,7 @@ export const gqlToForm = ((data) => {
         numDependentsFactor: numDependentsFactor ?? 0,
         stepbackTaskFactor: stepbackTaskFactor ?? 0,
         translateProjectConcurrencyLimit: translateProjectConcurrencyLimit ?? 0,
+        translateProjectCacheBytesLimit: translateProjectCacheBytesLimit ?? 0,
       },
       repotracker: {
         numNewRepoRevisionsToFetch: numNewRepoRevisionsToFetch ?? 0,

--- a/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/RunnersTab/types.ts
+++ b/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/RunnersTab/types.ts
@@ -51,6 +51,7 @@ export interface RunnersFormState {
       stepbackTaskFactor: number;
       numDependentsFactor: number;
       translateProjectConcurrencyLimit: number;
+      translateProjectCacheBytesLimit: number;
       groupVersions: boolean;
     };
     repotracker: {

--- a/apps/spruce/src/pages/adminSettings/tabs/testData.ts
+++ b/apps/spruce/src/pages/adminSettings/tabs/testData.ts
@@ -50,6 +50,7 @@ export const adminSettings: NonNullable<AdminSettingsQuery["adminSettings"]> = {
     targetTimeSeconds: 1,
     taskFinder: FinderVersion.Parallel,
     translateProjectConcurrencyLimit: 1,
+    translateProjectCacheBytesLimit: 1,
   },
   taskLimits: {
     maxConcurrentLargeParserProjectTasks: 1,

--- a/packages/lib/src/gql/generated/types.ts
+++ b/packages/lib/src/gql/generated/types.ts
@@ -3736,6 +3736,7 @@ export type SchedulerConfig = {
   stepbackTaskFactor?: Maybe<Scalars["Int"]["output"]>;
   targetTimeSeconds?: Maybe<Scalars["Int"]["output"]>;
   taskFinder?: Maybe<FinderVersion>;
+  translateProjectCacheBytesLimit?: Maybe<Scalars["Int"]["output"]>;
   translateProjectConcurrencyLimit?: Maybe<Scalars["Int"]["output"]>;
 };
 
@@ -3758,6 +3759,7 @@ export type SchedulerConfigInput = {
   stepbackTaskFactor: Scalars["Int"]["input"];
   targetTimeSeconds: Scalars["Int"]["input"];
   taskFinder: FinderVersion;
+  translateProjectCacheBytesLimit?: InputMaybe<Scalars["Int"]["input"]>;
   translateProjectConcurrencyLimit?: InputMaybe<Scalars["Int"]["input"]>;
 };
 


### PR DESCRIPTION
DEVPROD-36871

### Description
Adds the `translateProjectCacheBytesLimit` field to the Runners tab of the admin settings page, exposing the new byte budget for the project translation cache.

### Testing
Added

### Evergreen PR
https://github.com/evergreen-ci/evergreen/pull/10447