### PR TITLE
DEVPROD-36642: Delete unused fields from `BuildBaron` query

### DIFF
--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -8205,9 +8205,7 @@ export type BuildBaronQuery = {
     buildBaronConfigured: boolean;
     searchReturnInfo?: {
       __typename?: "SearchReturnInfo";
-      featuresURL: string;
       search: string;
-      source: string;
       issues: Array<{
         __typename?: "JiraTicket";
         key: string;

--- a/apps/spruce/src/gql/queries/build-baron.ts
+++ b/apps/spruce/src/gql/queries/build-baron.ts
@@ -6,7 +6,6 @@ export const BUILD_BARON = gql`
       bbTicketCreationDefined
       buildBaronConfigured
       searchReturnInfo {
-        featuresURL
         issues {
           fields {
             assigneeDisplayName
@@ -22,7 +21,6 @@ export const BUILD_BARON = gql`
           key
         }
         search
-        source
       }
     }
   }

--- a/apps/spruce/src/pages/task/taskTabs/buildBaronAndAnnotations/BuildBaron.test.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/buildBaronAndAnnotations/BuildBaron.test.tsx
@@ -147,6 +147,7 @@ const buildBaronQuery: BuildBaronQuery = {
     bbTicketCreationDefined: true,
     searchReturnInfo: {
       __typename: "SearchReturnInfo",
+      search: "test search string",
       issues: [
         {
           __typename: "JiraTicket",
@@ -200,10 +201,6 @@ const buildBaronQuery: BuildBaronQuery = {
           },
         },
       ],
-      search:
-        '(project in (EVG)) and ( text~"docker\\\\-cleanup" ) order by updatedDate desc',
-      source: "JIRA",
-      featuresURL: "",
     },
   },
 };

--- a/apps/spruce/src/pages/task/taskTabs/buildBaronAndAnnotations/BuildBaronContent.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/buildBaronAndAnnotations/BuildBaronContent.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { useQuery } from "@apollo/client/react";
 import { useErrorToast } from "@evg-ui/lib/hooks";
 import {
-  BuildBaron,
+  BuildBaronQuery,
   Annotation,
   CustomCreatedIssuesQuery,
   CustomCreatedIssuesQueryVariables,
@@ -16,7 +16,7 @@ import { Issues, SuspectedIssues } from "./Issues";
 import JiraIssueTable from "./JiraIssueTable";
 
 interface BuildBaronCoreProps {
-  bbData: BuildBaron;
+  bbData: BuildBaronQuery["buildBaron"];
   taskId: string;
   execution: number;
   annotation: Annotation;

--- a/apps/spruce/src/pages/task/taskTabs/buildBaronAndAnnotations/JiraIssueTable/index.tsx
+++ b/apps/spruce/src/pages/task/taskTabs/buildBaronAndAnnotations/JiraIssueTable/index.tsx
@@ -1,12 +1,12 @@
 import { StyledLink } from "@evg-ui/lib/components/styles";
 import { getJiraSearchUrl } from "constants/externalResources";
-import { BuildBaron } from "gql/generated/types";
+import { BuildBaronQuery } from "gql/generated/types";
 import { useSpruceConfig } from "hooks";
 import { TicketsTitle } from "../BBComponents";
 import JiraTicketList from "../JiraTicketList";
 
 interface JiraIssueTableProps {
-  bbData: BuildBaron;
+  bbData: BuildBaronQuery["buildBaron"];
 }
 const JiraIssueTable: React.FC<JiraIssueTableProps> = ({ bbData }) => {
   const spruceConfig = useSpruceConfig();


### PR DESCRIPTION
DEVPROD-36642

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->

<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
Deletes some unused fields from Build Baron query.

### Evergreen PR
* evergreen-ci/evergreen/pull/10448
