### PR TITLE
DEVPROD-36433: Disable spawnable checkbox for single task distros

### DIFF
--- a/apps/spruce/playwright/tests/distroSettings/general_section.spec.ts
+++ b/apps/spruce/playwright/tests/distroSettings/general_section.spec.ts
@@ -70,7 +70,7 @@ test.describe("general section", () => {
       await expect(singleTaskCheckbox).toBeEnabled();
       await clickCheckbox(singleTaskCheckbox);
       await expect(page.getByTestId("single-task-banner")).toContainText(
-        "This Distro will be converted to a Single Task Distro once saved. The distro will become unspawnable for personal use. Please review before confirming.",
+        "This distro will be converted to a Single Task Distro once saved and will become unspawnable for personal use. Please review before confirming.",
       );
       await save(page);
       await expect(page.getByTestId("single-task-banner")).toHaveCount(0);
@@ -83,7 +83,7 @@ test.describe("general section", () => {
       await expect(singleTaskCheckbox).toBeEnabled();
       await clickCheckbox(singleTaskCheckbox);
       await expect(page.getByTestId("single-task-banner")).toContainText(
-        "This Distro will no longer be a Single Task Distro once saved. Please review before confirming.",
+        "This distro will no longer be a Single Task Distro once saved. Please review before confirming.",
       );
       await save(page);
       await expect(page.getByTestId("single-task-banner")).toHaveCount(0);

--- a/apps/spruce/playwright/tests/distroSettings/general_section.spec.ts
+++ b/apps/spruce/playwright/tests/distroSettings/general_section.spec.ts
@@ -70,7 +70,7 @@ test.describe("general section", () => {
       await expect(singleTaskCheckbox).toBeEnabled();
       await clickCheckbox(singleTaskCheckbox);
       await expect(page.getByTestId("single-task-banner")).toContainText(
-        "This Distro will be converted to a Single Task Distro once saved. Please review before confirming.",
+        "This Distro will be converted to a Single Task Distro once saved. The distro will become unspawnable for personal use. Please review before confirming.",
       );
       await save(page);
       await expect(page.getByTestId("single-task-banner")).toHaveCount(0);

--- a/apps/spruce/playwright/tests/distroSettings/single_task_distro.spec.ts
+++ b/apps/spruce/playwright/tests/distroSettings/single_task_distro.spec.ts
@@ -1,4 +1,6 @@
 import { test, expect } from "../../fixtures";
+import { clickCheckbox, validateToast } from "../../helpers";
+import { save } from "./utils";
 
 test.describe("single task distro", () => {
   test("should render allowed projects and tasks", async ({ page }) => {
@@ -29,5 +31,32 @@ test.describe("single task distro", () => {
     await expect(inputs.nth(5)).toHaveValue("spruce");
     await expect(inputs.nth(6)).toHaveValue("lint");
     await expect(inputs.nth(7)).toHaveValue("storybook");
+  });
+
+  test("disables spawnable checkbox when distro is a single task distro", async ({
+    page,
+  }) => {
+    await page.goto("/distro/ubuntu1604-small/settings/host");
+    await expect(page.getByTestId("distro-settings-page")).toBeVisible();
+    const spawnableCheckbox = page.getByRole("checkbox", {
+      name: "Spawnable",
+    });
+    await expect(spawnableCheckbox).toBeEnabled();
+    await expect(spawnableCheckbox).toBeChecked();
+
+    await page.getByTestId("navitem-general").click();
+    await expect(page).toHaveURL("/distro/ubuntu1604-small/settings/general");
+    const singleTaskCheckbox = page.getByRole("checkbox", {
+      name: "Set distro as Single Task Distro",
+    });
+    await expect(singleTaskCheckbox).not.toBeChecked();
+    await clickCheckbox(singleTaskCheckbox);
+    await save(page);
+    await validateToast(page, "success", "Updated distro.");
+
+    await page.getByTestId("navitem-host").click();
+    await expect(page).toHaveURL("/distro/ubuntu1604-small/settings/host");
+    await expect(spawnableCheckbox).toBeDisabled();
+    await expect(spawnableCheckbox).not.toBeChecked();
   });
 });

--- a/apps/spruce/src/pages/distroSettings/Tabs.tsx
+++ b/apps/spruce/src/pages/distroSettings/Tabs.tsx
@@ -20,7 +20,7 @@ import { gqlToFormMap } from "./tabs/transformers";
 import { FormStateMap } from "./tabs/types";
 
 interface Props {
-  distro: DistroQuery["distro"];
+  distro: NonNullable<DistroQuery["distro"]>;
 }
 
 export const DistroSettingsTabs: React.FC<Props> = ({ distro }) => {
@@ -50,7 +50,6 @@ export const DistroSettingsTabs: React.FC<Props> = ({ distro }) => {
           element={
             <GeneralTab
               distroData={tabData[DistroSettingsTabRoutes.General]}
-              // @ts-expect-error: FIXME. This comment was added by an automated script.
               minimumHosts={distro.hostAllocatorSettings.minimumHosts}
             />
           }
@@ -69,7 +68,6 @@ export const DistroSettingsTabs: React.FC<Props> = ({ distro }) => {
           element={
             <TaskTab
               distroData={tabData[DistroSettingsTabRoutes.Task]}
-              // @ts-expect-error: FIXME. This comment was added by an automated script.
               provider={distro.provider}
             />
           }
@@ -79,7 +77,7 @@ export const DistroSettingsTabs: React.FC<Props> = ({ distro }) => {
           element={
             <HostTab
               distroData={tabData[DistroSettingsTabRoutes.Host]}
-              // @ts-expect-error: FIXME. This comment was added by an automated script.
+              isSingleTaskDistro={distro.singleTaskDistro}
               provider={distro.provider}
             />
           }

--- a/apps/spruce/src/pages/distroSettings/tabs/GeneralTab/GeneralTab.tsx
+++ b/apps/spruce/src/pages/distroSettings/tabs/GeneralTab/GeneralTab.tsx
@@ -27,7 +27,7 @@ export const GeneralTab: React.FC<TabProps> = ({
   const singleTaskDistroWarnings = useMemo(() => {
     if (!originalSingleTaskDistroValue && currentSingleTaskDistroValue) {
       return [
-        "This Distro will be converted to a Single Task Distro once saved. Please review before confirming.",
+        "This Distro will be converted to a Single Task Distro once saved. The distro will become unspawnable for personal use. Please review before confirming.",
       ];
     } else if (originalSingleTaskDistroValue && !currentSingleTaskDistroValue) {
       return [

--- a/apps/spruce/src/pages/distroSettings/tabs/GeneralTab/GeneralTab.tsx
+++ b/apps/spruce/src/pages/distroSettings/tabs/GeneralTab/GeneralTab.tsx
@@ -27,11 +27,11 @@ export const GeneralTab: React.FC<TabProps> = ({
   const singleTaskDistroWarnings = useMemo(() => {
     if (!originalSingleTaskDistroValue && currentSingleTaskDistroValue) {
       return [
-        "This Distro will be converted to a Single Task Distro once saved. The distro will become unspawnable for personal use. Please review before confirming.",
+        "This distro will be converted to a Single Task Distro once saved and will become unspawnable for personal use. Please review before confirming.",
       ];
     } else if (originalSingleTaskDistroValue && !currentSingleTaskDistroValue) {
       return [
-        "This Distro will no longer be a Single Task Distro once saved. Please review before confirming.",
+        "This distro will no longer be a Single Task Distro once saved. Please review before confirming.",
       ];
     }
     return [];

--- a/apps/spruce/src/pages/distroSettings/tabs/GeneralTab/transformers.test.ts
+++ b/apps/spruce/src/pages/distroSettings/tabs/GeneralTab/transformers.test.ts
@@ -51,6 +51,19 @@ describe("general tab", () => {
       });
     });
   });
+
+  it("sets userSpawnAllowed and isVirtualWorkStation to false when singleTaskDistro is true", () => {
+    const singleTaskForm: GeneralFormState = {
+      ...generalForm,
+      distroOptions: {
+        ...generalForm.distroOptions,
+        singleTaskDistro: true,
+      },
+    };
+    const result = formToGql(singleTaskForm, distroData);
+    expect(result.userSpawnAllowed).toBe(false);
+    expect(result.isVirtualWorkStation).toBe(false);
+  });
 });
 
 const generalForm: GeneralFormState = {

--- a/apps/spruce/src/pages/distroSettings/tabs/GeneralTab/transformers.ts
+++ b/apps/spruce/src/pages/distroSettings/tabs/GeneralTab/transformers.ts
@@ -62,5 +62,9 @@ export const formToGql = ((
   name: distroName.name,
   note: distroOptions.note,
   singleTaskDistro: distroOptions.singleTaskDistro,
+  ...(distroOptions.singleTaskDistro && {
+    userSpawnAllowed: false,
+    isVirtualWorkStation: false,
+  }),
   warningNote: distroOptions.warningNote,
 })) satisfies FormToGqlFunction<Tab>;

--- a/apps/spruce/src/pages/distroSettings/tabs/HostTab/HostTab.tsx
+++ b/apps/spruce/src/pages/distroSettings/tabs/HostTab/HostTab.tsx
@@ -7,14 +7,18 @@ import { BaseTab } from "../BaseTab";
 import { getFormSchema } from "./getFormSchema";
 import { HostFormState, TabProps } from "./types";
 
-export const HostTab: React.FC<TabProps> = ({ distroData, provider }) => {
+export const HostTab: React.FC<TabProps> = ({
+  distroData,
+  isSingleTaskDistro,
+  provider,
+}) => {
   const { getTab } = useDistroSettingsContext();
   const { formData } = getTab(DistroSettingsTabRoutes.Host);
   const architecture = formData?.setup?.arch;
 
   const formSchema = useMemo(
-    () => getFormSchema({ architecture, provider }),
-    [architecture, provider],
+    () => getFormSchema({ architecture, isSingleTaskDistro, provider }),
+    [architecture, isSingleTaskDistro, provider],
   );
 
   return (

--- a/apps/spruce/src/pages/distroSettings/tabs/HostTab/getFormSchema.tsx
+++ b/apps/spruce/src/pages/distroSettings/tabs/HostTab/getFormSchema.tsx
@@ -14,11 +14,13 @@ import {
 
 type FormSchemaParams = {
   architecture: Arch;
+  isSingleTaskDistro: boolean;
   provider: Provider;
 };
 
 export const getFormSchema = ({
   architecture,
+  isSingleTaskDistro,
   provider,
 }: FormSchemaParams): ReturnType<GetFormSchema> => {
   const hasStaticProvider = provider === Provider.Static;
@@ -123,7 +125,11 @@ export const getFormSchema = ({
       },
     },
     uiSchema: {
-      setup: setup.uiSchema(architecture, hasStaticProvider),
+      setup: setup.uiSchema(
+        architecture,
+        hasStaticProvider,
+        isSingleTaskDistro,
+      ),
       bootstrapSettings: bootstrapProperties.uiSchema(architecture),
       sshConfig: sshConfigProperties.uiSchema(hasStaticProvider),
       allocation: allocationProperties.uiSchema(

--- a/apps/spruce/src/pages/distroSettings/tabs/HostTab/schemaFields.tsx
+++ b/apps/spruce/src/pages/distroSettings/tabs/HostTab/schemaFields.tsx
@@ -118,7 +118,7 @@ const userSpawnAllowed = {
     }),
     ...(isSingleTaskDistro && {
       "ui:disabled": true,
-      "ui:tooltipDescription": "Single-task distros are not spawnable.",
+      "ui:tooltipDescription": "Single task distros are not spawnable.",
     }),
     "ui:description": "Allow users to spawn these hosts for personal use.",
     "ui:bold": true,

--- a/apps/spruce/src/pages/distroSettings/tabs/HostTab/schemaFields.tsx
+++ b/apps/spruce/src/pages/distroSettings/tabs/HostTab/schemaFields.tsx
@@ -111,10 +111,14 @@ const userSpawnAllowed = {
     type: "boolean" as const,
     title: "Spawnable",
   },
-  uiSchema: (hasStaticProvider: boolean) => ({
+  uiSchema: (hasStaticProvider: boolean, isSingleTaskDistro: boolean) => ({
     ...(hasStaticProvider && {
       "ui:disabled": true,
       "ui:tooltipDescription": "Static distros are not spawnable.",
+    }),
+    ...(isSingleTaskDistro && {
+      "ui:disabled": true,
+      "ui:tooltipDescription": "Single-task distros are not spawnable.",
     }),
     "ui:description": "Allow users to spawn these hosts for personal use.",
     "ui:bold": true,
@@ -586,7 +590,11 @@ export const setup = {
     mountpoints: mountpoints.schema,
     userSpawnAllowed: userSpawnAllowed.schema,
   },
-  uiSchema: (architecture: Arch, hasStaticProvider: boolean) => ({
+  uiSchema: (
+    architecture: Arch,
+    hasStaticProvider: boolean,
+    isSingleTaskDistro: boolean,
+  ) => ({
     "ui:ObjectFieldTemplate": CardFieldTemplate,
     bootstrapMethod: bootstrapMethod.uiSchema,
     communicationMethod: communicationMethod.uiSchema,
@@ -595,7 +603,10 @@ export const setup = {
     workDir: workDir.uiSchema,
     setupScript: setupScript.uiSchema,
     mountpoints: mountpoints.uiSchema,
-    userSpawnAllowed: userSpawnAllowed.uiSchema(hasStaticProvider),
+    userSpawnAllowed: userSpawnAllowed.uiSchema(
+      hasStaticProvider,
+      isSingleTaskDistro,
+    ),
     isVirtualWorkStation: isVirtualWorkStation.uiSchema(architecture),
     icecreamSchedulerHost: icecreamSchedulerHost.uiSchema,
     icecreamConfigPath: icecreamConfigPath.uiSchema,

--- a/apps/spruce/src/pages/distroSettings/tabs/HostTab/types.ts
+++ b/apps/spruce/src/pages/distroSettings/tabs/HostTab/types.ts
@@ -68,5 +68,6 @@ export interface HostFormState {
 
 export type TabProps = {
   distroData: HostFormState;
+  isSingleTaskDistro: boolean;
   provider: Provider;
 };


### PR DESCRIPTION
DEVPROD-36433

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->

<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
Two changes:
* Make the spawnable checkbox disabled if a distro is a single task distro.
* If a distro is being changed to be a single task distro, set its spawnable field to false.

Distro creation is not an issue because the distro will be `spawnable: false` by default ([source](https://github.com/evergreen-ci/evergreen/blob/02c79860dc8f9c1fdb867bdb6f46d01fc10796ca/rest/data/distro.go#L125-L149)).

### Before Merge
<s>Before merging, I will run a migration script to fix all existing distros with this error. I will use the ops channel to ask for LGTM.</s> **Done**.

### Testing
- Unit and e2e tests
