### PR TITLE
DEVPROD-37427: reword waterfall option on project page

### DIFF
--- a/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/GeneralTab/getFormSchema.tsx
+++ b/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/GeneralTab/getFormSchema.tsx
@@ -411,7 +411,7 @@ export const getFormSchema = (
         waterfallDisabled: {
           "ui:widget": widgets.RadioBoxWidget,
           "ui:description":
-            "By default, task activation is considered for all new commits on the waterfall. By disabling this setting, tasks will still appear but will be unscheduled by default.",
+            "When enabled (default), task activation is considered for all new commits on the waterfall. By disabling this setting, tasks will still appear but will be unscheduled by default.",
         },
       },
       scheduling: {

--- a/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/GeneralTab/getFormSchema.tsx
+++ b/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/GeneralTab/getFormSchema.tsx
@@ -411,7 +411,7 @@ export const getFormSchema = (
         waterfallDisabled: {
           "ui:widget": widgets.RadioBoxWidget,
           "ui:description":
-            "Disables automatic task activation on the waterfall. Tasks will still appear but will be unscheduled by default.",
+            "By default, task activation is considered for all new commits on the waterfall. By disabling this setting, tasks will still appear but will be unscheduled by default.",
         },
       },
       scheduling: {

--- a/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/GeneralTab/getFormSchema.tsx
+++ b/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/GeneralTab/getFormSchema.tsx
@@ -411,7 +411,7 @@ export const getFormSchema = (
         waterfallDisabled: {
           "ui:widget": widgets.RadioBoxWidget,
           "ui:description":
-            "When enabled (default), task activation is considered for all new commits on the waterfall. By disabling this setting, tasks will still appear but will be unscheduled by default.",
+            "When enabled (default), task activation is considered for all new commits on the waterfall. When this setting is disabled, tasks will still appear but will be unscheduled.",
         },
       },
       scheduling: {


### PR DESCRIPTION
DEVPROD-XXXX

I noticed that I think the language here is a little confusing, since it might sound like this is the behavior if the setting is _enabled_, so just suggesting a lil tweak.
