### PR TITLE
DEVPROD-37417: Standardize status colors

### DIFF
--- a/apps/spruce/src/constants/task.ts
+++ b/apps/spruce/src/constants/task.ts
@@ -3,7 +3,7 @@ import { ALL_VALUE, TreeDataEntry } from "@evg-ui/lib/components/TreeSelect";
 import { taskStatusToCopy } from "@evg-ui/lib/constants/task";
 import { TaskStatus, TaskStatusUmbrella } from "@evg-ui/lib/types/task";
 
-const { gray, green, purple, red, yellow } = palette;
+const { blue, gray, green, purple, red, yellow } = palette;
 
 const taskStatuses: TreeDataEntry[] = [
   {
@@ -181,9 +181,9 @@ export const mapUmbrellaStatusColors: Record<string, ColorScheme> = {
     text: yellow.dark2,
   },
   [TaskStatusUmbrella.SystemFailure]: {
-    fill: purple.dark2,
-    border: purple.dark3,
-    text: purple.light3,
+    border: purple.light2,
+    fill: purple.light3,
+    text: purple.dark2,
   },
   [TaskStatusUmbrella.Scheduled]: {
     fill: gray.dark1,
@@ -201,9 +201,9 @@ export const mapUmbrellaStatusColors: Record<string, ColorScheme> = {
     text: green.dark2,
   },
   [TaskStatus.SetupFailed]: {
-    fill: purple.light2,
-    border: purple.base,
-    text: purple.dark2,
+    fill: blue.light3,
+    border: blue.light2,
+    text: blue.dark1,
   },
 };
 
@@ -214,7 +214,7 @@ export const mapTaskToBarchartColor = {
   [TaskStatusUmbrella.Scheduled]: gray.base,
   [TaskStatusUmbrella.Failed]: red.base,
   [TaskStatus.Succeeded]: green.dark1,
-  [TaskStatus.SetupFailed]: purple.light2,
+  [TaskStatus.SetupFailed]: blue.base,
 };
 
 // Represents order for waterfall barchart

--- a/apps/spruce/src/pages/version/BuildVariantCard/testData.ts
+++ b/apps/spruce/src/pages/version/BuildVariantCard/testData.ts
@@ -70,6 +70,16 @@ const mocks: ApolloMock<
                   status: "started",
                   __typename: "StatusCount",
                 },
+                {
+                  count: 1,
+                  status: "setup-failed",
+                  __typename: "StatusCount",
+                },
+                {
+                  count: 2,
+                  status: "system-failed",
+                  __typename: "StatusCount",
+                },
               ],
               variant: "variant",
               __typename: "GroupedTaskStatusCount",

--- a/apps/spruce/src/utils/statuses/groupStatusesByUmbrellaStatus.test.ts
+++ b/apps/spruce/src/utils/statuses/groupStatusesByUmbrellaStatus.test.ts
@@ -3,7 +3,7 @@ import { taskStatusToCopy } from "@evg-ui/lib/constants/task";
 import { TaskStatus, TaskStatusUmbrella } from "@evg-ui/lib/types/task";
 import { groupStatusesByUmbrellaStatus } from "./groupStatusesByUmbrellaStatus";
 
-const { gray, green, purple, red, yellow } = palette;
+const { blue, gray, green, purple, red, yellow } = palette;
 
 describe("groupStatusesByUmbrellaStatus", () => {
   it("separates statuses into groups based on umbrella status", () => {
@@ -146,7 +146,7 @@ describe("groupStatusesByUmbrellaStatus", () => {
         {
           count: 3,
           statuses: [taskStatusToCopy[TaskStatus.SetupFailed]],
-          color: purple.light2,
+          color: blue.base,
           umbrellaStatus: TaskStatus.SetupFailed,
           statusCounts: { [TaskStatus.SetupFailed]: 3 },
         },

--- a/apps/spruce/src/utils/statuses/sort.ts
+++ b/apps/spruce/src/utils/statuses/sort.ts
@@ -7,7 +7,7 @@ const ordering = [
     TaskStatus.TestTimedOut,
     TaskStatus.TaskTimedOut,
   ]),
-  // lavender
+  // blue
   new Set([TaskStatus.SetupFailed]),
   // purple
   new Set([

--- a/packages/lib/src/components/Badge/TaskStatusBadge/index.tsx
+++ b/packages/lib/src/components/Badge/TaskStatusBadge/index.tsx
@@ -68,22 +68,17 @@ const mapTaskStatusToBadgeVariant: Record<string, Variant> = {
   [TaskStatus.TaskTimedOut]: Variant.Red,
   [TaskStatus.Succeeded]: Variant.Green,
   [TaskStatus.WillRun]: Variant.DarkGray,
+  [TaskStatus.SetupFailed]: Variant.Blue,
 };
 const customBadgeColors = (status: string) => {
   switch (status) {
-    case TaskStatus.SetupFailed:
-      return {
-        border: purple.base,
-        fill: purple.light2,
-        text: purple.dark2,
-      };
     case TaskStatus.SystemFailed:
     case TaskStatus.SystemUnresponsive:
     case TaskStatus.SystemTimedOut:
       return {
-        border: purple.dark3,
-        fill: purple.dark2,
-        text: purple.light3,
+        border: purple.light2,
+        fill: purple.light3,
+        text: purple.dark2,
       };
     case TaskStatus.KnownIssue:
       return {


### PR DESCRIPTION
DEVPROD-37417

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->

<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
<!-- add description, context, thought process, etc -->
The waterfall introduced blue for setup-failed tasks, which were previously lavender. Standardize these to use blue for task and build variant badges.

I also opted to convert system failure from dark purple to light so that all of our badges look nice and uniformly pastel (◕‿◕✿)

### Screenshots
<!-- add screenshots of visible changes -->
<img width="225" height="202" alt="image" src="https://github.com/user-attachments/assets/ee44eeb6-036f-40ad-a9fe-dc57e72c7888" />
<img width="1186" height="99" alt="image" src="https://github.com/user-attachments/assets/11bd8558-956b-4b9f-975e-a6775143d2e3" />

### Testing
<!-- add a description of how you tested it -->
Please review the Chromatic diffs!