### PR TITLE
DEVPROD-29652: Remove `eslint-plugin-sort-keys-plus`

### DIFF
--- a/apps/parsley/eslint.config.js
+++ b/apps/parsley/eslint.config.js
@@ -1,25 +1,3 @@
-import { fixupPluginRules } from "@eslint/compat";
-import { defineConfig } from "eslint/config";
-import * as sortKeysPlugin from "eslint-plugin-sort-keys-plus";
-import baseConfig, { errorIfStrict } from "@evg-ui/eslint-config";
+import baseConfig from "@evg-ui/eslint-config";
 
-export default defineConfig(
-  ...baseConfig,
-  // Sort Keys File ESLint (eslint-plugin-sort-keys-plus) settings.
-  // TODO DEVPROD-6890: This plugin should be dropped because the project has been abandoned.
-  // It may potentially be replaced by Perfectionist's sort-objects rule (https://perfectionist.dev/rules/sort-objects).
-  {
-    name: "sort-keys-plus/rules",
-    files: ["src/**/*.ts?(x)"],
-    plugins: {
-      "sort-keys-plus": fixupPluginRules(sortKeysPlugin),
-    },
-    rules: {
-      "sort-keys-plus/sort-keys": [
-        errorIfStrict,
-        "asc",
-        { allowLineSeparatedGroups: true, natural: true },
-      ],
-    },
-  },
-);
+export default baseConfig;

--- a/apps/parsley/package.json
+++ b/apps/parsley/package.json
@@ -93,7 +93,6 @@
   },
   "devDependencies": {
     "@emotion/css": "11.13.5",
-    "@eslint/compat": "^2.0.1",
     "@evg-ui/eslint-config": "workspace:*",
     "@evg-ui/lint-staged": "workspace:*",
     "@evg-ui/playwright-config": "workspace:*",
@@ -121,7 +120,6 @@
     "env-cmd": "10.1.0",
     "eslint": "^9.39.1",
     "eslint-plugin-prettier": "^5.5.4",
-    "eslint-plugin-sort-keys-plus": "^1.5.0",
     "prettier": "3.7.4",
     "rollup-plugin-visualizer": "7.0.1",
     "serve": "^14.2.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -221,9 +221,6 @@ importers:
       '@emotion/css':
         specifier: 11.13.5
         version: 11.13.5
-      '@eslint/compat':
-        specifier: ^2.0.1
-        version: 2.0.5(eslint@9.39.4(@types/eslint@9.6.1)(jiti@2.7.0))
       '@evg-ui/eslint-config':
         specifier: workspace:*
         version: link:../../packages/eslint-config
@@ -296,9 +293,6 @@ importers:
       eslint-plugin-prettier:
         specifier: ^5.5.4
         version: 5.5.5(@types/eslint@9.6.1)(eslint-config-prettier@10.1.8(eslint@9.39.4(@types/eslint@9.6.1)(jiti@2.7.0)))(eslint@9.39.4(@types/eslint@9.6.1)(jiti@2.7.0))(prettier@3.7.4)
-      eslint-plugin-sort-keys-plus:
-        specifier: ^1.5.0
-        version: 1.5.0
       prettier:
         specifier: 3.7.4
         version: 3.7.4
@@ -2177,15 +2171,6 @@ packages:
     resolution: {integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
 
-  '@eslint/compat@2.0.5':
-    resolution: {integrity: sha512-IbHDbHJfkVNv6xjlET8AIVo/K1NQt7YT4Rp6ok/clyBGcpRx1l6gv0Rq3vBvYfPJIZt6ODf66Zq08FJNDpnzgg==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
-    peerDependencies:
-      eslint: ^8.40 || 9 || 10
-    peerDependenciesMeta:
-      eslint:
-        optional: true
-
   '@eslint/config-array@0.21.2':
     resolution: {integrity: sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -2197,10 +2182,6 @@ packages:
   '@eslint/core@0.17.0':
     resolution: {integrity: sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@eslint/core@1.2.1':
-    resolution: {integrity: sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
   '@eslint/eslintrc@3.3.5':
     resolution: {integrity: sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==}
@@ -6441,10 +6422,6 @@ packages:
     peerDependencies:
       eslint: 5 - 10
 
-  eslint-plugin-sort-keys-plus@1.5.0:
-    resolution: {integrity: sha512-lQlIhJqVTFlvmlZOY0UDJ9mEtvgs+xtn9LG8GnA/rLqSoydCuIYJx/CI40RH3M/EasFB21TeYz6SrOm29OhgXA==}
-    engines: {node: '>=14'}
-
   eslint-plugin-storybook@10.3.5:
     resolution: {integrity: sha512-rEFkfU3ypF44GpB4tiJ9EFDItueoGvGi3+weLHZax2ON2MB7VIDsxdSUGvIU5tMURg+oWYlpzCyLm4TpDq2deA==}
     peerDependencies:
@@ -10206,12 +10183,6 @@ snapshots:
 
   '@eslint-community/regexpp@4.12.2': {}
 
-  '@eslint/compat@2.0.5(eslint@9.39.4(@types/eslint@9.6.1)(jiti@2.7.0))':
-    dependencies:
-      '@eslint/core': 1.2.1
-    optionalDependencies:
-      eslint: 9.39.4(@types/eslint@9.6.1)(jiti@2.7.0)
-
   '@eslint/config-array@0.21.2':
     dependencies:
       '@eslint/object-schema': 2.1.7
@@ -10226,10 +10197,6 @@ snapshots:
       '@eslint/core': 0.17.0
 
   '@eslint/core@0.17.0':
-    dependencies:
-      '@types/json-schema': 7.0.15
-
-  '@eslint/core@1.2.1':
     dependencies:
       '@types/json-schema': 7.0.15
 
@@ -16037,12 +16004,6 @@ snapshots:
     dependencies:
       eslint: 9.39.4(@types/eslint@9.6.1)(jiti@2.7.0)
       natural-compare-lite: 1.4.0
-
-  eslint-plugin-sort-keys-plus@1.5.0:
-    dependencies:
-      escape-string-regexp: 4.0.0
-      esquery: 1.6.0
-      natural-compare: 1.4.0
 
   eslint-plugin-storybook@10.3.5(@types/eslint@9.6.1)(@typescript/typescript6@6.0.2)(eslint@9.39.4(@types/eslint@9.6.1)(jiti@2.7.0))(storybook@10.5.0(@types/prettier@3.0.0)(@types/react@19.2.17)(prettier@3.7.4)(react@19.2.6)):
     dependencies:


### PR DESCRIPTION
[DEVPROD-29652](https://jira.mongodb.org/browse/DEVPROD-29652)

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->

<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
We _could_ keep this plugin, but applying it to other files is kind of a hassle and there are a number of exceptions (for example, form schemas cannot be sorted by key because we put the fields in an intentional order).

Given the fact that this rule never made it anywhere beyond Parsley, it might be simpler to just drop it.