### PR TITLE
DEVPROD-37400: Replace pride with regular evergreen logo

### DIFF
--- a/apps/spruce/src/components/Header/Navbar.tsx
+++ b/apps/spruce/src/components/Header/Navbar.tsx
@@ -5,7 +5,7 @@ import styled from "@emotion/styled";
 import { palette } from "@leafygreen-ui/palette";
 import Cookies from "js-cookie";
 import { Link, useParams } from "react-router-dom";
-import Icon, { AnimatedIcon, PrideLogo } from "@evg-ui/lib/components/Icon";
+import Icon, { EvergreenLogo } from "@evg-ui/lib/components/Icon";
 import { size } from "@evg-ui/lib/constants/tokens";
 import { useAuthProviderContext } from "@evg-ui/lib/context/AuthProvider";
 import { useNavbarAnalytics } from "analytics";
@@ -70,7 +70,7 @@ export const Navbar: React.FC = () => {
           onClick={() => sendEvent({ name: "Clicked logo link" })}
           to={routes.myPatches}
         >
-          <AnimatedIcon icon={PrideLogo} />
+          <EvergreenLogo size={36} />
         </LogoLink>
         <PrimaryLink
           data-cy="waterfall-link"

--- a/packages/lib/src/components/Icon/index.ts
+++ b/packages/lib/src/components/Icon/index.ts
@@ -14,3 +14,4 @@ const glyphMap = {
 export { glyphMap as glyphs, Size };
 export default createIconComponent(glyphMap);
 export { AnimatedIcon, PrideLogo, FallLogo, WinterLogo, SpringLogo };
+export { EvergreenLogo, ParsleyLogo } from "./icons";


### PR DESCRIPTION
DEVPROD-37400

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->

<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
<!-- add description, context, thought process, etc -->
Last year we replaced the pride logo on September 30 so I guess this is an improvement (or not...)

We previously used the LG icon implementation

```ts
<Icon glyph="EvergreenLogo" size={36} />
```

but it seems like `size` support for icons created via `createIconComponent` is broken. 

### Screenshots
<!-- add screenshots of visible changes -->
<img width="1334" height="936" alt="image" src="https://github.com/user-attachments/assets/a1379c6c-77de-4bd6-9b52-1c89695450ed" />
