### PR TITLE
DEVPROD-34996: Stop querying userLite

### DIFF
--- a/apps/parsley/src/gql/queries/get-user.ts
+++ b/apps/parsley/src/gql/queries/get-user.ts
@@ -2,7 +2,7 @@ import { gql } from "@apollo/client";
 
 export const GET_USER = gql`
   query User {
-    user: userLite {
+    user {
       userId: id
     }
   }

--- a/apps/spruce/src/gql/fragments/basePatch.ts
+++ b/apps/spruce/src/gql/fragments/basePatch.ts
@@ -14,7 +14,7 @@ export const BASE_PATCH = gql`
       id
     }
     status
-    user: userLite {
+    user {
       displayName
       userId: id
     }

--- a/apps/spruce/src/gql/fragments/patchesPage.ts
+++ b/apps/spruce/src/gql/fragments/patchesPage.ts
@@ -18,7 +18,7 @@ export const PATCHES_PAGE_PATCHES = gql`
         repo
       }
       status
-      user: userLite {
+      user {
         displayName
         userId: id
       }

--- a/apps/spruce/src/gql/queries/mainline-commits-for-history.ts
+++ b/apps/spruce/src/gql/queries/mainline-commits-for-history.ts
@@ -23,7 +23,7 @@ export const MAINLINE_COMMITS_FOR_HISTORY = gql`
           message
           order
           revision
-          user: userLite {
+          user {
             displayName
             userId: id
           }
@@ -49,7 +49,7 @@ export const MAINLINE_COMMITS_FOR_HISTORY = gql`
           message
           order
           revision
-          user: userLite {
+          user {
             displayName
             userId: id
           }

--- a/apps/spruce/src/gql/queries/user-distro-settings-permissions.ts
+++ b/apps/spruce/src/gql/queries/user-distro-settings-permissions.ts
@@ -2,7 +2,7 @@ import { gql } from "@apollo/client";
 
 export const USER_DISTRO_SETTINGS_PERMISSIONS = gql`
   query UserDistroSettingsPermissions($distroId: String!) {
-    user: userLite {
+    user {
       permissions {
         canCreateDistro
         distroPermissions(options: { distroId: $distroId }) {

--- a/apps/spruce/src/gql/queries/user-patches.ts
+++ b/apps/spruce/src/gql/queries/user-patches.ts
@@ -3,7 +3,7 @@ import { PATCHES_PAGE_PATCHES } from "../fragments/patchesPage";
 
 export const USER_PATCHES = gql`
   query UserPatches($userId: String, $patchesInput: PatchesInput!) {
-    user: userLite(userId: $userId) {
+    user(userId: $userId) {
       displayName
       patches(patchesInput: $patchesInput) {
         ...PatchesPagePatches

--- a/apps/spruce/src/gql/queries/user-project-settings-permissions.ts
+++ b/apps/spruce/src/gql/queries/user-project-settings-permissions.ts
@@ -2,7 +2,7 @@ import { gql } from "@apollo/client";
 
 export const USER_PROJECT_SETTINGS_PERMISSIONS = gql`
   query UserProjectSettingsPermissions($projectIdentifier: String!) {
-    user: userLite {
+    user {
       permissions {
         canCreateProject
         projectPermissions(options: { projectIdentifier: $projectIdentifier }) {

--- a/apps/spruce/src/gql/queries/user-repo-settings-permissions.ts
+++ b/apps/spruce/src/gql/queries/user-repo-settings-permissions.ts
@@ -2,7 +2,7 @@ import { gql } from "@apollo/client";
 
 export const USER_REPO_SETTINGS_PERMISSIONS = gql`
   query UserRepoSettingsPermissions($repoId: String!) {
-    user: userLite {
+    user {
       permissions {
         repoPermissions(options: { repoId: $repoId }) {
           id: repoId

--- a/apps/spruce/src/gql/queries/user-settings.ts
+++ b/apps/spruce/src/gql/queries/user-settings.ts
@@ -2,7 +2,7 @@ import { gql } from "@apollo/client";
 
 export const USER_SETTINGS = gql`
   query UserSettings {
-    user: userLite {
+    user {
       settings {
         dateFormat
         githubUser {

--- a/apps/spruce/src/gql/queries/user-subscriptions.ts
+++ b/apps/spruce/src/gql/queries/user-subscriptions.ts
@@ -2,7 +2,7 @@ import { gql } from "@apollo/client";
 
 export const USER_SUBSCRIPTIONS = gql`
   query UserSubscriptions {
-    user: userLite {
+    user {
       settings {
         notifications {
           buildBreakId

--- a/apps/spruce/src/gql/queries/user-token-exchange.ts
+++ b/apps/spruce/src/gql/queries/user-token-exchange.ts
@@ -2,7 +2,7 @@ import { gql } from "@apollo/client";
 
 export const USER_TOKEN_EXCHANGE = gql`
   query UserTokenExchange {
-    user: userLite {
+    user {
       hasTokenExchangePending
       tokenAccessTokenExpiresAt
       userId: id

--- a/apps/spruce/src/gql/queries/user.ts
+++ b/apps/spruce/src/gql/queries/user.ts
@@ -2,7 +2,7 @@ import { gql } from "@apollo/client";
 
 export const USER = gql`
   query User {
-    user: userLite {
+    user {
       displayName
       emailAddress
       permissions {

--- a/apps/spruce/src/gql/queries/version.ts
+++ b/apps/spruce/src/gql/queries/version.ts
@@ -105,7 +105,7 @@ export const VERSION = gql`
       taskCount(
         options: { includeNeverActivatedTasks: $includeNeverActivatedTasks }
       )
-      user: userLite {
+      user {
         displayName
         userId: id
       }

--- a/apps/spruce/src/gql/queries/waterfall.ts
+++ b/apps/spruce/src/gql/queries/waterfall.ts
@@ -15,7 +15,7 @@ export const WATERFALL = gql`
         order
         requester
         revision
-        user: userLite {
+        user {
           displayName
           userId: id
         }

--- a/packages/lib/src/context/AuthProvider/index.tsx
+++ b/packages/lib/src/context/AuthProvider/index.tsx
@@ -190,7 +190,7 @@ const AuthProvider: React.FC<{
         "content-type": "application/json",
       },
       body: JSON.stringify({
-        query: "{\n  userLite {\n    id\n  }\n}",
+        query: "{\n  user {\n    id\n  }\n}",
         variables: {},
       }),
       method: "POST",

--- a/packages/lib/src/gql/queries/user-beta-features.ts
+++ b/packages/lib/src/gql/queries/user-beta-features.ts
@@ -2,7 +2,7 @@ import { gql } from "@apollo/client";
 
 export const USER_BETA_FEATURES = gql`
   query UserBetaFeatures {
-    user: userLite {
+    user {
       betaFeatures {
         __typename
       }


### PR DESCRIPTION
DEVPROD-34996

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->

<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
<!-- add description, context, thought process, etc -->
This probably could have been included in https://github.com/evergreen-ci/ui/pull/1794 but oh well

Stop querying `userLite` fields, which were aliased to `user`. This is the reason why there are no component-level changes required. I opted to keep the `id` to `userId` alias because this change is very wide-reaching and I don't want to break any analytics etc. But let me know if you feel like this should also be aligned with the backend types.