### PR TITLE
DEVPROD-37078: Add translate project cache TTL to admin settings runners tab

### DIFF
--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -3724,6 +3724,7 @@ export type SchedulerConfig = {
   targetTimeSeconds?: Maybe<Scalars["Int"]["output"]>;
   taskFinder?: Maybe<FinderVersion>;
   translateProjectCacheBytesLimit?: Maybe<Scalars["Int"]["output"]>;
+  translateProjectCacheTTLSeconds?: Maybe<Scalars["Int"]["output"]>;
   translateProjectConcurrencyLimit?: Maybe<Scalars["Int"]["output"]>;
 };
 
@@ -3747,6 +3748,7 @@ export type SchedulerConfigInput = {
   targetTimeSeconds: Scalars["Int"]["input"];
   taskFinder: FinderVersion;
   translateProjectCacheBytesLimit?: InputMaybe<Scalars["Int"]["input"]>;
+  translateProjectCacheTTLSeconds?: InputMaybe<Scalars["Int"]["input"]>;
   translateProjectConcurrencyLimit?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
@@ -7172,6 +7174,7 @@ export type SaveAdminSettingsMutation = {
       targetTimeSeconds?: number | null;
       taskFinder?: FinderVersion | null;
       translateProjectCacheBytesLimit?: number | null;
+      translateProjectCacheTTLSeconds?: number | null;
       translateProjectConcurrencyLimit?: number | null;
     } | null;
     taskLimits?: {
@@ -7963,6 +7966,7 @@ export type AdminSettingsQuery = {
       targetTimeSeconds?: number | null;
       taskFinder?: FinderVersion | null;
       translateProjectCacheBytesLimit?: number | null;
+      translateProjectCacheTTLSeconds?: number | null;
       translateProjectConcurrencyLimit?: number | null;
     } | null;
     singleTaskDistro?: {

--- a/apps/spruce/src/gql/mutations/save-admin-settings.ts
+++ b/apps/spruce/src/gql/mutations/save-admin-settings.ts
@@ -75,6 +75,7 @@ export const SAVE_ADMIN_SETTINGS = gql`
         targetTimeSeconds
         taskFinder
         translateProjectCacheBytesLimit
+        translateProjectCacheTTLSeconds
         translateProjectConcurrencyLimit
       }
       taskLimits {

--- a/apps/spruce/src/gql/queries/admin-settings.ts
+++ b/apps/spruce/src/gql/queries/admin-settings.ts
@@ -341,6 +341,7 @@ export const ADMIN_SETTINGS = gql`
         targetTimeSeconds
         taskFinder
         translateProjectCacheBytesLimit
+        translateProjectCacheTTLSeconds
         translateProjectConcurrencyLimit
       }
 

--- a/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/RunnersTab/schemaFields.ts
+++ b/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/RunnersTab/schemaFields.ts
@@ -285,6 +285,12 @@ export const scheduler = {
       default: 0,
       minimum: 0,
     },
+    translateProjectCacheTTLSeconds: {
+      type: "number" as const,
+      title: "Translate Project Cache TTL (secs)",
+      default: 0,
+      minimum: 0,
+    },
     groupVersions: {
       type: "boolean" as const,
       title: "Group Versions",
@@ -342,6 +348,10 @@ export const scheduler = {
     translateProjectCacheBytesLimit: {
       "ui:description":
         "Byte budget for the project translation cache, measured against each entry's serialized size. 0 uses the built-in default.",
+    },
+    translateProjectCacheTTLSeconds: {
+      "ui:description":
+        "Lifetime of each project translation cache entry, in seconds. 0 uses the built-in default. Changing this rebuilds the cache.",
     },
     groupVersions: {
       "ui:fieldCss": fullWidthCss,

--- a/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/RunnersTab/transformers.test.ts
+++ b/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/RunnersTab/transformers.test.ts
@@ -67,6 +67,7 @@ const form: RunnersFormState = {
       stepbackTaskFactor: 1,
       translateProjectConcurrencyLimit: 1,
       translateProjectCacheBytesLimit: 1,
+      translateProjectCacheTTLSeconds: 1,
     },
     repotracker: {
       numNewRepoRevisionsToFetch: 1,
@@ -126,6 +127,7 @@ const gql: AdminSettingsInput = {
     stepbackTaskFactor: 1,
     translateProjectConcurrencyLimit: 1,
     translateProjectCacheBytesLimit: 1,
+    translateProjectCacheTTLSeconds: 1,
   },
   repotracker: {
     numNewRepoRevisionsToFetch: 1,

--- a/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/RunnersTab/transformers.ts
+++ b/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/RunnersTab/transformers.ts
@@ -58,6 +58,7 @@ export const gqlToForm = ((data) => {
     targetTimeSeconds,
     taskFinder,
     translateProjectCacheBytesLimit,
+    translateProjectCacheTTLSeconds,
     translateProjectConcurrencyLimit,
   } = scheduler ?? {};
 
@@ -119,6 +120,7 @@ export const gqlToForm = ((data) => {
         stepbackTaskFactor: stepbackTaskFactor ?? 0,
         translateProjectConcurrencyLimit: translateProjectConcurrencyLimit ?? 0,
         translateProjectCacheBytesLimit: translateProjectCacheBytesLimit ?? 0,
+        translateProjectCacheTTLSeconds: translateProjectCacheTTLSeconds ?? 0,
       },
       repotracker: {
         numNewRepoRevisionsToFetch: numNewRepoRevisionsToFetch ?? 0,

--- a/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/RunnersTab/types.ts
+++ b/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/RunnersTab/types.ts
@@ -52,6 +52,7 @@ export interface RunnersFormState {
       numDependentsFactor: number;
       translateProjectConcurrencyLimit: number;
       translateProjectCacheBytesLimit: number;
+      translateProjectCacheTTLSeconds: number;
       groupVersions: boolean;
     };
     repotracker: {

--- a/apps/spruce/src/pages/adminSettings/tabs/testData.ts
+++ b/apps/spruce/src/pages/adminSettings/tabs/testData.ts
@@ -51,6 +51,7 @@ export const adminSettings: NonNullable<AdminSettingsQuery["adminSettings"]> = {
     taskFinder: FinderVersion.Parallel,
     translateProjectConcurrencyLimit: 1,
     translateProjectCacheBytesLimit: 1,
+    translateProjectCacheTTLSeconds: 1,
   },
   taskLimits: {
     maxConcurrentLargeParserProjectTasks: 1,


### PR DESCRIPTION
DEVPROD-37078

### Description
 Adds a new **Translate Project Cache TTL (secs)** field to the Runners tab of the admin settings General page. This exposes the `translateProjectCacheTTLSeconds` scheduler setting, letting admins configure the lifetime of each project translation cache entry from the UI.

### Testing
Added 

### Evergreen PR
https://github.com/evergreen-ci/evergreen/pull/10471