### PR TITLE
DEVPROD-35447: Fail deploy script on typecheck and node errors

### DIFF
--- a/apps/spruce/package.json
+++ b/apps/spruce/package.json
@@ -9,7 +9,7 @@
     "build:local": "env-cmd -e local pnpm build",
     "build:prod": "env-cmd -e production pnpm build",
     "build:staging": "env-cmd -e staging pnpm build",
-    "build": "VITE_GIT_SHA=`git rev-parse HEAD` VITE_APP_VERSION=$npm_package_version vite build",
+    "build": "tsc && VITE_GIT_SHA=`git rev-parse HEAD` VITE_APP_VERSION=$npm_package_version vite build",
     "build:profiler:beta": "PROFILER=true VITE_PROFILE_HEAD='<script src=\"https://localhost:8097\"></script>' pnpm build:beta",
     "build:profiler:local": "PROFILER=true VITE_PROFILE_HEAD='<script src=\"https://localhost:8097\"></script>' pnpm build:local",
     "build:profiler:staging": "PROFILER=true VITE_PROFILE_HEAD='<script src=\"https://localhost:8097\"></script>' pnpm build:staging",

--- a/packages/deploy-utils/src/deploy.ts
+++ b/packages/deploy-utils/src/deploy.ts
@@ -15,18 +15,23 @@ if (!isTargetEnvironment(target)) {
   throw Error("VITE_RELEASE_STAGE must be specified");
 }
 
-if (process.argv.includes("--force")) {
-  if (!process.env.BUCKET) {
-    throw Error("Must specify BUCKET as environment variable");
-  }
+try {
+  if (process.argv.includes("--force")) {
+    if (!process.env.BUCKET) {
+      throw Error("Must specify BUCKET as environment variable");
+    }
 
-  buildAndPush(process.env.BUCKET);
-} else if (target === "production") {
-  prepareProdDeploy();
-} else {
-  console.error(
-    red(
-      `Please use Evergreen to deploy. If you need to force a local deploy, add --force.`,
-    ),
-  );
+    buildAndPush(process.env.BUCKET);
+  } else if (target === "production") {
+    await prepareProdDeploy();
+  } else {
+    console.error(
+      red(
+        `Please use Evergreen to deploy. If you need to force a local deploy, add --force.`,
+      ),
+    );
+  }
+} catch (err) {
+  console.error(red(String(err)));
+  process.exit(1);
 }


### PR DESCRIPTION
### Description
The deploy script would continue running (and exit 0) even when it hit a typecheck error or a node error. Two fixes:

- **Spruce's `build` script now runs `tsc` before `vite build`**, mirroring Parsley. Vite strips types without checking them, so a spruce deploy with type errors would previously build and push broken code.
- **`deploy.ts` now awaits `prepareProdDeploy()` and wraps the deploy flow in a try/catch** that logs the error and exits with code 1. Previously the un-awaited async call meant failures surfaced as unhandled promise rejections instead of stopping the script with a nonzero exit.

Replaces #1732 with a fix at the actual failure point rather than skipping hooks on the version commit.

### Screenshots
N/A — deploy tooling change with no UI impact.

### Testing
- `pnpm check-types` and `pnpm test run` pass in `packages/deploy-utils` (52 tests).
- `pnpm build` in `apps/spruce` runs `tsc` first and succeeds; a type error aborts the build before vite runs.

### Evergreen PR
N/A