### PR TITLE
DEVPROD-31461: Migrate `data-cy` -> `data-testid` attributes in Parsley

### DIFF
--- a/apps/parsley/playwright.config.ts
+++ b/apps/parsley/playwright.config.ts
@@ -20,4 +20,7 @@ export default createPlaywrightConfig({
       dependencies: ["setup"],
     },
   ],
+  use: {
+    testIdAttribute: "data-testid", // TODO: Remove override when we've finished migrating off data-cy attributes.
+  },
 });

--- a/apps/parsley/playwright/helpers/index.ts
+++ b/apps/parsley/playwright/helpers/index.ts
@@ -59,16 +59,16 @@ export const clearBounds = async (page: Page) => {
 
 export const clickToggle = async (
   page: Page,
-  toggleDataCy: string,
+  toggleDataTestId: string,
   enabled: boolean,
   tab: "search-and-filter" | "log-viewing" = "search-and-filter",
 ) => {
   await toggleDetailsPanel(page, true);
   if (tab === "log-viewing") {
-    await page.locator("button[data-cy='log-viewing-tab']").click();
+    await page.locator("button[data-testid='log-viewing-tab']").click();
   }
-  await page.getByTestId(toggleDataCy).click();
-  await expect(page.getByTestId(toggleDataCy)).toHaveAttribute(
+  await page.getByTestId(toggleDataTestId).click();
+  await expect(page.getByTestId(toggleDataTestId)).toHaveAttribute(
     "aria-checked",
     `${enabled}`,
   );

--- a/apps/parsley/playwright/tests/ansiLogs/ansi_filtering.spec.ts
+++ b/apps/parsley/playwright/tests/ansiLogs/ansi_filtering.spec.ts
@@ -19,12 +19,12 @@ test.describe("Filtering", () => {
         await expect(page).toHaveURL(/\?bookmarks=0,6,297&shareLine=5/);
         await helpers.addFilter(page, "doesNotMatchAnything");
 
-        const filteredRows = page.locator("[data-cy^='log-row-']");
+        const filteredRows = page.locator("[data-testid^='log-row-']");
         await expect(filteredRows).toHaveCount(4);
         const logRows = await filteredRows.all();
         for (const row of logRows) {
-          const dataCy = await row.getAttribute("data-cy");
-          expect(dataCy).toMatch(/log-row-(0|5|6|297)/);
+          const dataTestId = await row.getAttribute("data-testid");
+          expect(dataTestId).toMatch(/log-row-(0|5|6|297)/);
         }
       });
 
@@ -58,7 +58,7 @@ test.describe("Filtering", () => {
           );
 
           const filteredRows = page.locator(
-            "[data-cy^='log-row-']:not([data-bookmarked=true])",
+            "[data-testid^='log-row-']:not([data-bookmarked=true])",
           );
           await expect(filteredRows).not.toHaveCount(0);
           const logRows = await filteredRows.all();
@@ -82,7 +82,7 @@ test.describe("Filtering", () => {
           );
 
           const filteredRows = page.locator(
-            "[data-cy^='log-row-']:not([data-bookmarked=true])",
+            "[data-testid^='log-row-']:not([data-bookmarked=true])",
           );
           await expect(filteredRows).not.toHaveCount(0);
           const logRows = await filteredRows.all();
@@ -106,7 +106,7 @@ test.describe("Filtering", () => {
           );
 
           const filteredRows = page.locator(
-            "[data-cy^='log-row-']:not([data-bookmarked=true])",
+            "[data-testid^='log-row-']:not([data-bookmarked=true])",
           );
           await expect(filteredRows).not.toHaveCount(0);
           const logRows = await filteredRows.all();
@@ -134,7 +134,9 @@ test.describe("Filtering", () => {
           await expect(page).toHaveURL(
             new RegExp(`filters=010${filter1},001${filter2}`),
           );
-          const skippedLines = page.locator("[data-cy^='skipped-lines-row-']");
+          const skippedLines = page.locator(
+            "[data-testid^='skipped-lines-row-']",
+          );
           await expect(skippedLines).toHaveCount(0);
         });
       });
@@ -152,7 +154,7 @@ test.describe("Filtering", () => {
           );
 
           const filteredRows = page.locator(
-            "[data-cy^='log-row-']:not([data-bookmarked=true])",
+            "[data-testid^='log-row-']:not([data-bookmarked=true])",
           );
           await expect(filteredRows).not.toHaveCount(0);
           const logRows = await filteredRows.all();
@@ -175,7 +177,7 @@ test.describe("Filtering", () => {
           );
 
           const filteredRows = page.locator(
-            "[data-cy^='log-row-']:not([data-bookmarked=true])",
+            "[data-testid^='log-row-']:not([data-bookmarked=true])",
           );
           await expect(filteredRows).not.toHaveCount(0);
           await expect(
@@ -199,7 +201,7 @@ test.describe("Filtering", () => {
           );
 
           const filteredRows = page.locator(
-            "[data-cy^='log-row-']:not([data-bookmarked=true])",
+            "[data-testid^='log-row-']:not([data-bookmarked=true])",
           );
           await expect(filteredRows).not.toHaveCount(0);
           await expect(
@@ -227,7 +229,9 @@ test.describe("Filtering", () => {
           await expect(page).toHaveURL(
             new RegExp(`filters=010${filter1},001${filter2}`),
           );
-          const skippedLines = page.locator("[data-cy^='skipped-lines-row-']");
+          const skippedLines = page.locator(
+            "[data-testid^='skipped-lines-row-']",
+          );
           await expect(skippedLines).toHaveCount(0);
         });
       });
@@ -240,7 +244,7 @@ test.describe("Filtering", () => {
     test.beforeEach(async ({ page }) => {
       await page.goto(`${logLink}?filters=100${filter}`);
       await expect(page.getByTestId("ansi-row")).toHaveCount(0);
-      const skippedLines = page.locator("[data-cy^='skipped-lines-row-']");
+      const skippedLines = page.locator("[data-testid^='skipped-lines-row-']");
       await expect(skippedLines).not.toHaveCount(0);
     });
 
@@ -256,7 +260,7 @@ test.describe("Filtering", () => {
       await expect(page).toHaveURL(/filters=100running/);
 
       const filteredRows = page.locator(
-        "[data-cy^='log-row-']:not([data-bookmarked=true])",
+        "[data-testid^='log-row-']:not([data-bookmarked=true])",
       );
       await expect(filteredRows).not.toHaveCount(0);
       const logRows = await filteredRows.all();
@@ -272,7 +276,7 @@ test.describe("Filtering", () => {
         .getByRole("button", { name: "Delete filter" })
         .click();
       await expect(page).toHaveURL(/^(?!.*filters)/);
-      const skippedLines = page.locator("[data-cy^='skipped-lines-row-']");
+      const skippedLines = page.locator("[data-testid^='skipped-lines-row-']");
       await expect(skippedLines).toHaveCount(0);
     });
   });
@@ -284,7 +288,7 @@ test.describe("Filtering", () => {
     test("should be able to hide and unhide filters", async ({ page }) => {
       await page.goto(`${logLink}?filters=110${filter1},100${filter2}`);
       await expect(page.getByTestId("ansi-row")).toHaveCount(0);
-      const skippedLines = page.locator("[data-cy^='skipped-lines-row-']");
+      const skippedLines = page.locator("[data-testid^='skipped-lines-row-']");
       await expect(skippedLines).not.toHaveCount(0);
 
       await page.getByTestId("all-filters-toggle").click();

--- a/apps/parsley/playwright/tests/ansiLogs/ansi_log_view.spec.ts
+++ b/apps/parsley/playwright/tests/ansiLogs/ansi_log_view.spec.ts
@@ -17,7 +17,7 @@ test.describe("Basic evergreen log view", () => {
   }) => {
     await expect(page.getByTestId("log-row-22")).toBeVisible();
     await expect(page.getByTestId("log-row-22")).toContainText(longLogLine);
-    await helpers.isNotContainedInViewport(page, "[data-cy=log-row-22]");
+    await helpers.isNotContainedInViewport(page, "[data-testid=log-row-22]");
 
     await page.getByTestId("paginated-virtual-list").evaluate((el) => {
       el.scrollTo(500, 0);
@@ -30,7 +30,7 @@ test.describe("Basic evergreen log view", () => {
     await helpers.clickToggle(page, "wrap-toggle", true, "log-viewing");
     await expect(page.getByTestId("log-row-22")).toBeVisible();
     await expect(page.getByTestId("log-row-22")).toContainText(longLogLine);
-    await helpers.isContainedInViewport(page, "[data-cy=log-row-22]");
+    await helpers.isContainedInViewport(page, "[data-testid=log-row-22]");
   });
 
   test("should still allow horizontal scrolling when there are few logs on screen", async ({
@@ -170,7 +170,7 @@ test.describe("Jump to line", () => {
     page,
   }) => {
     await page.goto(logLink);
-    await expect(page.locator("[data-cy^='log-row-']")).not.toHaveCount(0);
+    await expect(page.locator("[data-testid^='log-row-']")).not.toHaveCount(0);
     await expect(page.getByTestId("log-row-4")).toBeVisible();
     await page.getByTestId("log-row-4").dblclick();
     await expect(page.getByTestId("bookmark-4")).toBeVisible();
@@ -186,7 +186,7 @@ test.describe("Jump to line", () => {
     page,
   }) => {
     await page.goto(`${logLink}?filters=100pass`);
-    await expect(page.locator("[data-cy^='log-row-']")).not.toHaveCount(0);
+    await expect(page.locator("[data-testid^='log-row-']")).not.toHaveCount(0);
     await page.getByTestId("log-row-56").dblclick();
     await expect(page.getByTestId("bookmark-56")).toBeVisible();
 

--- a/apps/parsley/playwright/tests/ansiLogs/ansi_searching.spec.ts
+++ b/apps/parsley/playwright/tests/ansiLogs/ansi_searching.spec.ts
@@ -120,7 +120,7 @@ test.describe("Searching", () => {
   test("should be able to search on filtered content", async ({ page }) => {
     await helpers.addFilter(page, "installation");
 
-    const skippedLines = page.locator("[data-cy^='skipped-lines-row-']");
+    const skippedLines = page.locator("[data-testid^='skipped-lines-row-']");
     await expect(skippedLines).toHaveCount(3);
 
     await helpers.addSearch(page, "info");
@@ -134,7 +134,7 @@ test.describe("Searching", () => {
     const filter = "nonexistent-term";
     await helpers.addFilter(page, filter);
 
-    const skippedLines = page.locator("[data-cy^='skipped-lines-row-']");
+    const skippedLines = page.locator("[data-testid^='skipped-lines-row-']");
     await expect(skippedLines).toHaveCount(1);
 
     await helpers.addSearch(page, "info");

--- a/apps/parsley/playwright/tests/project_filters.spec.ts
+++ b/apps/parsley/playwright/tests/project_filters.spec.ts
@@ -28,7 +28,7 @@ test.describe("project filters", () => {
     await expect(page).toHaveURL(
       /111%28NETWORK%257CASIO%257CEXECUTOR%257CCONNPOOL%257CREPL_HB%29/,
     );
-    const skippedLines = page.locator("[data-cy^='skipped-lines-row-']");
+    const skippedLines = page.locator("[data-testid^='skipped-lines-row-']");
     await expect(skippedLines).not.toHaveCount(0);
   });
 
@@ -56,7 +56,7 @@ test.describe("project filters", () => {
     await expect(page).toHaveURL(
       /110%2522Connection%2520accepted%2522%252C%2522attr%2522/,
     );
-    const skippedLines = page.locator("[data-cy^='skipped-lines-row-']");
+    const skippedLines = page.locator("[data-testid^='skipped-lines-row-']");
     await expect(skippedLines).not.toHaveCount(0);
   });
 

--- a/apps/parsley/playwright/tests/resmokeLogs/resmoke_evg_test_log_view.spec.ts
+++ b/apps/parsley/playwright/tests/resmokeLogs/resmoke_evg_test_log_view.spec.ts
@@ -14,7 +14,7 @@ test.describe("Basic resmoke log view", () => {
     page,
   }) => {
     await expect(page.getByTestId("log-row-16")).toBeVisible();
-    await helpers.isNotContainedInViewport(page, "[data-cy=log-row-16]");
+    await helpers.isNotContainedInViewport(page, "[data-testid=log-row-16]");
 
     await page.getByTestId("paginated-virtual-list").evaluate((el) => {
       el.scrollTo(500, 0);
@@ -26,7 +26,7 @@ test.describe("Basic resmoke log view", () => {
   }) => {
     await helpers.clickToggle(page, "wrap-toggle", true, "log-viewing");
     await expect(page.getByTestId("log-row-16")).toBeVisible();
-    await helpers.isContainedInViewport(page, "[data-cy=log-row-16]");
+    await helpers.isContainedInViewport(page, "[data-testid=log-row-16]");
   });
 
   test("should still allow horizontal scrolling when there are few logs on screen", async ({
@@ -88,7 +88,7 @@ test.describe("Resmoke syntax highlighting", () => {
   test("should not color non-resmoke log lines", async ({ page }) => {
     const resmokeRow = page
       .getByTestId("log-row-0")
-      .locator("[data-cy=resmoke-row]");
+      .locator("[data-testid=resmoke-row]");
     const color = await resmokeRow.evaluate((el) =>
       window.getComputedStyle(el).getPropertyValue("color"),
     );
@@ -105,13 +105,13 @@ test.describe("Resmoke syntax highlighting", () => {
 
     const row20Color = await page
       .getByTestId("log-row-20")
-      .locator("[data-cy=resmoke-row]")
+      .locator("[data-testid=resmoke-row]")
       .evaluate((el) => window.getComputedStyle(el).getPropertyValue("color"));
     expect(row20Color).toBe(colors.blue);
 
     const row21Color = await page
       .getByTestId("log-row-21")
-      .locator("[data-cy=resmoke-row]")
+      .locator("[data-testid=resmoke-row]")
       .evaluate((el) => window.getComputedStyle(el).getPropertyValue("color"));
     expect(row21Color).toBe(colors.blue);
   });
@@ -126,13 +126,13 @@ test.describe("Resmoke syntax highlighting", () => {
 
     const row19Color = await page
       .getByTestId("log-row-19")
-      .locator("[data-cy=resmoke-row]")
+      .locator("[data-testid=resmoke-row]")
       .evaluate((el) => window.getComputedStyle(el).getPropertyValue("color"));
     expect(row19Color).toBe(colors.green);
 
     const row20Color = await page
       .getByTestId("log-row-20")
-      .locator("[data-cy=resmoke-row]")
+      .locator("[data-testid=resmoke-row]")
       .evaluate((el) => window.getComputedStyle(el).getPropertyValue("color"));
     expect(row20Color).toBe(colors.blue);
   });

--- a/apps/parsley/playwright/tests/resmokeLogs/resmoke_filtering.spec.ts
+++ b/apps/parsley/playwright/tests/resmokeLogs/resmoke_filtering.spec.ts
@@ -19,12 +19,12 @@ test.describe("Filtering", () => {
         await expect(page).toHaveURL(/\?bookmarks=0,6,115&shareLine=5/);
         await helpers.addFilter(page, "doesNotMatchAnything");
 
-        const filteredRows = page.locator("[data-cy^='log-row-']");
+        const filteredRows = page.locator("[data-testid^='log-row-']");
         await expect(filteredRows).toHaveCount(4);
         const logRows = await filteredRows.all();
         for (const row of logRows) {
-          const dataCy = await row.getAttribute("data-cy");
-          expect(dataCy).toMatch(/log-row-(0|5|6|115)/);
+          const dataTestId = await row.getAttribute("data-testid");
+          expect(dataTestId).toMatch(/log-row-(0|5|6|115)/);
         }
       });
 
@@ -58,7 +58,7 @@ test.describe("Filtering", () => {
           );
 
           const filteredRows = page.locator(
-            "[data-cy^='log-row-']:not([data-bookmarked=true])",
+            "[data-testid^='log-row-']:not([data-bookmarked=true])",
           );
           await expect(filteredRows).not.toHaveCount(0);
           const logRows = await filteredRows.all();
@@ -81,7 +81,7 @@ test.describe("Filtering", () => {
             new RegExp(`filters=110${filter1},100${filter2}`),
           );
           const filteredRows = page.locator(
-            "[data-cy^='log-row-']:not([data-bookmarked=true])",
+            "[data-testid^='log-row-']:not([data-bookmarked=true])",
           );
           await expect(filteredRows).not.toHaveCount(0);
           const logRows = await filteredRows.all();
@@ -105,7 +105,7 @@ test.describe("Filtering", () => {
           );
 
           const filteredRows = page.locator(
-            "[data-cy^='log-row-']:not([data-bookmarked=true])",
+            "[data-testid^='log-row-']:not([data-bookmarked=true])",
           );
           await expect(filteredRows).not.toHaveCount(0);
           const logRows = await filteredRows.all();
@@ -133,7 +133,9 @@ test.describe("Filtering", () => {
           await expect(page).toHaveURL(
             new RegExp(`filters=010${filter1},001${filter2}`),
           );
-          const skippedLines = page.locator("[data-cy^='skipped-lines-row-']");
+          const skippedLines = page.locator(
+            "[data-testid^='skipped-lines-row-']",
+          );
           await expect(skippedLines).toHaveCount(0);
         });
       });
@@ -151,7 +153,7 @@ test.describe("Filtering", () => {
           );
 
           const filteredRows = page.locator(
-            "[data-cy^='log-row-']:not([data-bookmarked=true])",
+            "[data-testid^='log-row-']:not([data-bookmarked=true])",
           );
           await expect(filteredRows).not.toHaveCount(0);
           const logRows = await filteredRows.all();
@@ -174,7 +176,7 @@ test.describe("Filtering", () => {
           );
 
           const filteredRows = page.locator(
-            "[data-cy^='log-row-']:not([data-bookmarked=true])",
+            "[data-testid^='log-row-']:not([data-bookmarked=true])",
           );
           await expect(filteredRows).not.toHaveCount(0);
           await expect(
@@ -198,7 +200,7 @@ test.describe("Filtering", () => {
           );
 
           const filteredRows = page.locator(
-            "[data-cy^='log-row-']:not([data-bookmarked=true])",
+            "[data-testid^='log-row-']:not([data-bookmarked=true])",
           );
           await expect(filteredRows).not.toHaveCount(0);
           await expect(
@@ -226,7 +228,9 @@ test.describe("Filtering", () => {
           await expect(page).toHaveURL(
             new RegExp(`filters=010${filter1},001${filter2}`),
           );
-          const skippedLines = page.locator("[data-cy^='skipped-lines-row-']");
+          const skippedLines = page.locator(
+            "[data-testid^='skipped-lines-row-']",
+          );
           await expect(skippedLines).toHaveCount(0);
         });
       });
@@ -239,7 +243,7 @@ test.describe("Filtering", () => {
     test.beforeEach(async ({ page }) => {
       await page.goto(`${logLink}?filters=100${filter}`);
       await expect(page.getByTestId("resmoke-row")).toHaveCount(0);
-      const skippedLines = page.locator("[data-cy^='skipped-lines-row-']");
+      const skippedLines = page.locator("[data-testid^='skipped-lines-row-']");
       await expect(skippedLines).not.toHaveCount(0);
     });
 
@@ -255,7 +259,7 @@ test.describe("Filtering", () => {
       await expect(page).toHaveURL(/filters=100session/);
 
       const filteredRows = page.locator(
-        "[data-cy^='log-row-']:not([data-bookmarked=true])",
+        "[data-testid^='log-row-']:not([data-bookmarked=true])",
       );
       await expect(filteredRows).not.toHaveCount(0);
       const logRows = await filteredRows.all();
@@ -271,7 +275,7 @@ test.describe("Filtering", () => {
         .getByRole("button", { name: "Delete filter" })
         .click();
       await expect(page).toHaveURL(/^(?!.*filters)/);
-      const skippedLines = page.locator("[data-cy^='skipped-lines-row-']");
+      const skippedLines = page.locator("[data-testid^='skipped-lines-row-']");
       await expect(skippedLines).toHaveCount(0);
     });
   });
@@ -283,7 +287,7 @@ test.describe("Filtering", () => {
     test("should be able to hide and unhide filters", async ({ page }) => {
       await page.goto(`${logLink}?filters=110${filter1},100${filter2}`);
       await expect(page.getByTestId("resmoke-row")).toHaveCount(0);
-      const skippedLines = page.locator("[data-cy^='skipped-lines-row-']");
+      const skippedLines = page.locator("[data-testid^='skipped-lines-row-']");
       await expect(skippedLines).not.toHaveCount(0);
 
       await page.getByTestId("all-filters-toggle").click();

--- a/apps/parsley/playwright/tests/resmokeLogs/resmoke_searching.spec.ts
+++ b/apps/parsley/playwright/tests/resmokeLogs/resmoke_searching.spec.ts
@@ -114,7 +114,7 @@ test.describe("Searching", () => {
   test("should be able to search on filtered content", async ({ page }) => {
     await helpers.addFilter(page, "conn49");
 
-    const skippedLines = page.locator("[data-cy^='skipped-lines-row-']");
+    const skippedLines = page.locator("[data-testid^='skipped-lines-row-']");
     await expect(skippedLines).toHaveCount(7);
 
     await helpers.addSearch(page, "NETWORK");
@@ -128,7 +128,7 @@ test.describe("Searching", () => {
     const filter = "nonexistent-term";
     await helpers.addFilter(page, filter);
 
-    const skippedLines = page.locator("[data-cy^='skipped-lines-row-']");
+    const skippedLines = page.locator("[data-testid^='skipped-lines-row-']");
     await expect(skippedLines).toHaveCount(1);
 
     await helpers.addSearch(page, "conn49");

--- a/apps/parsley/playwright/tests/routes.spec.ts
+++ b/apps/parsley/playwright/tests/routes.spec.ts
@@ -17,7 +17,7 @@ test.describe("Parsley Routes", () => {
     const logLink =
       "/evergreen/spruce_ubuntu1604_test_2c9056df66d42fb1908d52eed096750a91f1f089_22_03_02_16_45_12/0/task";
     await page.goto(logLink);
-    await expect(page.locator("[data-cy^='log-row-']")).not.toHaveCount(0);
+    await expect(page.locator("[data-testid^='log-row-']")).not.toHaveCount(0);
     await expect(page.getByTestId("ansi-row")).not.toHaveCount(0);
     await expect(page.getByTestId("resmoke-row")).toBeHidden();
     await expect(page.getByText("Task logger initialized")).toBeVisible();
@@ -43,7 +43,7 @@ test.describe("Parsley Routes", () => {
     const testLogLine =
       "AssertionError: Timed out retrying after 4000ms: Too many elements found. Found '1', expected '0'";
     await page.goto(logLink);
-    await expect(page.locator("[data-cy^='log-row-']")).not.toHaveCount(0);
+    await expect(page.locator("[data-testid^='log-row-']")).not.toHaveCount(0);
     await expect(page.getByTestId("ansi-row")).not.toHaveCount(0);
     await expect(page.getByTestId("resmoke-row")).toBeHidden();
     await expect(page.getByText(testLogLine)).toBeVisible();
@@ -55,12 +55,12 @@ test.describe("Parsley Routes", () => {
     const logLink =
       "/taskFile/spruce_ubuntu1604_test_2c9056df66d42fb1908d52eed096750a91f1f089_22_03_02_16_45_12/0/sample%20file";
     await page.goto(logLink);
-    await expect(page.locator("[data-cy^='log-row-']")).not.toHaveCount(0);
+    await expect(page.locator("[data-testid^='log-row-']")).not.toHaveCount(0);
     await expect(page.getByTestId("ansi-row")).not.toHaveCount(0);
   });
 
   test("should show 404 when visiting a nonexistent page", async ({ page }) => {
     await page.goto("/this/is/not/a/real/page");
-    await expect(page.locator('[data-cy="404"]')).toBeVisible();
+    await expect(page.locator('[data-testid="404"]')).toBeVisible();
   });
 });

--- a/apps/parsley/playwright/tests/sectioning.spec.ts
+++ b/apps/parsley/playwright/tests/sectioning.spec.ts
@@ -5,7 +5,7 @@ const logLink =
   "/evergreen/mongodb_mongo_master_enterprise_amazon_linux2_arm64_all_feature_flags_jsCore_patch_9801cf147ed208ce4c0ff8dff4a97cdb216f4c22_65f06bd09ccd4eaaccca1391_24_03_12_14_51_29/0/task";
 
 const getTargetSelector = (rowIndex: number) =>
-  `[data-index='${rowIndex}'] >  [data-cy='section-header']`;
+  `[data-index='${rowIndex}'] >  [data-testid='section-header']`;
 
 test.describe("Sectioning", () => {
   test.beforeEach(async ({ page }) => {
@@ -19,7 +19,7 @@ test.describe("Sectioning", () => {
   }) => {
     // Check that sections is toggled.
     await helpers.toggleDetailsPanel(page, true);
-    await page.locator("button[data-cy='log-viewing-tab']").click();
+    await page.locator("button[data-testid='log-viewing-tab']").click();
     await expect(page.getByTestId("sections-toggle")).toBeChecked();
     await helpers.toggleDetailsPanel(page, false);
     // Assert sections are visible.
@@ -65,12 +65,12 @@ test.describe("Sectioning", () => {
     }
 
     const openLineNumbers = [0, 1, 2, 8, 9, 9616, 9617, 9618, 9619];
-    const visibleRows = page.locator("[data-cy^='log-row-']");
+    const visibleRows = page.locator("[data-testid^='log-row-']");
     await expect(visibleRows).toHaveCount(openLineNumbers.length);
     const logRows = await visibleRows.all();
     for (const row of logRows) {
-      const dataCy = await row.getAttribute("data-cy");
-      expect(dataCy).toMatch(/log-row-(0|1|2|8|9|9616|9617|9618|9619)/);
+      const dataTestId = await row.getAttribute("data-testid");
+      expect(dataTestId).toMatch(/log-row-(0|1|2|8|9|9616|9617|9618|9619)/);
     }
   });
 
@@ -81,7 +81,7 @@ test.describe("Sectioning", () => {
       "Function: f_expansions_write",
     );
     await page
-      .locator(`${getTargetSelector(3)} > [data-cy='caret-toggle']`)
+      .locator(`${getTargetSelector(3)} > [data-testid='caret-toggle']`)
       .click();
     await expect(page.locator(getTargetSelector(4))).toContainText(
       "Command: expansions.update (step 1 of 2)",
@@ -95,7 +95,7 @@ test.describe("Sectioning", () => {
       "Command: expansions.write (step 2.1 of 2)",
     );
     await page
-      .locator(`${getTargetSelector(8)} > [data-cy='caret-toggle']`)
+      .locator(`${getTargetSelector(8)} > [data-testid='caret-toggle']`)
       .click();
     await expect(page.locator("[data-index='9']")).toContainText(
       "[2024/03/12 11:18:36.035] Running task commands failed: running command: command failed: process encountered problem: exit code 1",
@@ -140,7 +140,7 @@ test.describe("Sectioning", () => {
     });
     await openAllSectionsButton.click();
     await page.getByTestId("bookmark-9614").click();
-    await expect(page.locator("[data-cy='line-index-9614']")).toBeVisible();
+    await expect(page.locator("[data-testid='line-index-9614']")).toBeVisible();
     await expect(page.getByTestId("sticky-headers")).toBeVisible();
     await expect(page.getByTestId("sticky-headers")).toContainText(
       "Function: run tests",

--- a/apps/parsley/src/components/BookmarksBar/BookmarksBar.test.tsx
+++ b/apps/parsley/src/components/BookmarksBar/BookmarksBar.test.tsx
@@ -41,13 +41,13 @@ describe("bookmarks bar", () => {
         route: "?bookmarks=1&shareLine=5",
       },
     );
-    const { children } = screen.getByDataCy("bookmark-list");
+    const { children } = screen.getByDataTestId("bookmark-list");
     expect(children).toHaveLength(3);
     expect((children.item(0) as Element).textContent).toContain("1");
     expect((children.item(1) as Element).textContent).toContain("3");
     expect((children.item(2) as Element).textContent).toContain("5");
     expect((children.item(2) as Element).children.item(1)).toStrictEqual(
-      screen.getByDataCy("link-icon"),
+      screen.getByDataTestId("link-icon"),
     );
   });
 
@@ -59,7 +59,7 @@ describe("bookmarks bar", () => {
         route: "?bookmarks=1,3&shareLine=5",
       },
     );
-    await user.click(screen.getByDataCy("clear-bookmarks"));
+    await user.click(screen.getByDataTestId("clear-bookmarks"));
     await waitFor(() => {
       expect(
         screen.queryByText("Are you sure you want to clear all bookmarks?"),
@@ -78,7 +78,7 @@ describe("bookmarks bar", () => {
         route: "?bookmarks=1,3",
       },
     );
-    await user.click(screen.getByDataCy("bookmark-3"));
+    await user.click(screen.getByDataTestId("bookmark-3"));
     expect(scrollToLine).toHaveBeenCalledTimes(1);
     expect(scrollToLine).toHaveBeenCalledWith(3);
   });

--- a/apps/parsley/src/components/BookmarksBar/index.tsx
+++ b/apps/parsley/src/components/BookmarksBar/index.tsx
@@ -62,7 +62,7 @@ const BookmarksBar: React.FC<BookmarksBarProps> = ({
   return (
     <Container>
       <Popconfirm
-        data-cy="clear-bookmarks-popconfirm"
+        data-testid="clear-bookmarks-popconfirm"
         onConfirm={() => {
           setBookmarks([]);
           sendEvent({ name: "Deleted all bookmarks" });
@@ -77,7 +77,7 @@ const BookmarksBar: React.FC<BookmarksBarProps> = ({
         trigger={
           <StyledButton
             ref={clearButtonRef}
-            data-cy="clear-bookmarks"
+            data-testid="clear-bookmarks"
             onClick={() => setClearButtonConfirmationOpen(true)}
             size="xsmall"
           >
@@ -87,11 +87,11 @@ const BookmarksBar: React.FC<BookmarksBarProps> = ({
       >
         Clear all bookmarks
       </Tooltip>
-      <LogLineContainer data-cy="bookmark-list">
+      <LogLineContainer data-testid="bookmark-list">
         {lineNumbers.map((l) => (
           <LogLineNumber
             key={`bookmark-${l}`}
-            data-cy={`bookmark-${l}`}
+            data-testid={`bookmark-${l}`}
             failed={l === failingLine}
             onClick={() => {
               sendEvent({ name: "Used bookmark to navigate to a line" });
@@ -100,7 +100,7 @@ const BookmarksBar: React.FC<BookmarksBarProps> = ({
           >
             <span data-bookmark={l}>{l}</span>
             {l === shareLine && (
-              <StyledIcon data-cy="link-icon" glyph="Link" size="small" />
+              <StyledIcon data-testid="link-icon" glyph="Link" size="small" />
             )}
           </LogLineNumber>
         ))}

--- a/apps/parsley/src/components/Breadcrumbs/Breadcrumbs.test.tsx
+++ b/apps/parsley/src/components/Breadcrumbs/Breadcrumbs.test.tsx
@@ -9,26 +9,30 @@ import Breadcrumbs from ".";
 
 describe("breadcrumbs", () => {
   it("should render an individual breadcrumb", () => {
-    render(<Breadcrumbs breadcrumbs={[{ "data-cy": "bc", text: "test" }]} />);
+    render(
+      <Breadcrumbs breadcrumbs={[{ "data-testid": "bc", text: "test" }]} />,
+    );
     expect(screen.getByText("test")).toBeInTheDocument();
-    expect(screen.queryByDataCy("breadcrumb-chevron")).not.toBeInTheDocument();
+    expect(
+      screen.queryByDataTestId("breadcrumb-chevron"),
+    ).not.toBeInTheDocument();
   });
 
   it("should render many breadcrumbs separated by chevrons", () => {
     const breadcrumbs = [
-      { "data-cy": "bc-1", text: "test 1" },
-      { "data-cy": "bc-2", text: "test 2" },
+      { "data-testid": "bc-1", text: "test 1" },
+      { "data-testid": "bc-2", text: "test 2" },
     ];
     render(<Breadcrumbs breadcrumbs={breadcrumbs} />);
     expect(screen.getByText("test 1")).toBeInTheDocument();
     expect(screen.getByText("test 2")).toBeInTheDocument();
-    expect(screen.queryAllByDataCy("breadcrumb-chevron")).toHaveLength(1);
+    expect(screen.queryAllByDataTestId("breadcrumb-chevron")).toHaveLength(1);
   });
 
   it("breadcrumbs with long text should be collapsed to 30 characters by default and viewable with a tooltip", async () => {
     const user = userEvent.setup();
     const longMessage = "some really long string that could be a patch title";
-    const breadcrumbs = [{ "data-cy": "bc", text: longMessage }];
+    const breadcrumbs = [{ "data-testid": "bc", text: longMessage }];
     render(<Breadcrumbs breadcrumbs={breadcrumbs} />);
     expect(screen.queryByText(longMessage)).not.toBeInTheDocument();
 
@@ -37,7 +41,7 @@ describe("breadcrumbs", () => {
     ).toBeInTheDocument();
     await user.hover(screen.getByText(trimStringFromMiddle(longMessage, 30)));
     await waitFor(() => {
-      expect(screen.getByDataCy("breadcrumb-tooltip")).toBeInTheDocument();
+      expect(screen.getByDataTestId("breadcrumb-tooltip")).toBeInTheDocument();
     });
     expect(screen.getByText(longMessage)).toBeInTheDocument();
   });
@@ -46,7 +50,7 @@ describe("breadcrumbs", () => {
     const user = userEvent.setup();
     const longMessage = "some really long string that could be a patch title";
     const breadcrumbs = [
-      { "data-cy": "bc", text: longMessage, trimLength: 25 },
+      { "data-testid": "bc", text: longMessage, trimLength: 25 },
     ];
     render(<Breadcrumbs breadcrumbs={breadcrumbs} />);
     expect(screen.queryByText(longMessage)).not.toBeInTheDocument();
@@ -56,7 +60,7 @@ describe("breadcrumbs", () => {
     ).toBeInTheDocument();
     await user.hover(screen.getByText(trimStringFromMiddle(longMessage, 25)));
     await waitFor(() => {
-      expect(screen.getByDataCy("breadcrumb-tooltip")).toBeInTheDocument();
+      expect(screen.getByDataTestId("breadcrumb-tooltip")).toBeInTheDocument();
     });
     expect(screen.getByText(longMessage)).toBeInTheDocument();
   });
@@ -64,13 +68,13 @@ describe("breadcrumbs", () => {
   it("should not display a tooltip if the text is short", async () => {
     const user = userEvent.setup();
     const shortMessage = "short";
-    const breadcrumbs = [{ "data-cy": "bc", text: shortMessage }];
+    const breadcrumbs = [{ "data-testid": "bc", text: shortMessage }];
     render(<Breadcrumbs breadcrumbs={breadcrumbs} />);
     expect(screen.getByText(shortMessage)).toBeInTheDocument();
     await user.hover(screen.getByText(shortMessage));
     await waitFor(() => {
       expect(
-        screen.queryByDataCy("breadcrumb-tooltip"),
+        screen.queryByDataTestId("breadcrumb-tooltip"),
       ).not.toBeInTheDocument();
     });
   });
@@ -78,7 +82,9 @@ describe("breadcrumbs", () => {
   it("clicking on a tooltip with a link and event handler should call the event", async () => {
     const user = userEvent.setup();
     const onClick = vi.fn();
-    const breadcrumbs = [{ "data-cy": "bc", onClick, text: "test", to: "/" }];
+    const breadcrumbs = [
+      { "data-testid": "bc", onClick, text: "test", to: "/" },
+    ];
     render(<Breadcrumbs breadcrumbs={breadcrumbs} />);
     expect(screen.getByText("test")).toBeInTheDocument();
     expect(screen.getByRole("link")).toHaveAttribute("href", "/");
@@ -92,7 +98,7 @@ describe("breadcrumbs", () => {
     const user = userEvent.setup();
     const breadcrumbs = [
       {
-        "data-cy": "bc",
+        "data-testid": "bc",
         text: "My Breadcrumb",
         tooltipText: "My Tooltip Text",
       },

--- a/apps/parsley/src/components/Breadcrumbs/index.tsx
+++ b/apps/parsley/src/components/Breadcrumbs/index.tsx
@@ -10,7 +10,7 @@ import { trimStringFromMiddle } from "@evg-ui/lib/utils/string";
 const { gray } = palette;
 
 export interface Breadcrumb {
-  "data-cy"?: string;
+  "data-testid"?: string;
   href?: string;
   onClick?: () => void;
   text: ReactNode;
@@ -22,13 +22,13 @@ interface BreadcrumbsProps {
   breadcrumbs: Breadcrumb[];
 }
 const Breadcrumbs: React.FC<BreadcrumbsProps> = ({ breadcrumbs }) => (
-  <Container data-cy="breadcrumb-container">
+  <Container data-testid="breadcrumb-container">
     {breadcrumbs.map((bc, index) => (
-      <Fragment key={`breadcrumb-${bc["data-cy"]}`}>
+      <Fragment key={`breadcrumb-${bc["data-testid"]}`}>
         <BreadcrumbFragment breadcrumb={bc} />
         {breadcrumbs.length - 1 !== index && (
           <Icon
-            data-cy="breadcrumb-chevron"
+            data-testid="breadcrumb-chevron"
             fill={gray.dark2}
             glyph="ChevronRight"
             size="small"
@@ -46,7 +46,7 @@ const BreadcrumbFragment: React.FC<BreadcrumbFragmentProps> = ({
   breadcrumb,
 }) => {
   const {
-    "data-cy": dataCy,
+    "data-testid": dataTestId,
     href,
     onClick,
     text = "",
@@ -62,23 +62,23 @@ const BreadcrumbFragment: React.FC<BreadcrumbFragmentProps> = ({
   let trigger;
   if (to) {
     trigger = (
-      <StyledRouterLink data-cy={dataCy} onClick={onClick} to={to}>
+      <StyledRouterLink data-testid={dataTestId} onClick={onClick} to={to}>
         {message}
       </StyledRouterLink>
     );
   } else if (href) {
     trigger = (
-      <StyledLink data-cy={dataCy} href={href} onClick={onClick}>
+      <StyledLink data-testid={dataTestId} href={href} onClick={onClick}>
         {message}
       </StyledLink>
     );
   } else {
-    trigger = <div data-cy={dataCy}>{message}</div>;
+    trigger = <div data-testid={dataTestId}>{message}</div>;
   }
 
   return (
     <Tooltip
-      data-cy="breadcrumb-tooltip"
+      data-testid="breadcrumb-tooltip"
       enabled={shouldTrimMessage || !!tooltipText}
       trigger={trigger}
       triggerEvent="hover"

--- a/apps/parsley/src/components/Chatbot/Chatbot.test.tsx
+++ b/apps/parsley/src/components/Chatbot/Chatbot.test.tsx
@@ -50,14 +50,14 @@ describe("ToggleChatbotButton", () => {
     await waitFor(() => {
       expect(screen.getByRole("button", { name: "Parsley AI" })).toBeVisible();
     });
-    expect(screen.getByDataCy("chat-drawer")).toHaveAttribute(
+    expect(screen.getByDataTestId("chat-drawer")).toHaveAttribute(
       "aria-hidden",
       "true",
     );
     await user.click(screen.getByRole("button", { name: "Parsley AI" }));
     expect(screen.getByPlaceholderText("Type your message here")).toBeVisible();
     await waitFor(() => {
-      expect(screen.getByDataCy("chat-drawer")).toHaveAttribute(
+      expect(screen.getByDataTestId("chat-drawer")).toHaveAttribute(
         "aria-hidden",
         "false",
       );

--- a/apps/parsley/src/components/Chatbot/index.tsx
+++ b/apps/parsley/src/components/Chatbot/index.tsx
@@ -146,7 +146,7 @@ export const Chatbot: React.FC<{ children: React.ReactNode }> = ({
           }}
         />
       }
-      data-cy="chat-drawer"
+      data-testid="chat-drawer"
     >
       {children}
     </ChatDrawer>

--- a/apps/parsley/src/components/DetailsMenu/DetailsMenu.test.tsx
+++ b/apps/parsley/src/components/DetailsMenu/DetailsMenu.test.tsx
@@ -57,20 +57,20 @@ describe("detailsMenu", () => {
     const user = userEvent.setup();
 
     renderDetailsMenu();
-    expect(screen.queryByDataCy("details-menu")).not.toBeInTheDocument();
+    expect(screen.queryByDataTestId("details-menu")).not.toBeInTheDocument();
     const detailsButton = screen.getByRole("button", {
       name: "Details",
     });
     expect(detailsButton).toBeEnabled();
     await user.click(detailsButton);
-    expect(screen.getByDataCy("details-menu")).toBeInTheDocument();
+    expect(screen.getByDataTestId("details-menu")).toBeInTheDocument();
   });
 
   it("updating search range should flash the details button", async () => {
     vi.useFakeTimers();
 
     const { hook } = renderDetailsMenu();
-    expect(screen.queryByDataCy("details-menu")).not.toBeInTheDocument();
+    expect(screen.queryByDataTestId("details-menu")).not.toBeInTheDocument();
     const detailsButton = screen.getByRole("button", {
       name: "Details",
     });

--- a/apps/parsley/src/components/DetailsMenu/DetailsMenuCard/ButtonRow/ButtonRow.test.tsx
+++ b/apps/parsley/src/components/DetailsMenu/DetailsMenuCard/ButtonRow/ButtonRow.test.tsx
@@ -19,12 +19,12 @@ describe("buttonRow", () => {
       renderWithRouterMatch(<ButtonRow />, {
         wrapper: logContextWrapper(logLines),
       });
-      expect(screen.getByDataCy("copy-text-button")).toHaveAttribute(
+      expect(screen.getByDataTestId("copy-text-button")).toHaveAttribute(
         "aria-disabled",
         "true",
       );
       // Tooltip should appear only if button is disabled.
-      await user.hover(screen.getByDataCy("copy-text-button"));
+      await user.hover(screen.getByDataTestId("copy-text-button"));
       await waitFor(() => {
         expect(screen.getByText("No bookmarks to copy.")).toBeInTheDocument();
       });
@@ -36,14 +36,14 @@ describe("buttonRow", () => {
         route: "?bookmarks=0,2",
         wrapper: logContextWrapper(logLines),
       });
-      const copyButton = screen.getByDataCy("copy-text-button");
+      const copyButton = screen.getByDataTestId("copy-text-button");
       expect(copyButton).toBeEnabled();
       expect(copyButton).toHaveTextContent("Copy Jira");
 
       // Button text should change after clicking on the button.
       await user.click(copyButton);
       await waitFor(() => {
-        expect(screen.getByDataCy("copy-text-button")).toHaveTextContent(
+        expect(screen.getByDataTestId("copy-text-button")).toHaveTextContent(
           "Copied",
         );
       });
@@ -56,7 +56,7 @@ describe("buttonRow", () => {
         wrapper: logContextWrapper(logLines),
       });
 
-      const copyButton = screen.getByDataCy("copy-text-button");
+      const copyButton = screen.getByDataTestId("copy-text-button");
       expect(copyButton).toBeEnabled();
 
       await user.click(copyButton);
@@ -85,7 +85,7 @@ describe("buttonRow", () => {
         `${logLines[0]}\n...\n${logLines[2]}\n...\n${logLines[5]}\n`,
       );
 
-      const copyButton = screen.getByDataCy("copy-text-button");
+      const copyButton = screen.getByDataTestId("copy-text-button");
       expect(copyButton).toHaveTextContent("Copied");
 
       await waitFor(
@@ -102,7 +102,7 @@ describe("buttonRow", () => {
       renderWithRouterMatch(<ButtonRow />, {
         wrapper: logContextWrapper(logLines),
       });
-      expect(screen.getByDataCy("download-log-button")).toHaveAttribute(
+      expect(screen.getByDataTestId("download-log-button")).toHaveAttribute(
         "aria-disabled",
         "true",
       );

--- a/apps/parsley/src/components/DetailsMenu/DetailsMenuCard/ButtonRow/CopyTextButton.tsx
+++ b/apps/parsley/src/components/DetailsMenu/DetailsMenuCard/ButtonRow/CopyTextButton.tsx
@@ -121,7 +121,7 @@ const Button: React.FC<{ bookmarks: number[] }> = ({ bookmarks }) => {
           }
         }
       `}
-      data-cy="copy-text-button"
+      data-testid="copy-text-button"
       disabled={!bookmarks.length}
       label={copied ? "Copied" : primaryOption.label}
       leftGlyph={<Icon data-testid="copy-glyph" glyph="Copy" />}

--- a/apps/parsley/src/components/DetailsMenu/DetailsMenuCard/ButtonRow/index.tsx
+++ b/apps/parsley/src/components/DetailsMenu/DetailsMenuCard/ButtonRow/index.tsx
@@ -25,7 +25,7 @@ const ButtonRow: React.FC = () => {
           justify="middle"
           trigger={
             <Button
-              data-cy="job-logs-button"
+              data-testid="job-logs-button"
               disabled={!jobLogsURL}
               href={jobLogsURL}
               leftGlyph={<Icon glyph="Export" />}
@@ -42,7 +42,7 @@ const ButtonRow: React.FC = () => {
           justify="middle"
           trigger={
             <Button
-              data-cy="raw-log-button"
+              data-testid="raw-log-button"
               disabled={!rawLogURL}
               href={rawLogURL}
               leftGlyph={<Icon glyph="Export" />}
@@ -59,7 +59,7 @@ const ButtonRow: React.FC = () => {
           justify="middle"
           trigger={
             <Button
-              data-cy="html-log-button"
+              data-testid="html-log-button"
               disabled={!htmlLogURL}
               href={htmlLogURL}
               leftGlyph={<Icon glyph="Export" />}
@@ -76,7 +76,7 @@ const ButtonRow: React.FC = () => {
           justify="middle"
           trigger={
             <Button
-              data-cy="download-log-button"
+              data-testid="download-log-button"
               disabled={!rawLogURL}
               leftGlyph={<Icon glyph="Download" />}
               onClick={() => {

--- a/apps/parsley/src/components/DetailsMenu/DetailsMenuCard/CliCommandButton/CliCommandButton.tsx
+++ b/apps/parsley/src/components/DetailsMenu/DetailsMenuCard/CliCommandButton/CliCommandButton.tsx
@@ -15,7 +15,7 @@ const CliCommandButton: React.FC = () => {
 
   return (
     <StyledCopyable
-      data-cy="cli-command-copyable"
+      data-testid="cli-command-copyable"
       label="Fetch the log via Evergreen CLI"
     >
       {command}

--- a/apps/parsley/src/components/DetailsMenu/DetailsMenuCard/SearchRangeInput/SearchRangeInput.test.tsx
+++ b/apps/parsley/src/components/DetailsMenu/DetailsMenuCard/SearchRangeInput/SearchRangeInput.test.tsx
@@ -10,11 +10,11 @@ describe("search range input", () => {
     const user = userEvent.setup();
     const { router } = render(<SearchRangeInput />);
 
-    const lowerBound = screen.getByDataCy("range-lower-bound");
+    const lowerBound = screen.getByDataTestId("range-lower-bound");
     await user.type(lowerBound, "99");
     expect(router.state.location.search).toBe("?lower=99");
 
-    const upperBound = screen.getByDataCy("range-upper-bound");
+    const upperBound = screen.getByDataTestId("range-upper-bound");
     await user.type(upperBound, "100");
     expect(router.state.location.search).toBe("?lower=99&upper=100");
   });
@@ -23,7 +23,7 @@ describe("search range input", () => {
     const user = userEvent.setup();
     const { router } = render(<SearchRangeInput />);
 
-    const lowerBound = screen.getByDataCy("range-lower-bound");
+    const lowerBound = screen.getByDataTestId("range-lower-bound");
     await user.type(lowerBound, "99");
 
     expect(router.state.location.search).toBe("?lower=99");
@@ -36,12 +36,12 @@ describe("search range input", () => {
     const user = userEvent.setup();
     render(<SearchRangeInput />);
 
-    const upperBound = screen.getByDataCy("range-upper-bound");
+    const upperBound = screen.getByDataTestId("range-upper-bound");
     await user.type(upperBound, "8");
 
-    const lowerBound = screen.getByDataCy("range-lower-bound");
+    const lowerBound = screen.getByDataTestId("range-lower-bound");
     await user.type(lowerBound, "9");
 
-    expect(screen.getByDataCy("range-error-message")).toBeInTheDocument();
+    expect(screen.getByDataTestId("range-error-message")).toBeInTheDocument();
   });
 });

--- a/apps/parsley/src/components/DetailsMenu/DetailsMenuCard/SearchRangeInput/index.tsx
+++ b/apps/parsley/src/components/DetailsMenu/DetailsMenuCard/SearchRangeInput/index.tsx
@@ -51,7 +51,7 @@ const SearchRangeInput: React.FC = () => {
         <RangeInputWrapper>
           <RangeInput
             aria-labelledby="Range Lower Bound"
-            data-cy="range-lower-bound"
+            data-testid="range-lower-bound"
             min={0}
             onChange={(e) => updateLowerBound(e.target.value)}
             placeholder="0"
@@ -62,7 +62,7 @@ const SearchRangeInput: React.FC = () => {
           />
           <RangeInput
             aria-labelledby="Range Upper Bound"
-            data-cy="range-upper-bound"
+            data-testid="range-upper-bound"
             min={0}
             onChange={(e) => updateUpperBound(e.target.value)}
             placeholder="100"
@@ -73,7 +73,7 @@ const SearchRangeInput: React.FC = () => {
           />
         </RangeInputWrapper>
         {hasError && (
-          <ErrorMessage data-cy="range-error-message">
+          <ErrorMessage data-testid="range-error-message">
             Specified range is not valid.
           </ErrorMessage>
         )}

--- a/apps/parsley/src/components/DetailsMenu/DetailsMenuCard/Toggles/BaseToggle/BaseToggle.test.tsx
+++ b/apps/parsley/src/components/DetailsMenu/DetailsMenuCard/Toggles/BaseToggle/BaseToggle.test.tsx
@@ -9,7 +9,7 @@ describe("base toggle", () => {
   it("properly renders labels", () => {
     render(
       <BaseToggle
-        data-cy="toggle"
+        data-testid="toggle"
         label="Test Label"
         leftLabel="Left"
         onChange={vi.fn()}
@@ -28,14 +28,14 @@ describe("base toggle", () => {
     const toggleFunc = vi.fn();
     render(
       <BaseToggle
-        data-cy="toggle"
+        data-testid="toggle"
         label="test"
         onChange={toggleFunc}
         tooltip="test tooltip"
         value={false}
       />,
     );
-    const toggle = screen.getByDataCy("toggle");
+    const toggle = screen.getByDataTestId("toggle");
     await user.click(toggle);
 
     expect(toggleFunc).toHaveBeenCalledTimes(1);
@@ -46,7 +46,7 @@ describe("base toggle", () => {
   it("should be possible to disable the toggle", () => {
     render(
       <BaseToggle
-        data-cy="toggle"
+        data-testid="toggle"
         disabled
         label="Test Label"
         leftLabel="Left"
@@ -56,6 +56,6 @@ describe("base toggle", () => {
         value
       />,
     );
-    expect(screen.getByDataCy("toggle")).toBeDisabled();
+    expect(screen.getByDataTestId("toggle")).toBeDisabled();
   });
 });

--- a/apps/parsley/src/components/DetailsMenu/DetailsMenuCard/Toggles/BaseToggle/index.tsx
+++ b/apps/parsley/src/components/DetailsMenu/DetailsMenuCard/Toggles/BaseToggle/index.tsx
@@ -9,7 +9,7 @@ import { DetailRow, DetailsLabel } from "../../styles";
 const { gray } = palette;
 
 interface BaseToggleProps {
-  ["data-cy"]?: string;
+  ["data-testid"]?: string;
   disabled?: boolean;
   leftLabel?: string;
   rightLabel?: string;
@@ -22,7 +22,7 @@ interface BaseToggleProps {
 const BaseToggle = forwardRef<HTMLDivElement, BaseToggleProps>(
   (
     {
-      "data-cy": dataCy,
+      "data-testid": dataTestId,
       disabled = false,
       label,
       leftLabel = "OFF",
@@ -41,7 +41,7 @@ const BaseToggle = forwardRef<HTMLDivElement, BaseToggleProps>(
           <Toggle
             aria-labelledby={`${label} Toggle`}
             checked={value}
-            data-cy={dataCy}
+            data-testid={dataTestId}
             disabled={disabled}
             onChange={onChange}
             size={ToggleSize.Small}

--- a/apps/parsley/src/components/DetailsMenu/DetailsMenuCard/Toggles/CaseSensitiveToggle/CaseSensitiveToggle.test.tsx
+++ b/apps/parsley/src/components/DetailsMenu/DetailsMenuCard/Toggles/CaseSensitiveToggle/CaseSensitiveToggle.test.tsx
@@ -18,14 +18,14 @@ describe("case sensitivity toggle", () => {
 
   it("defaults to 'false' if stored value is unset", () => {
     render(<CaseSensitiveToggle />, { wrapper });
-    const caseSensitiveToggle = screen.getByDataCy("case-sensitive-toggle");
+    const caseSensitiveToggle = screen.getByDataTestId("case-sensitive-toggle");
     expect(caseSensitiveToggle).toHaveAttribute("aria-checked", "false");
   });
 
   it("should read from localStorage properly", () => {
     localStorage.setItem(CASE_SENSITIVE, "true");
     render(<CaseSensitiveToggle />, { wrapper });
-    const caseSensitiveToggle = screen.getByDataCy("case-sensitive-toggle");
+    const caseSensitiveToggle = screen.getByDataTestId("case-sensitive-toggle");
     expect(caseSensitiveToggle).toHaveAttribute("aria-checked", "true");
   });
 
@@ -33,7 +33,7 @@ describe("case sensitivity toggle", () => {
     const user = userEvent.setup();
     localStorage.setItem(CASE_SENSITIVE, "true");
     const { router } = render(<CaseSensitiveToggle />, { wrapper });
-    const caseSensitiveToggle = screen.getByDataCy("case-sensitive-toggle");
+    const caseSensitiveToggle = screen.getByDataTestId("case-sensitive-toggle");
 
     await user.click(caseSensitiveToggle);
     expect(caseSensitiveToggle).toHaveAttribute("aria-checked", "false");

--- a/apps/parsley/src/components/DetailsMenu/DetailsMenuCard/Toggles/CaseSensitiveToggle/index.tsx
+++ b/apps/parsley/src/components/DetailsMenu/DetailsMenuCard/Toggles/CaseSensitiveToggle/index.tsx
@@ -8,7 +8,7 @@ const CaseSensitiveToggle: React.FC = () => {
   const { caseSensitive, setCaseSensitive } = preferences;
   return (
     <BaseToggle
-      data-cy="case-sensitive-toggle"
+      data-testid="case-sensitive-toggle"
       label="Case Sensitive"
       onChange={(value) => {
         setCaseSensitive(value);

--- a/apps/parsley/src/components/DetailsMenu/DetailsMenuCard/Toggles/ExcludeTimestampsToggle/index.tsx
+++ b/apps/parsley/src/components/DetailsMenu/DetailsMenuCard/Toggles/ExcludeTimestampsToggle/index.tsx
@@ -26,7 +26,7 @@ const ExcludeTimestampsToggle: React.FC = () => {
 
   return (
     <BaseToggle
-      data-cy="exclude-timestamps-toggle"
+      data-testid="exclude-timestamps-toggle"
       disabled={!isSupported}
       label="Exclude Timestamps"
       onChange={(value) => {

--- a/apps/parsley/src/components/DetailsMenu/DetailsMenuCard/Toggles/ExpandableRowsToggle/ExpandableRowsToggle.test.tsx
+++ b/apps/parsley/src/components/DetailsMenu/DetailsMenuCard/Toggles/ExpandableRowsToggle/ExpandableRowsToggle.test.tsx
@@ -18,14 +18,18 @@ describe("expandable rows toggle", () => {
 
   it("defaults to 'true' if stored value is unset", () => {
     render(<ExpandableRowsToggle />, { wrapper });
-    const expandableRowsToggle = screen.getByDataCy("expandable-rows-toggle");
+    const expandableRowsToggle = screen.getByDataTestId(
+      "expandable-rows-toggle",
+    );
     expect(expandableRowsToggle).toHaveAttribute("aria-checked", "true");
   });
 
   it("should read from localStorage properly", () => {
     localStorage.setItem(EXPANDABLE_ROWS, "true");
     render(<ExpandableRowsToggle />, { wrapper });
-    const expandableRowsToggle = screen.getByDataCy("expandable-rows-toggle");
+    const expandableRowsToggle = screen.getByDataTestId(
+      "expandable-rows-toggle",
+    );
     expect(expandableRowsToggle).toHaveAttribute("aria-checked", "true");
   });
 
@@ -34,7 +38,9 @@ describe("expandable rows toggle", () => {
     localStorage.setItem(EXPANDABLE_ROWS, "true");
     const { router } = render(<ExpandableRowsToggle />, { wrapper });
 
-    const expandableRowsToggle = screen.getByDataCy("expandable-rows-toggle");
+    const expandableRowsToggle = screen.getByDataTestId(
+      "expandable-rows-toggle",
+    );
     expect(expandableRowsToggle).toHaveAttribute("aria-checked", "true");
 
     await user.click(expandableRowsToggle);
@@ -48,7 +54,9 @@ describe("expandable rows toggle", () => {
       route: "?expandable=false",
       wrapper,
     });
-    const expandableRowsToggle = screen.getByDataCy("expandable-rows-toggle");
+    const expandableRowsToggle = screen.getByDataTestId(
+      "expandable-rows-toggle",
+    );
     expect(expandableRowsToggle).toHaveAttribute("aria-checked", "false");
   });
 });

--- a/apps/parsley/src/components/DetailsMenu/DetailsMenuCard/Toggles/ExpandableRowsToggle/index.tsx
+++ b/apps/parsley/src/components/DetailsMenu/DetailsMenuCard/Toggles/ExpandableRowsToggle/index.tsx
@@ -8,7 +8,7 @@ const ExpandableRowsToggle: React.FC = () => {
   const { expandableRows, setExpandableRows } = preferences;
   return (
     <BaseToggle
-      data-cy="expandable-rows-toggle"
+      data-testid="expandable-rows-toggle"
       label="Expandable Rows"
       onChange={(value) => {
         setExpandableRows(value);

--- a/apps/parsley/src/components/DetailsMenu/DetailsMenuCard/Toggles/FilterLogicToggle/FilterLogic.test.tsx
+++ b/apps/parsley/src/components/DetailsMenu/DetailsMenuCard/Toggles/FilterLogicToggle/FilterLogic.test.tsx
@@ -20,14 +20,14 @@ describe("filter logic toggle", () => {
 
   it("defaults to 'and' if stored value is unset", () => {
     render(<FilterLogicToggle />, { wrapper });
-    const filterLogicToggle = screen.getByDataCy("filter-logic-toggle");
+    const filterLogicToggle = screen.getByDataTestId("filter-logic-toggle");
     expect(filterLogicToggle).toHaveAttribute("aria-checked", "false");
   });
 
   it("should read from localStorage properly", () => {
     localStorage.setItem(FILTER_LOGIC, "or");
     render(<FilterLogicToggle />, { wrapper });
-    const filterLogicToggle = screen.getByDataCy("filter-logic-toggle");
+    const filterLogicToggle = screen.getByDataTestId("filter-logic-toggle");
     expect(filterLogicToggle).toHaveAttribute("aria-checked", "true");
   });
 
@@ -38,7 +38,7 @@ describe("filter logic toggle", () => {
       wrapper,
     });
 
-    const filterLogicToggle = screen.getByDataCy("filter-logic-toggle");
+    const filterLogicToggle = screen.getByDataTestId("filter-logic-toggle");
     expect(filterLogicToggle).toHaveAttribute("aria-checked", "true");
 
     await user.click(filterLogicToggle);
@@ -56,7 +56,7 @@ describe("filter logic toggle", () => {
       route: "?filterLogic=and",
       wrapper,
     });
-    const filterLogicToggle = screen.getByDataCy("filter-logic-toggle");
+    const filterLogicToggle = screen.getByDataTestId("filter-logic-toggle");
     expect(filterLogicToggle).toHaveAttribute("aria-checked", "false");
   });
 });

--- a/apps/parsley/src/components/DetailsMenu/DetailsMenuCard/Toggles/FilterLogicToggle/index.tsx
+++ b/apps/parsley/src/components/DetailsMenu/DetailsMenuCard/Toggles/FilterLogicToggle/index.tsx
@@ -20,7 +20,7 @@ const FilterLogicToggle: React.FC = () => {
   };
   return (
     <BaseToggle
-      data-cy="filter-logic-toggle"
+      data-testid="filter-logic-toggle"
       label="Filter Logic"
       leftLabel="AND"
       onChange={onChange}

--- a/apps/parsley/src/components/DetailsMenu/DetailsMenuCard/Toggles/HighlightFiltersToggle/HighlightFiltersToggle.test.tsx
+++ b/apps/parsley/src/components/DetailsMenu/DetailsMenuCard/Toggles/HighlightFiltersToggle/HighlightFiltersToggle.test.tsx
@@ -17,7 +17,7 @@ describe("highlight filter toggle", () => {
 
   it("defaults to 'false' if stored value is unset", () => {
     render(<HighlightFiltersToggle />, { wrapper });
-    const highlightFiltersToggle = screen.getByDataCy(
+    const highlightFiltersToggle = screen.getByDataTestId(
       "highlight-filters-toggle",
     );
     expect(highlightFiltersToggle).toHaveAttribute("aria-checked", "false");
@@ -26,7 +26,7 @@ describe("highlight filter toggle", () => {
   it("should read from localStorage properly", () => {
     localStorage.setItem(HIGHLIGHT_FILTERS, "true");
     render(<HighlightFiltersToggle />, { wrapper });
-    const highlightFiltersToggle = screen.getByDataCy(
+    const highlightFiltersToggle = screen.getByDataTestId(
       "highlight-filters-toggle",
     );
     expect(highlightFiltersToggle).toHaveAttribute("aria-checked", "true");

--- a/apps/parsley/src/components/DetailsMenu/DetailsMenuCard/Toggles/HighlightFiltersToggle/index.tsx
+++ b/apps/parsley/src/components/DetailsMenu/DetailsMenuCard/Toggles/HighlightFiltersToggle/index.tsx
@@ -14,7 +14,7 @@ const HighlightFiltersToggle: React.FC = () => {
   };
   return (
     <BaseToggle
-      data-cy="highlight-filters-toggle"
+      data-testid="highlight-filters-toggle"
       label="Highlight Filters"
       leftLabel="OFF"
       onChange={onChange}

--- a/apps/parsley/src/components/DetailsMenu/DetailsMenuCard/Toggles/JumpToFailingLineToggle/JumpToFailingLineToggle.test.tsx
+++ b/apps/parsley/src/components/DetailsMenu/DetailsMenuCard/Toggles/JumpToFailingLineToggle/JumpToFailingLineToggle.test.tsx
@@ -22,7 +22,7 @@ describe("jump to failing line toggle", () => {
 
   it("defaults to 'true' when localStorage is unset", () => {
     render(<JumpToFailingLineToggle />, { wrapper });
-    const jumpToFailingLineToggle = screen.getByDataCy(
+    const jumpToFailingLineToggle = screen.getByDataTestId(
       "jump-to-failing-line-toggle",
     );
     expect(jumpToFailingLineToggle).toHaveAttribute("aria-checked", "true");
@@ -31,7 +31,7 @@ describe("jump to failing line toggle", () => {
   it("reads from localStorage when set to 'false'", () => {
     localStorage.setItem(JUMP_TO_FAILING_LINE_ENABLED, "false");
     render(<JumpToFailingLineToggle />, { wrapper });
-    const jumpToFailingLineToggle = screen.getByDataCy(
+    const jumpToFailingLineToggle = screen.getByDataTestId(
       "jump-to-failing-line-toggle",
     );
     expect(jumpToFailingLineToggle).toHaveAttribute("aria-checked", "false");
@@ -46,7 +46,7 @@ describe("jump to failing line toggle", () => {
     act(() => {
       hook.current.setLogMetadata({ logType: LogTypes.EVERGREEN_TEST_LOGS });
     });
-    const jumpToFailingLineToggle = screen.getByDataCy(
+    const jumpToFailingLineToggle = screen.getByDataTestId(
       "jump-to-failing-line-toggle",
     );
     expect(jumpToFailingLineToggle).toHaveAttribute("aria-disabled", "true");
@@ -61,7 +61,7 @@ describe("jump to failing line toggle", () => {
     act(() => {
       hook.current.setLogMetadata({ logType: LogTypes.EVERGREEN_TASK_LOGS });
     });
-    const jumpToFailingLineToggle = screen.getByDataCy(
+    const jumpToFailingLineToggle = screen.getByDataTestId(
       "jump-to-failing-line-toggle",
     );
     expect(jumpToFailingLineToggle).toHaveAttribute("aria-disabled", "false");
@@ -79,7 +79,7 @@ describe("jump to failing line toggle", () => {
       hook.current.setLogMetadata({ logType: LogTypes.EVERGREEN_TASK_LOGS });
     });
 
-    const jumpToFailingLineToggle = screen.getByDataCy(
+    const jumpToFailingLineToggle = screen.getByDataTestId(
       "jump-to-failing-line-toggle",
     );
     expect(jumpToFailingLineToggle).toHaveAttribute("aria-checked", "true");

--- a/apps/parsley/src/components/DetailsMenu/DetailsMenuCard/Toggles/JumpToFailingLineToggle/index.tsx
+++ b/apps/parsley/src/components/DetailsMenu/DetailsMenuCard/Toggles/JumpToFailingLineToggle/index.tsx
@@ -11,7 +11,7 @@ const JumpToFailingLineToggle: React.FC = () => {
 
   return (
     <BaseToggle
-      data-cy="jump-to-failing-line-toggle"
+      data-testid="jump-to-failing-line-toggle"
       disabled={!isTaskLog}
       label="Jump to Failing Line"
       onChange={(value) => {

--- a/apps/parsley/src/components/DetailsMenu/DetailsMenuCard/Toggles/PrettyPrintToggle/PrettyPrintToggle.test.tsx
+++ b/apps/parsley/src/components/DetailsMenu/DetailsMenuCard/Toggles/PrettyPrintToggle/PrettyPrintToggle.test.tsx
@@ -22,7 +22,7 @@ describe("pretty print toggle", () => {
 
   it("defaults to 'false'", () => {
     render(<PrettyPrintToggle />, { wrapper });
-    const prettyPrintToggle = screen.getByDataCy("pretty-print-toggle");
+    const prettyPrintToggle = screen.getByDataTestId("pretty-print-toggle");
     expect(prettyPrintToggle).toHaveAttribute("aria-checked", "false");
   });
 
@@ -36,7 +36,7 @@ describe("pretty print toggle", () => {
     act(() => {
       hook.current.setLogMetadata({ renderingType: LogRenderingTypes.Resmoke });
     });
-    const prettyPrintToggle = screen.getByDataCy("pretty-print-toggle");
+    const prettyPrintToggle = screen.getByDataTestId("pretty-print-toggle");
 
     await user.click(prettyPrintToggle);
     expect(prettyPrintToggle).toHaveAttribute("aria-checked", "true");

--- a/apps/parsley/src/components/DetailsMenu/DetailsMenuCard/Toggles/PrettyPrintToggle/index.tsx
+++ b/apps/parsley/src/components/DetailsMenu/DetailsMenuCard/Toggles/PrettyPrintToggle/index.tsx
@@ -10,7 +10,7 @@ const PrettyPrintToggle: React.FC = () => {
 
   return (
     <BaseToggle
-      data-cy="pretty-print-toggle"
+      data-testid="pretty-print-toggle"
       label="Pretty Print Bookmarks"
       onChange={(value) => {
         setPrettyPrint(value);

--- a/apps/parsley/src/components/DetailsMenu/DetailsMenuCard/Toggles/SectionsToggle/SectionsToggle.test.tsx
+++ b/apps/parsley/src/components/DetailsMenu/DetailsMenuCard/Toggles/SectionsToggle/SectionsToggle.test.tsx
@@ -22,14 +22,14 @@ describe("sections toggle", () => {
 
   it("defaults to 'true' when localStorage is unset", () => {
     render(<SectionsToggle />, { wrapper });
-    const sectionsToggle = screen.getByDataCy("sections-toggle");
+    const sectionsToggle = screen.getByDataTestId("sections-toggle");
     expect(sectionsToggle).toHaveAttribute("aria-checked", "true");
   });
 
   it("reads from localStorage when set to 'false'", () => {
     localStorage.setItem(SECTIONS_ENABLED, "false");
     render(<SectionsToggle />, { wrapper });
-    const sectionsToggle = screen.getByDataCy("sections-toggle");
+    const sectionsToggle = screen.getByDataTestId("sections-toggle");
     expect(sectionsToggle).toHaveAttribute("aria-checked", "false");
   });
 
@@ -44,7 +44,7 @@ describe("sections toggle", () => {
         logType: LogTypes.EVERGREEN_COMPLETE_LOGS,
       });
     });
-    const sectionsToggle = screen.getByDataCy("sections-toggle");
+    const sectionsToggle = screen.getByDataTestId("sections-toggle");
     expect(sectionsToggle).toHaveAttribute("aria-disabled", "true");
   });
 
@@ -57,7 +57,7 @@ describe("sections toggle", () => {
     act(() => {
       hook.current.setLogMetadata({ logType: LogTypes.EVERGREEN_TASK_LOGS });
     });
-    const sectionsToggle = screen.getByDataCy("sections-toggle");
+    const sectionsToggle = screen.getByDataTestId("sections-toggle");
     expect(sectionsToggle).toHaveAttribute("aria-disabled", "false");
   });
 
@@ -73,7 +73,7 @@ describe("sections toggle", () => {
       hook.current.setLogMetadata({ logType: LogTypes.EVERGREEN_TASK_LOGS });
     });
 
-    const sectionsToggle = screen.getByDataCy("sections-toggle");
+    const sectionsToggle = screen.getByDataTestId("sections-toggle");
     expect(sectionsToggle).toHaveAttribute("aria-checked", "true");
     await user.click(sectionsToggle);
     expect(sectionsToggle).toHaveAttribute("aria-checked", "false");

--- a/apps/parsley/src/components/DetailsMenu/DetailsMenuCard/Toggles/SectionsToggle/index.tsx
+++ b/apps/parsley/src/components/DetailsMenu/DetailsMenuCard/Toggles/SectionsToggle/index.tsx
@@ -12,7 +12,7 @@ const SectionsToggle: React.FC = () => {
 
   return (
     <BaseToggle
-      data-cy="sections-toggle"
+      data-testid="sections-toggle"
       disabled={!isTaskLog}
       label="Sections"
       onChange={(value) => {

--- a/apps/parsley/src/components/DetailsMenu/DetailsMenuCard/Toggles/StickyHeadersToggle/StickyHeadersToggle.test.tsx
+++ b/apps/parsley/src/components/DetailsMenu/DetailsMenuCard/Toggles/StickyHeadersToggle/StickyHeadersToggle.test.tsx
@@ -26,20 +26,20 @@ describe("sticky headers toggle", () => {
   it("defaults to 'false' if stored value is unset", () => {
     localStorage.clear();
     render(<StickyHeadersToggle />, { wrapper });
-    const stickyHeadersToggle = screen.getByDataCy("sticky-headers-toggle");
+    const stickyHeadersToggle = screen.getByDataTestId("sticky-headers-toggle");
     expect(stickyHeadersToggle).toHaveAttribute("aria-checked", "false");
   });
 
   it("should read from localStorage properly", () => {
     render(<StickyHeadersToggle />, { wrapper });
-    const stickyHeadersToggle = screen.getByDataCy("sticky-headers-toggle");
+    const stickyHeadersToggle = screen.getByDataTestId("sticky-headers-toggle");
     expect(stickyHeadersToggle).toHaveAttribute("aria-checked", "true");
   });
 
   it("should not update the URL when clicked", async () => {
     const user = userEvent.setup();
     const { router } = render(<StickyHeadersToggle />, { wrapper });
-    const stickyHeadersToggle = screen.getByDataCy("sticky-headers-toggle");
+    const stickyHeadersToggle = screen.getByDataTestId("sticky-headers-toggle");
     expect(stickyHeadersToggle).toHaveAttribute("aria-checked", "true");
     await user.click(stickyHeadersToggle);
     expect(router.state.location.search).toBe("");
@@ -61,7 +61,9 @@ describe("sticky headers toggle", () => {
       expect(hook.current.sectioning.sectioningEnabled).toBe(true);
     });
     await waitFor(() => {
-      const stickyHeadersToggle = screen.getByDataCy("sticky-headers-toggle");
+      const stickyHeadersToggle = screen.getByDataTestId(
+        "sticky-headers-toggle",
+      );
       expect(stickyHeadersToggle).toHaveAttribute("aria-disabled", "false");
     });
   });
@@ -83,7 +85,9 @@ describe("sticky headers toggle", () => {
       expect(hook.current.sectioning.sectioningEnabled).toBe(false);
     });
     await waitFor(() => {
-      const stickyHeadersToggle = screen.getByDataCy("sticky-headers-toggle");
+      const stickyHeadersToggle = screen.getByDataTestId(
+        "sticky-headers-toggle",
+      );
       expect(stickyHeadersToggle).toHaveAttribute("aria-disabled", "true");
     });
   });

--- a/apps/parsley/src/components/DetailsMenu/DetailsMenuCard/Toggles/StickyHeadersToggle/index.tsx
+++ b/apps/parsley/src/components/DetailsMenu/DetailsMenuCard/Toggles/StickyHeadersToggle/index.tsx
@@ -9,7 +9,7 @@ const StickyHeadersToggle: React.FC = () => {
 
   return (
     <BaseToggle
-      data-cy="sticky-headers-toggle"
+      data-testid="sticky-headers-toggle"
       disabled={!sectioning.sectioningEnabled}
       label="Sticky Headers"
       onChange={(value) => {

--- a/apps/parsley/src/components/DetailsMenu/DetailsMenuCard/Toggles/WordWrapFormatToggle/WordWrapFormatToggle.test.tsx
+++ b/apps/parsley/src/components/DetailsMenu/DetailsMenuCard/Toggles/WordWrapFormatToggle/WordWrapFormatToggle.test.tsx
@@ -27,7 +27,9 @@ describe("word wrap format toggle", () => {
     );
     render(<Component />, { wrapper });
     expect(hook.current.preferences.wrap).toBe(false);
-    const wordWrapFormatToggle = screen.getByDataCy("word-wrap-format-toggle");
+    const wordWrapFormatToggle = screen.getByDataTestId(
+      "word-wrap-format-toggle",
+    );
     act(() => {
       hook.current.preferences.setWrap(true);
     });
@@ -41,7 +43,9 @@ describe("word wrap format toggle", () => {
     );
     render(<Component />, { wrapper });
     expect(hook.current.preferences.wordWrapFormat).toBe("standard");
-    const wordWrapFormatToggle = screen.getByDataCy("word-wrap-format-toggle");
+    const wordWrapFormatToggle = screen.getByDataTestId(
+      "word-wrap-format-toggle",
+    );
     expect(wordWrapFormatToggle).toHaveAttribute("aria-checked", "false");
   });
 
@@ -51,7 +55,9 @@ describe("word wrap format toggle", () => {
       <WordWrapFormatToggle />,
     );
     render(<Component />, { wrapper });
-    const wordWrapFormatToggle = screen.getByDataCy("word-wrap-format-toggle");
+    const wordWrapFormatToggle = screen.getByDataTestId(
+      "word-wrap-format-toggle",
+    );
     expect(wordWrapFormatToggle).toHaveAttribute("aria-checked", "false");
   });
 
@@ -65,7 +71,9 @@ describe("word wrap format toggle", () => {
     act(() => {
       hook.current.preferences.setWrap(true);
     });
-    const wordWrapFormatToggle = screen.getByDataCy("word-wrap-format-toggle");
+    const wordWrapFormatToggle = screen.getByDataTestId(
+      "word-wrap-format-toggle",
+    );
 
     await user.click(wordWrapFormatToggle);
     expect(wordWrapFormatToggle).toHaveAttribute("aria-checked", "true");

--- a/apps/parsley/src/components/DetailsMenu/DetailsMenuCard/Toggles/WordWrapFormatToggle/index.tsx
+++ b/apps/parsley/src/components/DetailsMenu/DetailsMenuCard/Toggles/WordWrapFormatToggle/index.tsx
@@ -26,7 +26,7 @@ const WordWrapFormatToggle: React.FC = () => {
   };
   return (
     <BaseToggle
-      data-cy="word-wrap-format-toggle"
+      data-testid="word-wrap-format-toggle"
       disabled={!wrap}
       label="Aggressive Word Wrap"
       leftLabel="OFF"

--- a/apps/parsley/src/components/DetailsMenu/DetailsMenuCard/Toggles/WrapToggle/WrapToggle.test.tsx
+++ b/apps/parsley/src/components/DetailsMenu/DetailsMenuCard/Toggles/WrapToggle/WrapToggle.test.tsx
@@ -17,14 +17,14 @@ describe("wrap toggle", () => {
   });
   it("defaults to 'false'", () => {
     render(<WrapToggle />, { wrapper });
-    const wrapToggle = screen.getByDataCy("wrap-toggle");
+    const wrapToggle = screen.getByDataTestId("wrap-toggle");
     expect(wrapToggle).toHaveAttribute("aria-checked", "false");
   });
 
   it("should update localStorage but not the URL", async () => {
     const user = userEvent.setup();
     const { router } = render(<WrapToggle />, { wrapper });
-    const wrapToggle = screen.getByDataCy("wrap-toggle");
+    const wrapToggle = screen.getByDataTestId("wrap-toggle");
 
     await user.click(wrapToggle);
     expect(wrapToggle).toHaveAttribute("aria-checked", "true");

--- a/apps/parsley/src/components/DetailsMenu/DetailsMenuCard/Toggles/WrapToggle/index.tsx
+++ b/apps/parsley/src/components/DetailsMenu/DetailsMenuCard/Toggles/WrapToggle/index.tsx
@@ -8,7 +8,7 @@ const WrapToggle: React.FC = () => {
   const { setWrap, wrap } = preferences;
   return (
     <BaseToggle
-      data-cy="wrap-toggle"
+      data-testid="wrap-toggle"
       label="Wrap"
       onChange={(value) => {
         setWrap(value);

--- a/apps/parsley/src/components/DetailsMenu/DetailsMenuCard/Toggles/ZebraStripingToggle/ZebraStripingToggle.test.tsx
+++ b/apps/parsley/src/components/DetailsMenu/DetailsMenuCard/Toggles/ZebraStripingToggle/ZebraStripingToggle.test.tsx
@@ -20,20 +20,20 @@ describe("zebra striping toggle", () => {
   it("defaults to 'false' if stored value is unset", () => {
     localStorage.clear();
     render(<ZebraStripingToggle />, { wrapper });
-    const zebraStripingToggle = screen.getByDataCy("zebra-striping-toggle");
+    const zebraStripingToggle = screen.getByDataTestId("zebra-striping-toggle");
     expect(zebraStripingToggle).toHaveAttribute("aria-checked", "false");
   });
 
   it("should read from localStorage properly", () => {
     render(<ZebraStripingToggle />, { wrapper });
-    const zebraStripingToggle = screen.getByDataCy("zebra-striping-toggle");
+    const zebraStripingToggle = screen.getByDataTestId("zebra-striping-toggle");
     expect(zebraStripingToggle).toHaveAttribute("aria-checked", "true");
   });
 
   it("should not update the URL", async () => {
     const user = userEvent.setup();
     const { router } = render(<ZebraStripingToggle />, { wrapper });
-    const zebraStripingToggle = screen.getByDataCy("zebra-striping-toggle");
+    const zebraStripingToggle = screen.getByDataTestId("zebra-striping-toggle");
 
     await user.click(zebraStripingToggle);
     expect(zebraStripingToggle).toHaveAttribute("aria-checked", "false");

--- a/apps/parsley/src/components/DetailsMenu/DetailsMenuCard/Toggles/ZebraStripingToggle/index.tsx
+++ b/apps/parsley/src/components/DetailsMenu/DetailsMenuCard/Toggles/ZebraStripingToggle/index.tsx
@@ -8,7 +8,7 @@ const ZebraStripingToggle: React.FC = () => {
   const { setZebraStriping, zebraStriping } = preferences;
   return (
     <BaseToggle
-      data-cy="zebra-striping-toggle"
+      data-testid="zebra-striping-toggle"
       label="Zebra Striping"
       onChange={(value) => {
         setZebraStriping(value);

--- a/apps/parsley/src/components/DetailsMenu/DetailsMenuCard/index.tsx
+++ b/apps/parsley/src/components/DetailsMenu/DetailsMenuCard/index.tsx
@@ -22,22 +22,22 @@ import {
 } from "./Toggles";
 
 interface DetailsMenuProps {
-  "data-cy"?: string;
+  "data-testid"?: string;
 }
 
 const DetailsMenuCard = forwardRef<HTMLDivElement, DetailsMenuProps>(
-  ({ "data-cy": dataCy }, ref) => {
+  ({ "data-testid": dataTestId }, ref) => {
     const [selectedTab, setSelectedTab] = useState(0);
 
     return (
-      <Container ref={ref} data-cy={dataCy}>
+      <Container ref={ref} data-testid={dataTestId}>
         <H3>Parsley Settings</H3>
         <Tabs
           aria-label="Details Card Tabs"
           onValueChange={setSelectedTab}
           value={selectedTab}
         >
-          <Tab data-cy="search-and-filter-tab" name="Search & Filter">
+          <Tab data-testid="search-and-filter-tab" name="Search & Filter">
             <Row>
               <Column>
                 <SearchRangeInput />
@@ -49,7 +49,7 @@ const DetailsMenuCard = forwardRef<HTMLDivElement, DetailsMenuProps>(
             <ButtonRow />
             <CliCommandButton />
           </Tab>
-          <Tab data-cy="log-viewing-tab" name="Log Viewing">
+          <Tab data-testid="log-viewing-tab" name="Log Viewing">
             <Row>
               <Column>
                 <WrapToggle />

--- a/apps/parsley/src/components/DetailsMenu/index.tsx
+++ b/apps/parsley/src/components/DetailsMenu/index.tsx
@@ -66,7 +66,7 @@ const DetailsMenu: React.FC<DetailsMenuProps> = ({ disabled, ...rest }) => {
       setIsOpen={setIsOpen}
       {...rest}
     >
-      <DetailsMenuCard ref={detailsMenuRef} data-cy="details-menu" />
+      <DetailsMenuCard ref={detailsMenuRef} data-testid="details-menu" />
     </AnimatedPopoverButton>
   );
 };

--- a/apps/parsley/src/components/LogPane/LogPane.test.tsx
+++ b/apps/parsley/src/components/LogPane/LogPane.test.tsx
@@ -229,7 +229,7 @@ describe("logPane", () => {
       render(<LogPane rowCount={list.length} rowRenderer={RowRenderer} />, {
         wrapper,
       });
-      expect(screen.getByDataCy("sticky-headers")).toBeInTheDocument();
+      expect(screen.getByDataTestId("sticky-headers")).toBeInTheDocument();
     });
 
     it("should not render sticky headers when stickyHeaders is disabled", () => {
@@ -254,7 +254,9 @@ describe("logPane", () => {
       render(<LogPane rowCount={list.length} rowRenderer={RowRenderer} />, {
         wrapper,
       });
-      expect(screen.queryByDataCy("sticky-headers")).not.toBeInTheDocument();
+      expect(
+        screen.queryByDataTestId("sticky-headers"),
+      ).not.toBeInTheDocument();
     });
 
     it("should not render sticky headers when sectioning is disabled", () => {
@@ -279,7 +281,9 @@ describe("logPane", () => {
       render(<LogPane rowCount={list.length} rowRenderer={RowRenderer} />, {
         wrapper,
       });
-      expect(screen.queryByDataCy("sticky-headers")).not.toBeInTheDocument();
+      expect(
+        screen.queryByDataTestId("sticky-headers"),
+      ).not.toBeInTheDocument();
     });
   });
 });

--- a/apps/parsley/src/components/LogRow/AnsiRow/AnsiRow.test.tsx
+++ b/apps/parsley/src/components/LogRow/AnsiRow/AnsiRow.test.tsx
@@ -38,11 +38,11 @@ describe("ansiRow", () => {
   });
   it("does not render an ansi row if getLine returns undefined", () => {
     renderRow({ ...ansiProps, lineIndex: 99, lineNumber: 99 }, {});
-    expect(screen.queryByDataCy("ansi-row")).toBeNull();
+    expect(screen.queryByDataTestId("ansi-row")).toBeNull();
   });
   it("renders an ansi row if getLine returns an empty string", () => {
     renderRow({ ...ansiProps, lineIndex: 10, lineNumber: 10 }, {});
-    expect(screen.getByDataCy("ansi-row")).toBeInTheDocument();
+    expect(screen.getByDataTestId("ansi-row")).toBeInTheDocument();
   });
   it("displays a log line and its text for a given index", () => {
     renderRow({ ...ansiProps, lineIndex: 0, lineNumber: 0 }, {});
@@ -69,7 +69,9 @@ describe("ansiRow", () => {
       },
       {},
     );
-    expect(screen.getByDataCy("highlight")).toHaveTextContent("highlight me");
+    expect(screen.getByDataTestId("highlight")).toHaveTextContent(
+      "highlight me",
+    );
   });
   it("should highlight text that have matching highlights", () => {
     renderRow(
@@ -81,7 +83,9 @@ describe("ansiRow", () => {
       },
       {},
     );
-    expect(screen.getByDataCy("highlight")).toHaveTextContent("highlight me");
+    expect(screen.getByDataTestId("highlight")).toHaveTextContent(
+      "highlight me",
+    );
   });
 
   it("should pretty print logs", () => {
@@ -125,7 +129,9 @@ describe("ansiRow", () => {
       expect(
         screen.getByText(priorityLogLines[0].substring(8)),
       ).toBeInTheDocument();
-      expect(screen.getByDataCy("ansi-row")).toHaveStyle(`color: ${rgbBlack}`);
+      expect(screen.getByDataTestId("ansi-row")).toHaveStyle(
+        `color: ${rgbBlack}`,
+      );
     });
 
     it("renders a high-priority line in red", () => {
@@ -140,7 +146,9 @@ describe("ansiRow", () => {
       expect(
         screen.getByText(priorityLogLines[3].substring(8)),
       ).toBeInTheDocument();
-      expect(screen.getByDataCy("ansi-row")).toHaveStyle(`color: ${rgbRed}`);
+      expect(screen.getByDataTestId("ansi-row")).toHaveStyle(
+        `color: ${rgbRed}`,
+      );
     });
   });
 });

--- a/apps/parsley/src/components/LogRow/AnsiRow/index.tsx
+++ b/apps/parsley/src/components/LogRow/AnsiRow/index.tsx
@@ -37,7 +37,7 @@ const AnsiRow: React.FC<AnsiRowProps> = ({ getLine, lineNumber, ...rest }) => {
   return (
     <BaseRow
       color={severity ? mapLogLevelToColor[severity] : undefined}
-      data-cy="ansi-row"
+      data-testid="ansi-row"
       lineNumber={lineNumber}
       {...rest}
     >

--- a/apps/parsley/src/components/LogRow/BaseRow/Highlighter.test.tsx
+++ b/apps/parsley/src/components/LogRow/BaseRow/Highlighter.test.tsx
@@ -4,11 +4,11 @@ import Highlighter from "./Highlighter";
 describe("highlighter", () => {
   it("renders the text color correctly", () => {
     renderWithRouterMatch(
-      <Highlighter color="salmon" data-cy="test-row">
+      <Highlighter color="salmon" data-testid="test-row">
         Test blah test blah
       </Highlighter>,
     );
-    expect(screen.getByDataCy("test-row")).toHaveStyle(
+    expect(screen.getByDataTestId("test-row")).toHaveStyle(
       `color: rgb(250, 128, 114)`,
     );
   });
@@ -19,8 +19,8 @@ describe("highlighter", () => {
       renderWithRouterMatch(
         <Highlighter searchTerm={regexp}>Test blah test blah</Highlighter>,
       );
-      expect(screen.queryAllByDataCy("highlight")).toHaveLength(2);
-      screen.getAllByDataCy("highlight").forEach((highlight) => {
+      expect(screen.queryAllByDataTestId("highlight")).toHaveLength(2);
+      screen.getAllByDataTestId("highlight").forEach((highlight) => {
         expect(highlight).toHaveTextContent(/test/i);
       });
     });
@@ -28,11 +28,11 @@ describe("highlighter", () => {
       const { rerender } = renderWithRouterMatch(
         <Highlighter searchTerm={/test/gi}>Test blah test blah</Highlighter>,
       );
-      expect(screen.queryAllByDataCy("highlight")).toHaveLength(2);
+      expect(screen.queryAllByDataTestId("highlight")).toHaveLength(2);
       rerender(
         <Highlighter searchTerm={/test/g}>Test blah test blah</Highlighter>,
       );
-      expect(screen.queryAllByDataCy("highlight")).toHaveLength(1);
+      expect(screen.queryAllByDataTestId("highlight")).toHaveLength(1);
     });
   });
 
@@ -42,8 +42,8 @@ describe("highlighter", () => {
       renderWithRouterMatch(
         <Highlighter highlights={regexp}>Test blah test blah</Highlighter>,
       );
-      expect(screen.queryAllByDataCy("highlight")).toHaveLength(4);
-      screen.getAllByDataCy("highlight").forEach((highlight) => {
+      expect(screen.queryAllByDataTestId("highlight")).toHaveLength(4);
+      screen.getAllByDataTestId("highlight").forEach((highlight) => {
         expect(highlight).toHaveTextContent(/test|blah/i);
       });
     });

--- a/apps/parsley/src/components/LogRow/BaseRow/Highlighter.tsx
+++ b/apps/parsley/src/components/LogRow/BaseRow/Highlighter.tsx
@@ -2,7 +2,7 @@ import { memo, useMemo } from "react";
 import highlightHtml from "utils/highlightHtml";
 
 interface HighlighterProps {
-  ["data-cy"]?: string;
+  ["data-testid"]?: string;
   children: string;
   color?: string;
   highlights?: RegExp;
@@ -13,7 +13,7 @@ const Highlighter: React.FC<HighlighterProps> = memo((props) => {
   const {
     children: text,
     color,
-    "data-cy": dataCy,
+    "data-testid": dataTestId,
     highlights,
     searchTerm,
   } = props;
@@ -24,7 +24,7 @@ const Highlighter: React.FC<HighlighterProps> = memo((props) => {
   );
 
   return (
-    <span data-cy={dataCy} style={{ color }}>
+    <span data-testid={dataTestId} style={{ color }}>
       {htmlToRender}
     </span>
   );

--- a/apps/parsley/src/components/LogRow/BaseRow/LineNumber/index.tsx
+++ b/apps/parsley/src/components/LogRow/BaseRow/LineNumber/index.tsx
@@ -9,7 +9,7 @@ const LineNumber: React.FC<{ lineNumber: number }> = ({ lineNumber }) => {
   };
   return (
     <Index
-      data-cy={`line-index-${lineNumber}`}
+      data-testid={`line-index-${lineNumber}`}
       lineNumber={lineNumber}
       onClick={handleClick}
       title="Use shift+click to select multiple lines"

--- a/apps/parsley/src/components/LogRow/BaseRow/Row.test.tsx
+++ b/apps/parsley/src/components/LogRow/BaseRow/Row.test.tsx
@@ -29,9 +29,9 @@ const renderRow = (
 
 describe("row", () => {
   it("renders a log line", () => {
-    renderRow({ ...rowProps, children: testLog, "data-cy": "test" }, {});
+    renderRow({ ...rowProps, children: testLog, "data-testid": "test" }, {});
     expect(screen.getByText(testLog)).toBeVisible();
-    expect(screen.getByDataCy("test")).toBeVisible();
+    expect(screen.getByDataTestId("test")).toBeVisible();
   });
 
   it("properly escapes a log line with tags and renders its contents", () => {
@@ -96,7 +96,7 @@ describe("row", () => {
         {},
       );
 
-      expect(screen.getByDataCy("highlight")).toHaveTextContent("Test");
+      expect(screen.getByDataTestId("highlight")).toHaveTextContent("Test");
     });
     it("should not highlight matching search text if it is outside of range", () => {
       const regexp = /Test/i;
@@ -113,7 +113,7 @@ describe("row", () => {
         {},
       );
 
-      expect(screen.queryByDataCy("highlight")).not.toBeInTheDocument();
+      expect(screen.queryByDataTestId("highlight")).not.toBeInTheDocument();
     });
     it("highlighted terms should highlight the matching text", () => {
       const regexp = /Test/i;
@@ -126,7 +126,7 @@ describe("row", () => {
         {},
       );
 
-      expect(screen.getByDataCy("highlight")).toHaveTextContent("Test");
+      expect(screen.getByDataTestId("highlight")).toHaveTextContent("Test");
     });
   });
 });

--- a/apps/parsley/src/components/LogRow/BaseRow/SharingMenu/SharingMenu.test.tsx
+++ b/apps/parsley/src/components/LogRow/BaseRow/SharingMenu/SharingMenu.test.tsx
@@ -60,7 +60,7 @@ describe("sharingMenu", () => {
   it("should render an open menu after clicking the trigger", async () => {
     const user = userEvent.setup();
     renderSharingMenu();
-    await user.click(screen.getByDataCy("log-link-1"));
+    await user.click(screen.getByDataTestId("log-link-1"));
     expect(
       screen.getByText("Copy share link to selected line"),
     ).toBeInTheDocument();
@@ -105,7 +105,7 @@ describe("sharingMenu", () => {
     act(() => {
       hook.current.handleSelectLine(1, false);
     });
-    await user.click(screen.getByDataCy("log-link-1"));
+    await user.click(screen.getByDataTestId("log-link-1"));
 
     expect(screen.getByText("Copy selected contents")).toBeInTheDocument();
     await user.click(screen.getByText("Copy selected contents"));
@@ -138,7 +138,7 @@ describe("sharingMenu", () => {
     act(() => {
       hook.current.handleSelectLine(1, false);
     });
-    await user.click(screen.getByDataCy("log-link-1"));
+    await user.click(screen.getByDataTestId("log-link-1"));
 
     expect(screen.getByText("Copy selected contents")).toBeInTheDocument();
     await user.click(screen.getByText("Copy selected contents"));
@@ -249,7 +249,7 @@ describe("sharingMenu", () => {
   it("should show 'Add to Parsley AI' for non-uploaded logs", async () => {
     const user = userEvent.setup();
     renderSharingMenu();
-    await user.click(screen.getByDataCy("log-link-1"));
+    await user.click(screen.getByDataTestId("log-link-1"));
     expect(screen.getByText("Add to Parsley AI")).toBeInTheDocument();
   });
 });

--- a/apps/parsley/src/components/LogRow/BaseRow/SharingMenu/index.tsx
+++ b/apps/parsley/src/components/LogRow/BaseRow/SharingMenu/index.tsx
@@ -135,13 +135,13 @@ const SharingMenu: React.FC<SharingMenuProps> = ({ lineNumber, shared }) => {
   return (
     <StyledMenu
       align="right"
-      data-cy="sharing-menu"
+      data-testid="sharing-menu"
       open={open}
       setOpen={setMenuOpen}
       trigger={
         <MenuIcon
           aria-label="Expand share menu"
-          data-cy={`log-link-${lineNumber}`}
+          data-testid={`log-link-${lineNumber}`}
           onClick={setMenuOpen}
         >
           <Icon glyph={shared ? "ArrowWithCircle" : "Ellipsis"} />

--- a/apps/parsley/src/components/LogRow/BaseRow/index.tsx
+++ b/apps/parsley/src/components/LogRow/BaseRow/index.tsx
@@ -21,7 +21,7 @@ const { red, yellow } = palette;
 
 interface BaseRowProps extends Omit<LogLineRow, "getLine"> {
   children: string;
-  "data-cy"?: string;
+  "data-testid"?: string;
   color?: string;
 }
 
@@ -30,7 +30,7 @@ interface BaseRowProps extends Omit<LogLineRow, "getLine"> {
  * It is responsible for handling any highlights for the row, as well as rendering line counts and bookmarks.
  * @param BaseRowProps - props to be passed to the BaseRow component
  * @param BaseRowProps.children - the text to be rendered
- * @param BaseRowProps."data-cy" - data-cy attribute to be added to the row
+ * @param BaseRowProps."data-testid" - data-testid attribute to be added to the row
  * @param BaseRowProps.lineIndex - the index of the line in the log
  * @param BaseRowProps.failingLine - the failing log line number
  * @param BaseRowProps.highlightRegex - the regex to be highlighted
@@ -47,7 +47,7 @@ interface BaseRowProps extends Omit<LogLineRow, "getLine"> {
 const BaseRow: React.FC<BaseRowProps> = ({
   children,
   color,
-  "data-cy": dataCyText,
+  "data-testid": dataTestId,
   failingLine,
   highlightRegex,
   lineIndex,
@@ -129,10 +129,10 @@ const BaseRow: React.FC<BaseRowProps> = ({
       {...rest}
       bookmarked={bookmarked}
       data-bookmarked={bookmarked}
-      data-cy={`log-row-${lineNumber}`}
       data-failed={failed}
       data-highlighted={highlighted}
       data-shared={shared}
+      data-testid={`log-row-${lineNumber}`}
       failed={failed}
       highlighted={highlighted || isLineBetweenSelectedLines}
       onDoubleClick={handleDoubleClick}
@@ -143,7 +143,7 @@ const BaseRow: React.FC<BaseRowProps> = ({
       ) : (
         <EllipsisButton
           aria-label="Expand share menu"
-          data-cy={`log-link-${lineNumber}`}
+          data-testid={`log-link-${lineNumber}`}
           onClick={handleEllipsisClick}
         >
           <Icon glyph={shared ? "ArrowWithCircle" : "Ellipsis"} />
@@ -153,7 +153,7 @@ const BaseRow: React.FC<BaseRowProps> = ({
       <StyledPre shouldWrap={wrap} wordWrapFormat={wordWrapFormat}>
         <Highlighter
           color={color}
-          data-cy={dataCyText}
+          data-testid={dataTestId}
           highlights={highlightRegex}
           searchTerm={inRange ? searchTerm : undefined}
         >

--- a/apps/parsley/src/components/LogRow/CaretToggle/index.tsx
+++ b/apps/parsley/src/components/LogRow/CaretToggle/index.tsx
@@ -13,7 +13,7 @@ interface Props {
 const CaretToggle: React.FC<Props> = ({ onClick, open }) => (
   <IconButton
     aria-label={`${open ? "Close" : "Open"} section`}
-    data-cy="caret-toggle"
+    data-testid="caret-toggle"
     onClick={onClick}
   >
     <AnimatedIcon fill={gray.dark1} glyph="ChevronRight" open={open} />

--- a/apps/parsley/src/components/LogRow/ResmokeRow/ResmokeRow.test.tsx
+++ b/apps/parsley/src/components/LogRow/ResmokeRow/ResmokeRow.test.tsx
@@ -30,12 +30,12 @@ describe("resmokeRow", () => {
   });
   it("does not render a resmoke row if getLine returns undefined", () => {
     renderRow({ ...resmokeProps, lineIndex: 99, lineNumber: 99 }, {});
-    expect(screen.queryByDataCy("resmoke-row")).toBeNull();
+    expect(screen.queryByDataTestId("resmoke-row")).toBeNull();
   });
   it("renders a resmoke row if getLine returns an empty string", () => {
     renderRow({ ...resmokeProps, lineIndex: 9, lineNumber: 9 }, {});
 
-    expect(screen.getByDataCy("resmoke-row")).toBeInTheDocument();
+    expect(screen.getByDataTestId("resmoke-row")).toBeInTheDocument();
   });
   it("displays a log line and its text for a given index", () => {
     renderRow({ ...resmokeProps, lineIndex: 0, lineNumber: 0 }, {});
@@ -53,7 +53,7 @@ describe("resmokeRow", () => {
     );
 
     expect(getResmokeLineColor).toHaveBeenCalledWith(7);
-    expect(screen.getByDataCy("resmoke-row")).toHaveStyle("color: #ff0000");
+    expect(screen.getByDataTestId("resmoke-row")).toHaveStyle("color: #ff0000");
   });
   it("should highlight text that match a search term", () => {
     renderRow(
@@ -61,7 +61,7 @@ describe("resmokeRow", () => {
       {},
     );
 
-    expect(screen.queryByDataCy("highlight")).toHaveTextContent("mongod");
+    expect(screen.queryByDataTestId("highlight")).toHaveTextContent("mongod");
   });
   it("should highlight text that have a matching highlight term", () => {
     renderRow(
@@ -74,7 +74,7 @@ describe("resmokeRow", () => {
       {},
     );
 
-    expect(screen.queryByDataCy("highlight")).toHaveTextContent("mongod");
+    expect(screen.queryByDataTestId("highlight")).toHaveTextContent("mongod");
   });
 
   it("should pretty print logs", () => {

--- a/apps/parsley/src/components/LogRow/ResmokeRow/index.tsx
+++ b/apps/parsley/src/components/LogRow/ResmokeRow/index.tsx
@@ -27,7 +27,7 @@ const ResmokeRow: React.FC<ResmokeRowProps> = ({
   return lineContent !== undefined ? (
     <BaseRow
       color={lineColor}
-      data-cy="resmoke-row"
+      data-testid="resmoke-row"
       lineNumber={lineNumber}
       {...rest}
     >

--- a/apps/parsley/src/components/LogRow/SectionHeader/SectionHeader.test.tsx
+++ b/apps/parsley/src/components/LogRow/SectionHeader/SectionHeader.test.tsx
@@ -37,7 +37,7 @@ describe("SectionHeader", () => {
       <SectionHeader {...sectionHeaderProps} failingLine={15} />,
       { wrapper },
     );
-    expect(screen.getByDataCy("section-status-pass")).toBeVisible();
+    expect(screen.getByDataTestId("section-status-pass")).toBeVisible();
   });
 
   it("displays X icon if status is failing", () => {
@@ -45,7 +45,7 @@ describe("SectionHeader", () => {
       <SectionHeader {...sectionHeaderProps} failingLine={5} />,
       { wrapper },
     );
-    expect(screen.getByDataCy("section-status-fail")).toBeVisible();
+    expect(screen.getByDataTestId("section-status-fail")).toBeVisible();
   });
 
   it("renders as opened if 'open' prop is true", async () => {
@@ -55,7 +55,7 @@ describe("SectionHeader", () => {
         sectionHeaderLine={{ ...baseSectionHeaderLine, isOpen: true }}
       />,
     );
-    expect(screen.getByDataCy("section-header")).toHaveAttribute(
+    expect(screen.getByDataTestId("section-header")).toHaveAttribute(
       "aria-expanded",
       "true",
     );
@@ -65,7 +65,7 @@ describe("SectionHeader", () => {
     renderWithRouterMatch(<SectionHeader {...sectionHeaderProps} />, {
       wrapper,
     });
-    expect(screen.getByDataCy("section-header")).toHaveAttribute(
+    expect(screen.getByDataTestId("section-header")).toHaveAttribute(
       "aria-expanded",
       "false",
     );
@@ -89,7 +89,7 @@ describe("SectionHeader", () => {
     renderWithRouterMatch(<SectionHeader {...sectionHeaderProps} />, {
       wrapper,
     });
-    const openButton = screen.getByDataCy("caret-toggle");
+    const openButton = screen.getByDataTestId("caret-toggle");
     await user.click(openButton);
     expect(sendEventMock).toHaveBeenCalledTimes(1);
     expect(sendEventMock).toHaveBeenCalledWith({
@@ -112,7 +112,7 @@ describe("SectionHeader", () => {
       <SectionHeader {...sectionHeaderProps} />,
       { wrapper },
     );
-    expect(screen.getByDataCy("section-header")).toHaveAttribute(
+    expect(screen.getByDataTestId("section-header")).toHaveAttribute(
       "aria-expanded",
       "false",
     );
@@ -122,12 +122,12 @@ describe("SectionHeader", () => {
         sectionHeaderLine={{ ...baseSectionHeaderLine, isOpen: true }}
       />,
     );
-    expect(screen.getByDataCy("section-header")).toHaveAttribute(
+    expect(screen.getByDataTestId("section-header")).toHaveAttribute(
       "aria-expanded",
       "true",
     );
     rerender(<SectionHeader {...sectionHeaderProps} />);
-    expect(screen.getByDataCy("section-header")).toHaveAttribute(
+    expect(screen.getByDataTestId("section-header")).toHaveAttribute(
       "aria-expanded",
       "false",
     );

--- a/apps/parsley/src/components/LogRow/SectionHeader/SubsectionControls.test.tsx
+++ b/apps/parsley/src/components/LogRow/SectionHeader/SubsectionControls.test.tsx
@@ -84,8 +84,8 @@ describe("SectionControls", () => {
       },
     }));
     renderWithRouterMatch(<SubsectionControls {...props} />, { wrapper });
-    expect(screen.getByDataCy("open-subsections-btn")).toBeVisible();
-    await user.click(screen.getByDataCy("open-subsections-btn"));
+    expect(screen.getByDataTestId("open-subsections-btn")).toBeVisible();
+    await user.click(screen.getByDataTestId("open-subsections-btn"));
     expect(sendEventMock).toHaveBeenCalledOnce();
     expect(sendEventMock).toHaveBeenCalledWith({
       name: "Clicked open subsections button",
@@ -98,7 +98,7 @@ describe("SectionControls", () => {
       "function-1",
       true,
     );
-    await user.click(screen.getByDataCy("close-subsections-btn"));
+    await user.click(screen.getByDataTestId("close-subsections-btn"));
     await waitFor(() =>
       expect(toggleAllCommandsInFunctionMock).toHaveBeenCalledWith(
         "function-1",

--- a/apps/parsley/src/components/LogRow/SectionHeader/SubsectionControls.tsx
+++ b/apps/parsley/src/components/LogRow/SectionHeader/SubsectionControls.tsx
@@ -27,7 +27,7 @@ const SubsectionControls: React.FC<{
     <>
       {showExpandButton && (
         <Button
-          data-cy="open-subsections-btn"
+          data-testid="open-subsections-btn"
           onClick={() => {
             sendEvent({
               name: "Clicked open subsections button",
@@ -44,7 +44,7 @@ const SubsectionControls: React.FC<{
       )}
       {showCloseButton && (
         <Button
-          data-cy="close-subsections-btn"
+          data-testid="close-subsections-btn"
           onClick={() => {
             toggleAllCommandsInFunction(functionID, false);
             sendEvent({

--- a/apps/parsley/src/components/LogRow/SectionHeader/index.tsx
+++ b/apps/parsley/src/components/LogRow/SectionHeader/index.tsx
@@ -33,7 +33,7 @@ const SectionHeader: React.FC<SectionHeaderProps> = ({
     <div
       aria-expanded={open}
       css={sectionHeaderWrapperStyle}
-      data-cy="section-header"
+      data-testid="section-header"
     >
       <CaretToggle
         onClick={() => {

--- a/apps/parsley/src/components/LogRow/SectionStatusIcon/index.tsx
+++ b/apps/parsley/src/components/LogRow/SectionStatusIcon/index.tsx
@@ -13,6 +13,6 @@ export const SectionStatusIcon: React.FC<Props> = ({ status }) => {
   const glyph =
     status === SectionStatus.Pass ? "CheckmarkWithCircle" : "XWithCircle";
   return (
-    <Icon data-cy={`section-status-${status}`} fill={fill} glyph={glyph} />
+    <Icon data-testid={`section-status-${status}`} fill={fill} glyph={glyph} />
   );
 };

--- a/apps/parsley/src/components/LogRow/SkippedLinesRow/index.tsx
+++ b/apps/parsley/src/components/LogRow/SkippedLinesRow/index.tsx
@@ -54,7 +54,7 @@ const SkippedLinesRow: React.FC<SkippedLinesRowProps> = ({
   };
 
   return (
-    <LineWrapper data-cy={`skipped-lines-row-${start}-${lineEndInclusive}`}>
+    <LineWrapper data-testid={`skipped-lines-row-${start}-${lineEndInclusive}`}>
       <StyledBody>{lineText}</StyledBody>
       <ButtonContainer>
         <Button

--- a/apps/parsley/src/components/LogRow/SubsectionHeader/SubsectionHeader.test.tsx
+++ b/apps/parsley/src/components/LogRow/SubsectionHeader/SubsectionHeader.test.tsx
@@ -58,7 +58,7 @@ describe("SubsectionHeader", () => {
         wrapper,
       },
     );
-    expect(screen.getByDataCy("section-header")).toHaveAttribute(
+    expect(screen.getByDataTestId("section-header")).toHaveAttribute(
       "aria-expanded",
       "true",
     );
@@ -68,7 +68,7 @@ describe("SubsectionHeader", () => {
     renderWithRouterMatch(<SubsectionHeader {...subsectionHeaderProps} />, {
       wrapper,
     });
-    expect(screen.getByDataCy("section-header")).toHaveAttribute(
+    expect(screen.getByDataTestId("section-header")).toHaveAttribute(
       "aria-expanded",
       "false",
     );
@@ -92,7 +92,7 @@ describe("SubsectionHeader", () => {
     renderWithRouterMatch(<SubsectionHeader {...subsectionHeaderProps} />, {
       wrapper,
     });
-    const openButton = screen.getByDataCy("caret-toggle");
+    const openButton = screen.getByDataTestId("caret-toggle");
     await user.click(openButton);
     expect(toggleFunctionSectionMock).toHaveBeenCalledTimes(1);
     expect(toggleFunctionSectionMock).toHaveBeenCalledWith({
@@ -116,7 +116,7 @@ describe("SubsectionHeader", () => {
       <SubsectionHeader {...subsectionHeaderProps} />,
       { wrapper },
     );
-    expect(screen.getByDataCy("section-header")).toHaveAttribute(
+    expect(screen.getByDataTestId("section-header")).toHaveAttribute(
       "aria-expanded",
       "false",
     );
@@ -126,12 +126,12 @@ describe("SubsectionHeader", () => {
         subsectionHeaderLine={{ ...baseSubsectionHeaderLine, isOpen: true }}
       />,
     );
-    expect(screen.getByDataCy("section-header")).toHaveAttribute(
+    expect(screen.getByDataTestId("section-header")).toHaveAttribute(
       "aria-expanded",
       "true",
     );
     rerender(<SubsectionHeader {...subsectionHeaderProps} />);
-    expect(screen.getByDataCy("section-header")).toHaveAttribute(
+    expect(screen.getByDataTestId("section-header")).toHaveAttribute(
       "aria-expanded",
       "false",
     );
@@ -148,7 +148,7 @@ describe("SubsectionHeader", () => {
       />,
       { wrapper },
     );
-    expect(screen.getByDataCy("section-status-pass")).toBeVisible();
+    expect(screen.getByDataTestId("section-status-pass")).toBeVisible();
     rerender(
       <SubsectionHeader
         {...subsectionHeaderProps}
@@ -159,9 +159,11 @@ describe("SubsectionHeader", () => {
         }}
       />,
     );
-    expect(screen.getByDataCy("section-status-fail")).toBeVisible();
+    expect(screen.getByDataTestId("section-status-fail")).toBeVisible();
     rerender(<SubsectionHeader {...subsectionHeaderProps} />);
-    expect(screen.queryByDataCy("section-status-pass")).not.toBeInTheDocument();
+    expect(
+      screen.queryByDataTestId("section-status-pass"),
+    ).not.toBeInTheDocument();
   });
 });
 

--- a/apps/parsley/src/components/LogRow/SubsectionHeader/index.tsx
+++ b/apps/parsley/src/components/LogRow/SubsectionHeader/index.tsx
@@ -51,7 +51,7 @@ const SubsectionHeader: React.FC<SubsectionHeaderProps> = ({
           ? sectionHeaderWrapperStyle
           : subsectionHeaderWrapperStyle
       }
-      data-cy="section-header"
+      data-testid="section-header"
     >
       <CaretToggle
         onClick={() => {

--- a/apps/parsley/src/components/LogWindow/LogWindow.test.tsx
+++ b/apps/parsley/src/components/LogWindow/LogWindow.test.tsx
@@ -54,7 +54,7 @@ describe("LogWindow keyboard shortcuts", () => {
 
     // Chat drawer should be closed initially
     await waitFor(() => {
-      expect(screen.getByDataCy("chat-drawer")).toHaveAttribute(
+      expect(screen.getByDataTestId("chat-drawer")).toHaveAttribute(
         "aria-hidden",
         "true",
       );
@@ -64,7 +64,7 @@ describe("LogWindow keyboard shortcuts", () => {
     await user.keyboard("{]}");
 
     await waitFor(() => {
-      expect(screen.getByDataCy("chat-drawer")).toHaveAttribute(
+      expect(screen.getByDataTestId("chat-drawer")).toHaveAttribute(
         "aria-hidden",
         "false",
       );
@@ -74,7 +74,7 @@ describe("LogWindow keyboard shortcuts", () => {
     await user.keyboard("{]}");
 
     await waitFor(() => {
-      expect(screen.getByDataCy("chat-drawer")).toHaveAttribute(
+      expect(screen.getByDataTestId("chat-drawer")).toHaveAttribute(
         "aria-hidden",
         "true",
       );
@@ -105,7 +105,7 @@ describe("LogWindow keyboard shortcuts", () => {
 
     // Chat drawer should be closed initially
     await waitFor(() => {
-      expect(screen.getByDataCy("chat-drawer")).toHaveAttribute(
+      expect(screen.getByDataTestId("chat-drawer")).toHaveAttribute(
         "aria-hidden",
         "true",
       );
@@ -120,7 +120,7 @@ describe("LogWindow keyboard shortcuts", () => {
     });
 
     // Drawer should still be closed
-    expect(screen.getByDataCy("chat-drawer")).toHaveAttribute(
+    expect(screen.getByDataTestId("chat-drawer")).toHaveAttribute(
       "aria-hidden",
       "true",
     );

--- a/apps/parsley/src/components/LogWindow/index.tsx
+++ b/apps/parsley/src/components/LogWindow/index.tsx
@@ -61,7 +61,7 @@ const LogWindow: React.FC = () => {
   );
 
   return (
-    <Container data-cy="log-window">
+    <Container data-testid="log-window">
       <SidePanel
         clearExpandedLines={clearExpandedLines}
         collapseLines={collapseLines}

--- a/apps/parsley/src/components/NavBar/UploadLink/UploadLink.test.tsx
+++ b/apps/parsley/src/components/NavBar/UploadLink/UploadLink.test.tsx
@@ -11,7 +11,7 @@ describe("uploadLink", () => {
     const clearLogs = vi.fn();
     render(<UploadLink clearLogs={clearLogs} hasLogs={false} />);
     expect(screen.getByText("Upload")).toBeInTheDocument();
-    expect(screen.queryByDataCy("upload-link")).toHaveAttribute(
+    expect(screen.queryByDataTestId("upload-link")).toHaveAttribute(
       "href",
       "/upload",
     );
@@ -22,10 +22,13 @@ describe("uploadLink", () => {
     const clearLogs = vi.fn();
     render(<UploadLink clearLogs={clearLogs} hasLogs />);
     expect(screen.getByText("Upload")).toBeInTheDocument();
-    expect(screen.queryByDataCy("upload-link")).toHaveAttribute("href", "/");
+    expect(screen.queryByDataTestId("upload-link")).toHaveAttribute(
+      "href",
+      "/",
+    );
     await user.click(screen.getByText("Upload"));
     await waitFor(() => {
-      expect(screen.queryByDataCy("confirmation-modal")).toBeVisible();
+      expect(screen.queryByDataTestId("confirmation-modal")).toBeVisible();
     });
   });
 
@@ -35,7 +38,7 @@ describe("uploadLink", () => {
     render(<UploadLink clearLogs={clearLogs} hasLogs />);
     await user.click(screen.getByText("Upload"));
     await waitFor(() => {
-      expect(screen.queryByDataCy("confirmation-modal")).toBeVisible();
+      expect(screen.queryByDataTestId("confirmation-modal")).toBeVisible();
     });
 
     const cancelButton = screen.getByRole("button", {
@@ -43,7 +46,7 @@ describe("uploadLink", () => {
     });
     await user.click(cancelButton);
     await waitFor(() => {
-      expect(screen.queryByDataCy("confirmation-modal")).not.toBeVisible();
+      expect(screen.queryByDataTestId("confirmation-modal")).not.toBeVisible();
     });
     expect(clearLogs).not.toHaveBeenCalled();
   });
@@ -57,14 +60,14 @@ describe("uploadLink", () => {
     });
     await user.click(screen.getByText("Upload"));
     await waitFor(() => {
-      expect(screen.queryByDataCy("confirmation-modal")).toBeVisible();
+      expect(screen.queryByDataTestId("confirmation-modal")).toBeVisible();
     });
     const confirmButton = screen.getByRole("button", {
       name: "Confirm",
     });
     await user.click(confirmButton);
     await waitFor(() => {
-      expect(screen.queryByDataCy("confirmation-modal")).not.toBeVisible();
+      expect(screen.queryByDataTestId("confirmation-modal")).not.toBeVisible();
     });
     expect(router.state.location.pathname).toBe("/upload");
     expect(clearLogs).toHaveBeenCalledTimes(1);

--- a/apps/parsley/src/components/NavBar/UploadLink/index.tsx
+++ b/apps/parsley/src/components/NavBar/UploadLink/index.tsx
@@ -33,7 +33,7 @@ const UploadLink: React.FC<UploadLinkProps> = ({ clearLogs, hasLogs }) => {
   return (
     <>
       <StyledRouterLink
-        data-cy="upload-link"
+        data-testid="upload-link"
         onClick={handleClick}
         to={hasLogs ? "#" : routes.upload}
       >
@@ -51,7 +51,7 @@ const UploadLink: React.FC<UploadLinkProps> = ({ clearLogs, hasLogs }) => {
             navigate(routes.upload);
           },
         }}
-        data-cy="confirmation-modal"
+        data-testid="confirmation-modal"
         open={open}
         title="Navigating away will clear your current logs."
         variant="danger"

--- a/apps/parsley/src/components/PaginatedVirtualList/index.tsx
+++ b/apps/parsley/src/components/PaginatedVirtualList/index.tsx
@@ -107,7 +107,7 @@ const PaginatedVirtualList = forwardRef<
           }
         }}
         className={className}
-        data-cy="paginated-virtual-list"
+        data-testid="paginated-virtual-list"
         increaseViewportBy={
           overscan === 0 ? { bottom: 50, top: 0 } : { bottom: 0, top: 0 }
         }

--- a/apps/parsley/src/components/ProjectFiltersModal/ProjectFiltersModal.test.tsx
+++ b/apps/parsley/src/components/ProjectFiltersModal/ProjectFiltersModal.test.tsx
@@ -48,7 +48,7 @@ describe("projectFiltersModal", () => {
       hook.current.setLogMetadata(logMetadata);
     });
     await waitForModalLoad();
-    expect(screen.getByDataCy("no-filters-message")).toBeInTheDocument();
+    expect(screen.getByDataTestId("no-filters-message")).toBeInTheDocument();
   });
 
   it("lists all of a project's filters", async () => {
@@ -163,11 +163,11 @@ describe("projectFiltersModal", () => {
 
 const waitForModalLoad = async () => {
   await waitFor(() =>
-    expect(screen.queryByDataCy("project-filters-modal")).toBeVisible(),
+    expect(screen.queryByDataTestId("project-filters-modal")).toBeVisible(),
   );
   await waitFor(() =>
     expect(
-      screen.queryByDataCy("table-loader-loading-row"),
+      screen.queryByDataTestId("table-loader-loading-row"),
     ).not.toBeInTheDocument(),
   );
 };

--- a/apps/parsley/src/components/ProjectFiltersModal/index.tsx
+++ b/apps/parsley/src/components/ProjectFiltersModal/index.tsx
@@ -142,7 +142,7 @@ const ProjectFiltersModal: React.FC<ProjectFiltersModalProps> = ({
         disabled: !hasNewFilters,
         onClick: handleConfirm,
       }}
-      data-cy="project-filters-modal"
+      data-testid="project-filters-modal"
       open={open}
       setOpen={setOpen}
       // @ts-expect-error - size is not a valid prop for ConfirmationModal but it is valid for the underlying Modal component
@@ -155,7 +155,7 @@ const ProjectFiltersModal: React.FC<ProjectFiltersModalProps> = ({
           .filter(isRowDisabled)}
         emptyComponent={
           <TablePlaceholder
-            data-cy="no-filters-message"
+            data-testid="no-filters-message"
             glyph="MagnifyingGlass"
             message={
               <p>

--- a/apps/parsley/src/components/Search/Search.test.tsx
+++ b/apps/parsley/src/components/Search/Search.test.tsx
@@ -32,7 +32,7 @@ const renderSearch = (route?: string) => {
       LogRenderingTypes.Default,
     );
   });
-  expect(screen.getByDataCy("searchbar-input")).not.toBeDisabled();
+  expect(screen.getByDataTestId("searchbar-input")).not.toBeDisabled();
 
   return {
     hook,
@@ -46,13 +46,13 @@ describe("Search", () => {
   });
   it("renders", () => {
     renderSearch();
-    expect(screen.getByDataCy("searchbar-input")).toBeInTheDocument();
+    expect(screen.getByDataTestId("searchbar-input")).toBeInTheDocument();
   });
   it("applying a search should update the search state", async () => {
     const user = userEvent.setup();
     const { hook } = renderSearch();
-    expect(screen.getByDataCy("searchbar-input")).not.toBeDisabled();
-    await user.type(screen.getByDataCy("searchbar-input"), "test");
+    expect(screen.getByDataTestId("searchbar-input")).not.toBeDisabled();
+    await user.type(screen.getByDataTestId("searchbar-input"), "test");
     await waitFor(() => {
       expect(hook.current.searchState.hasSearch).toBe(true);
     });
@@ -62,8 +62,11 @@ describe("Search", () => {
     const user = userEvent.setup();
     const { utils } = renderSearch();
     expect(utils.router.state.location.search).toBe("");
-    await user.type(screen.getByDataCy("searchbar-input"), "test");
-    await user.type(screen.getByDataCy("searchbar-input"), "{Meta>}{enter}");
+    await user.type(screen.getByDataTestId("searchbar-input"), "test");
+    await user.type(
+      screen.getByDataTestId("searchbar-input"),
+      "{Meta>}{enter}",
+    );
     expect(utils.router.state.location.search).toBe(
       `?${QueryParams.Filters}=100test`,
     );
@@ -74,8 +77,11 @@ describe("Search", () => {
     expect(utils.router.state.location.search).toBe("");
     await user.click(screen.getByText("Filter"));
     await user.click(screen.getByText("Highlight"));
-    await user.type(screen.getByDataCy("searchbar-input"), "test");
-    await user.type(screen.getByDataCy("searchbar-input"), "{Meta>}{enter}");
+    await user.type(screen.getByDataTestId("searchbar-input"), "test");
+    await user.type(
+      screen.getByDataTestId("searchbar-input"),
+      "{Meta>}{enter}",
+    );
     expect(utils.router.state.location.search).toBe(
       `?${[QueryParams.Highlights]}=test`,
     );
@@ -88,9 +94,9 @@ describe("Search", () => {
     });
     expect(utils.router.state.location.search).toBe("");
     await user.click(screen.getByText("Filter"));
-    await user.type(screen.getByDataCy("searchbar-input"), "test");
+    await user.type(screen.getByDataTestId("searchbar-input"), "test");
     await user.type(
-      screen.getByDataCy("searchbar-input"),
+      screen.getByDataTestId("searchbar-input"),
       "{Meta>}{enter}",
       {},
     );
@@ -106,8 +112,11 @@ describe("Search", () => {
     });
     expect(utils.router.state.location.search).toBe("?search=test");
     await user.click(screen.getByText("Filter"));
-    await user.type(screen.getByDataCy("searchbar-input"), "test");
-    await user.type(screen.getByDataCy("searchbar-input"), "{Meta>}{enter}");
+    await user.type(screen.getByDataTestId("searchbar-input"), "test");
+    await user.type(
+      screen.getByDataTestId("searchbar-input"),
+      "{Meta>}{enter}",
+    );
     expect(utils.router.state.location.search).toBe(
       `?${QueryParams.Filters}=100test&${QueryParams.Highlights}=test&search=test`,
     );
@@ -115,26 +124,35 @@ describe("Search", () => {
   it("should persist search history", async () => {
     const user = userEvent.setup();
     renderSearch();
-    await user.type(screen.getByDataCy("searchbar-input"), "test");
-    await user.type(screen.getByDataCy("searchbar-input"), "{Meta>}{enter}");
-    await user.type(screen.getByDataCy("searchbar-input"), "test2");
+    await user.type(screen.getByDataTestId("searchbar-input"), "test");
     await user.type(
-      screen.getByDataCy("searchbar-input"),
+      screen.getByDataTestId("searchbar-input"),
+      "{Meta>}{enter}",
+    );
+    await user.type(screen.getByDataTestId("searchbar-input"), "test2");
+    await user.type(
+      screen.getByDataTestId("searchbar-input"),
       "{Meta>}{enter}",
       {},
     );
-    await user.click(screen.getByDataCy("search-suggestion-button"));
+    await user.click(screen.getByDataTestId("search-suggestion-button"));
     expect(screen.getByText("test2")).toBeInTheDocument();
     expect(screen.getByText("test")).toBeInTheDocument();
   });
   it("selecting a search suggestion should update the search state", async () => {
     const user = userEvent.setup();
     const { hook } = renderSearch();
-    await user.type(screen.getByDataCy("searchbar-input"), "first_search");
-    await user.type(screen.getByDataCy("searchbar-input"), "{Meta>}{enter}");
-    await user.type(screen.getByDataCy("searchbar-input"), "second_search");
-    await user.type(screen.getByDataCy("searchbar-input"), "{Meta>}{enter}");
-    await user.click(screen.getByDataCy("search-suggestion-button"));
+    await user.type(screen.getByDataTestId("searchbar-input"), "first_search");
+    await user.type(
+      screen.getByDataTestId("searchbar-input"),
+      "{Meta>}{enter}",
+    );
+    await user.type(screen.getByDataTestId("searchbar-input"), "second_search");
+    await user.type(
+      screen.getByDataTestId("searchbar-input"),
+      "{Meta>}{enter}",
+    );
+    await user.click(screen.getByDataTestId("search-suggestion-button"));
     expect(screen.getByText("first_search")).toBeInTheDocument();
     await user.click(screen.getByText("first_search"));
     expect(screen.getByText("first_search")).toBeInTheDocument();

--- a/apps/parsley/src/components/Search/SearchBar/SearchBar.test.tsx
+++ b/apps/parsley/src/components/Search/SearchBar/SearchBar.test.tsx
@@ -11,7 +11,7 @@ describe("searchbar", () => {
   it("disables properly", () => {
     render(<SearchBar disabled />);
     const { isDisabled } = getTestUtils();
-    expect(screen.getByDataCy("searchbar-select")).toHaveAttribute(
+    expect(screen.getByDataTestId("searchbar-select")).toHaveAttribute(
       "aria-disabled",
       "true",
     );
@@ -22,7 +22,7 @@ describe("searchbar", () => {
     const paginate = vi.fn();
     render(<SearchBar paginate={paginate} />);
 
-    const input = screen.getByDataCy("searchbar-input");
+    const input = screen.getByDataTestId("searchbar-input");
     await user.type(input, "test");
     expect(input).toHaveValue("test");
     await user.type(input, "{enter}");
@@ -35,7 +35,7 @@ describe("searchbar", () => {
     const paginate = vi.fn();
     render(<SearchBar paginate={paginate} />);
 
-    const input = screen.getByDataCy("searchbar-input");
+    const input = screen.getByDataTestId("searchbar-input");
     await user.type(input, "test");
     expect(input).toHaveValue("test");
     await user.type(input, "{Shift>}{enter}");
@@ -48,7 +48,7 @@ describe("searchbar", () => {
     const onSubmit = vi.fn();
     render(<SearchBar onSubmit={onSubmit} />);
 
-    const input = screen.getByDataCy("searchbar-input");
+    const input = screen.getByDataTestId("searchbar-input");
     await user.type(input, "test");
     expect(input).toHaveValue("test");
     await user.type(input, "{Control>}{enter}");
@@ -61,10 +61,10 @@ describe("searchbar", () => {
     const onSubmit = vi.fn();
     render(<SearchBar onSubmit={onSubmit} />);
 
-    const input = screen.getByDataCy("searchbar-input");
+    const input = screen.getByDataTestId("searchbar-input");
     await user.type(input, "test");
     expect(input).toHaveValue("test");
-    await user.click(screen.getByDataCy("searchbar-submit"));
+    await user.click(screen.getByDataTestId("searchbar-submit"));
     expect(onSubmit).toHaveBeenCalledTimes(1);
     expect(onSubmit).toHaveBeenCalledWith("filter", "test");
   });
@@ -73,12 +73,12 @@ describe("searchbar", () => {
     const onSubmit = vi.fn();
     render(<SearchBar onSubmit={onSubmit} validator={(i) => i.length > 5} />);
 
-    const input = screen.getByDataCy("searchbar-input");
+    const input = screen.getByDataTestId("searchbar-input");
     await user.type(input, "test");
     expect(input).toHaveValue("test");
     const { isError } = getTestUtils();
     expect(isError()).toBe(true);
-    expect(screen.queryByDataCy("searchbar-submit")).toHaveAttribute(
+    expect(screen.queryByDataTestId("searchbar-submit")).toHaveAttribute(
       "aria-disabled",
       "true",
     );
@@ -89,7 +89,7 @@ describe("searchbar", () => {
     const onSubmit = vi.fn();
     render(<SearchBar onSubmit={onSubmit} validator={(i) => i.length > 5} />);
 
-    const input = screen.getByDataCy("searchbar-input");
+    const input = screen.getByDataTestId("searchbar-input");
     await user.type(input, "test");
     await user.type(input, "{Control>}{enter}");
     expect(input).toHaveValue("test");
@@ -100,15 +100,15 @@ describe("searchbar", () => {
     const onSubmit = vi.fn();
     render(<SearchBar onSubmit={onSubmit} />);
 
-    const input = screen.getByDataCy("searchbar-input");
+    const input = screen.getByDataTestId("searchbar-input");
     await user.type(input, "test");
     expect(input).toHaveValue("test");
     await user.type(input, "{Control>}{enter}");
     expect(onSubmit).toHaveBeenCalledTimes(1);
     expect(onSubmit).toHaveBeenCalledWith("filter", "test");
 
-    await user.click(screen.getByDataCy("searchbar-select"));
-    await user.click(screen.getByDataCy("highlight-option"));
+    await user.click(screen.getByDataTestId("searchbar-select"));
+    await user.click(screen.getByDataTestId("highlight-option"));
     await user.type(input, "test");
     expect(input).toHaveValue("test");
     await user.type(input, "{Control>}{enter}");
@@ -119,9 +119,9 @@ describe("searchbar", () => {
     const onSubmit = vi.fn();
     render(<SearchBar onSubmit={onSubmit} validator={() => true} />);
 
-    const input = screen.getByDataCy("searchbar-input");
-    await user.click(screen.getByDataCy("searchbar-select"));
-    await user.click(screen.getByDataCy("filter-option"));
+    const input = screen.getByDataTestId("searchbar-input");
+    await user.click(screen.getByDataTestId("searchbar-select"));
+    await user.click(screen.getByDataTestId("filter-option"));
     await user.type(input, "test");
     await user.type(input, "{Control>}{enter}");
     expect(input).toHaveValue("");
@@ -133,7 +133,7 @@ describe("searchbar", () => {
     const onChange = vi.fn();
     render(<SearchBar onChange={onChange} />);
 
-    const input = screen.getByDataCy("searchbar-input");
+    const input = screen.getByDataTestId("searchbar-input");
     await user.type(input, "test");
     expect(input).toHaveValue("test");
     vi.advanceTimersByTime(1000);
@@ -146,7 +146,7 @@ describe("searchbar", () => {
     const onChange = vi.fn();
     render(<SearchBar onChange={onChange} validator={(i) => i.length > 4} />);
 
-    const input = screen.getByDataCy("searchbar-input");
+    const input = screen.getByDataTestId("searchbar-input");
     await user.type(input, "test");
     expect(input).toHaveValue("test");
     vi.advanceTimersByTime(1000);
@@ -161,7 +161,7 @@ describe("searchbar", () => {
     const user = userEvent.setup();
     render(<SearchBar onSubmit={vi.fn()} />);
 
-    const input = screen.getByDataCy("searchbar-input") as HTMLInputElement;
+    const input = screen.getByDataTestId("searchbar-input") as HTMLInputElement;
     const inputText = "input text";
     await user.type(input, inputText);
     await user.click(document.body as HTMLElement);
@@ -176,7 +176,7 @@ describe("searchbar", () => {
     const user = userEvent.setup();
     render(<SearchBar onSubmit={vi.fn()} />);
 
-    const input = screen.getByDataCy("searchbar-input") as HTMLInputElement;
+    const input = screen.getByDataTestId("searchbar-input") as HTMLInputElement;
     const inputText = "input text";
     await user.type(input, inputText);
     await user.click(document.body as HTMLElement);
@@ -201,13 +201,13 @@ describe("searchbar", () => {
       <SearchBar onChange={onChange} searchSuggestions={searchSuggestions} />,
     );
 
-    await user.click(screen.getByDataCy("search-suggestion-button"));
+    await user.click(screen.getByDataTestId("search-suggestion-button"));
     await waitFor(() => {
-      expect(screen.getByDataCy("search-suggestion-popover")).toBeVisible();
+      expect(screen.getByDataTestId("search-suggestion-popover")).toBeVisible();
     });
     await user.click(screen.getByText("apple"));
 
-    const input = screen.getByDataCy("searchbar-input") as HTMLInputElement;
+    const input = screen.getByDataTestId("searchbar-input") as HTMLInputElement;
     expect(input).toHaveValue("apple");
     expect(input).toHaveFocus();
     vi.advanceTimersByTime(1000);
@@ -227,7 +227,7 @@ describe("searchbar", () => {
       <SearchBar onSubmit={vi.fn()} searchSuggestions={searchSuggestions} />,
     );
 
-    const input = screen.getByDataCy("searchbar-input") as HTMLInputElement;
+    const input = screen.getByDataTestId("searchbar-input") as HTMLInputElement;
     await user.type(input, "ap");
     expect(input).toHaveValue("ap");
     expect(screen.getByText("apple")).toBeVisible();
@@ -244,7 +244,7 @@ describe("searchbar", () => {
       <SearchBar onSubmit={vi.fn()} searchSuggestions={searchSuggestions} />,
     );
 
-    const input = screen.getByDataCy("searchbar-input") as HTMLInputElement;
+    const input = screen.getByDataTestId("searchbar-input") as HTMLInputElement;
     await user.type(input, "apple");
     expect(input).toHaveValue("apple");
     expect(screen.queryByText("apple")).toBeNull();
@@ -261,7 +261,7 @@ describe("searchbar", () => {
       <SearchBar onSubmit={vi.fn()} searchSuggestions={searchSuggestions} />,
     );
 
-    const input = screen.getByDataCy("searchbar-input") as HTMLInputElement;
+    const input = screen.getByDataTestId("searchbar-input") as HTMLInputElement;
     await user.type(input, "ap");
     expect(input).toHaveValue("ap");
     await user.type(input, "{tab}");

--- a/apps/parsley/src/components/Search/SearchBar/SearchPopover/SearchPopover.test.tsx
+++ b/apps/parsley/src/components/Search/SearchBar/SearchPopover/SearchPopover.test.tsx
@@ -23,7 +23,7 @@ const singleGroupSuggestions: SearchSuggestionGroup[] = [
 describe("search popover", () => {
   it("disables properly", () => {
     render(<SearchPopover disabled searchSuggestions={[]} />);
-    expect(screen.getByDataCy("search-suggestion-button")).toHaveAttribute(
+    expect(screen.getByDataTestId("search-suggestion-button")).toHaveAttribute(
       "aria-disabled",
       "true",
     );
@@ -38,22 +38,24 @@ describe("search popover", () => {
         searchSuggestions={mockSearchSuggestions}
       />,
     );
-    await user.click(screen.getByDataCy("search-suggestion-button"));
+    await user.click(screen.getByDataTestId("search-suggestion-button"));
     await waitFor(() => {
-      expect(screen.getByDataCy("search-suggestion-popover")).toBeVisible();
+      expect(screen.getByDataTestId("search-suggestion-popover")).toBeVisible();
     });
     await user.click(screen.getByRole("menuitem", { name: "apple" }));
     expect(onClick).toHaveBeenCalledTimes(1);
     expect(onClick).toHaveBeenCalledWith("apple");
-    expect(screen.getByDataCy("search-suggestion-popover")).not.toBeVisible();
+    expect(
+      screen.getByDataTestId("search-suggestion-popover"),
+    ).not.toBeVisible();
   });
 
   it("should display group titles and suggestions with proper structure", async () => {
     const user = userEvent.setup();
     render(<SearchPopover searchSuggestions={mockSearchSuggestions} />);
-    await user.click(screen.getByDataCy("search-suggestion-button"));
+    await user.click(screen.getByDataTestId("search-suggestion-button"));
     await waitFor(() => {
-      expect(screen.getByDataCy("search-suggestion-popover")).toBeVisible();
+      expect(screen.getByDataTestId("search-suggestion-popover")).toBeVisible();
     });
 
     // Check group titles are displayed
@@ -80,9 +82,9 @@ describe("search popover", () => {
         searchSuggestions={singleGroupSuggestions}
       />,
     );
-    await user.click(screen.getByDataCy("search-suggestion-button"));
+    await user.click(screen.getByDataTestId("search-suggestion-button"));
     await waitFor(() => {
-      expect(screen.getByDataCy("search-suggestion-popover")).toBeVisible();
+      expect(screen.getByDataTestId("search-suggestion-popover")).toBeVisible();
     });
     const menuItem = screen.getByRole("menuitem", { name: "apple" });
     menuItem.focus();
@@ -90,7 +92,9 @@ describe("search popover", () => {
     await user.keyboard("{Enter}");
     expect(onClick).toHaveBeenCalledTimes(1);
     expect(onClick).toHaveBeenCalledWith("apple");
-    expect(screen.getByDataCy("search-suggestion-popover")).not.toBeVisible();
+    expect(
+      screen.getByDataTestId("search-suggestion-popover"),
+    ).not.toBeVisible();
   });
 
   it("should be able to submit an option with spacebar", async () => {
@@ -102,9 +106,9 @@ describe("search popover", () => {
         searchSuggestions={singleGroupSuggestions}
       />,
     );
-    await user.click(screen.getByDataCy("search-suggestion-button"));
+    await user.click(screen.getByDataTestId("search-suggestion-button"));
     await waitFor(() => {
-      expect(screen.getByDataCy("search-suggestion-popover")).toBeVisible();
+      expect(screen.getByDataTestId("search-suggestion-popover")).toBeVisible();
     });
     const menuItem = screen.getByRole("menuitem", { name: "apple" });
     menuItem.focus();
@@ -112,15 +116,17 @@ describe("search popover", () => {
     await user.keyboard(" ");
     expect(onClick).toHaveBeenCalledTimes(1);
     expect(onClick).toHaveBeenCalledWith("apple");
-    expect(screen.getByDataCy("search-suggestion-popover")).not.toBeVisible();
+    expect(
+      screen.getByDataTestId("search-suggestion-popover"),
+    ).not.toBeVisible();
   });
 
   it("should indicate if there are no search suggestions", async () => {
     const user = userEvent.setup();
     render(<SearchPopover searchSuggestions={[]} />);
-    await user.click(screen.getByDataCy("search-suggestion-button"));
+    await user.click(screen.getByDataTestId("search-suggestion-button"));
     await waitFor(() => {
-      expect(screen.getByDataCy("search-suggestion-popover")).toBeVisible();
+      expect(screen.getByDataTestId("search-suggestion-popover")).toBeVisible();
     });
     expect(
       screen.getByText(/No suggestions available for this project/),
@@ -130,12 +136,14 @@ describe("search popover", () => {
   it("should close when user clicks outside of popover", async () => {
     const user = userEvent.setup();
     render(<SearchPopover searchSuggestions={[]} />);
-    await user.click(screen.getByDataCy("search-suggestion-button"));
+    await user.click(screen.getByDataTestId("search-suggestion-button"));
     await waitFor(() => {
-      expect(screen.getByDataCy("search-suggestion-popover")).toBeVisible();
+      expect(screen.getByDataTestId("search-suggestion-popover")).toBeVisible();
     });
     await user.click(document.body as HTMLElement);
-    expect(screen.getByDataCy("search-suggestion-popover")).not.toBeVisible();
+    expect(
+      screen.getByDataTestId("search-suggestion-popover"),
+    ).not.toBeVisible();
   });
 
   it("should navigate options with arrow keys and select with enter across groups", async () => {
@@ -147,9 +155,9 @@ describe("search popover", () => {
         searchSuggestions={singleGroupSuggestions}
       />,
     );
-    await user.click(screen.getByDataCy("search-suggestion-button"));
+    await user.click(screen.getByDataTestId("search-suggestion-button"));
     await waitFor(() => {
-      expect(screen.getByDataCy("search-suggestion-popover")).toBeVisible();
+      expect(screen.getByDataTestId("search-suggestion-popover")).toBeVisible();
     });
 
     const menu = screen.getByRole("menu");
@@ -163,7 +171,9 @@ describe("search popover", () => {
 
     expect(onClick).toHaveBeenCalledTimes(1);
     expect(onClick).toHaveBeenCalledWith("banana");
-    expect(screen.getByDataCy("search-suggestion-popover")).not.toBeVisible();
+    expect(
+      screen.getByDataTestId("search-suggestion-popover"),
+    ).not.toBeVisible();
   });
 
   it("should navigate across multiple groups with arrow keys", async () => {
@@ -175,9 +185,9 @@ describe("search popover", () => {
         searchSuggestions={mockSearchSuggestions}
       />,
     );
-    await user.click(screen.getByDataCy("search-suggestion-button"));
+    await user.click(screen.getByDataTestId("search-suggestion-button"));
     await waitFor(() => {
-      expect(screen.getByDataCy("search-suggestion-popover")).toBeVisible();
+      expect(screen.getByDataTestId("search-suggestion-popover")).toBeVisible();
     });
 
     const menu = screen.getByRole("menu");
@@ -192,7 +202,9 @@ describe("search popover", () => {
 
     expect(onClick).toHaveBeenCalledTimes(1);
     expect(onClick).toHaveBeenCalledWith("carrot");
-    expect(screen.getByDataCy("search-suggestion-popover")).not.toBeVisible();
+    expect(
+      screen.getByDataTestId("search-suggestion-popover"),
+    ).not.toBeVisible();
   });
 
   it("should wrap around when navigating with arrow keys", async () => {
@@ -204,9 +216,9 @@ describe("search popover", () => {
         searchSuggestions={mockSearchSuggestions}
       />,
     );
-    await user.click(screen.getByDataCy("search-suggestion-button"));
+    await user.click(screen.getByDataTestId("search-suggestion-button"));
     await waitFor(() => {
-      expect(screen.getByDataCy("search-suggestion-popover")).toBeVisible();
+      expect(screen.getByDataTestId("search-suggestion-popover")).toBeVisible();
     });
 
     const menu = screen.getByRole("menu");
@@ -219,15 +231,17 @@ describe("search popover", () => {
 
     expect(onClick).toHaveBeenCalledTimes(1);
     expect(onClick).toHaveBeenCalledWith("lettuce");
-    expect(screen.getByDataCy("search-suggestion-popover")).not.toBeVisible();
+    expect(
+      screen.getByDataTestId("search-suggestion-popover"),
+    ).not.toBeVisible();
   });
 
   it("should maintain focus within the menu when using keyboard navigation", async () => {
     const user = userEvent.setup();
     render(<SearchPopover searchSuggestions={mockSearchSuggestions} />);
-    await user.click(screen.getByDataCy("search-suggestion-button"));
+    await user.click(screen.getByDataTestId("search-suggestion-button"));
     await waitFor(() => {
-      expect(screen.getByDataCy("search-suggestion-popover")).toBeVisible();
+      expect(screen.getByDataTestId("search-suggestion-popover")).toBeVisible();
     });
 
     const menu = screen.getByRole("menu");

--- a/apps/parsley/src/components/Search/SearchBar/SearchPopover/index.tsx
+++ b/apps/parsley/src/components/Search/SearchBar/SearchPopover/index.tsx
@@ -88,7 +88,7 @@ const SearchPopover: React.FC<SearchPopoverProps> = ({
       <IconButton
         ref={buttonRef}
         aria-labelledby="View search suggestions"
-        data-cy="search-suggestion-button"
+        data-testid="search-suggestion-button"
         disabled={disabled}
         onClick={() => setIsOpen(!isOpen)}
         title="View search suggestions"
@@ -98,7 +98,7 @@ const SearchPopover: React.FC<SearchPopoverProps> = ({
           <Icon fill={gray.base} glyph="CaretDown" />
         </>
       </IconButton>
-      <Popover active={isOpen} data-cy="search-suggestion-popover">
+      <Popover active={isOpen} data-testid="search-suggestion-popover">
         <div
           ref={popoverRef}
           aria-label="Search suggestions"

--- a/apps/parsley/src/components/Search/SearchBar/index.tsx
+++ b/apps/parsley/src/components/Search/SearchBar/index.tsx
@@ -147,7 +147,7 @@ const SearchBar: React.FC<SearchBarProps> = ({
       <StyledSelect
         allowDeselect={false}
         aria-labelledby="searchbar-select"
-        data-cy="searchbar-select"
+        data-testid="searchbar-select"
         disabled={disabled}
         dropdownWidthBasis="option"
         onChange={handleChangeSelect}
@@ -155,21 +155,21 @@ const SearchBar: React.FC<SearchBarProps> = ({
       >
         <Option
           key={SearchBarActions.Filter}
-          data-cy="filter-option"
+          data-testid="filter-option"
           value={SearchBarActions.Filter}
         >
           Filter
         </Option>
         <Option
           key={SearchBarActions.Highlight}
-          data-cy="highlight-option"
+          data-testid="highlight-option"
           value={SearchBarActions.Highlight}
         >
           Highlight
         </Option>
         <Option
           key={SearchBarActions.Bookmark}
-          data-cy="bookmark-option"
+          data-testid="bookmark-option"
           value={SearchBarActions.Bookmark}
         >
           Bookmark
@@ -203,7 +203,7 @@ const SearchBar: React.FC<SearchBarProps> = ({
         <StyledInput
           ref={inputRef}
           aria-labelledby="searchbar-input"
-          data-cy="searchbar-input"
+          data-testid="searchbar-input"
           disabled={disabled}
           errorMessage={validatorMessage}
           onChange={(e) => handleOnChange(e.target.value)}
@@ -233,7 +233,7 @@ const SearchBar: React.FC<SearchBarProps> = ({
         >
           <IconButton
             aria-label="Select plus"
-            data-cy="searchbar-submit"
+            data-testid="searchbar-submit"
             disabled={disabled || input.length === 0 || !isValid}
             onClick={handleOnSubmit}
           >
@@ -281,7 +281,7 @@ const StyledInput = styled(TextInputWithGlyph)`
   }
 
   /* This reflect the side dropdown width */
-  input[data-cy="searchbar-input"] {
+  input[data-testid="searchbar-input"] {
     padding-left: 42px;
   }
 

--- a/apps/parsley/src/components/Search/SearchBarGuideCue/SearchBarGuideCue.test.tsx
+++ b/apps/parsley/src/components/Search/SearchBarGuideCue/SearchBarGuideCue.test.tsx
@@ -17,13 +17,13 @@ describe("search bar guide cue", () => {
 
     render(<SearchBarGuideCue />);
     await waitFor(() => {
-      expect(screen.getByDataCy("searchbar-guide-cue")).toBeInTheDocument();
+      expect(screen.getByDataTestId("searchbar-guide-cue")).toBeInTheDocument();
     });
   });
 
   it("does not show the guide cue if the user has seen it before", () => {
     localStorage.setItem(HAS_SEEN_SEARCHBAR_GUIDE_CUE, "true");
     render(<SearchBarGuideCue />);
-    expect(screen.queryByDataCy("searchbar-guide-cue")).toBeNull();
+    expect(screen.queryByDataTestId("searchbar-guide-cue")).toBeNull();
   });
 });

--- a/apps/parsley/src/components/Search/SearchBarGuideCue/index.tsx
+++ b/apps/parsley/src/components/Search/SearchBarGuideCue/index.tsx
@@ -24,7 +24,7 @@ const SearchBarGuideCue: React.FC = () => {
   return (
     <GuideCue
       currentStep={1}
-      data-cy="searchbar-guide-cue"
+      data-testid="searchbar-guide-cue"
       numberOfSteps={1}
       onPrimaryButtonClick={onHideCue}
       open={openGuideCue}

--- a/apps/parsley/src/components/Search/SearchResults/SearchCount.tsx
+++ b/apps/parsley/src/components/Search/SearchResults/SearchCount.tsx
@@ -13,7 +13,7 @@ const SearchCount: React.FC<SearchCountProps> = ({
   matchingSearchCount,
 }) => (
   <StyledBody
-    data-cy="search-count"
+    data-testid="search-count"
     has-matches={`${matchingSearchCount !== 0}`}
   >
     {matchingSearchCount !== 0

--- a/apps/parsley/src/components/ShortcutModal/ShortcutModal.test.tsx
+++ b/apps/parsley/src/components/ShortcutModal/ShortcutModal.test.tsx
@@ -35,11 +35,11 @@ describe("shortcutModal", () => {
       route: "/",
       wrapper: wrapper(),
     });
-    expect(screen.getByDataCy("shortcut-modal")).not.toBeVisible();
+    expect(screen.getByDataTestId("shortcut-modal")).not.toBeVisible();
 
     await user.keyboard("{Shift>}{?}{/Shift}");
     await waitFor(() => {
-      expect(screen.getByDataCy("shortcut-modal")).toBeVisible();
+      expect(screen.getByDataTestId("shortcut-modal")).toBeVisible();
     });
   });
 
@@ -50,16 +50,16 @@ describe("shortcutModal", () => {
       route: "/",
       wrapper: wrapper(),
     });
-    expect(screen.getByDataCy("shortcut-modal")).not.toBeVisible();
+    expect(screen.getByDataTestId("shortcut-modal")).not.toBeVisible();
 
     await user.keyboard("{Shift>}{?}{/Shift}");
     await waitFor(() => {
-      expect(screen.getByDataCy("shortcut-modal")).toBeVisible();
+      expect(screen.getByDataTestId("shortcut-modal")).toBeVisible();
     });
 
     await user.click(document.body as HTMLElement);
     await waitFor(() => {
-      expect(screen.getByDataCy("shortcut-modal")).not.toBeVisible();
+      expect(screen.getByDataTestId("shortcut-modal")).not.toBeVisible();
     });
   });
 
@@ -87,7 +87,7 @@ describe("shortcutModal", () => {
 
     await user.keyboard("{Shift>}{?}{/Shift}");
     await waitFor(() => {
-      expect(screen.getByDataCy("shortcut-modal")).toBeVisible();
+      expect(screen.getByDataTestId("shortcut-modal")).toBeVisible();
     });
 
     expect(
@@ -119,7 +119,7 @@ describe("shortcutModal", () => {
 
     await user.keyboard("{Shift>}{?}{/Shift}");
     await waitFor(() => {
-      expect(screen.getByDataCy("shortcut-modal")).toBeVisible();
+      expect(screen.getByDataTestId("shortcut-modal")).toBeVisible();
     });
 
     expect(

--- a/apps/parsley/src/components/ShortcutModal/index.tsx
+++ b/apps/parsley/src/components/ShortcutModal/index.tsx
@@ -94,7 +94,7 @@ const ShortcutModal: React.FC<ShortcutModalProps> = ({ open, setOpen }) => {
   });
 
   return (
-    <Modal data-cy="shortcut-modal" open={open} setOpen={setOpen}>
+    <Modal data-testid="shortcut-modal" open={open} setOpen={setOpen}>
       <div ref={modalRef}>
         <ModalTitle>
           <H3>Parsley Keyboard Shortcuts</H3>

--- a/apps/parsley/src/components/SidePanel/NavGroup/BaseNavGroup/index.tsx
+++ b/apps/parsley/src/components/SidePanel/NavGroup/BaseNavGroup/index.tsx
@@ -10,7 +10,7 @@ import { size } from "@evg-ui/lib/constants/tokens";
 const { green } = palette;
 
 interface BaseNavGroupProps<T> {
-  ["data-cy"]: string;
+  ["data-testid"]: string;
   children: ReactNode;
   glyph: keyof typeof glyphs;
   items: T[];
@@ -23,7 +23,7 @@ interface BaseNavGroupProps<T> {
 const BaseNavGroup = <T,>({
   additionalHeaderText,
   children,
-  "data-cy": dataCy,
+  "data-testid": dataTestId,
   defaultMessage,
   glyph,
   items,
@@ -33,7 +33,7 @@ const BaseNavGroup = <T,>({
     glyph={<Icon fill={green.dark2} glyph={glyph} />}
     hasActiveItem={items.length > 0}
     header={
-      <NavGroupHeader data-cy={`${dataCy}-nav-group-header`}>
+      <NavGroupHeader data-testid={`${dataTestId}-nav-group-header`}>
         <NavGroupTitle>{navGroupTitle}</NavGroupTitle>
         <Badge variant={Variant.Green}>{items.length}</Badge>
         {additionalHeaderText}
@@ -43,7 +43,7 @@ const BaseNavGroup = <T,>({
     {items.length ? (
       children
     ) : (
-      <DefaultMessageWrapper data-cy={`${dataCy}-default-message`}>
+      <DefaultMessageWrapper data-testid={`${dataTestId}-default-message`}>
         <Body>{defaultMessage}</Body>
       </DefaultMessageWrapper>
     )}

--- a/apps/parsley/src/components/SidePanel/NavGroup/ExpandedNavGroup/ExpandedNavGroup.test.tsx
+++ b/apps/parsley/src/components/SidePanel/NavGroup/ExpandedNavGroup/ExpandedNavGroup.test.tsx
@@ -10,7 +10,7 @@ describe("expanded lines", () => {
   it("shows a message when no lines have been expanded", () => {
     render(<ExpandedNavGroup {...props} />);
     expect(
-      screen.getByDataCy("expanded-lines-default-message"),
+      screen.getByDataTestId("expanded-lines-default-message"),
     ).toBeInTheDocument();
   });
 
@@ -40,7 +40,7 @@ describe("expanded lines", () => {
         ]}
       />,
     );
-    const navGroupHeader = screen.getByDataCy(
+    const navGroupHeader = screen.getByDataTestId(
       "expanded-lines-nav-group-header",
     );
     expect(within(navGroupHeader).getByText("4")).toBeInTheDocument();

--- a/apps/parsley/src/components/SidePanel/NavGroup/ExpandedNavGroup/index.tsx
+++ b/apps/parsley/src/components/SidePanel/NavGroup/ExpandedNavGroup/index.tsx
@@ -20,7 +20,7 @@ const ExpandedNavGroup: React.FC<ExpandedNavGroupProps> = ({
 
   return (
     <BaseNavGroup
-      data-cy="expanded-lines"
+      data-testid="expanded-lines"
       defaultMessage="No lines have been expanded."
       glyph="Expand"
       items={expandedLines}
@@ -29,7 +29,7 @@ const ExpandedNavGroup: React.FC<ExpandedNavGroupProps> = ({
       {expandedLines.map((e, idx) => (
         <ExpandedLine
           key={`expanded-row-${e[0]}-to-${e[1]}`}
-          data-cy={`expanded-row-${e[0]}-to-${e[1]}`}
+          data-testid={`expanded-row-${e[0]}-to-${e[1]}`}
         >
           <IconButton
             aria-label="Delete range"

--- a/apps/parsley/src/components/SidePanel/NavGroup/FilterNavGroup/AllFiltersToggle/AllFiltersToggle.test.tsx
+++ b/apps/parsley/src/components/SidePanel/NavGroup/FilterNavGroup/AllFiltersToggle/AllFiltersToggle.test.tsx
@@ -8,7 +8,7 @@ import AllFiltersToggle from ".";
 describe("all filters toggle", () => {
   it("defaults to 'true'", () => {
     render(<AllFiltersToggle />);
-    const allFiltersToggle = screen.getByDataCy("all-filters-toggle");
+    const allFiltersToggle = screen.getByDataTestId("all-filters-toggle");
     expect(allFiltersToggle).toHaveAttribute("aria-checked", "true");
   });
 
@@ -17,7 +17,7 @@ describe("all filters toggle", () => {
     const { router } = render(<AllFiltersToggle />, {
       route: "?filters=100abc,100def,100ghi",
     });
-    const allFiltersToggle = screen.getByDataCy("all-filters-toggle");
+    const allFiltersToggle = screen.getByDataTestId("all-filters-toggle");
 
     await user.click(allFiltersToggle);
     expect(allFiltersToggle).toHaveAttribute("aria-checked", "false");

--- a/apps/parsley/src/components/SidePanel/NavGroup/FilterNavGroup/AllFiltersToggle/index.tsx
+++ b/apps/parsley/src/components/SidePanel/NavGroup/FilterNavGroup/AllFiltersToggle/index.tsx
@@ -24,7 +24,7 @@ const AllFiltersToggle: React.FC = () => {
     <StyledToggle
       aria-labelledby="Show or hide all filters toggle"
       checked={showFilters}
-      data-cy="all-filters-toggle"
+      data-testid="all-filters-toggle"
       onChange={onChange}
       size={ToggleSize.XSmall}
     />

--- a/apps/parsley/src/components/SidePanel/NavGroup/FilterNavGroup/FilterGroup/FilterGroup.test.tsx
+++ b/apps/parsley/src/components/SidePanel/NavGroup/FilterNavGroup/FilterGroup/FilterGroup.test.tsx
@@ -31,12 +31,12 @@ describe("filters", () => {
       />,
     );
     await user.click(screen.getByLabelText("Edit filter"));
-    expect(screen.getByDataCy("edit-filter-name")).toBeInTheDocument();
-    expect(screen.getByDataCy("edit-filter-name")).toHaveValue(
+    expect(screen.getByDataTestId("edit-filter-name")).toBeInTheDocument();
+    expect(screen.getByDataTestId("edit-filter-name")).toHaveValue(
       defaultFilter.expression,
     );
 
-    expect(screen.getByDataCy("edit-filter-name")).toHaveFocus();
+    expect(screen.getByDataTestId("edit-filter-name")).toHaveFocus();
     const confirmButton = screen.getByRole("button", {
       name: "Apply",
     });
@@ -55,8 +55,8 @@ describe("filters", () => {
     );
     // Clear the text input and submit a new filter.
     await user.click(screen.getByLabelText("Edit filter"));
-    await user.clear(screen.getByDataCy("edit-filter-name"));
-    await user.type(screen.getByDataCy("edit-filter-name"), "newFilter");
+    await user.clear(screen.getByDataTestId("edit-filter-name"));
+    await user.type(screen.getByDataTestId("edit-filter-name"), "newFilter");
 
     const confirmButton = screen.getByRole("button", {
       name: "Apply",
@@ -83,16 +83,16 @@ describe("filters", () => {
     );
     // Clear the text input and submit a new filter.
     await user.click(screen.getByLabelText("Edit filter"));
-    await user.clear(screen.getByDataCy("edit-filter-name"));
+    await user.clear(screen.getByDataTestId("edit-filter-name"));
     await user.type(
-      screen.getByDataCy("edit-filter-name"),
+      screen.getByDataTestId("edit-filter-name"),
       "some [[invalid regex",
     );
     const confirmButton = screen.getByRole("button", {
       name: "Apply",
     });
     expect(confirmButton).toHaveAttribute("aria-disabled", "true");
-    await user.clear(screen.getByDataCy("edit-filter-name"));
+    await user.clear(screen.getByDataTestId("edit-filter-name"));
     expect(confirmButton).toHaveAttribute("aria-disabled", "true");
   });
 
@@ -203,8 +203,8 @@ describe("filters", () => {
         filter={{ ...defaultFilter, expression: "invalid (regex" }}
       />,
     );
-    expect(screen.getByDataCy("validation-error-icon")).toBeInTheDocument();
-    await user.hover(screen.getByDataCy("validation-error-icon"));
+    expect(screen.getByDataTestId("validation-error-icon")).toBeInTheDocument();
+    await user.hover(screen.getByDataTestId("validation-error-icon"));
     await expect(
       screen.findByText("Invalid Regular Expression: Unterminated group"),
     ).resolves.toBeInTheDocument();
@@ -242,8 +242,8 @@ describe("filters", () => {
       name: "Apply",
     });
     expect(confirmButton).toHaveAttribute("aria-disabled", "true");
-    await user.clear(screen.getByDataCy("edit-filter-name"));
-    await user.type(screen.getByDataCy("edit-filter-name"), "newFilter");
+    await user.clear(screen.getByDataTestId("edit-filter-name"));
+    await user.type(screen.getByDataTestId("edit-filter-name"), "newFilter");
     expect(
       screen.queryByText("Invalid Regular Expression: Unterminated group"),
     ).not.toBeInTheDocument();
@@ -260,17 +260,17 @@ describe("filters", () => {
       />,
     );
     await user.click(screen.getByLabelText("Edit filter"));
-    expect(screen.getByDataCy("edit-filter-name")).toHaveValue(
+    expect(screen.getByDataTestId("edit-filter-name")).toHaveValue(
       defaultFilter.expression,
     );
-    await user.clear(screen.getByDataCy("edit-filter-name"));
+    await user.clear(screen.getByDataTestId("edit-filter-name"));
     expect(screen.getByText("Filter cannot be empty")).toBeInTheDocument();
     const cancelButton = screen.getByRole("button", {
       name: "Cancel",
     });
     await user.click(cancelButton);
     expect(screen.getByText(defaultFilter.expression)).toBeInTheDocument();
-    expect(screen.queryByDataCy("edit-filter-name")).toBeNull();
+    expect(screen.queryByDataTestId("edit-filter-name")).toBeNull();
     expect(screen.queryByText("Filter cannot be empty")).toBeNull();
   });
   it("if the filter group is collapsed, editing should expand it", async () => {
@@ -283,21 +283,18 @@ describe("filters", () => {
         filter={defaultFilter}
       />,
     );
-    expect(screen.getByDataCy("accordion-collapse-container")).toHaveAttribute(
-      "aria-expanded",
-      "true",
-    );
-    await user.click(screen.getByDataCy("accordion-toggle"));
-    expect(screen.getByDataCy("accordion-collapse-container")).toHaveAttribute(
-      "aria-expanded",
-      "false",
-    );
+    expect(
+      screen.getByDataTestId("accordion-collapse-container"),
+    ).toHaveAttribute("aria-expanded", "true");
+    await user.click(screen.getByDataTestId("accordion-toggle"));
+    expect(
+      screen.getByDataTestId("accordion-collapse-container"),
+    ).toHaveAttribute("aria-expanded", "false");
     await user.click(screen.getByLabelText("Edit filter"));
 
-    expect(screen.getByDataCy("accordion-collapse-container")).toHaveAttribute(
-      "aria-expanded",
-      "true",
-    );
+    expect(
+      screen.getByDataTestId("accordion-collapse-container"),
+    ).toHaveAttribute("aria-expanded", "true");
   });
   it("if the user is editing a filter and collapses the group, the edit should be cancelled", async () => {
     const user = userEvent.setup();
@@ -310,17 +307,15 @@ describe("filters", () => {
       />,
     );
     await user.click(screen.getByLabelText("Edit filter"));
-    expect(screen.getByDataCy("edit-filter-name")).toBeInTheDocument();
-    await user.click(screen.getByDataCy("accordion-toggle"));
-    expect(screen.getByDataCy("accordion-collapse-container")).toHaveAttribute(
-      "aria-expanded",
-      "false",
-    );
-    await user.click(screen.getByDataCy("accordion-toggle"));
-    expect(screen.getByDataCy("accordion-collapse-container")).toHaveAttribute(
-      "aria-expanded",
-      "true",
-    );
-    expect(screen.queryByDataCy("edit-filter-name")).toBeNull();
+    expect(screen.getByDataTestId("edit-filter-name")).toBeInTheDocument();
+    await user.click(screen.getByDataTestId("accordion-toggle"));
+    expect(
+      screen.getByDataTestId("accordion-collapse-container"),
+    ).toHaveAttribute("aria-expanded", "false");
+    await user.click(screen.getByDataTestId("accordion-toggle"));
+    expect(
+      screen.getByDataTestId("accordion-collapse-container"),
+    ).toHaveAttribute("aria-expanded", "true");
+    expect(screen.queryByDataTestId("edit-filter-name")).toBeNull();
   });
 });

--- a/apps/parsley/src/components/SidePanel/NavGroup/FilterNavGroup/FilterGroup/index.tsx
+++ b/apps/parsley/src/components/SidePanel/NavGroup/FilterNavGroup/FilterGroup/index.tsx
@@ -89,7 +89,7 @@ const FilterGroup: React.FC<FilterGroupProps> = ({
           {showTooltip && (
             <IconWithTooltip
               color={red.base}
-              data-cy="validation-error-icon"
+              data-testid="validation-error-icon"
               glyph="ImportantWithCircle"
             >
               {validationMessage}
@@ -149,7 +149,7 @@ const FilterGroup: React.FC<FilterGroupProps> = ({
               aria-label="Edit filter name"
               aria-labelledby="Edit filter name"
               autoFocus // eslint-disable-line jsx-a11y/no-autofocus
-              data-cy="edit-filter-name"
+              data-testid="edit-filter-name"
               errorMessage={isNewExpressionValid ? "" : validationMessage}
               onChange={(e) => {
                 setNewFilterExpression(e.target.value);

--- a/apps/parsley/src/components/SidePanel/NavGroup/FilterNavGroup/FilterNavGroup.test.tsx
+++ b/apps/parsley/src/components/SidePanel/NavGroup/FilterNavGroup/FilterNavGroup.test.tsx
@@ -19,7 +19,9 @@ describe("filters", () => {
 
   it("shows a message when no filters have been applied", () => {
     render(<FilterNavGroup {...props} />, { wrapper });
-    expect(screen.getByDataCy("filters-default-message")).toBeInTheDocument();
+    expect(
+      screen.getByDataTestId("filters-default-message"),
+    ).toBeInTheDocument();
   });
 
   it("filters should properly display based on the URL", () => {
@@ -36,7 +38,7 @@ describe("filters", () => {
       route: "?filters=100one,100two,100three,100four",
       wrapper,
     });
-    const navGroupHeader = screen.getByDataCy("filters-nav-group-header");
+    const navGroupHeader = screen.getByDataTestId("filters-nav-group-header");
     expect(within(navGroupHeader).getByText("4")).toBeInTheDocument();
   });
 
@@ -47,8 +49,11 @@ describe("filters", () => {
     });
     // Edit the first filter.
     await user.click(screen.getAllByLabelText("Edit filter")[0]);
-    await user.clear(screen.getAllByDataCy("edit-filter-name")[0]);
-    await user.type(screen.getAllByDataCy("edit-filter-name")[0], "newFilter");
+    await user.clear(screen.getAllByDataTestId("edit-filter-name")[0]);
+    await user.type(
+      screen.getAllByDataTestId("edit-filter-name")[0],
+      "newFilter",
+    );
     const confirmButton = screen.getByRole("button", {
       name: "Apply",
     });
@@ -69,8 +74,11 @@ describe("filters", () => {
     });
     // Edit the first filter.
     await user.click(screen.getAllByLabelText("Edit filter")[0]);
-    await user.clear(screen.getAllByDataCy("edit-filter-name")[0]);
-    await user.type(screen.getAllByDataCy("edit-filter-name")[0], "filter2");
+    await user.clear(screen.getAllByDataTestId("edit-filter-name")[0]);
+    await user.type(
+      screen.getAllByDataTestId("edit-filter-name")[0],
+      "filter2",
+    );
     const confirmButton = screen.getByRole("button", {
       name: "Apply",
     });
@@ -88,8 +96,11 @@ describe("filters", () => {
     });
     // Edit the first filter.
     await user.click(screen.getAllByLabelText("Edit filter")[0]);
-    await user.clear(screen.getAllByDataCy("edit-filter-name")[0]);
-    await user.type(screen.getAllByDataCy("edit-filter-name")[0], "newFilter");
+    await user.clear(screen.getAllByDataTestId("edit-filter-name")[0]);
+    await user.type(
+      screen.getAllByDataTestId("edit-filter-name")[0],
+      "newFilter",
+    );
     const cancelButton = screen.getByRole("button", {
       name: "Cancel",
     });

--- a/apps/parsley/src/components/SidePanel/NavGroup/FilterNavGroup/index.tsx
+++ b/apps/parsley/src/components/SidePanel/NavGroup/FilterNavGroup/index.tsx
@@ -93,7 +93,7 @@ const FilterNavGroup: React.FC<FilterNavGroupProps> = ({
             </ModalTrigger>
           </>
         }
-        data-cy="filters"
+        data-testid="filters"
         defaultMessage="No filters have been applied."
         glyph="Filter"
         items={filters}
@@ -102,7 +102,7 @@ const FilterNavGroup: React.FC<FilterNavGroupProps> = ({
         {filters.map((filter) => (
           <FilterWrapper
             key={filter.expression}
-            data-cy={`filter-${filter.expression}`}
+            data-testid={`filter-${filter.expression}`}
           >
             <FilterGroup
               deleteFilter={deleteFilter}

--- a/apps/parsley/src/components/SidePanel/NavGroup/HighlightNavGroup/HighlightNavGroup.test.tsx
+++ b/apps/parsley/src/components/SidePanel/NavGroup/HighlightNavGroup/HighlightNavGroup.test.tsx
@@ -9,7 +9,9 @@ import HighlightNavGroup from ".";
 describe("highlights", () => {
   it("shows a message when there are no highlighted terms", () => {
     render(<HighlightNavGroup />);
-    expect(screen.getByDataCy("highlight-default-message")).toBeInTheDocument();
+    expect(
+      screen.getByDataTestId("highlight-default-message"),
+    ).toBeInTheDocument();
   });
 
   it("highlighted terms should properly display based on the URL", () => {
@@ -24,7 +26,7 @@ describe("highlights", () => {
     render(<HighlightNavGroup />, {
       route: "?highlights=one,two,three,four",
     });
-    const navGroupHeader = screen.getByDataCy("highlight-nav-group-header");
+    const navGroupHeader = screen.getByDataTestId("highlight-nav-group-header");
     expect(within(navGroupHeader).getByText("4")).toBeInTheDocument();
   });
 

--- a/apps/parsley/src/components/SidePanel/NavGroup/HighlightNavGroup/index.tsx
+++ b/apps/parsley/src/components/SidePanel/NavGroup/HighlightNavGroup/index.tsx
@@ -22,7 +22,7 @@ const HighlightNavGroup: React.FC = () => {
 
   return (
     <BaseNavGroup
-      data-cy="highlight"
+      data-testid="highlight"
       defaultMessage="No terms have been highlighted."
       glyph="Highlight"
       items={highlights}
@@ -38,7 +38,7 @@ const HighlightNavGroup: React.FC = () => {
           </IconButton>
           <StyledHighlight
             color={highlightColorList[index % highlightColorList.length]}
-            data-cy="side-nav-highlight"
+            data-testid="side-nav-highlight"
           >
             {highlight}
           </StyledHighlight>

--- a/apps/parsley/src/components/SidePanel/index.tsx
+++ b/apps/parsley/src/components/SidePanel/index.tsx
@@ -11,7 +11,7 @@ import {
 } from "./NavGroup";
 
 interface SidePanelProps {
-  ["data-cy"]?: string;
+  ["data-testid"]?: string;
   expandedLines: ExpandedLines;
   collapseLines: (idx: number) => void;
   clearExpandedLines: () => void;
@@ -22,7 +22,7 @@ interface SidePanelProps {
 const SidePanel: React.FC<SidePanelProps> = ({
   clearExpandedLines,
   collapseLines,
-  "data-cy": dataCy,
+  "data-testid": dataTestId,
   expandedLines,
   panelCollapsed,
   setPanelCollapsed,
@@ -30,7 +30,7 @@ const SidePanel: React.FC<SidePanelProps> = ({
   <StyledSideNav
     aria-label="Side panel"
     collapsed={panelCollapsed}
-    data-cy={dataCy}
+    data-testid={dataTestId}
     setCollapsed={(collapse) => {
       // panelCollapsed represents the initial state of the sidenav
       setLocalStorageBoolean(DRAWER_OPENED, !panelCollapsed);

--- a/apps/parsley/src/components/StickyHeaders/index.tsx
+++ b/apps/parsley/src/components/StickyHeaders/index.tsx
@@ -36,7 +36,7 @@ const StickyHeaders: React.FC<StickyHeaderProps> = ({
   }, [sectionHeader, subsectionHeader, onHeightChange]);
 
   return (
-    <StickyHeaderContainer ref={containerRef} data-cy="sticky-headers">
+    <StickyHeaderContainer ref={containerRef} data-testid="sticky-headers">
       {isNumber(sectionHeader) &&
         sectionHeaderLine &&
         isSectionHeaderRow(sectionHeaderLine) && (

--- a/apps/parsley/src/components/SubHeader/EvergreenTaskSubHeader.test.tsx
+++ b/apps/parsley/src/components/SubHeader/EvergreenTaskSubHeader.test.tsx
@@ -25,7 +25,7 @@ describe("evergreen task subheader", () => {
     });
     // check_codegen task should be failing
     expect(screen.getByText("check_codegen")).toBeInTheDocument();
-    expect(screen.getByDataCy("task-status-badge").textContent).toContain(
+    expect(screen.getByDataTestId("task-status-badge").textContent).toContain(
       "Failed",
     );
     // JustAFakeTestInALonelyWorld test should not be in the document

--- a/apps/parsley/src/components/SubHeader/EvergreenTaskSubHeader.tsx
+++ b/apps/parsley/src/components/SubHeader/EvergreenTaskSubHeader.tsx
@@ -92,11 +92,11 @@ export const EvergreenTaskSubHeader: React.FC<Props> = ({
 
   const breadcrumbs = [
     {
-      "data-cy": "project-breadcrumb",
+      "data-testid": "project-breadcrumb",
       text: projectIdentifier,
     },
     {
-      "data-cy": "version-breadcrumb",
+      "data-testid": "version-breadcrumb",
       text: isPatch ? (
         `Patch ${patchNumber}`
       ) : (
@@ -105,7 +105,7 @@ export const EvergreenTaskSubHeader: React.FC<Props> = ({
       tooltipText: message,
     },
     {
-      "data-cy": "task-breadcrumb",
+      "data-testid": "task-breadcrumb",
       href: getEvergreenTaskURL(taskID, taskExecution),
       onClick: () => {
         sendEvent({ name: "Clicked task link" });
@@ -121,7 +121,7 @@ export const EvergreenTaskSubHeader: React.FC<Props> = ({
     ...(testID
       ? [
           {
-            "data-cy": "test-breadcrumb",
+            "data-testid": "test-breadcrumb",
             text: (
               <>
                 {trimStringFromMiddle(currentTest?.testFile ?? "Test", 80)}{" "}
@@ -138,7 +138,7 @@ export const EvergreenTaskSubHeader: React.FC<Props> = ({
     ...(fileName
       ? [
           {
-            "data-cy": "file-breadcrumb",
+            "data-testid": "file-breadcrumb",
             text: fileName,
           },
         ]
@@ -146,7 +146,7 @@ export const EvergreenTaskSubHeader: React.FC<Props> = ({
     ...(groupID
       ? [
           {
-            "data-cy": "group-breadcrumb",
+            "data-testid": "group-breadcrumb",
             text: groupID,
           },
         ]

--- a/apps/parsley/src/components/SubHeader/index.tsx
+++ b/apps/parsley/src/components/SubHeader/index.tsx
@@ -21,7 +21,7 @@ const SubHeader: React.FC<SubHeaderProps> = ({ setSidePanelCollapsed }) => {
     logMetadata || {};
 
   return (
-    <Container data-cy="log-header">
+    <Container data-testid="log-header">
       {isUploadedLog ? (
         <Header>
           <Icon glyph="File" size="large" />

--- a/apps/parsley/src/pages/404/NotFoundSvg.tsx
+++ b/apps/parsley/src/pages/404/NotFoundSvg.tsx
@@ -2,7 +2,7 @@ import notFound from "./notFound.svg";
 
 // It's not possible to lazy load an SVG, so we wrap the SVG in a React component.
 const NotFoundSvg: React.FC = () => (
-  <img alt="Page not found" data-cy="404" src={notFound} />
+  <img alt="Page not found" data-testid="404" src={notFound} />
 );
 
 export default NotFoundSvg;

--- a/apps/parsley/src/pages/LogDrop/FileDropper.tsx
+++ b/apps/parsley/src/pages/LogDrop/FileDropper.tsx
@@ -185,7 +185,7 @@ const FileDropper: React.FC = () => {
   return (
     <Container>
       <BorderBox>
-        <Dropzone {...getRootProps()} data-cy="upload-zone">
+        <Dropzone {...getRootProps()} data-testid="upload-zone">
           {visibleUI}
         </Dropzone>
       </BorderBox>

--- a/apps/parsley/src/pages/LogDrop/ParseLogSelect/index.tsx
+++ b/apps/parsley/src/pages/LogDrop/ParseLogSelect/index.tsx
@@ -39,7 +39,7 @@ const ParseLogSelect: React.FC<ParseLogSelectProps> = ({
       </Label>
       <Select
         aria-labelledby="parse-log-select"
-        data-cy="parse-log-select"
+        data-testid="parse-log-select"
         onChange={(value) => {
           setLocalStorageString(LAST_SELECTED_LOG_TYPE, value);
           setLogType(value as SelectState);

--- a/apps/parsley/src/utils/escapeTags/index.ts
+++ b/apps/parsley/src/utils/escapeTags/index.ts
@@ -2,8 +2,8 @@ import xss, { IWhiteList } from "xss";
 
 const allowedTags: IWhiteList = {
   a: ["href", "target", "rel", "class", "style"],
-  mark: ["style", "data-cy", "color"],
-  span: ["style", "data-cy"],
+  mark: ["style", "data-testid", "color"],
+  span: ["style", "data-testid"],
 };
 
 /**

--- a/apps/parsley/src/utils/highlightHtml/highlightHtml.test.tsx
+++ b/apps/parsley/src/utils/highlightHtml/highlightHtml.test.tsx
@@ -6,13 +6,13 @@ describe("highlightHtml", () => {
     render(
       <>
         {highlightHtml(
-          "<a href='https://donthighlightme.com'>highlight me</a> highlight me <span data-cy='dont-highlight-me'>highlight me</span>",
+          "<a href='https://donthighlightme.com'>highlight me</a> highlight me <span data-testid='dont-highlight-me'>highlight me</span>",
           /highlight/gi,
         )}
       </>,
     );
-    expect(screen.queryAllByDataCy("highlight")).toHaveLength(3);
-    expect(screen.getByDataCy("dont-highlight-me")).toBeInTheDocument();
+    expect(screen.queryAllByDataTestId("highlight")).toHaveLength(3);
+    expect(screen.getByDataTestId("dont-highlight-me")).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "highlight me" })).toHaveAttribute(
       "href",
       "https://donthighlightme.com",
@@ -22,19 +22,21 @@ describe("highlightHtml", () => {
     render(
       <>
         {highlightHtml(
-          "<blah blah> <span data-cy='dont-highlight-me'>blah blah</span>",
+          "<blah blah> <span data-testid='dont-highlight-me'>blah blah</span>",
           /</gi,
         )}
       </>,
     );
-    expect(screen.queryAllByDataCy("highlight")).toHaveLength(1);
-    expect(screen.queryByDataCy("highlight")).toHaveTextContent("<");
-    expect(screen.getByDataCy("dont-highlight-me")).toBeInTheDocument();
+    expect(screen.queryAllByDataTestId("highlight")).toHaveLength(1);
+    expect(screen.queryByDataTestId("highlight")).toHaveTextContent("<");
+    expect(screen.getByDataTestId("dont-highlight-me")).toBeInTheDocument();
   });
   it("highlights the content inside of <> if it's not a valid HTML tag", () => {
     render(<>{highlightHtml("<Downloading package...>", /Downloading/gi)}</>);
-    expect(screen.queryAllByDataCy("highlight")).toHaveLength(1);
-    expect(screen.getByDataCy("highlight")).toHaveTextContent("Downloading");
+    expect(screen.queryAllByDataTestId("highlight")).toHaveLength(1);
+    expect(screen.getByDataTestId("highlight")).toHaveTextContent(
+      "Downloading",
+    );
   });
   it("applies multiple highlights with different colors", () => {
     render(
@@ -46,7 +48,7 @@ describe("highlightHtml", () => {
         )}
       </>,
     );
-    const highlights = screen.queryAllByDataCy("highlight");
+    const highlights = screen.queryAllByDataTestId("highlight");
     expect(highlights).toHaveLength(3);
     const colors = new Set(highlights.map((el) => el.getAttribute("color")));
     expect(colors.size).toBe(3);
@@ -54,8 +56,8 @@ describe("highlightHtml", () => {
   it("should deduplicate highlights and searches", () => {
     const regexp = /test/i;
     render(<>{highlightHtml("This is a test", regexp, regexp)}</>);
-    expect(screen.queryAllByDataCy("highlight")).toHaveLength(1);
-    expect(screen.getByDataCy("highlight")).toHaveTextContent("test");
+    expect(screen.queryAllByDataTestId("highlight")).toHaveLength(1);
+    expect(screen.getByDataTestId("highlight")).toHaveTextContent("test");
   });
   it("should show both highlights and searches if they are on the same line", () => {
     render(
@@ -67,8 +69,8 @@ describe("highlightHtml", () => {
         )}
       </>,
     );
-    expect(screen.queryAllByDataCy("highlight")).toHaveLength(2);
-    screen.getAllByDataCy("highlight").forEach((highlight) => {
+    expect(screen.queryAllByDataTestId("highlight")).toHaveLength(2);
+    screen.getAllByDataTestId("highlight").forEach((highlight) => {
       expect(highlight).toHaveTextContent(/building|production/i);
     });
   });

--- a/apps/parsley/src/utils/highlightHtml/index.tsx
+++ b/apps/parsley/src/utils/highlightHtml/index.tsx
@@ -28,7 +28,7 @@ const highlightHtml = (
           highlightedText = highlighter(
             searchTerm,
             highlightedText,
-            (match) => `<mark data-cy="highlight">${match}</mark>`,
+            (match) => `<mark data-testid="highlight">${match}</mark>`,
           );
         }
 
@@ -40,7 +40,7 @@ const highlightHtml = (
             highlights,
             highlightedText,
             (match, index) =>
-              `<mark data-cy="highlight" color="${
+              `<mark data-testid="highlight" color="${
                 highlightColorList[index % highlightColorList.length]
               }">${match}</mark>`,
           );

--- a/apps/parsley/src/utils/renderHtml/renderHtml.test.tsx
+++ b/apps/parsley/src/utils/renderHtml/renderHtml.test.tsx
@@ -7,44 +7,48 @@ describe("renderHtml", () => {
     expect(screen.getByText("test string")).toBeInTheDocument();
   });
   it("renders a string with html and preserves allowed elements with their props", () => {
-    render(<>{renderHtml("test <span data-cy='element'>string</span>")}</>);
-    expect(screen.queryByDataCy("element")).toHaveTextContent("string");
+    render(<>{renderHtml("test <span data-testid='element'>string</span>")}</>);
+    expect(screen.queryByDataTestId("element")).toHaveTextContent("string");
   });
   it("renders a string with html and escapes disallowed elements", () => {
     const { rerender } = render(
       <>
         {renderHtml(
-          "<span data-cy='log-line'>test <script data-cy='should-not-exist'>alert('test')</script></span>",
+          "<span data-testid='log-line'>test <script data-testid='should-not-exist'>alert('test')</script></span>",
         )}
       </>,
     );
-    expect(screen.queryByDataCy("should-not-exist")).toBeNull();
-    expect(screen.queryByDataCy("log-line")).toHaveTextContent(
-      "test <script data-cy='should-not-exist'>alert('test')</script>",
+    expect(screen.queryByDataTestId("should-not-exist")).toBeNull();
+    expect(screen.queryByDataTestId("log-line")).toHaveTextContent(
+      "test <script data-testid='should-not-exist'>alert('test')</script>",
     );
     rerender(
       <>
-        {renderHtml("<span data-cy='log-line'>test <mongo::<std:lib >></span>")}
+        {renderHtml(
+          "<span data-testid='log-line'>test <mongo::<std:lib >></span>",
+        )}
       </>,
     );
-    expect(screen.queryByDataCy("log-line")).toHaveTextContent(
+    expect(screen.queryByDataTestId("log-line")).toHaveTextContent(
       "test <mongo::<std:lib >>",
     );
   });
   it("replaces a element with a react component if specified", () => {
     const Component = ({ children }: { children: React.ReactElement }) => (
-      <div data-cy="component">✨{children}✨</div>
+      <div data-testid="component">✨{children}✨</div>
     );
     render(
       <>
-        {renderHtml("test <span data-cy='element'>string</span>", {
+        {renderHtml("test <span data-testid='element'>string</span>", {
           // @ts-expect-error - This is expecting a react component but its an Emotion component which are virtually the same thing
           transformNode: { span: Component },
         })}
       </>,
     );
-    expect(screen.queryByDataCy("element")).not.toBeInTheDocument();
-    expect(screen.getByDataCy("component")).toBeInTheDocument();
-    expect(screen.queryByDataCy("component")).toHaveTextContent("✨string✨");
+    expect(screen.queryByDataTestId("element")).not.toBeInTheDocument();
+    expect(screen.getByDataTestId("component")).toBeInTheDocument();
+    expect(screen.queryByDataTestId("component")).toHaveTextContent(
+      "✨string✨",
+    );
   });
 });

--- a/apps/spruce/src/components/FilterChips/FilterChips.test.tsx
+++ b/apps/spruce/src/components/FilterChips/FilterChips.test.tsx
@@ -95,7 +95,7 @@ describe("filterChips", () => {
     render(
       <FilterChips chips={chips} onClearAll={vi.fn()} onRemove={onRemove} />,
     );
-    const closeChip = screen.getAllByDataTestid("chip-dismiss-button")[0];
+    const closeChip = screen.getAllByDataTestId("chip-dismiss-button")[0];
     expect(closeChip).toBeInTheDocument();
     await user.click(closeChip);
     expect(onRemove).toHaveBeenCalledWith({

--- a/apps/spruce/src/components/FilterChips/useFilterChipQueryParams.test.tsx
+++ b/apps/spruce/src/components/FilterChips/useFilterChipQueryParams.test.tsx
@@ -80,7 +80,7 @@ describe("filterChips - queryParams", () => {
 
     const chip = screen.queryByDataCy("filter-chip");
     expect(chip).toHaveTextContent("Variant: variant1");
-    const closeChip = screen.getByDataTestid("chip-dismiss-button");
+    const closeChip = screen.getByDataTestId("chip-dismiss-button");
     expect(closeChip).toBeInTheDocument();
     await user.click(closeChip);
 
@@ -98,7 +98,7 @@ describe("filterChips - queryParams", () => {
     let chips = screen.queryAllByDataCy("filter-chip");
     expect(chips).toHaveLength(2);
     expect(screen.getByText("Variant: variant1")).toBeInTheDocument();
-    const closeChip = screen.getAllByDataTestid("chip-dismiss-button")[0];
+    const closeChip = screen.getAllByDataTestId("chip-dismiss-button")[0];
     await user.click(closeChip);
     chips = screen.queryAllByDataCy("filter-chip");
     expect(chips).toHaveLength(1);

--- a/apps/spruce/src/pages/task/metadata/GeneralSection/TaskOwnership/TaskOwnership.test.tsx
+++ b/apps/spruce/src/pages/task/metadata/GeneralSection/TaskOwnership/TaskOwnership.test.tsx
@@ -126,7 +126,7 @@ describe("TaskOwnership", () => {
     expect(screen.getByText("Task owner:")).toBeInTheDocument();
     expect(screen.getByText("Evergreen UI Team")).toBeInTheDocument();
 
-    await user.hover(screen.getByDataTestid("info-sprinkle-icon"));
+    await user.hover(screen.getByDataTestId("info-sprinkle-icon"));
 
     await waitFor(() => {
       expect(
@@ -134,7 +134,7 @@ describe("TaskOwnership", () => {
       ).toBeInTheDocument();
     });
 
-    await user.unhover(screen.getByDataTestid("info-sprinkle-icon"));
+    await user.unhover(screen.getByDataTestId("info-sprinkle-icon"));
   });
 
   it("renders fallback text when no team name is available", async () => {

--- a/packages/fungi/src/ChatDrawer/index.tsx
+++ b/packages/fungi/src/ChatDrawer/index.tsx
@@ -5,6 +5,7 @@ type Props = {
   children: React.ReactNode;
   chatContent: React.ReactNode;
   "data-cy"?: string;
+  "data-testid"?: string;
   drawerTitle?: React.ReactNode;
 };
 
@@ -12,6 +13,7 @@ export const ChatDrawer = ({
   chatContent,
   children,
   "data-cy": dataCy,
+  "data-testid": dataTestId,
   drawerTitle,
 }: React.PropsWithChildren<Props>) => {
   const { appName, drawerOpen, setDrawerOpen } = useChatContext();
@@ -26,6 +28,7 @@ export const ChatDrawer = ({
       drawer={
         <Drawer
           data-cy={dataCy}
+          data-testid={dataTestId}
           hasPadding={false}
           title={drawerTitle || appName}
         >

--- a/packages/lib/src/components/Accordion/index.tsx
+++ b/packages/lib/src/components/Accordion/index.tsx
@@ -75,6 +75,7 @@ const Accordion: React.FC<AccordionProps> = ({
     <div className={className} data-cy={dataCy}>
       <AccordionToggle
         data-cy="accordion-toggle"
+        data-testid="accordion-toggle"
         onClick={toggleAccordionHandler}
         role="button"
       >
@@ -91,6 +92,7 @@ const Accordion: React.FC<AccordionProps> = ({
       <AnimatedAccordion
         aria-expanded={accordionOpen}
         data-cy="accordion-collapse-container"
+        data-testid="accordion-collapse-container"
         disableAnimations={disableAnimations}
         hide={!accordionOpen}
       >

--- a/packages/lib/src/components/Badge/TaskStatusBadge/index.tsx
+++ b/packages/lib/src/components/Badge/TaskStatusBadge/index.tsx
@@ -45,6 +45,7 @@ const TaskStatusBadge: React.FC<TaskStatusBadgeProps> = ({
     <StyledBadge
       key={status}
       data-cy="task-status-badge"
+      data-testid="task-status-badge"
       variant={mapTaskStatusToBadgeVariant[status]}
       {...customBadgeColors(status)}
     >

--- a/packages/lib/src/components/Badge/TestStatusBadge/index.tsx
+++ b/packages/lib/src/components/Badge/TestStatusBadge/index.tsx
@@ -30,6 +30,7 @@ const TestStatusBadge: React.FC<TestStatusBadgeProps> = ({ status }) => {
     <Badge
       key={status}
       data-cy="test-status-badge"
+      data-testid="test-status-badge"
       variant={statusToBadgeColor[testStatus] || Variant.LightGray}
     >
       {statusToCopy[testStatus] || status}

--- a/packages/lib/src/components/Table/TableLoader/LoadingRow.tsx
+++ b/packages/lib/src/components/Table/TableLoader/LoadingRow.tsx
@@ -6,7 +6,7 @@ interface LoadingRowProps {
   numColumns: number;
 }
 const LoadingRow: React.FC<LoadingRowProps> = ({ numColumns }) => (
-  <tr data-cy="table-loader-loading-row">
+  <tr data-cy="table-loader-loading-row" data-testid="table-loader-loading-row">
     {Array.from({ length: numColumns }, (_, i) => (
       <LoadingCell key={i}>
         <Skeleton size="small" />

--- a/packages/lib/src/context/toast/index.tsx
+++ b/packages/lib/src/context/toast/index.tsx
@@ -58,7 +58,7 @@ const ToastProviderCore: React.FC<{ children: ReactNode }> = ({ children }) => {
 
       return pushToast({
         // @ts-expect-error: data-cy doesn't exist as a prop on Toast but it will be propagated correctly.
-        "data-cy": "toast",
+        "data-cy": "lg-toast",
         "data-variant": mapLeafyGreenVariantToToast[variant],
         description: <WordBreak>{message}</WordBreak>,
         dismissible: closable,

--- a/packages/lib/src/context/toast/toast.test.tsx
+++ b/packages/lib/src/context/toast/toast.test.tsx
@@ -17,6 +17,8 @@ const wrapper = ({ children }: { children: React.ReactNode }) => (
   </ToastProvider>
 );
 
+const toastDataTestId = "lg-toast";
+
 describe("toast", () => {
   const closeIconLabel = "Close Message";
 
@@ -44,7 +46,7 @@ describe("toast", () => {
   it("should not display a toast by default", () => {
     const { Component } = renderComponentWithHook(useToastContext, <div />);
     render(<Component />, { wrapper });
-    expect(screen.queryByDataCy("toast")).toBeNull();
+    expect(screen.queryByDataCy(toastDataTestId)).toBeNull();
   });
 
   it("should be able to set a custom title for a toast", async () => {
@@ -75,7 +77,7 @@ describe("toast", () => {
       act(() => {
         hook.current.success("test string");
       });
-      expect(screen.getByDataCy("toast")).toBeInTheDocument();
+      expect(screen.getByDataCy(toastDataTestId)).toBeInTheDocument();
       expect(screen.getByText("Success!")).toBeInTheDocument();
       expect(screen.getByText("test string")).toBeInTheDocument();
     });
@@ -91,7 +93,7 @@ describe("toast", () => {
       act(() => {
         hook.current.error("test string");
       });
-      expect(screen.getByDataCy("toast")).toBeInTheDocument();
+      expect(screen.getByDataCy(toastDataTestId)).toBeInTheDocument();
       expect(screen.getByText("Error!")).toBeInTheDocument();
       expect(screen.getByText("test string")).toBeInTheDocument();
     });
@@ -107,7 +109,7 @@ describe("toast", () => {
       act(() => {
         hook.current.warning("test string");
       });
-      expect(screen.getByDataCy("toast")).toBeInTheDocument();
+      expect(screen.getByDataCy(toastDataTestId)).toBeInTheDocument();
       expect(screen.getByText("Warning!")).toBeInTheDocument();
       expect(screen.getByText("test string")).toBeInTheDocument();
     });
@@ -123,7 +125,7 @@ describe("toast", () => {
       act(() => {
         hook.current.info("test string");
       });
-      expect(screen.getByDataCy("toast")).toBeInTheDocument();
+      expect(screen.getByDataCy(toastDataTestId)).toBeInTheDocument();
       expect(screen.getByText("Something Happened!")).toBeInTheDocument();
       expect(screen.getByText("test string")).toBeInTheDocument();
     });
@@ -139,7 +141,7 @@ describe("toast", () => {
       act(() => {
         hook.current.progress("test string", 0.8);
       });
-      expect(screen.getByDataCy("toast")).toBeInTheDocument();
+      expect(screen.getByDataCy(toastDataTestId)).toBeInTheDocument();
       expect(screen.getByText("Loading...")).toBeInTheDocument();
       expect(screen.getByText("test string")).toBeInTheDocument();
 
@@ -162,10 +164,10 @@ describe("toast", () => {
         hook.current.info("test string");
       });
 
-      expect(screen.getByDataCy("toast")).toBeInTheDocument();
+      expect(screen.getByDataCy(toastDataTestId)).toBeInTheDocument();
       await user.click(screen.getByLabelText(closeIconLabel));
       await waitFor(() => {
-        expect(screen.queryByDataCy("toast")).not.toBeInTheDocument();
+        expect(screen.queryByDataCy(toastDataTestId)).not.toBeInTheDocument();
       });
     });
 
@@ -180,7 +182,7 @@ describe("toast", () => {
       act(() => {
         hook.current.info("test string", false);
       });
-      expect(screen.getByDataCy("toast")).toBeInTheDocument();
+      expect(screen.getByDataCy(toastDataTestId)).toBeInTheDocument();
       expect(screen.queryByLabelText(closeIconLabel)).toBeNull();
     });
 
@@ -198,10 +200,10 @@ describe("toast", () => {
         hook.current.info("test string", true, { onClose });
       });
 
-      expect(screen.getByDataCy("toast")).toBeInTheDocument();
+      expect(screen.getByDataCy(toastDataTestId)).toBeInTheDocument();
       await user.click(screen.getByLabelText(closeIconLabel));
       await waitFor(() => {
-        expect(screen.queryByDataCy("toast")).not.toBeInTheDocument();
+        expect(screen.queryByDataCy(toastDataTestId)).not.toBeInTheDocument();
       });
       expect(onClose).toHaveBeenCalledTimes(1);
     });
@@ -217,14 +219,14 @@ describe("toast", () => {
       act(() => {
         hook.current.info("test string");
       });
-      expect(screen.getByDataCy("toast")).toBeInTheDocument();
+      expect(screen.getByDataCy(toastDataTestId)).toBeInTheDocument();
 
       // Advance timer so that the timeout is triggered.
       act(() => {
         vi.advanceTimersByTime(TOAST_TIMEOUT);
       });
       await waitFor(() => {
-        expect(screen.queryByDataCy("toast")).not.toBeInTheDocument();
+        expect(screen.queryByDataCy(toastDataTestId)).not.toBeInTheDocument();
       });
     });
   });

--- a/packages/lib/src/pages/LoginPage/index.tsx
+++ b/packages/lib/src/pages/LoginPage/index.tsx
@@ -44,6 +44,7 @@ const LoginPage: React.FC<LoginPageProps> = ({ ignoreAuthCheck }) => {
       >
         <TextInput
           data-cy="login-username"
+          data-testid="login-username"
           label="Username"
           onChange={(e) => setUsername(e.target.value)}
           type="text"
@@ -51,6 +52,7 @@ const LoginPage: React.FC<LoginPageProps> = ({ ignoreAuthCheck }) => {
         />
         <TextInput
           data-cy="login-password"
+          data-testid="login-password"
           label="Password"
           onChange={(e) => setPassword(e.target.value)}
           type="password"
@@ -58,6 +60,7 @@ const LoginPage: React.FC<LoginPageProps> = ({ ignoreAuthCheck }) => {
         />
         <StyledButton
           data-cy="login-submit"
+          data-testid="login-submit"
           onClick={() => localLogin({ password, username })}
           type="submit"
           variant="baseGreen"

--- a/packages/lib/src/test_utils/custom-queries.ts
+++ b/packages/lib/src/test_utils/custom-queries.ts
@@ -34,24 +34,24 @@ const [
   getMissingErrorDataCy,
 );
 
-const queryAllByDataTestid: OmitFirstArg<AllByAttribute> = (...args) =>
+const queryAllByDataTestId: OmitFirstArg<AllByAttribute> = (...args) =>
   queryHelpers.queryAllByAttribute("data-testid", ...args);
 
-const getMultipleErrorDataTestid: GetErrorFunction = (_, dataTestidValue) =>
+const getMultipleErrorDataTestId: GetErrorFunction = (_, dataTestidValue) =>
   `Found multiple elements with the data-testid attribute of: ${dataTestidValue}`;
-const getMissingErrorDataTestid: GetErrorFunction = (_, dataTestidValue) =>
+const getMissingErrorDataTestId: GetErrorFunction = (_, dataTestidValue) =>
   `Unable to find an element with the data-testid attribute of: ${dataTestidValue}`;
 
 const [
-  queryByDataTestid,
-  getAllByDataTestid,
-  getByDataTestid,
-  findAllByDataTestid,
-  findByDataTestid,
+  queryByDataTestId,
+  getAllByDataTestId,
+  getByDataTestId,
+  findAllByDataTestId,
+  findByDataTestId,
 ] = buildQueries(
-  queryAllByDataTestid,
-  getMultipleErrorDataTestid,
-  getMissingErrorDataTestid,
+  queryAllByDataTestId,
+  getMultipleErrorDataTestId,
+  getMissingErrorDataTestId,
 );
 
 export {
@@ -61,10 +61,10 @@ export {
   getAllByDataCy,
   findAllByDataCy,
   findByDataCy,
-  queryByDataTestid,
-  queryAllByDataTestid,
-  getByDataTestid,
-  getAllByDataTestid,
-  findAllByDataTestid,
-  findByDataTestid,
+  queryByDataTestId,
+  queryAllByDataTestId,
+  getByDataTestId,
+  getAllByDataTestId,
+  findAllByDataTestId,
+  findByDataTestId,
 };

--- a/packages/playwright-config/helpers/constants.ts
+++ b/packages/playwright-config/helpers/constants.ts
@@ -13,4 +13,4 @@ export const users = {
   regular: { username: "regular", password: "password" },
 };
 
-export const toastDataCy = "toast";
+export const toastDataCy = "lg-toast";


### PR DESCRIPTION
DEVPROD-31461
<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->

<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
Change from `data-cy` -> `data-testid` for Parsley. I will do Spruce in another PR because it's too big.
