### PR TITLE
PLATFORMS-30919 / PLATFORMS-30918: Container isolation distro settings and task badge

### DIFF
--- a/apps/parsley/src/components/SubHeader/EvergreenTaskSubHeader.test.tsx
+++ b/apps/parsley/src/components/SubHeader/EvergreenTaskSubHeader.test.tsx
@@ -4,7 +4,10 @@ import {
   screen,
   waitFor,
 } from "@evg-ui/lib/test_utils";
+import { ApolloMock } from "@evg-ui/lib/test_utils/types";
 import { LogTypes } from "constants/enums";
+import { TaskQuery, TaskQueryVariables } from "gql/generated/types";
+import { GET_TASK } from "gql/queries";
 import { evergreenTaskMock } from "test_data/task";
 import { EvergreenTaskSubHeader } from "./EvergreenTaskSubHeader";
 
@@ -31,5 +34,83 @@ describe("evergreen task subheader", () => {
     // JustAFakeTestInALonelyWorld test should not be in the document
     expect(screen.queryByText("JustAFakeTestInALonelyWorld")).toBeNull();
     expect(screen.queryByText("test-status-badge")).toBeNull();
+  });
+
+  it("does not render a Container badge for a task that ran on a host", async () => {
+    render(
+      <MockedProvider mocks={[evergreenTaskMock]}>
+        <EvergreenTaskSubHeader
+          execution={0}
+          taskID="spruce_ubuntu1604_check_codegen_d54e2c6ede60e004c48d3c4d996c59579c7bbd1f_22_03_02_15_41_35"
+        />
+      </MockedProvider>,
+    );
+    await waitFor(() => {
+      expect(screen.getByText("check_codegen")).toBeInTheDocument();
+    });
+    expect(
+      screen.queryByDataCy("task-execution-platform-badge"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders a Container badge for a task that ran in a container", async () => {
+    const containerTaskMock: ApolloMock<TaskQuery, TaskQueryVariables> = {
+      request: {
+        query: GET_TASK,
+        variables: {
+          execution: 0,
+          taskId: "a-container-task-id",
+        },
+      },
+      result: {
+        data: {
+          task: {
+            __typename: "Task",
+            details: {
+              description: "",
+              failingCommand: "",
+              status: "success",
+            },
+            displayName: "check_codegen",
+            displayStatus: "failed",
+            execution: 0,
+            executionPlatform: "container",
+            id: "a-container-task-id",
+            logs: {
+              agentLogLink: "log-link.com?type=E",
+              allLogLink: "log-link.com?type=ALL",
+              systemLogLink: "log-link.com?type=S",
+              taskLogLink: "log-link.com?type=T",
+            },
+            patchNumber: 1236,
+            versionMetadata: {
+              __typename: "VersionLite",
+              id: "spruce_d54e2c6ede60e004c48d3c4d996c59579c7bbd1f",
+              isPatch: false,
+              message: "v2.28.5",
+              projectMetadata: {
+                id: "spruce",
+                identifier: "spruce",
+              },
+              revision: "d54e2c6ede60e004c48d3c4d996c59579c7bbd1f",
+            },
+          },
+        },
+      },
+    };
+    render(
+      <MockedProvider mocks={[containerTaskMock]}>
+        <EvergreenTaskSubHeader execution={0} taskID="a-container-task-id" />
+      </MockedProvider>,
+    );
+    await waitFor(() => {
+      expect(screen.getByText("check_codegen")).toBeInTheDocument();
+    });
+    expect(
+      screen.getByDataCy("task-execution-platform-badge"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByDataCy("task-execution-platform-badge"),
+    ).toHaveTextContent("Container");
   });
 });

--- a/apps/parsley/src/components/SubHeader/EvergreenTaskSubHeader.tsx
+++ b/apps/parsley/src/components/SubHeader/EvergreenTaskSubHeader.tsx
@@ -1,4 +1,5 @@
 import { skipToken, useQuery } from "@apollo/client/react";
+import { Badge, Variant } from "@leafygreen-ui/badge";
 import { InlineCode } from "@leafygreen-ui/typography";
 import TaskStatusBadge from "@evg-ui/lib/components/Badge/TaskStatusBadge";
 import TestStatusBadge from "@evg-ui/lib/components/Badge/TestStatusBadge";
@@ -83,6 +84,7 @@ export const EvergreenTaskSubHeader: React.FC<Props> = ({
     displayName,
     displayStatus,
     execution: taskExecution,
+    executionPlatform,
     patchNumber,
     versionMetadata,
   } = taskData;
@@ -113,7 +115,15 @@ export const EvergreenTaskSubHeader: React.FC<Props> = ({
       text: (
         <>
           {trimStringFromMiddle(displayName, 30)}{" "}
-          <TaskStatusBadge status={displayStatus as TaskStatus} />
+          <TaskStatusBadge status={displayStatus as TaskStatus} />{" "}
+          {executionPlatform === "container" && (
+            <Badge
+              data-cy="task-execution-platform-badge"
+              variant={Variant.Blue}
+            >
+              Container
+            </Badge>
+          )}
         </>
       ),
       tooltipText: displayName.length > 30 && displayName,

--- a/apps/parsley/src/gql/fragments/base-task.ts
+++ b/apps/parsley/src/gql/fragments/base-task.ts
@@ -6,6 +6,7 @@ export const BASE_TASK = gql`
     displayName
     displayStatus
     execution
+    executionPlatform
     patchNumber
     versionMetadata: version {
       id

--- a/apps/parsley/src/gql/generated/types.ts
+++ b/apps/parsley/src/gql/generated/types.ts
@@ -444,6 +444,7 @@ export type BootstrapSettings = {
   __typename?: "BootstrapSettings";
   clientDir: Scalars["String"]["output"];
   communication: CommunicationMethod;
+  containerIsolation: ContainerIsolationSettings;
   env: Array<EnvVar>;
   jasperBinaryDir: Scalars["String"]["output"];
   jasperCredentialsPath: Scalars["String"]["output"];
@@ -458,6 +459,7 @@ export type BootstrapSettings = {
 export type BootstrapSettingsInput = {
   clientDir: Scalars["String"]["input"];
   communication: CommunicationMethod;
+  containerIsolation: ContainerIsolationSettingsInput;
   env: Array<EnvVarInput>;
   jasperBinaryDir: Scalars["String"]["input"];
   jasperCredentialsPath: Scalars["String"]["input"];
@@ -632,6 +634,29 @@ export enum CommunicationMethod {
   Rpc = "RPC",
   Ssh = "SSH",
 }
+
+/**
+ * ContainerIsolationSettings controls per-task Docker container isolation for a
+ * distro. When enabled, task subprocess calls (shell.exec, subprocess.exec) run
+ * inside an ephemeral Docker container rather than directly on the host.
+ */
+export type ContainerIsolationSettings = {
+  __typename?: "ContainerIsolationSettings";
+  enabled: Scalars["Boolean"]["output"];
+  image: Scalars["String"]["output"];
+  /**
+   * RequireIsolation opts into fail-closed behavior. When true, container
+   * creation or image-pull failure fails the task immediately rather than
+   * degrading to host-mode. Default (false) is fail-open.
+   */
+  requireIsolation: Scalars["Boolean"]["output"];
+};
+
+export type ContainerIsolationSettingsInput = {
+  enabled: Scalars["Boolean"]["input"];
+  image: Scalars["String"]["input"];
+  requireIsolation: Scalars["Boolean"]["input"];
+};
 
 export type ContainerPool = {
   __typename?: "ContainerPool";
@@ -1940,6 +1965,7 @@ export type Mutation = {
   removePublicKey: Array<PublicKey>;
   removeVolume: Scalars["Boolean"]["output"];
   reprovisionToNew: Scalars["Int"]["output"];
+  resetAPIKey?: Maybe<UserConfig>;
   restartAdminTasks: RestartAdminTasksPayload;
   restartJasper: Scalars["Int"]["output"];
   restartTask: Task;
@@ -4105,6 +4131,12 @@ export type Task = {
   errors?: Maybe<Array<Scalars["String"]["output"]>>;
   estimatedStart?: Maybe<Scalars["Duration"]["output"]>;
   execution: Scalars["Int"]["output"];
+  /**
+   * executionPlatform indicates the environment the task ran in: "host" for a
+   * task that ran directly on the host, or "container" for a task that ran
+   * inside a Docker container on the host.
+   */
+  executionPlatform: Scalars["String"]["output"];
   executionSteps?: Maybe<Array<TaskExecutionStep>>;
   executionTasks?: Maybe<Array<Scalars["String"]["output"]>>;
   executionTasksFull?: Maybe<Array<Task>>;
@@ -5143,6 +5175,7 @@ export type BaseTaskFragment = {
   displayName: string;
   displayStatus: string;
   execution: number;
+  executionPlatform: string;
   patchNumber?: number | null;
   versionMetadata: {
     __typename?: "VersionLite";
@@ -5171,6 +5204,7 @@ export type TaskQuery = {
     displayName: string;
     displayStatus: string;
     execution: number;
+    executionPlatform: string;
     patchNumber?: number | null;
     details?: {
       __typename?: "TaskEndDetail";

--- a/apps/parsley/src/pages/LogView/LoadingPage/useResolveLogURLAndRenderingType.test.tsx
+++ b/apps/parsley/src/pages/LogView/LoadingPage/useResolveLogURLAndRenderingType.test.tsx
@@ -951,6 +951,7 @@ const evergreenTaskMock: ApolloMock<TaskQuery, TaskQueryVariables> = {
         displayName: "check_codegen",
         displayStatus: "failed",
         execution: 0,
+        executionPlatform: "host",
         id: "a-task-id",
         logs: {
           agentLogLink: "agent-link.com?type=E",

--- a/apps/parsley/src/test_data/task.ts
+++ b/apps/parsley/src/test_data/task.ts
@@ -23,6 +23,7 @@ export const evergreenTaskMock: ApolloMock<TaskQuery, TaskQueryVariables> = {
         displayName: "check_codegen",
         displayStatus: "failed",
         execution: 0,
+        executionPlatform: "host",
         id: "spruce_ubuntu1604_check_codegen_d54e2c6ede60e004c48d3c4d996c59579c7bbd1f_22_03_02_15_41_35",
         logs: {
           agentLogLink: "log-link.com?type=E",

--- a/apps/spruce/src/components/SpruceForm/SpruceForm.test.tsx
+++ b/apps/spruce/src/components/SpruceForm/SpruceForm.test.tsx
@@ -244,6 +244,42 @@ describe("spruce form", () => {
       });
     });
 
+    describe("checkbox", () => {
+      it("renders an error banner when validation fails", () => {
+        const validate = vi.fn((_formData, err) => {
+          err.enabled.addError("Some error");
+          return err;
+        });
+
+        const { formData, schema, uiSchema } = checkbox;
+        render(
+          <SpruceForm
+            formData={formData}
+            onChange={vi.fn()}
+            schema={schema}
+            uiSchema={uiSchema}
+            validate={validate}
+          />,
+        );
+        expect(screen.getByDataCy("error-banner")).toHaveTextContent(
+          "Some error",
+        );
+      });
+
+      it("does not render an error banner when there are no errors", () => {
+        const { formData, schema, uiSchema } = checkbox;
+        render(
+          <SpruceForm
+            formData={formData}
+            onChange={vi.fn()}
+            schema={schema}
+            uiSchema={uiSchema}
+          />,
+        );
+        expect(screen.queryByDataCy("error-banner")).not.toBeInTheDocument();
+      });
+    });
+
     describe("select", () => {
       it("renders with the specified default selected", () => {
         const { formData, schema, uiSchema } = select;
@@ -615,6 +651,24 @@ const textArea = (emptyValue?: string) => ({
     },
   },
 });
+
+const checkbox = {
+  formData: { enabled: false },
+  schema: {
+    type: "object" as const,
+    properties: {
+      enabled: {
+        type: "boolean" as const,
+        title: "Enabled",
+      },
+    },
+  },
+  uiSchema: {
+    enabled: {
+      "ui:data-cy": "enabled-checkbox",
+    },
+  },
+};
 
 const select = {
   formData: {},

--- a/apps/spruce/src/components/SpruceForm/Widgets/LeafyGreenWidgets.tsx
+++ b/apps/spruce/src/components/SpruceForm/Widgets/LeafyGreenWidgets.tsx
@@ -106,6 +106,7 @@ export const LeafyGreenCheckBox: React.FC<SpruceWidgetProps> = ({
   label,
   onChange,
   options,
+  rawErrors,
   readonly,
   value,
 }) => {
@@ -119,6 +120,7 @@ export const LeafyGreenCheckBox: React.FC<SpruceWidgetProps> = ({
     tooltipDescription,
     warnings,
   } = options;
+  const { errors, hasError } = processErrors(rawErrors);
   return (
     <ElementWrapper css={elementWrapperCSS} limitMaxWidth>
       <Checkbox
@@ -147,6 +149,11 @@ export const LeafyGreenCheckBox: React.FC<SpruceWidgetProps> = ({
         }
         onChange={(e) => onChange(e.target.checked)}
       />
+      {hasError ? (
+        <StyledBanner data-cy="error-banner" variant="danger">
+          {errors.join(", ")}
+        </StyledBanner>
+      ) : null}
       {warnings?.length ? (
         <StyledBanner
           data-cy={dataCyBanner || "warning-banner"}

--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -4128,6 +4128,12 @@ export type Task = {
   errors?: Maybe<Array<Scalars["String"]["output"]>>;
   estimatedStart?: Maybe<Scalars["Duration"]["output"]>;
   execution: Scalars["Int"]["output"];
+  /**
+   * executionPlatform indicates the environment the task ran in: "host" for a
+   * task that ran directly on the host, or "container" for a task that ran
+   * inside a Docker container on the host.
+   */
+  executionPlatform: Scalars["String"]["output"];
   executionSteps?: Maybe<Array<TaskExecutionStep>>;
   executionTasks?: Maybe<Array<Scalars["String"]["output"]>>;
   executionTasksFull?: Maybe<Array<Task>>;
@@ -11406,6 +11412,7 @@ export type TaskQuery = {
     distroId: string;
     errors?: Array<string> | null;
     estimatedStart?: number | null;
+    executionPlatform: string;
     expectedDuration?: number | null;
     finishTime?: Date | null;
     generatedBy?: string | null;

--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -441,6 +441,7 @@ export type BootstrapSettings = {
   __typename?: "BootstrapSettings";
   clientDir: Scalars["String"]["output"];
   communication: CommunicationMethod;
+  containerIsolation: ContainerIsolationSettings;
   env: Array<EnvVar>;
   jasperBinaryDir: Scalars["String"]["output"];
   jasperCredentialsPath: Scalars["String"]["output"];
@@ -455,6 +456,7 @@ export type BootstrapSettings = {
 export type BootstrapSettingsInput = {
   clientDir: Scalars["String"]["input"];
   communication: CommunicationMethod;
+  containerIsolation: ContainerIsolationSettingsInput;
   env: Array<EnvVarInput>;
   jasperBinaryDir: Scalars["String"]["input"];
   jasperCredentialsPath: Scalars["String"]["input"];
@@ -629,6 +631,29 @@ export enum CommunicationMethod {
   Rpc = "RPC",
   Ssh = "SSH",
 }
+
+/**
+ * ContainerIsolationSettings controls per-task Docker container isolation for a
+ * distro. When enabled, task subprocess calls (shell.exec, subprocess.exec) run
+ * inside an ephemeral Docker container rather than directly on the host.
+ */
+export type ContainerIsolationSettings = {
+  __typename?: "ContainerIsolationSettings";
+  enabled: Scalars["Boolean"]["output"];
+  image: Scalars["String"]["output"];
+  /**
+   * RequireIsolation opts into fail-closed behavior. When true, container
+   * creation or image-pull failure fails the task immediately rather than
+   * degrading to host-mode. Default (false) is fail-open.
+   */
+  requireIsolation: Scalars["Boolean"]["output"];
+};
+
+export type ContainerIsolationSettingsInput = {
+  enabled: Scalars["Boolean"]["input"];
+  image: Scalars["String"]["input"];
+  requireIsolation: Scalars["Boolean"]["input"];
+};
 
 export type ContainerPool = {
   __typename?: "ContainerPool";
@@ -1937,6 +1962,7 @@ export type Mutation = {
   removePublicKey: Array<PublicKey>;
   removeVolume: Scalars["Boolean"]["output"];
   reprovisionToNew: Scalars["Int"]["output"];
+  resetAPIKey?: Maybe<UserConfig>;
   restartAdminTasks: RestartAdminTasksPayload;
   restartJasper: Scalars["Int"]["output"];
   restartTask: Task;
@@ -8415,6 +8441,12 @@ export type DistroQuery = {
       rootDir: string;
       serviceUser: string;
       shellPath: string;
+      containerIsolation: {
+        __typename?: "ContainerIsolationSettings";
+        enabled: boolean;
+        image: string;
+        requireIsolation: boolean;
+      };
       env: Array<{ __typename?: "EnvVar"; key: string; value: string }>;
       preconditionScripts: Array<{
         __typename?: "PreconditionScript";

--- a/apps/spruce/src/gql/mocks/taskData.ts
+++ b/apps/spruce/src/gql/mocks/taskData.ts
@@ -80,6 +80,7 @@ export const taskQuery: TaskQueryType = {
     distroId: "ubuntu1604-small",
     estimatedStart: 1000,
     execution: 0,
+    executionPlatform: "host",
     expectedDuration: 123,
     hostId: "i-0e0e62799806e037d",
     latestExecution: 0,

--- a/apps/spruce/src/gql/queries/distro.ts
+++ b/apps/spruce/src/gql/queries/distro.ts
@@ -10,6 +10,11 @@ export const DISTRO = gql`
       bootstrapSettings {
         clientDir
         communication
+        containerIsolation {
+          enabled
+          image
+          requireIsolation
+        }
         env {
           key
           value

--- a/apps/spruce/src/gql/queries/task.ts
+++ b/apps/spruce/src/gql/queries/task.ts
@@ -78,6 +78,7 @@ export const TASK = gql`
       distroId
       errors
       estimatedStart
+      executionPlatform
       executionTasksFull {
         ...BaseTask
         id

--- a/apps/spruce/src/pages/distroSettings/tabs/HostTab/HostTab.test.tsx
+++ b/apps/spruce/src/pages/distroSettings/tabs/HostTab/HostTab.test.tsx
@@ -1,0 +1,115 @@
+import { FieldValidation } from "@rjsf/core";
+import { BootstrapMethod, CommunicationMethod } from "gql/generated/types";
+import { validate } from "./HostTab";
+import { HostFormState } from "./types";
+
+const emptyField = (): FieldValidation => ({
+  __errors: [],
+  addError: vi.fn(),
+});
+
+const makeErrors = () => ({
+  setup: { communicationMethod: emptyField() },
+  sshConfig: { execUser: emptyField() },
+  containerIsolation: {
+    image: emptyField(),
+    requireIsolation: emptyField(),
+  },
+});
+
+const baseFormData: HostFormState = {
+  setup: {
+    bootstrapMethod: BootstrapMethod.Ssh,
+    communicationMethod: CommunicationMethod.Ssh,
+  },
+  sshConfig: {
+    execUser: "exec-user",
+  },
+  containerIsolation: {
+    enabled: false,
+    image: "",
+    requireIsolation: false,
+  },
+} as unknown as HostFormState;
+
+describe("host tab validate", () => {
+  it("does not add errors when container isolation is disabled and unconfigured", () => {
+    const errors = makeErrors();
+    validate(baseFormData, errors as unknown as Parameters<typeof validate>[1]);
+    expect(errors.sshConfig.execUser.addError).not.toHaveBeenCalled();
+    expect(errors.containerIsolation.image.addError).not.toHaveBeenCalled();
+    expect(
+      errors.containerIsolation.requireIsolation.addError,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("requires exec user when container isolation is enabled", () => {
+    const errors = makeErrors();
+    const formData = {
+      ...baseFormData,
+      sshConfig: { execUser: "" },
+      containerIsolation: {
+        enabled: true,
+        image: "some-image",
+        requireIsolation: false,
+      },
+    } as unknown as HostFormState;
+    validate(formData, errors as unknown as Parameters<typeof validate>[1]);
+    expect(errors.sshConfig.execUser.addError).toHaveBeenCalledWith(
+      "Exec User is required when Container Isolation is enabled.",
+    );
+  });
+
+  it("requires a container image when container isolation is enabled", () => {
+    const errors = makeErrors();
+    const formData = {
+      ...baseFormData,
+      containerIsolation: {
+        enabled: true,
+        image: "",
+        requireIsolation: false,
+      },
+    } as unknown as HostFormState;
+    validate(formData, errors as unknown as Parameters<typeof validate>[1]);
+    expect(errors.containerIsolation.image.addError).toHaveBeenCalledWith(
+      "Container Image is required when Container Isolation is enabled.",
+    );
+  });
+
+  it("rejects require isolation when container isolation is disabled", () => {
+    const errors = makeErrors();
+    const formData = {
+      ...baseFormData,
+      containerIsolation: {
+        enabled: false,
+        image: "",
+        requireIsolation: true,
+      },
+    } as unknown as HostFormState;
+    validate(formData, errors as unknown as Parameters<typeof validate>[1]);
+    expect(
+      errors.containerIsolation.requireIsolation.addError,
+    ).toHaveBeenCalledWith(
+      "Require Isolation has no effect when Container Isolation is not enabled.",
+    );
+  });
+
+  it("does not add errors for a fully valid container isolation config", () => {
+    const errors = makeErrors();
+    const formData = {
+      ...baseFormData,
+      sshConfig: { execUser: "exec-user" },
+      containerIsolation: {
+        enabled: true,
+        image: "some-image",
+        requireIsolation: true,
+      },
+    } as unknown as HostFormState;
+    validate(formData, errors as unknown as Parameters<typeof validate>[1]);
+    expect(errors.sshConfig.execUser.addError).not.toHaveBeenCalled();
+    expect(errors.containerIsolation.image.addError).not.toHaveBeenCalled();
+    expect(
+      errors.containerIsolation.requireIsolation.addError,
+    ).not.toHaveBeenCalled();
+  });
+});

--- a/apps/spruce/src/pages/distroSettings/tabs/HostTab/HostTab.tsx
+++ b/apps/spruce/src/pages/distroSettings/tabs/HostTab/HostTab.tsx
@@ -58,5 +58,17 @@ const validate = ((formData, errors) => {
     );
   }
 
+  if (containerIsolation?.enabled && !containerIsolation?.image) {
+    errors.containerIsolation.image.addError(
+      "Container Image is required when Container Isolation is enabled.",
+    );
+  }
+
+  if (containerIsolation?.requireIsolation && !containerIsolation?.enabled) {
+    errors.containerIsolation.requireIsolation.addError(
+      "Require Isolation has no effect when Container Isolation is not enabled.",
+    );
+  }
+
   return errors;
 }) satisfies ValidateProps<HostFormState>;

--- a/apps/spruce/src/pages/distroSettings/tabs/HostTab/HostTab.tsx
+++ b/apps/spruce/src/pages/distroSettings/tabs/HostTab/HostTab.tsx
@@ -33,7 +33,9 @@ export const HostTab: React.FC<TabProps> = ({
 
 const validate = ((formData, errors) => {
   const {
+    containerIsolation,
     setup: { bootstrapMethod, communicationMethod },
+    sshConfig,
   } = formData;
 
   // Ensure either Legacy SSH or non-legacy methods are used for both communication and bootstrapping.
@@ -45,6 +47,14 @@ const validate = ((formData, errors) => {
   ) {
     errors.setup.communicationMethod.addError(
       "Legacy and non-legacy bootstrapping and communication are incompatible.",
+    );
+  }
+
+  // Container isolation requires an exec user to scope between-task process
+  // cleanup inside the container's PID namespace.
+  if (containerIsolation?.enabled && !sshConfig?.execUser) {
+    errors.sshConfig.execUser.addError(
+      "Exec User is required when Container Isolation is enabled.",
     );
   }
 

--- a/apps/spruce/src/pages/distroSettings/tabs/HostTab/HostTab.tsx
+++ b/apps/spruce/src/pages/distroSettings/tabs/HostTab/HostTab.tsx
@@ -31,7 +31,7 @@ export const HostTab: React.FC<TabProps> = ({
   );
 };
 
-const validate = ((formData, errors) => {
+export const validate = ((formData, errors) => {
   const {
     containerIsolation,
     setup: { bootstrapMethod, communicationMethod },

--- a/apps/spruce/src/pages/distroSettings/tabs/HostTab/getFormSchema.tsx
+++ b/apps/spruce/src/pages/distroSettings/tabs/HostTab/getFormSchema.tsx
@@ -4,6 +4,7 @@ import { nonWindowsArchitectures, windowsArchitectures } from "./constants";
 import {
   allocation as allocationProperties,
   bootstrap as bootstrapProperties,
+  containerIsolation as containerIsolationProperties,
   icecreamConfigPath,
   icecreamSchedulerHost,
   isVirtualWorkStation,
@@ -103,6 +104,7 @@ export const getFormSchema = ({
                   },
                 },
                 sshConfig,
+                containerIsolation,
                 allocation,
               },
             },
@@ -117,6 +119,7 @@ export const getFormSchema = ({
                 },
                 bootstrapSettings,
                 sshConfig,
+                containerIsolation,
                 allocation,
               },
             },
@@ -132,6 +135,7 @@ export const getFormSchema = ({
       ),
       bootstrapSettings: bootstrapProperties.uiSchema(architecture),
       sshConfig: sshConfigProperties.uiSchema(hasStaticProvider),
+      containerIsolation: containerIsolationProperties.uiSchema(architecture),
       allocation: allocationProperties.uiSchema(
         hasEC2Provider,
         hasStaticProvider,
@@ -150,6 +154,12 @@ const sshConfig = {
   type: "object" as const,
   title: "User and SSH Configuration",
   properties: sshConfigProperties.schema,
+};
+
+const containerIsolation = {
+  type: "object" as const,
+  title: "Container Isolation",
+  properties: containerIsolationProperties.schema,
 };
 
 const allocation = {

--- a/apps/spruce/src/pages/distroSettings/tabs/HostTab/schemaFields.tsx
+++ b/apps/spruce/src/pages/distroSettings/tabs/HostTab/schemaFields.tsx
@@ -428,6 +428,41 @@ const execUser = {
   },
 };
 
+const containerIsolationEnabled = {
+  schema: {
+    type: "boolean" as const,
+    title: "Enabled",
+  },
+  uiSchema: {
+    "ui:description":
+      "Run task subprocess calls (shell.exec, subprocess.exec) inside an ephemeral Docker container instead of directly on the host. Requires Exec User to be set in the User and SSH Configuration section.",
+    "ui:bold": true,
+  },
+};
+
+const containerIsolationImage = {
+  schema: {
+    type: "string" as const,
+    title: "Container Image",
+  },
+  uiSchema: {
+    "ui:description": "ECR image URI used to create the task container.",
+    "ui:placeholder":
+      "557821124784.dkr.ecr.us-east-1.amazonaws.com/repository:tag",
+  },
+};
+
+const containerIsolationRequireIsolation = {
+  schema: {
+    type: "boolean" as const,
+    title: "Require Isolation",
+  },
+  uiSchema: {
+    "ui:description":
+      "When on, a task fails immediately if its container cannot start. When off (the default), a task falls back to running directly on the host if the container cannot start.",
+  },
+};
+
 const authorizedKeysFile = {
   schema: {
     type: "string" as const,
@@ -706,5 +741,23 @@ export const sshConfig = {
     execUser: execUser.uiSchema,
     authorizedKeysFile: authorizedKeysFile.uiSchema(hasStaticProvider),
     sshOptions: sshOptions.uiSchema,
+  }),
+};
+
+export const containerIsolation = {
+  schema: {
+    enabled: containerIsolationEnabled.schema,
+    image: containerIsolationImage.schema,
+    requireIsolation: containerIsolationRequireIsolation.schema,
+  },
+  uiSchema: (architecture: Arch) => ({
+    "ui:ObjectFieldTemplate": CardFieldTemplate,
+    // Container isolation is only supported on Linux.
+    ...(!linuxArchitectures.includes(architecture) && {
+      "ui:widget": "hidden",
+    }),
+    enabled: containerIsolationEnabled.uiSchema,
+    image: containerIsolationImage.uiSchema,
+    requireIsolation: containerIsolationRequireIsolation.uiSchema,
   }),
 };

--- a/apps/spruce/src/pages/distroSettings/tabs/HostTab/transformers.test.ts
+++ b/apps/spruce/src/pages/distroSettings/tabs/HostTab/transformers.test.ts
@@ -67,6 +67,11 @@ const form: HostFormState = {
     ],
     preconditionScripts: [],
   },
+  containerIsolation: {
+    enabled: false,
+    image: "",
+    requireIsolation: false,
+  },
   sshConfig: {
     user: "admin",
     execUser: "execUser",

--- a/apps/spruce/src/pages/distroSettings/tabs/HostTab/transformers.ts
+++ b/apps/spruce/src/pages/distroSettings/tabs/HostTab/transformers.ts
@@ -12,6 +12,7 @@ export const gqlToForm = ((data) => {
     bootstrapSettings: {
       clientDir,
       communication,
+      containerIsolation,
       env,
       jasperBinaryDir,
       jasperCredentialsPath,
@@ -65,6 +66,7 @@ export const gqlToForm = ((data) => {
       env,
       preconditionScripts,
     },
+    containerIsolation,
     sshConfig: {
       user,
       execUser,
@@ -80,7 +82,7 @@ export const gqlToForm = ((data) => {
 }) satisfies GqlToFormFunction<Tab>;
 
 export const formToGql = ((
-  { allocation, bootstrapSettings, setup, sshConfig },
+  { allocation, bootstrapSettings, containerIsolation, setup, sshConfig },
   distro,
 ) => {
   const { acceptableHostIdleTimeSeconds, ...hostAllocatorSettings } =
@@ -92,6 +94,7 @@ export const formToGql = ((
     bootstrapSettings: {
       clientDir: bootstrapSettings.clientDir,
       communication: setup.communicationMethod,
+      containerIsolation,
       env: bootstrapSettings.env,
       jasperBinaryDir: bootstrapSettings.jasperBinaryDir,
       jasperCredentialsPath: bootstrapSettings.jasperCredentialsPath,

--- a/apps/spruce/src/pages/distroSettings/tabs/HostTab/types.ts
+++ b/apps/spruce/src/pages/distroSettings/tabs/HostTab/types.ts
@@ -47,6 +47,11 @@ export interface HostFormState {
       script: string;
     }>;
   };
+  containerIsolation: {
+    enabled: boolean;
+    image: string;
+    requireIsolation: boolean;
+  };
   sshConfig: {
     user: string;
     execUser: string;

--- a/apps/spruce/src/pages/distroSettings/tabs/testData.ts
+++ b/apps/spruce/src/pages/distroSettings/tabs/testData.ts
@@ -23,6 +23,11 @@ const distroData: DistroQuery["distro"] = {
   bootstrapSettings: {
     clientDir: "/home/evg/client",
     communication: CommunicationMethod.LegacySsh,
+    containerIsolation: {
+      enabled: false,
+      image: "",
+      requireIsolation: false,
+    },
     env: [
       {
         key: "foo",

--- a/apps/spruce/src/pages/task/ActionButtons/MarkReviewed/taskData.ts
+++ b/apps/spruce/src/pages/task/ActionButtons/MarkReviewed/taskData.ts
@@ -92,6 +92,7 @@ export const taskData: NonNullable<TaskQuery["task"]> = {
   displayTask: null,
   distroId: "ubuntu2204-large",
   estimatedStart: 0,
+  executionPlatform: "host",
   executionTasksFull: null,
   expectedDuration: 129456,
   files: {
@@ -230,6 +231,7 @@ export const displayTaskData: NonNullable<TaskQuery["task"]> &
   displayTask: null,
   distroId: "",
   estimatedStart: 0,
+  executionPlatform: "host",
   executionTasksFull: [
     {
       id: "evergreen_ui_spruce_e2e_spruce_0_patch_da7ae2020c5af16fdc5daf95a6420b36ec742a06_68795d3e3ec03f0007deb52c_25_07_17_20_29_51",

--- a/apps/spruce/src/pages/task/metadata/Metadata.stories.tsx
+++ b/apps/spruce/src/pages/task/metadata/Metadata.stories.tsx
@@ -28,6 +28,20 @@ export const Default: CustomStoryObj<typeof Metadata> = {
   ),
 };
 
+export const RanInContainer: CustomStoryObj<typeof Metadata> = {
+  render: (args) => (
+    <Container>
+      <Metadata
+        {...args}
+        task={{
+          ...taskQuery.task,
+          executionPlatform: "container",
+        }}
+      />
+    </Container>
+  ),
+};
+
 export const WithDependencies: CustomStoryObj<typeof Metadata> = {
   render: (args) => (
     <Container>

--- a/apps/spruce/src/pages/task/metadata/Metadata.test.tsx
+++ b/apps/spruce/src/pages/task/metadata/Metadata.test.tsx
@@ -102,6 +102,31 @@ describe("metadata", () => {
     expect(screen.getByDataCy("cost-details-button")).toBeInTheDocument();
   });
 
+  it("shows a Container badge when the task ran in a container", () => {
+    render(<Metadata loading={false} task={taskInContainer.task} />, {
+      route: `/task/${taskId}`,
+      path: "/task/:id",
+      wrapper,
+    });
+    expect(
+      screen.getByDataCy("task-metadata-execution-platform"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByDataCy("task-metadata-execution-platform"),
+    ).toHaveTextContent("Container");
+  });
+
+  it("does not show a Container badge when the task ran on a host", () => {
+    render(<Metadata loading={false} task={taskQuery.task} />, {
+      route: `/task/${taskId}`,
+      path: "/task/:id",
+      wrapper,
+    });
+    expect(
+      screen.queryByDataCy("task-metadata-execution-platform"),
+    ).not.toBeInTheDocument();
+  });
+
   it("can reopen cost modal after closing", async () => {
     const user = userEvent.setup();
     render(<Metadata loading={false} task={taskWithCostAndFinishTime.task} />, {
@@ -187,5 +212,12 @@ const taskWithCostAndFinishTime: TaskQueryType = {
     ...taskWithCost.task,
     finishTime: new Date("2024-01-02"),
     status: "succeeded",
+  },
+};
+
+const taskInContainer: TaskQueryType = {
+  task: {
+    ...taskQuery.task,
+    executionPlatform: "container",
   },
 };

--- a/apps/spruce/src/pages/task/metadata/index.tsx
+++ b/apps/spruce/src/pages/task/metadata/index.tsx
@@ -1,3 +1,4 @@
+import { Badge, Variant } from "@leafygreen-ui/badge";
 import { StyledLink, StyledRouterLink } from "@evg-ui/lib/components/styles";
 import { useTaskAnalytics } from "analytics";
 import MetadataCard, {
@@ -50,6 +51,7 @@ export const Metadata: React.FC<Props> = ({ error, loading, task }) => {
     displayTask,
     distroId,
     execution,
+    executionPlatform,
     executionTasksFull,
     hostId,
     id: taskId,
@@ -96,6 +98,11 @@ export const Metadata: React.FC<Props> = ({ error, loading, task }) => {
 
       {!isDisplayTask && (
         <MetadataCard title="Host Information">
+          {executionPlatform === "container" && (
+            <MetadataItem data-cy="task-metadata-execution-platform">
+              <Badge variant={Variant.Blue}>Container</Badge>
+            </MetadataItem>
+          )}
           {hostId && (
             <MetadataItem label="ID">
               <StyledLink


### PR DESCRIPTION
### Description

Two UI tasks for GOAL-279 (per-task Docker container isolation), rounding out Phase 0 alongside the backend work on `wratner/evergreen`.

**PLATFORMS-30919: Distro configuration settings for container isolation**
- Adds a "Container Isolation" card to the distro Host tab exposing `enabled`, `image` (ECR URI), and `requireIsolation`, backed by `BootstrapSettings.containerIsolation` in GraphQL.
- Client-side validation mirrors the backend's `Distro.ValidateBootstrapSettings`: `image` required when `enabled`, exec user required when `enabled` (reusing the existing top-level `execUser` field rather than duplicating it), and `requireIsolation` rejected when `enabled` is false.
- Card is hidden for non-Linux architectures, matching the existing `resourceLimits` convention in the same file.
- Adds `rawErrors` support to the shared `LeafyGreenCheckBox` widget so checkbox-backed fields can surface inline validation errors — previously any error attached to a checkbox field silently blocked Save with no visible explanation.

**PLATFORMS-30918: Surface when a task ran in a container**
- Adds a blue "Container" badge to the Spruce task metadata page (Host Information card) and a smaller secondary badge to Parsley's task breadcrumb, driven by the new `Task.executionPlatform` GraphQL field.
- Verified Parsley's log-rendering pipeline has no platform-dependent branching (no regression risk for container-task logs).

### Screenshots
See linked staging verification in ticket comments.

### Testing
- `pnpm check-types` and `pnpm eslint:strict` clean in both `apps/spruce` and `apps/parsley`.
- Unit tests added/updated for HostTab validation, the new checkbox widget error path, Spruce task metadata badge, and Parsley breadcrumb badge.
- Full end-to-end verification on staging against the corresponding evergreen backend branch (`platforms-30919-distro-container-isolation` on `wratner/evergreen`), including all three client-side validation paths, successful save/round-trip, and the container badge rendering against a real container-run task.

### Evergreen PR
Corresponding backend branch: `wratner/evergreen@platforms-30919-distro-container-isolation` (PR pending).