### PR TITLE
DEVPROD-31461: Make lib backwards compatible with `data-testid`

### DIFF
--- a/packages/fungi/src/ChatDrawer/index.tsx
+++ b/packages/fungi/src/ChatDrawer/index.tsx
@@ -4,7 +4,6 @@ import { useChatContext } from "#Context";
 type Props = {
   children: React.ReactNode;
   chatContent: React.ReactNode;
-  "data-cy"?: string;
   "data-testid"?: string;
   drawerTitle?: React.ReactNode;
 };
@@ -12,7 +11,6 @@ type Props = {
 export const ChatDrawer = ({
   chatContent,
   children,
-  "data-cy": dataCy,
   "data-testid": dataTestId,
   drawerTitle,
 }: React.PropsWithChildren<Props>) => {
@@ -27,7 +25,6 @@ export const ChatDrawer = ({
       displayMode={DisplayMode.Embedded}
       drawer={
         <Drawer
-          data-cy={dataCy}
           data-testid={dataTestId}
           hasPadding={false}
           title={drawerTitle || appName}

--- a/packages/fungi/src/ChatFeed/ChatFeed.test.tsx
+++ b/packages/fungi/src/ChatFeed/ChatFeed.test.tsx
@@ -27,7 +27,7 @@ describe("ChatFeed", () => {
 
     await user.type(textarea, message);
     await user.click(screen.getByRole("button"));
-    expect(screen.queryByDataCy("message-user")).toHaveTextContent(message);
+    expect(screen.queryByDataTestId("message-user")).toHaveTextContent(message);
   });
 
   describe("prompt suggestions", () => {
@@ -63,7 +63,7 @@ describe("ChatFeed", () => {
       expect(screen.getByText("Bar")).toBeVisible();
       await user.click(screen.getByRole("button", { name: "Bar" }));
       expect(screen.queryByText("Suggested Prompts")).not.toBeInTheDocument();
-      expect(screen.queryByDataCy("message-user")).toHaveTextContent("Bar");
+      expect(screen.queryByDataTestId("message-user")).toHaveTextContent("Bar");
     });
   });
 
@@ -89,7 +89,9 @@ describe("ChatFeed", () => {
       expect(mockTransformMessage).toHaveBeenCalledWith(message, {
         pendingChips: [],
       });
-      expect(screen.queryByDataCy("message-user")).toHaveTextContent(message);
+      expect(screen.queryByDataTestId("message-user")).toHaveTextContent(
+        message,
+      );
     });
   });
 
@@ -116,8 +118,12 @@ describe("ChatFeed", () => {
           appName: "Parsley AI Test",
         }),
       });
-      expect(screen.queryByDataCy(chip1.identifier)).not.toBeInTheDocument();
-      expect(screen.queryByDataCy(chip2.identifier)).not.toBeInTheDocument();
+      expect(
+        screen.queryByDataTestId(chip1.identifier),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByDataTestId(chip2.identifier),
+      ).not.toBeInTheDocument();
     });
 
     it("displays chips if they are present", () => {
@@ -127,8 +133,8 @@ describe("ChatFeed", () => {
           initialChips: chipMap,
         }),
       });
-      expect(screen.getByDataCy(chip1.identifier)).toBeInTheDocument();
-      expect(screen.getByDataCy(chip2.identifier)).toBeInTheDocument();
+      expect(screen.getByDataTestId(chip1.identifier)).toBeInTheDocument();
+      expect(screen.getByDataTestId(chip2.identifier)).toBeInTheDocument();
     });
 
     it("allows dismissing chips via dismiss button", async () => {
@@ -143,8 +149,10 @@ describe("ChatFeed", () => {
         name: "Dismiss chip",
       });
       await user.click(dismissButtons[0]);
-      expect(screen.queryByDataCy(chip1.identifier)).not.toBeInTheDocument();
-      expect(screen.getByDataCy(chip2.identifier)).toBeInTheDocument();
+      expect(
+        screen.queryByDataTestId(chip1.identifier),
+      ).not.toBeInTheDocument();
+      expect(screen.getByDataTestId(chip2.identifier)).toBeInTheDocument();
     });
 
     it("clears chips after sending a message", async () => {
@@ -156,8 +164,8 @@ describe("ChatFeed", () => {
         }),
       });
 
-      expect(screen.getByDataCy(chip1.identifier)).toBeInTheDocument();
-      expect(screen.getByDataCy(chip2.identifier)).toBeInTheDocument();
+      expect(screen.getByDataTestId(chip1.identifier)).toBeInTheDocument();
+      expect(screen.getByDataTestId(chip2.identifier)).toBeInTheDocument();
       expect(
         screen.getAllByRole("button", {
           name: "Dismiss chip",
@@ -170,8 +178,8 @@ describe("ChatFeed", () => {
       await user.click(screen.getByRole("button", { name: "Send message" }));
 
       // Note: the chips are still going to be present because they get rendered alongside the message.
-      expect(screen.getByDataCy(chip1.identifier)).toBeInTheDocument();
-      expect(screen.getByDataCy(chip2.identifier)).toBeInTheDocument();
+      expect(screen.getByDataTestId(chip1.identifier)).toBeInTheDocument();
+      expect(screen.getByDataTestId(chip2.identifier)).toBeInTheDocument();
       expect(
         screen.queryAllByRole("button", {
           name: "Dismiss chip",

--- a/packages/fungi/src/ContextChips/index.tsx
+++ b/packages/fungi/src/ContextChips/index.tsx
@@ -20,7 +20,7 @@ export const ContextChips: React.FC<ContextChipsProps> = ({
 }) => (
   <ChipContainer dismissible={dismissible}>
     {chips.map((chip) => (
-      <SingleChip key={chip.identifier} data-cy={chip.identifier}>
+      <SingleChip key={chip.identifier} data-testid={chip.identifier}>
         <RichLink
           // @ts-expect-error: The types aren't exported from LG
           badgeColor={chip.badgeColor ?? "purple"}

--- a/packages/fungi/src/MessageRenderer/ToolRenderer/MergedFindingsView.tsx
+++ b/packages/fungi/src/MessageRenderer/ToolRenderer/MergedFindingsView.tsx
@@ -217,8 +217,8 @@ export const MergedFindingsView: React.FC<MergedFindingsViewProps> = ({
     <Container>
       <Header>
         <Badge
-          data-cy="merged-findings-status"
           data-status={overallStatus}
+          data-testid="merged-findings-status"
           variant={statusConfig[overallStatus].variant}
         >
           {statusConfig[overallStatus].label}

--- a/packages/fungi/src/MessageRenderer/ToolRenderer/ToolRenderer.test.tsx
+++ b/packages/fungi/src/MessageRenderer/ToolRenderer/ToolRenderer.test.tsx
@@ -71,7 +71,7 @@ describe("ToolRenderer", () => {
         }}
       />,
     );
-    expect(screen.queryByDataCy("tool-use-chip")).not.toBeInTheDocument();
+    expect(screen.queryByDataTestId("tool-use-chip")).not.toBeInTheDocument();
   });
 
   it("renders a tool with an error state if the output is an error", () => {
@@ -208,7 +208,7 @@ describe("ToolRenderer", () => {
       />,
     );
     expect(screen.getByText("Analyzed logs")).toBeInTheDocument();
-    expect(screen.queryByDataCy("tool-output")).not.toBeInTheDocument();
+    expect(screen.queryByDataTestId("tool-output")).not.toBeInTheDocument();
     await user.click(
       screen.getByRole("button", { name: /expand additional content/i }),
     );
@@ -244,7 +244,7 @@ describe("ToolRenderer", () => {
     );
     expect(screen.getByText("Analyzed logs")).toBeInTheDocument();
     expect(screen.queryByText("analysis complete")).not.toBeInTheDocument();
-    expect(screen.queryByDataCy("tool-output")).not.toBeInTheDocument();
+    expect(screen.queryByDataTestId("tool-output")).not.toBeInTheDocument();
   });
 
   it("does not render expandable content for askEvergreenAgentTool", () => {

--- a/packages/fungi/src/MessageRenderer/ToolRenderer/index.tsx
+++ b/packages/fungi/src/MessageRenderer/ToolRenderer/index.tsx
@@ -68,7 +68,7 @@ export const ToolRenderer: React.FC<ToolRendererProps> = ({
 
   return (
     <StyledActionCard
-      data-cy="tool-use-chip"
+      data-testid="tool-use-chip"
       description={description}
       onToggleExpanded={setIsExpanded}
       showExpandButton={!!renderedOutput}
@@ -84,7 +84,7 @@ export const ToolRenderer: React.FC<ToolRendererProps> = ({
       ) : (
         renderedOutput &&
         isExpanded && (
-          <RichOutput data-cy="tool-output">{renderedOutput}</RichOutput>
+          <RichOutput data-testid="tool-output">{renderedOutput}</RichOutput>
         )
       )}
     </StyledActionCard>

--- a/packages/fungi/src/MessageRenderer/index.tsx
+++ b/packages/fungi/src/MessageRenderer/index.tsx
@@ -50,7 +50,7 @@ export const MessageRenderer: React.FC<
           return (
             <StyledMessage
               key={key}
-              data-cy={`message-${role}`}
+              data-testid={`message-${role}`}
               isSender={isSender}
               messageBody={displayText}
               sourceType={MessageSourceType.Markdown}

--- a/packages/lib/src/components-via/ErrorFallback/index.tsx
+++ b/packages/lib/src/components-via/ErrorFallback/index.tsx
@@ -8,7 +8,7 @@ interface ErrorFallbackProps {
 }
 
 export const ErrorFallback: React.FC<ErrorFallbackProps> = ({ homeURL }) => (
-  <Center data-cy="error-fallback">
+  <Center data-testid="error-fallback">
     <Paragraph>
       <WhiteText textStyle={TextStyle.heading1}>
         Ouch! That&apos;s gotta hurt,

--- a/packages/lib/src/components/Accordion/Accordion.test.tsx
+++ b/packages/lib/src/components/Accordion/Accordion.test.tsx
@@ -9,18 +9,16 @@ describe("accordion", () => {
         accordion content
       </Accordion>,
     );
-    await user.click(screen.getByDataCy("accordion-toggle"));
+    await user.click(screen.getByDataTestId("accordion-toggle"));
     expect(screen.getByText("expanded")).toBeInTheDocument();
-    expect(screen.getByDataCy("accordion-collapse-container")).toHaveAttribute(
-      "aria-expanded",
-      "true",
-    );
-    await user.click(screen.getByDataCy("accordion-toggle"));
+    expect(
+      screen.getByDataTestId("accordion-collapse-container"),
+    ).toHaveAttribute("aria-expanded", "true");
+    await user.click(screen.getByDataTestId("accordion-toggle"));
     expect(screen.getByText("collapsed")).toBeInTheDocument();
-    expect(screen.getByDataCy("accordion-collapse-container")).toHaveAttribute(
-      "aria-expanded",
-      "false",
-    );
+    expect(
+      screen.getByDataTestId("accordion-collapse-container"),
+    ).toHaveAttribute("aria-expanded", "false");
   });
 
   it("should be expanded if defaultOpen is true", () => {
@@ -29,10 +27,9 @@ describe("accordion", () => {
         accordion content
       </Accordion>,
     );
-    expect(screen.getByDataCy("accordion-collapse-container")).toHaveAttribute(
-      "aria-expanded",
-      "true",
-    );
+    expect(
+      screen.getByDataTestId("accordion-collapse-container"),
+    ).toHaveAttribute("aria-expanded", "true");
   });
 
   it("calls onToggle when accordion is toggled", async () => {
@@ -43,28 +40,26 @@ describe("accordion", () => {
         accordion content
       </Accordion>,
     );
-    await user.click(screen.getByDataCy("accordion-toggle"));
-    expect(screen.getByDataCy("accordion-collapse-container")).toHaveAttribute(
-      "aria-expanded",
-      "true",
-    );
+    await user.click(screen.getByDataTestId("accordion-toggle"));
+    expect(
+      screen.getByDataTestId("accordion-collapse-container"),
+    ).toHaveAttribute("aria-expanded", "true");
     expect(onToggle).toHaveBeenCalledTimes(1);
-    await user.click(screen.getByDataCy("accordion-toggle"));
-    expect(screen.getByDataCy("accordion-collapse-container")).toHaveAttribute(
-      "aria-expanded",
-      "false",
-    );
+    await user.click(screen.getByDataTestId("accordion-toggle"));
+    expect(
+      screen.getByDataTestId("accordion-collapse-container"),
+    ).toHaveAttribute("aria-expanded", "false");
     expect(onToggle).toHaveBeenCalledTimes(2);
   });
 
   it("uses titleTag if provided", () => {
-    const titleTag = () => <span data-cy="my-custom-tag" />;
+    const titleTag = () => <span data-testid="my-custom-tag" />;
     render(
       <Accordion title="accordion title" titleTag={titleTag}>
         accordion content
       </Accordion>,
     );
-    expect(screen.getByDataCy("my-custom-tag")).toBeInTheDocument();
+    expect(screen.getByDataTestId("my-custom-tag")).toBeInTheDocument();
   });
   it("when controlled, accordion should be open if open prop is true", () => {
     const { rerender } = render(
@@ -72,19 +67,17 @@ describe("accordion", () => {
         accordion content
       </Accordion>,
     );
-    expect(screen.getByDataCy("accordion-collapse-container")).toHaveAttribute(
-      "aria-expanded",
-      "true",
-    );
+    expect(
+      screen.getByDataTestId("accordion-collapse-container"),
+    ).toHaveAttribute("aria-expanded", "true");
     rerender(
       <Accordion open={false} title="accordion title">
         accordion content
       </Accordion>,
     );
-    expect(screen.getByDataCy("accordion-collapse-container")).toHaveAttribute(
-      "aria-expanded",
-      "false",
-    );
+    expect(
+      screen.getByDataTestId("accordion-collapse-container"),
+    ).toHaveAttribute("aria-expanded", "false");
   });
   it("when controlled, accordion should call a callback when the user toggles it open or closed", async () => {
     const onToggle = vi.fn();
@@ -94,11 +87,10 @@ describe("accordion", () => {
         accordion content
       </Accordion>,
     );
-    expect(screen.getByDataCy("accordion-collapse-container")).toHaveAttribute(
-      "aria-expanded",
-      "true",
-    );
-    await user.click(screen.getByDataCy("accordion-toggle"));
+    expect(
+      screen.getByDataTestId("accordion-collapse-container"),
+    ).toHaveAttribute("aria-expanded", "true");
+    await user.click(screen.getByDataTestId("accordion-toggle"));
     expect(onToggle).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/lib/src/components/Accordion/index.tsx
+++ b/packages/lib/src/components/Accordion/index.tsx
@@ -24,6 +24,7 @@ interface AccordionProps {
   children: React.ReactNode;
   className?: string;
   "data-cy"?: string;
+  "data-testid"?: string;
   defaultOpen?: boolean;
   disableAnimations?: boolean;
   onToggle?: (s: { isVisible: boolean }) => void;
@@ -41,6 +42,7 @@ const Accordion: React.FC<AccordionProps> = ({
   children,
   className,
   "data-cy": dataCy,
+  "data-testid": dataTestId,
   defaultOpen = false,
   disableAnimations = true,
   onToggle = () => {},
@@ -72,7 +74,7 @@ const Accordion: React.FC<AccordionProps> = ({
   };
 
   return (
-    <div className={className} data-cy={dataCy}>
+    <div className={className} data-cy={dataCy} data-testid={dataTestId}>
       <AccordionToggle
         data-cy="accordion-toggle"
         data-testid="accordion-toggle"

--- a/packages/lib/src/components/Badge/TaskStatusBadge/TaskStatusBadge.test.tsx
+++ b/packages/lib/src/components/Badge/TaskStatusBadge/TaskStatusBadge.test.tsx
@@ -5,12 +5,12 @@ import TaskStatusBadge from ".";
 describe("TaskStatusBadge", () => {
   it("should render a badge with the expected status", () => {
     render(<TaskStatusBadge status={TaskStatus.Succeeded} />);
-    expect(screen.getByDataCy("task-status-badge")).toBeInTheDocument();
+    expect(screen.getByDataTestId("task-status-badge")).toBeInTheDocument();
     expect(screen.getByText("Succeeded")).toBeInTheDocument();
   });
   it("should render a badge with a task count if a count is provided", () => {
     render(<TaskStatusBadge status={TaskStatus.KnownIssue} taskCount={2} />);
-    expect(screen.getByDataCy("task-status-badge")).toBeInTheDocument();
+    expect(screen.getByDataTestId("task-status-badge")).toBeInTheDocument();
     expect(screen.getByText("2 Known Issue")).toBeInTheDocument();
   });
 });

--- a/packages/lib/src/components/ErrorBoundary/ErrorBoundary.test.tsx
+++ b/packages/lib/src/components/ErrorBoundary/ErrorBoundary.test.tsx
@@ -54,7 +54,7 @@ describe("Error boundary", () => {
           componentStack: expect.any(String),
         }),
       });
-      expect(screen.getByDataCy("error-fallback")).toBeInTheDocument();
+      expect(screen.getByDataTestId("error-fallback")).toBeInTheDocument();
     });
   });
   describe("When sentry is initialized", () => {
@@ -97,7 +97,7 @@ describe("Error boundary", () => {
       render(<TestErrorBoundary />);
       expect(screen.getByText("Error")).toBeInTheDocument();
 
-      expect(screen.getByDataCy("error-fallback")).toBeInTheDocument();
+      expect(screen.getByDataTestId("error-fallback")).toBeInTheDocument();
     });
     it("should refresh the page when an old bundle error occurs", () => {
       const err = new Error(dynamicallyLoadedModuleErrorMessage);
@@ -114,7 +114,7 @@ describe("Error boundary", () => {
       );
       render(<TestErrorBoundary />);
       expect(screen.getByText("Error")).toBeInTheDocument();
-      expect(screen.getByDataCy("error-fallback")).toBeInTheDocument();
+      expect(screen.getByDataTestId("error-fallback")).toBeInTheDocument();
       expect(window.location.reload).toHaveBeenCalled();
     });
   });

--- a/packages/lib/src/components/ErrorBoundary/ErrorFallback/ErrorFallback.tsx
+++ b/packages/lib/src/components/ErrorBoundary/ErrorFallback/ErrorFallback.tsx
@@ -11,7 +11,7 @@ interface ErrorFallbackProps {
   homeURL: string;
 }
 const ErrorFallback: React.FC<ErrorFallbackProps> = ({ homeURL }) => (
-  <Center data-cy="error-fallback">
+  <Center data-cy="error-fallback" data-testid="error-fallback">
     <Text>
       <StyledHeader>Error</StyledHeader>
       <StyledSubtitle>

--- a/packages/lib/src/components/ExpiringAnnouncementTooltip/ExpiringAnnouncementTooltip.test.tsx
+++ b/packages/lib/src/components/ExpiringAnnouncementTooltip/ExpiringAnnouncementTooltip.test.tsx
@@ -73,7 +73,7 @@ describe("ExpiringAnnouncementTooltip", () => {
       await waitFor(() => {
         expect(screen.getByText("New Release")).toBeVisible();
       });
-      await user.click(screen.getByDataCy("announcement-tooltip-trigger"));
+      await user.click(screen.getByDataTestId("announcement-tooltip-trigger"));
       await waitFor(() => {
         expect(screen.queryByText("New Release")).not.toBeVisible();
       });
@@ -141,7 +141,7 @@ describe("ExpiringAnnouncementTooltip", () => {
       expect(mockedGet).toHaveBeenCalledOnce();
       expect(screen.queryByText("New Release")).not.toBeInTheDocument();
 
-      await user.click(screen.getByDataCy("announcement-tooltip-trigger"));
+      await user.click(screen.getByDataTestId("announcement-tooltip-trigger"));
       await waitFor(() => {
         expect(screen.getByText("New Release")).toBeVisible();
       });

--- a/packages/lib/src/components/ExpiringAnnouncementTooltip/index.tsx
+++ b/packages/lib/src/components/ExpiringAnnouncementTooltip/index.tsx
@@ -51,6 +51,7 @@ export const ExpiringAnnouncementTooltip: React.FC<
       <IconContainer ref={infoRef}>
         <Icon
           data-cy="announcement-tooltip-trigger"
+          data-testid="announcement-tooltip-trigger"
           fill={palette.gray.dark2}
           glyph="InfoWithCircle"
           onClick={() => setOpen((o) => !o)}

--- a/packages/lib/src/components/FullPageLoad/index.tsx
+++ b/packages/lib/src/components/FullPageLoad/index.tsx
@@ -1,7 +1,7 @@
 import styled from "@emotion/styled";
 
 export const FullPageLoad: React.FC = () => (
-  <FullPage data-cy="loading-page">
+  <FullPage>
     <div>LOADING...</div>
   </FullPage>
 );

--- a/packages/lib/src/components/Icon/AnimatedIcon/AnimatedIcon.test.tsx
+++ b/packages/lib/src/components/Icon/AnimatedIcon/AnimatedIcon.test.tsx
@@ -4,14 +4,14 @@ import AnimatedIcon from ".";
 
 // Mock an SVG component to be passed as the icon prop
 const MockIcon = forwardRef<SVGSVGElement>((props, ref) => (
-  <svg ref={ref} data-cy="test-svg" {...props} />
+  <svg ref={ref} data-testid="test-svg" {...props} />
 ));
 MockIcon.displayName = "MockIcon";
 
 describe("AnimatedIcon", () => {
   it("renders the icon correctly", () => {
     render(<AnimatedIcon icon={MockIcon} />);
-    const svgElement = screen.getByDataCy("test-svg");
+    const svgElement = screen.getByDataTestId("test-svg");
     expect(svgElement).toBeInTheDocument();
   });
 
@@ -56,7 +56,7 @@ describe("AnimatedIcon", () => {
             else if (ref) ref.current = el;
           }
         }}
-        data-cy="test-svg"
+        data-testid="test-svg"
         {...props}
       >
         <animate />
@@ -66,7 +66,7 @@ describe("AnimatedIcon", () => {
 
     render(<AnimatedIcon icon={MockIconWithAnimations} />);
 
-    const svgElement = screen.getByDataCy("test-svg");
+    const svgElement = screen.getByDataTestId("test-svg");
 
     // Mouse enter triggers unpauseAnimations
     fireEvent.mouseEnter(svgElement);

--- a/packages/lib/src/components/Icon/icons/ArrowWithCircle.tsx
+++ b/packages/lib/src/components/Icon/icons/ArrowWithCircle.tsx
@@ -5,14 +5,12 @@ const { black } = palette;
 
 export const ArrowWithCircle: React.ComponentType<LeafygreenIconProps> = ({
   className,
-  "data-cy": dataCy,
   fill = black,
   onClick,
 }) => (
   <svg
     aria-label="Arrow With Circle Icon"
     className={className}
-    data-cy={dataCy}
     fill="none"
     height="14"
     onClick={onClick}

--- a/packages/lib/src/components/Icon/icons/GitHub.tsx
+++ b/packages/lib/src/components/Icon/icons/GitHub.tsx
@@ -5,14 +5,12 @@ const { black } = palette;
 
 export const GitHub: React.ComponentType<LeafygreenIconProps> = ({
   className,
-  "data-cy": dataCy,
   fill = black,
   onClick,
 }) => (
   <svg
     aria-label="GitHub Icon"
     className={className}
-    data-cy={dataCy}
     fill="none"
     height={16}
     onClick={onClick}

--- a/packages/lib/src/components/Icon/icons/Ignored.tsx
+++ b/packages/lib/src/components/Icon/icons/Ignored.tsx
@@ -2,14 +2,12 @@ import { LeafygreenIconProps } from "../types";
 
 export const Ignored: React.ComponentType<LeafygreenIconProps> = ({
   className,
-  "data-cy": dataCy,
   fill,
   size = 16,
 }) => (
   <svg
     aria-label="Ignored Icon"
     className={className}
-    data-cy={dataCy}
     fill="currentColor"
     height={size}
     width={size}

--- a/packages/lib/src/components/Icon/types.ts
+++ b/packages/lib/src/components/Icon/types.ts
@@ -3,5 +3,4 @@ import type { Size } from "@leafygreen-ui/icon";
 export interface LeafygreenIconProps extends React.SVGProps<SVGSVGElement> {
   size?: number | (typeof Size)[keyof typeof Size];
   role?: "presentation" | "img";
-  ["data-cy"]?: string;
 }

--- a/packages/lib/src/components/IconWithTooltip/IconWithTooltip.test.tsx
+++ b/packages/lib/src/components/IconWithTooltip/IconWithTooltip.test.tsx
@@ -5,13 +5,13 @@ describe("icon with tooltip", () => {
   it("renders a tooltip when hovered", async () => {
     const user = userEvent.setup();
     render(
-      <IconWithTooltip data-cy="Icon" glyph="Warning">
+      <IconWithTooltip data-testid="Icon" glyph="Warning">
         Some Text
       </IconWithTooltip>,
     );
     expect(screen.queryByText("Some Text")).toBeNull();
 
-    const trigger = await screen.findByDataCy("Icon");
+    const trigger = await screen.findByTestId("Icon");
     await user.hover(trigger);
     await waitFor(() => {
       expect(screen.getByText("Some Text")).toBeVisible();

--- a/packages/lib/src/components/IconWithTooltip/index.tsx
+++ b/packages/lib/src/components/IconWithTooltip/index.tsx
@@ -1,25 +1,33 @@
 import styled from "@emotion/styled";
-import { Tooltip, TooltipProps } from "@leafygreen-ui/tooltip";
+import {
+  Align,
+  Justify,
+  Tooltip,
+  TooltipProps,
+  TriggerEvent,
+} from "@leafygreen-ui/tooltip";
 import Icon from "../Icon";
 
 interface IconWithTooltipProps extends React.ComponentProps<typeof Icon> {
   ["data-cy"]?: string;
+  ["data-testid"]?: string;
 }
 
 const IconWithTooltip: React.FC<IconWithTooltipProps> = ({
   children,
   "data-cy": dataCy,
+  "data-testid": dataTestId,
   ...rest
 }) => (
   <StyledTooltip
-    align="top"
-    justify="middle"
+    align={Align.Top}
+    justify={Justify.Middle}
     trigger={
-      <IconWrapper data-cy={dataCy}>
+      <IconWrapper data-cy={dataCy} data-testid={dataTestId}>
         <Icon {...rest} />
       </IconWrapper>
     }
-    triggerEvent="hover"
+    triggerEvent={TriggerEvent.Hover}
   >
     {children}
   </StyledTooltip>

--- a/packages/lib/src/components/PageSizeSelector/PageSizeSelector.test.tsx
+++ b/packages/lib/src/components/PageSizeSelector/PageSizeSelector.test.tsx
@@ -5,13 +5,7 @@ describe("pageSizeSelector", () => {
   it("selecting page size should call onChange prop", async () => {
     const user = userEvent.setup();
     const onChange = vi.fn();
-    render(
-      <PageSizeSelector
-        data-cy="page-size-selector"
-        onChange={onChange}
-        value={10}
-      />,
-    );
+    render(<PageSizeSelector onChange={onChange} value={10} />);
     await user.click(screen.getByRole("button", { name: "10 / page" }));
     await waitFor(() => {
       expect(screen.queryByText("20 / page")).toBeVisible();

--- a/packages/lib/src/components/Pagination/Pagination.stories.tsx
+++ b/packages/lib/src/components/Pagination/Pagination.stories.tsx
@@ -23,8 +23,7 @@ export const Default: CustomStoryObj<typeof Pagination> = {
   args: {
     totalResults: 100,
     pageSize: 10,
-    // @ts-expect-error: FIXME. This comment was added by an automated script.
-    onChange: null,
+    onChange: () => {},
   },
 };
 

--- a/packages/lib/src/components/Pagination/Pagination.test.tsx
+++ b/packages/lib/src/components/Pagination/Pagination.test.tsx
@@ -19,7 +19,7 @@ describe("pagination", () => {
       <Pagination currentPage={0} pageSize={5} totalResults={10} />,
     );
     expect(router.state.location.search).toBe("");
-    expect(screen.queryByDataCy("prev-page-button")).toHaveAttribute(
+    expect(screen.queryByDataTestId("prev-page-button")).toHaveAttribute(
       "aria-disabled",
       "true",
     );
@@ -29,7 +29,7 @@ describe("pagination", () => {
       <Pagination currentPage={1} pageSize={5} totalResults={10} />,
     );
     expect(router.state.location.search).toBe("");
-    expect(screen.queryByDataCy("next-page-button")).toHaveAttribute(
+    expect(screen.queryByDataTestId("next-page-button")).toHaveAttribute(
       "aria-disabled",
       "true",
     );
@@ -41,7 +41,7 @@ describe("pagination", () => {
     );
 
     expect(router.state.location.search).toBe("");
-    await user.click(screen.getByDataCy("next-page-button"));
+    await user.click(screen.getByDataTestId("next-page-button"));
     expect(router.state.location.search).toBe("?page=1");
   });
   it("paginating backward should update the url with the new page number by default", async () => {
@@ -51,7 +51,7 @@ describe("pagination", () => {
     );
 
     expect(router.state.location.search).toBe("");
-    await user.click(screen.getByDataCy("prev-page-button"));
+    await user.click(screen.getByDataTestId("prev-page-button"));
     expect(router.state.location.search).toBe("?page=0");
   });
 
@@ -66,18 +66,18 @@ describe("pagination", () => {
         totalResults={10}
       />,
     );
-    await user.click(screen.getByDataCy("next-page-button"));
+    await user.click(screen.getByDataTestId("next-page-button"));
     expect(onChange).toHaveBeenCalledWith(1);
   });
   it("should disable pagination if there  is only one page", () => {
     renderWithRouterMatch(
       <Pagination currentPage={0} pageSize={5} totalResults={5} />,
     );
-    expect(screen.queryByDataCy("prev-page-button")).toHaveAttribute(
+    expect(screen.queryByDataTestId("prev-page-button")).toHaveAttribute(
       "aria-disabled",
       "true",
     );
-    expect(screen.queryByDataCy("next-page-button")).toHaveAttribute(
+    expect(screen.queryByDataTestId("next-page-button")).toHaveAttribute(
       "aria-disabled",
       "true",
     );
@@ -86,11 +86,11 @@ describe("pagination", () => {
     renderWithRouterMatch(
       <Pagination currentPage={0} pageSize={5} totalResults={5} />,
     );
-    expect(screen.queryByDataCy("prev-page-button")).toHaveAttribute(
+    expect(screen.queryByDataTestId("prev-page-button")).toHaveAttribute(
       "aria-disabled",
       "true",
     );
-    expect(screen.queryByDataCy("next-page-button")).toHaveAttribute(
+    expect(screen.queryByDataTestId("next-page-button")).toHaveAttribute(
       "aria-disabled",
       "true",
     );

--- a/packages/lib/src/components/Pagination/index.tsx
+++ b/packages/lib/src/components/Pagination/index.tsx
@@ -1,5 +1,5 @@
 import styled from "@emotion/styled";
-import { Button } from "@leafygreen-ui/button";
+import { Button, Size as ButtonSize } from "@leafygreen-ui/button";
 import { Disclaimer } from "@leafygreen-ui/typography";
 import { size } from "../../constants/tokens";
 import usePagination from "../../hooks/usePagination";
@@ -46,13 +46,14 @@ const Pagination: React.FC<Props> = ({
     countLimit && totalResults >= countLimit ? "many" : numPages;
 
   return (
-    <Container data-cy="pagination">
+    <Container data-cy="pagination" data-testid="pagination">
       <StyledButton
         data-cy="prev-page-button"
+        data-testid="prev-page-button"
         disabled={currentPage === 0}
         leftGlyph={<Icon glyph="ChevronLeft" size="small" />}
         onClick={handlePrevClick}
-        size="small"
+        size={ButtonSize.Small}
       />
       <PageLabel>
         <Disclaimer>
@@ -61,10 +62,11 @@ const Pagination: React.FC<Props> = ({
       </PageLabel>
       <StyledButton
         data-cy="next-page-button"
+        data-testid="next-page-button"
         disabled={numPages === 0 || currentPage === numPages - 1}
         leftGlyph={<Icon glyph="ChevronRight" size="small" />}
         onClick={handleNextClick}
-        size="small"
+        size={ButtonSize.Small}
       />
     </Container>
   );

--- a/packages/lib/src/components/Popconfirm/index.tsx
+++ b/packages/lib/src/components/Popconfirm/index.tsx
@@ -13,7 +13,6 @@ type PopconfirmProps = Omit<
 > & {
   confirmDisabled?: boolean;
   confirmText?: string;
-  "data-cy"?: string;
   onConfirm?: (e?: React.MouseEvent) => void;
   children: React.ReactNode;
 };
@@ -73,7 +72,7 @@ const Popconfirm: React.FC<PopconfirmProps> = ({
         <ButtonWrapper>
           <Button
             as="button"
-            data-cy="popconfirm-cancel-button"
+            data-testid="popconfirm-cancel-button"
             onClick={() => {
               onClose();
               setOpen(false);
@@ -85,6 +84,7 @@ const Popconfirm: React.FC<PopconfirmProps> = ({
           <Button
             as="button"
             data-cy="popconfirm-confirm-button"
+            data-testid="popconfirm-confirm-button"
             disabled={confirmDisabled}
             onClick={(e) => {
               onConfirm(e);

--- a/packages/lib/src/components/Table/BaseTable.tsx
+++ b/packages/lib/src/components/Table/BaseTable.tsx
@@ -41,10 +41,12 @@ declare module "@tanstack/table-core" {
   interface ColumnMeta<TData extends RowData, TValue> {
     search?: {
       "data-cy"?: string;
+      "data-testid"?: string;
       placeholder?: string;
     };
     treeSelect?: {
       "data-cy"?: string;
+      "data-testid"?: string;
       // Configures whether or not the tree select should be filtered to only represent values found in the table.
       // Note that this may not be very performant for large tables.
       filterOptions?: boolean;
@@ -60,7 +62,9 @@ const { blue } = palette;
 
 interface SpruceTableProps<T extends LGRowData> {
   "data-cy-row"?: string;
+  "data-testid-row"?: string;
   "data-cy-table"?: string;
+  "data-testid-table"?: string;
   emptyComponent?: React.ReactNode;
   loading?: boolean;
   /** estimated number of rows the table will have */
@@ -88,6 +92,8 @@ export const BaseTable = forwardRef<HTMLDivElement, BaseTableProps<any>>(
     {
       "data-cy-row": dataCyRow,
       "data-cy-table": dataCyTable,
+      "data-testid-row": dataTestIdRow,
+      "data-testid-table": dataTestIdTable,
       disabledRowIndexes = [],
       emptyComponent,
       loading,
@@ -112,6 +118,7 @@ export const BaseTable = forwardRef<HTMLDivElement, BaseTableProps<any>>(
         <Table
           ref={ref}
           data-cy={dataCyTable}
+          data-testid={dataTestIdTable}
           table={table}
           verticalAlignment={verticalAlignment}
           {...args}
@@ -145,6 +152,7 @@ export const BaseTable = forwardRef<HTMLDivElement, BaseTableProps<any>>(
                     <RenderableRow
                       key={row.id}
                       dataCyRow={dataCyRow}
+                      dataTestIdRow={dataTestIdRow}
                       disabled={disabledRowIndexes?.includes(row.index)}
                       isSelected={selectedRowIndexes.includes(row.index)}
                       row={row}
@@ -157,6 +165,7 @@ export const BaseTable = forwardRef<HTMLDivElement, BaseTableProps<any>>(
                   <RenderableRow
                     key={row.id}
                     dataCyRow={dataCyRow}
+                    dataTestIdRow={dataTestIdRow}
                     disabled={disabledRowIndexes?.includes(row.index)}
                     isSelected={selectedRowIndexes.includes(row.index)}
                     row={row}
@@ -218,6 +227,7 @@ const TableHeaderCell = <T extends LGRowData>({
         (meta?.treeSelect ? (
           <TableFilterPopover
             data-cy={meta.treeSelect?.["data-cy"]}
+            data-testid={meta.treeSelect?.["data-testid"]}
             onConfirm={(value) => {
               header.column.setFilterValue(value);
               if (usePagination) {
@@ -242,6 +252,7 @@ const TableHeaderCell = <T extends LGRowData>({
         ) : (
           <TableSearchPopover
             data-cy={meta?.search?.["data-cy"]}
+            data-testid={meta?.search?.["data-testid"]}
             onConfirm={(value) => {
               header.column.setFilterValue(value);
               if (usePagination) {
@@ -270,6 +281,7 @@ const cellStyle = css`
 
 const RenderableRow = <T extends LGRowData>({
   dataCyRow = "leafygreen-table-row",
+  dataTestIdRow = "leafygreen-table-row",
   disabled = false,
   isSelected = false,
   row,
@@ -277,6 +289,7 @@ const RenderableRow = <T extends LGRowData>({
   virtualRow,
 }: {
   dataCyRow?: string;
+  dataTestIdRow?: string;
   row: LeafyGreenTableRow<T>;
   virtualRow?: VirtualItem;
   isSelected?: boolean;
@@ -299,6 +312,7 @@ const RenderableRow = <T extends LGRowData>({
         data-cy={dataCyRow}
         data-index={row.index}
         data-selected={isSelected}
+        data-testid={dataTestIdRow}
         disabled={disabled}
         row={row}
         virtualRow={virtualRow}

--- a/packages/lib/src/components/Table/TableControl/ResultCountLabel/index.tsx
+++ b/packages/lib/src/components/Table/TableControl/ResultCountLabel/index.tsx
@@ -5,20 +5,27 @@ interface Props {
   denominator: number;
   dataCyNumerator?: string;
   dataCyDenominator?: string;
+  dataTestIdNumerator?: string;
+  dataTestIdDenominator?: string;
   label: string;
 }
 export const ResultCountLabel: React.FC<Props> = ({
   dataCyDenominator,
   dataCyNumerator,
+  dataTestIdDenominator,
+  dataTestIdNumerator,
   denominator,
   label,
   numerator,
 }) => (
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore: FIXME. This component is throwing an invalid type
   <Body>
-    <span data-cy={dataCyNumerator}>{numerator}</span>/
-    <span data-cy={dataCyDenominator}>{denominator}</span>
+    <span data-cy={dataCyNumerator} data-testid={dataTestIdNumerator}>
+      {numerator}
+    </span>
+    /
+    <span data-cy={dataCyDenominator} data-testid={dataTestIdDenominator}>
+      {denominator}
+    </span>
     <span> {label}</span>
   </Body>
 );

--- a/packages/lib/src/components/Table/TableControl/index.tsx
+++ b/packages/lib/src/components/Table/TableControl/index.tsx
@@ -46,12 +46,15 @@ const TableControl: React.FC<Props> = ({
         <ResultCountLabel
           dataCyDenominator="total-count"
           dataCyNumerator="filtered-count"
+          dataTestIdDenominator="total-count"
+          dataTestIdNumerator="filtered-count"
           denominator={totalCount}
           label={label}
           numerator={filteredCount}
         />
         <PaddedButton
           data-cy="clear-all-filters"
+          data-testid="clear-all-filters"
           disabled={disabled}
           onClick={onClearAll}
           size="small"
@@ -62,13 +65,11 @@ const TableControl: React.FC<Props> = ({
       <TableControlInnerRow>
         <Pagination
           currentPage={page}
-          data-cy="tasks-table-pagination"
           onChange={onPageChange}
           pageSize={limit}
           totalResults={filteredCount}
         />
         <PageSizeSelector
-          data-cy="tasks-table-page-size-selector"
           disabled={disabled}
           onChange={handlePageSizeChange}
           value={limit}

--- a/packages/lib/src/components/Table/TablePopover/TableFilterPopover/TableFilterPopover.test.tsx
+++ b/packages/lib/src/components/Table/TablePopover/TableFilterPopover/TableFilterPopover.test.tsx
@@ -12,19 +12,19 @@ describe("table filter popover", () => {
     const user = userEvent.setup();
     render(
       <TableFilterPopover
-        data-cy="test-popover"
+        data-testid="test-popover"
         onConfirm={vi.fn()}
         options={options}
         value={[]}
       />,
     );
-    expect(screen.queryByDataCy("test-popover-wrapper")).toBeNull();
+    expect(screen.queryByDataTestId("test-popover-wrapper")).toBeNull();
     const icon = screen.getByRole("button", {
       name: "Table Filter Popover Icon",
     });
     await user.click(icon);
     await waitFor(() => {
-      expect(screen.queryByDataCy("test-popover-wrapper")).toBeVisible();
+      expect(screen.queryByDataTestId("test-popover-wrapper")).toBeVisible();
     });
   });
 
@@ -32,7 +32,7 @@ describe("table filter popover", () => {
     const user = userEvent.setup();
     render(
       <TableFilterPopover
-        data-cy="test-popover"
+        data-testid="test-popover"
         onConfirm={vi.fn()}
         options={options}
         value={["success"]}
@@ -43,7 +43,7 @@ describe("table filter popover", () => {
     });
     await user.click(icon);
     await waitFor(() => {
-      expect(screen.queryByDataCy("test-popover-wrapper")).toBeVisible();
+      expect(screen.queryByDataTestId("test-popover-wrapper")).toBeVisible();
     });
     const checkbox = screen.getByLabelText("Success");
     expect(checkbox).toBeChecked();
@@ -54,7 +54,7 @@ describe("table filter popover", () => {
     const onConfirm = vi.fn();
     render(
       <TableFilterPopover
-        data-cy="test-popover"
+        data-testid="test-popover"
         onConfirm={onConfirm}
         options={options}
         value={[]}
@@ -65,7 +65,7 @@ describe("table filter popover", () => {
     });
     await user.click(icon);
     await waitFor(() => {
-      expect(screen.queryByDataCy("test-popover-wrapper")).toBeVisible();
+      expect(screen.queryByDataTestId("test-popover-wrapper")).toBeVisible();
     });
 
     const checkboxLabel = screen.getByText("Success"); // LeafyGreen checkbox has pointer-events: none so click on the label instead.
@@ -78,7 +78,7 @@ describe("table filter popover", () => {
     const user = userEvent.setup();
     render(
       <TableFilterPopover
-        data-cy="test-popover"
+        data-testid="test-popover"
         onConfirm={vi.fn()}
         options={[]}
         value={[]}
@@ -89,7 +89,7 @@ describe("table filter popover", () => {
     });
     await user.click(icon);
     await waitFor(() => {
-      expect(screen.queryByDataCy("test-popover-wrapper")).toBeVisible();
+      expect(screen.queryByDataTestId("test-popover-wrapper")).toBeVisible();
     });
     expect(screen.getByText("No filters available.")).toBeVisible();
   });

--- a/packages/lib/src/components/Table/TablePopover/TableFilterPopover/index.tsx
+++ b/packages/lib/src/components/Table/TablePopover/TableFilterPopover/index.tsx
@@ -13,6 +13,7 @@ const { blue, gray } = palette;
 
 interface TableFilterPopoverProps {
   "data-cy"?: string;
+  "data-testid"?: string;
   onConfirm: (filters: string[]) => void;
   options: TreeDataEntry[];
   value: string[];
@@ -20,6 +21,7 @@ interface TableFilterPopoverProps {
 
 const TableFilterPopover: React.FC<TableFilterPopoverProps> = ({
   "data-cy": dataCy,
+  "data-testid": dataTestId,
   onConfirm,
   options,
   value,
@@ -46,6 +48,7 @@ const TableFilterPopover: React.FC<TableFilterPopoverProps> = ({
         aria-label="Table Filter Popover Icon"
         data-cy={dataCy}
         data-highlighted={hasFilters}
+        data-testid={dataTestId}
         onClick={() => setActive(!active)}
       >
         <Icon color={iconColor} glyph="Filter" />
@@ -57,7 +60,11 @@ const TableFilterPopover: React.FC<TableFilterPopoverProps> = ({
         refEl={buttonRef}
         spacing={DEFAULT_SPACING}
       >
-        <PopoverContainer ref={popoverRef} data-cy={`${dataCy}-wrapper`}>
+        <PopoverContainer
+          ref={popoverRef}
+          data-cy={`${dataCy}-wrapper`}
+          data-testid={`${dataTestId}-wrapper`}
+        >
           {options.length > 0 ? (
             <TreeSelect onChange={onChange} state={value} tData={options} />
           ) : (

--- a/packages/lib/src/components/Table/TablePopover/TableSearchPopover/TableSearchPopover.test.tsx
+++ b/packages/lib/src/components/Table/TablePopover/TableSearchPopover/TableSearchPopover.test.tsx
@@ -6,18 +6,18 @@ describe("table search popover", () => {
     const user = userEvent.setup();
     render(
       <TableSearchPopover
-        data-cy="test-popover"
+        data-testid="test-popover"
         onConfirm={vi.fn()}
         value=""
       />,
     );
-    expect(screen.queryByDataCy("test-popover-wrapper")).toBeNull();
+    expect(screen.queryByDataTestId("test-popover-wrapper")).toBeNull();
     const icon = screen.getByRole("button", {
       name: "Table Search Popover Icon",
     });
     await user.click(icon);
     await waitFor(() => {
-      expect(screen.queryByDataCy("test-popover-wrapper")).toBeVisible();
+      expect(screen.queryByDataTestId("test-popover-wrapper")).toBeVisible();
     });
   });
 
@@ -25,7 +25,7 @@ describe("table search popover", () => {
     const user = userEvent.setup();
     render(
       <TableSearchPopover
-        data-cy="test-popover"
+        data-testid="test-popover"
         onConfirm={vi.fn()}
         value="test_value"
       />,
@@ -35,7 +35,7 @@ describe("table search popover", () => {
     });
     await user.click(icon);
     await waitFor(() => {
-      expect(screen.queryByDataCy("test-popover-wrapper")).toBeVisible();
+      expect(screen.queryByDataTestId("test-popover-wrapper")).toBeVisible();
     });
     const input = screen.getByPlaceholderText("Search");
     expect(input).toHaveValue("test_value");
@@ -46,7 +46,7 @@ describe("table search popover", () => {
     const onConfirm = vi.fn();
     render(
       <TableSearchPopover
-        data-cy="test-popover"
+        data-testid="test-popover"
         onConfirm={onConfirm}
         value=""
       />,
@@ -56,7 +56,7 @@ describe("table search popover", () => {
     });
     await user.click(icon);
     await waitFor(() => {
-      expect(screen.queryByDataCy("test-popover-wrapper")).toBeVisible();
+      expect(screen.queryByDataTestId("test-popover-wrapper")).toBeVisible();
     });
     const input = screen.getByPlaceholderText("Search");
     await user.type(input, "test_value{enter}");
@@ -69,7 +69,7 @@ describe("table search popover", () => {
     const user = userEvent.setup();
     render(
       <TableSearchPopover
-        data-cy="test-popover"
+        data-testid="test-popover"
         onConfirm={vi.fn()}
         value=""
       />,
@@ -79,7 +79,7 @@ describe("table search popover", () => {
     });
     await user.click(icon);
     await waitFor(() => {
-      expect(screen.queryByDataCy("test-popover-wrapper")).toBeVisible();
+      expect(screen.queryByDataTestId("test-popover-wrapper")).toBeVisible();
     });
     const input = screen.getByPlaceholderText("Search");
     expect(input).toHaveFocus();
@@ -89,7 +89,7 @@ describe("table search popover", () => {
     const user = userEvent.setup();
     render(
       <TableSearchPopover
-        data-cy="test-popover"
+        data-testid="test-popover"
         onConfirm={vi.fn()}
         value="test_value"
       />,
@@ -99,7 +99,7 @@ describe("table search popover", () => {
     });
     await user.click(icon);
     await waitFor(() => {
-      expect(screen.queryByDataCy("test-popover-wrapper")).toBeVisible();
+      expect(screen.queryByDataTestId("test-popover-wrapper")).toBeVisible();
     });
     const input = screen.getByPlaceholderText("Search");
     expect(input).toHaveSelection("test_value");

--- a/packages/lib/src/components/Table/TablePopover/TableSearchPopover/index.tsx
+++ b/packages/lib/src/components/Table/TablePopover/TableSearchPopover/index.tsx
@@ -18,6 +18,7 @@ const { blue, gray } = palette;
 
 interface TableSearchPopoverProps {
   "data-cy"?: string;
+  "data-testid"?: string;
   onConfirm: (search: string) => void;
   placeholder?: string;
   value: string;
@@ -25,6 +26,7 @@ interface TableSearchPopoverProps {
 
 const TableSearchPopover: React.FC<TableSearchPopoverProps> = ({
   "data-cy": dataCy,
+  "data-testid": dataTestId,
   onConfirm,
   placeholder,
   value,
@@ -64,6 +66,7 @@ const TableSearchPopover: React.FC<TableSearchPopoverProps> = ({
         active={active}
         aria-label="Table Search Popover Icon"
         data-cy={dataCy}
+        data-testid={dataTestId}
         onClick={() => setActive(!active)}
       >
         <Icon color={iconColor} glyph="MagnifyingGlass" />
@@ -75,13 +78,18 @@ const TableSearchPopover: React.FC<TableSearchPopoverProps> = ({
         refEl={buttonRef}
         spacing={DEFAULT_SPACING}
       >
-        <PopoverContainer ref={popoverRef} data-cy={`${dataCy}-wrapper`}>
+        <PopoverContainer
+          ref={popoverRef}
+          data-cy={`${dataCy}-wrapper`}
+          data-testid={`${dataTestId}-wrapper`}
+        >
           <InputContainer>
             <Description>Press enter to filter.</Description>
             <SearchInput
               ref={(el) => setInputRef(el)}
               aria-label="Search table"
               data-cy={`${dataCy}-input-filter`}
+              data-testid={`${dataTestId}-input-filter`}
               onChange={(e) => setInput(e.target.value)}
               onKeyDown={(e) => e.key === "Enter" && onEnter()}
               placeholder={placeholder}

--- a/packages/lib/src/components/TreeSelect/FilterInputControls/index.tsx
+++ b/packages/lib/src/components/TreeSelect/FilterInputControls/index.tsx
@@ -1,5 +1,9 @@
 import styled from "@emotion/styled";
-import { Button } from "@leafygreen-ui/button";
+import {
+  Button,
+  Size as ButtonSize,
+  Variant as ButtonVariant,
+} from "@leafygreen-ui/button";
 import { size } from "../../../constants/tokens";
 
 interface Props {
@@ -13,17 +17,16 @@ export const FilterInputControls: React.FC<Props> = ({
   onClickSubmit,
   submitButtonCopy = "Filter",
 }) => (
-  <ButtonsWrapper data-cy="filter-input-controls">
+  <ButtonsWrapper>
     <ButtonWrapper>
-      <Button data-cy="reset-button" onClick={onClickReset} size="small">
+      <Button onClick={onClickReset} size={ButtonSize.Small}>
         Reset
       </Button>
     </ButtonWrapper>
     <Button
-      data-cy="filter-button"
       onClick={onClickSubmit}
-      size="small"
-      variant="primary"
+      size={ButtonSize.Small}
+      variant={ButtonVariant.Primary}
     >
       {submitButtonCopy}
     </Button>

--- a/packages/lib/src/components/TreeSelect/TreeSelect.stories.tsx
+++ b/packages/lib/src/components/TreeSelect/TreeSelect.stories.tsx
@@ -11,10 +11,9 @@ export const Default: CustomStoryObj<typeof TreeSelect> = {
 };
 
 const BaseTreeSelect = (props: TreeSelectProps) => {
-  const [value, setValue] = useState([]);
+  const [value, setValue] = useState<string[]>([]);
   return (
-    // @ts-expect-error: FIXME. This comment was added by an automated script.
-    <TreeSelect onChange={setValue} state={value} tData={treeData} {...props} />
+    <TreeSelect {...props} onChange={setValue} state={value} tData={treeData} />
   );
 };
 

--- a/packages/lib/src/components/TreeSelect/TreeSelect.test.tsx
+++ b/packages/lib/src/components/TreeSelect/TreeSelect.test.tsx
@@ -4,7 +4,7 @@ import { TreeSelect } from ".";
 describe("treeSelect", () => {
   it("renders each value in the tree", () => {
     render(<TreeSelect onChange={() => {}} state={[]} tData={treeData} />);
-    expect(screen.getByDataCy("tree-select-options")).toBeInTheDocument();
+    expect(screen.getByDataTestId("tree-select-options")).toBeInTheDocument();
     for (let i = 0; i < treeData.length; i++) {
       expect(screen.getByText(treeData[i].title)).toBeInTheDocument();
     }
@@ -14,7 +14,7 @@ describe("treeSelect", () => {
     render(
       <TreeSelect onChange={() => {}} state={["pass"]} tData={treeData} />,
     );
-    expect(screen.getByDataCy("tree-select-options")).toBeInTheDocument();
+    expect(screen.getByDataTestId("tree-select-options")).toBeInTheDocument();
     const checkbox = screen.queryByLabelText("Pass");
     expect(checkbox).toBeChecked();
   });
@@ -24,8 +24,7 @@ describe("treeSelect", () => {
     const onChange = vi.fn();
     render(<TreeSelect onChange={onChange} state={[]} tData={treeData} />);
     expect(screen.getByText("Pass")).toBeInTheDocument();
-    // @ts-expect-error: FIXME. This comment was added by an automated script.
-    await user.click(screen.queryByText("Pass"));
+    await user.click(screen.getByText("Pass"));
     expect(onChange).toHaveBeenCalledWith(["pass"]);
   });
 
@@ -34,8 +33,7 @@ describe("treeSelect", () => {
     const onChange = vi.fn();
     render(<TreeSelect onChange={onChange} state={[]} tData={treeData} />);
     expect(screen.getByText("All")).toBeInTheDocument();
-    // @ts-expect-error: FIXME. This comment was added by an automated script.
-    await user.click(screen.queryByText("All"));
+    await user.click(screen.getByText("All"));
     expect(onChange).toHaveBeenCalledWith([
       "all",
       "pass",
@@ -67,8 +65,7 @@ describe("treeSelect", () => {
     expect(screen.queryByLabelText("Failing Umbrella")).toBeChecked();
     expect(screen.queryByLabelText("System Failure")).toBeChecked();
     expect(screen.queryByLabelText("Fail")).toBeChecked();
-    // @ts-expect-error: FIXME. This comment was added by an automated script.
-    await user.click(screen.queryByText("Fail"));
+    await user.click(screen.getByText("Fail"));
     expect(onChange).toHaveBeenCalledWith(["system-failure"]);
   });
 
@@ -79,8 +76,7 @@ describe("treeSelect", () => {
       <TreeSelect onChange={onChange} state={[]} tData={nestedTreeData} />,
     );
     expect(screen.getByText("Failing Umbrella")).toBeInTheDocument();
-    // @ts-expect-error: FIXME. This comment was added by an automated script.
-    await user.click(screen.queryByText("Failing Umbrella"));
+    await user.click(screen.getByText("Failing Umbrella"));
     expect(onChange).toHaveBeenCalledWith([
       "failing-umbrella",
       "system-failure",

--- a/packages/lib/src/components/TreeSelect/TreeSelect.tsx
+++ b/packages/lib/src/components/TreeSelect/TreeSelect.tsx
@@ -50,17 +50,17 @@ export const TreeSelect: React.FC<TreeSelectProps> = ({
           // remove children nodes if parent exists in state
           (accum, value) => {
             const { target } = findNode({ value, tData });
-            if (target.children) {
+            if (target?.children) {
+              const { children } = target;
               return accum.filter(
-                // @ts-expect-error: FIXME. This comment was added by an automated script.
-                (v) => !target.children.find((child) => child.value === v),
+                (v) => !children.find((child) => child.value === v),
               );
             }
             return accum;
           },
           [...filteredState],
         )
-        .map((value) => findNode({ value, tData }).target.title)
+        .map((value) => findNode({ value, tData }).target?.title ?? value)
         .join(", ");
 
   useEffect(() => {
@@ -102,11 +102,10 @@ const renderCheckboxes = ({
 }: {
   tData: TreeDataEntry[];
   state: string[];
-  onChange: (v: [string]) => void;
+  onChange: (v: string[]) => void;
 }): React.JSX.Element[] => {
   const rows: React.JSX.Element[] = [];
   tData.forEach((entry) => {
-    // @ts-expect-error: FIXME. This comment was added by an automated script.
     renderCheckboxesHelper({ rows, data: entry, onChange, state, tData });
   });
   return rows;
@@ -175,21 +174,20 @@ const handleOnChange = ({
 }): void => {
   const isAlreadyChecked = state.includes(value); // is checkbox already selected
   const { parent, siblings, target } = findNode({ value, tData });
-  const isParent = target.children;
-  const isAll = target.value === ALL_VALUE; // is all button clicked
   if (!target) {
     onChange([...state]);
+    return;
   }
   // is all button checked
+  const isAll = target.value === ALL_VALUE;
   if (isAll) {
     if (isAlreadyChecked) {
       onChange([]);
     } else {
       onChange(getAllValues(tData));
     }
-  } else if (isParent) {
+  } else if (target.children) {
     // has list of children
-    // @ts-expect-error: FIXME. This comment was added by an automated script.
     const childrenValues = target.children.map((child) => child.value);
     if (isAlreadyChecked) {
       onChange(
@@ -257,8 +255,8 @@ const adjustAll = ({
 };
 
 interface FindNodeResult {
-  target: TreeDataEntry;
-  parent: TreeDataEntry;
+  target: TreeDataEntry | null;
+  parent: TreeDataEntry | null;
   siblings: TreeDataEntry[] | TreeDataChildEntry[];
 }
 
@@ -273,7 +271,6 @@ const findNode = ({
     if (curr.value === value) {
       return {
         target: curr,
-        // @ts-expect-error: FIXME. This comment was added by an automated script.
         parent: null,
         siblings: tData.filter((v) => v.value !== value),
       };
@@ -290,9 +287,7 @@ const findNode = ({
     }
   }
   return {
-    // @ts-expect-error: FIXME. This comment was added by an automated script.
     target: null,
-    // @ts-expect-error: FIXME. This comment was added by an automated script.
     parent: null,
     siblings: [],
   };
@@ -300,11 +295,10 @@ const findNode = ({
 
 // returns all values in tData from parents and children
 const getAllValues = (tData: TreeDataEntry[]): string[] =>
-  tData.reduce((accum, currNode) => {
+  tData.reduce<string[]>((accum, currNode) => {
     const childrenValues = currNode.children
       ? currNode.children.map((child) => child.value)
       : [];
-    // @ts-expect-error: FIXME. This comment was added by an automated script.
     return accum.concat([currNode.value]).concat(childrenValues);
   }, []);
 

--- a/packages/lib/src/components/TreeSelect/TreeSelect.tsx
+++ b/packages/lib/src/components/TreeSelect/TreeSelect.tsx
@@ -10,6 +10,8 @@ const { gray } = palette;
 export const ALL_VALUE = "all";
 const ALL_COPY = "All";
 export interface TreeSelectProps {
+  "data-cy"?: string;
+  "data-testid"?: string;
   isVisible?: boolean;
   onChange: (s: string[]) => void;
   setOptionsLabel?: (v: string) => void;
@@ -17,7 +19,6 @@ export interface TreeSelectProps {
   tData: TreeDataEntry[];
   onReset?: () => void;
   onFilter?: () => void;
-  "data-cy"?: string;
 }
 export interface TreeDataChildEntry {
   title: string;
@@ -30,6 +31,7 @@ export interface TreeDataEntry extends TreeDataChildEntry {
 
 export const TreeSelect: React.FC<TreeSelectProps> = ({
   "data-cy": dataCy,
+  "data-testid": dataTestId,
   isVisible = true,
   onChange,
   onFilter,
@@ -70,7 +72,10 @@ export const TreeSelect: React.FC<TreeSelectProps> = ({
   }
 
   return (
-    <CheckboxContainer data-cy={dataCy || "tree-select-options"}>
+    <CheckboxContainer
+      data-cy={dataCy || "tree-select-options"}
+      data-testid={dataTestId || "tree-select-options"}
+    >
       {renderCheckboxes({
         state: filteredState,
         tData,
@@ -128,7 +133,6 @@ const renderCheckboxesHelper = ({
       <Checkbox
         bold={false}
         checked={state.includes(data.value)}
-        className="cy-checkbox"
         label={data.title}
         onChange={onChangeFn}
       />
@@ -148,7 +152,6 @@ const renderCheckboxesHelper = ({
           <Checkbox
             bold={false}
             checked={state.includes(child.value)}
-            className="cy-checkbox"
             label={child.title}
             onChange={onChangeChildFn}
           />

--- a/packages/lib/src/context/toast/toast.test.tsx
+++ b/packages/lib/src/context/toast/toast.test.tsx
@@ -46,7 +46,7 @@ describe("toast", () => {
   it("should not display a toast by default", () => {
     const { Component } = renderComponentWithHook(useToastContext, <div />);
     render(<Component />, { wrapper });
-    expect(screen.queryByDataCy(toastDataTestId)).toBeNull();
+    expect(screen.queryByDataTestId(toastDataTestId)).toBeNull();
   });
 
   it("should be able to set a custom title for a toast", async () => {
@@ -77,7 +77,7 @@ describe("toast", () => {
       act(() => {
         hook.current.success("test string");
       });
-      expect(screen.getByDataCy(toastDataTestId)).toBeInTheDocument();
+      expect(screen.getByDataTestId(toastDataTestId)).toBeInTheDocument();
       expect(screen.getByText("Success!")).toBeInTheDocument();
       expect(screen.getByText("test string")).toBeInTheDocument();
     });
@@ -93,7 +93,7 @@ describe("toast", () => {
       act(() => {
         hook.current.error("test string");
       });
-      expect(screen.getByDataCy(toastDataTestId)).toBeInTheDocument();
+      expect(screen.getByDataTestId(toastDataTestId)).toBeInTheDocument();
       expect(screen.getByText("Error!")).toBeInTheDocument();
       expect(screen.getByText("test string")).toBeInTheDocument();
     });
@@ -109,7 +109,7 @@ describe("toast", () => {
       act(() => {
         hook.current.warning("test string");
       });
-      expect(screen.getByDataCy(toastDataTestId)).toBeInTheDocument();
+      expect(screen.getByDataTestId(toastDataTestId)).toBeInTheDocument();
       expect(screen.getByText("Warning!")).toBeInTheDocument();
       expect(screen.getByText("test string")).toBeInTheDocument();
     });
@@ -125,7 +125,7 @@ describe("toast", () => {
       act(() => {
         hook.current.info("test string");
       });
-      expect(screen.getByDataCy(toastDataTestId)).toBeInTheDocument();
+      expect(screen.getByDataTestId(toastDataTestId)).toBeInTheDocument();
       expect(screen.getByText("Something Happened!")).toBeInTheDocument();
       expect(screen.getByText("test string")).toBeInTheDocument();
     });
@@ -141,7 +141,7 @@ describe("toast", () => {
       act(() => {
         hook.current.progress("test string", 0.8);
       });
-      expect(screen.getByDataCy(toastDataTestId)).toBeInTheDocument();
+      expect(screen.getByDataTestId(toastDataTestId)).toBeInTheDocument();
       expect(screen.getByText("Loading...")).toBeInTheDocument();
       expect(screen.getByText("test string")).toBeInTheDocument();
 
@@ -164,10 +164,12 @@ describe("toast", () => {
         hook.current.info("test string");
       });
 
-      expect(screen.getByDataCy(toastDataTestId)).toBeInTheDocument();
+      expect(screen.getByDataTestId(toastDataTestId)).toBeInTheDocument();
       await user.click(screen.getByLabelText(closeIconLabel));
       await waitFor(() => {
-        expect(screen.queryByDataCy(toastDataTestId)).not.toBeInTheDocument();
+        expect(
+          screen.queryByDataTestId(toastDataTestId),
+        ).not.toBeInTheDocument();
       });
     });
 
@@ -182,7 +184,7 @@ describe("toast", () => {
       act(() => {
         hook.current.info("test string", false);
       });
-      expect(screen.getByDataCy(toastDataTestId)).toBeInTheDocument();
+      expect(screen.getByDataTestId(toastDataTestId)).toBeInTheDocument();
       expect(screen.queryByLabelText(closeIconLabel)).toBeNull();
     });
 
@@ -200,10 +202,12 @@ describe("toast", () => {
         hook.current.info("test string", true, { onClose });
       });
 
-      expect(screen.getByDataCy(toastDataTestId)).toBeInTheDocument();
+      expect(screen.getByDataTestId(toastDataTestId)).toBeInTheDocument();
       await user.click(screen.getByLabelText(closeIconLabel));
       await waitFor(() => {
-        expect(screen.queryByDataCy(toastDataTestId)).not.toBeInTheDocument();
+        expect(
+          screen.queryByDataTestId(toastDataTestId),
+        ).not.toBeInTheDocument();
       });
       expect(onClose).toHaveBeenCalledTimes(1);
     });
@@ -219,14 +223,16 @@ describe("toast", () => {
       act(() => {
         hook.current.info("test string");
       });
-      expect(screen.getByDataCy(toastDataTestId)).toBeInTheDocument();
+      expect(screen.getByDataTestId(toastDataTestId)).toBeInTheDocument();
 
       // Advance timer so that the timeout is triggered.
       act(() => {
         vi.advanceTimersByTime(TOAST_TIMEOUT);
       });
       await waitFor(() => {
-        expect(screen.queryByDataCy(toastDataTestId)).not.toBeInTheDocument();
+        expect(
+          screen.queryByDataTestId(toastDataTestId),
+        ).not.toBeInTheDocument();
       });
     });
   });

--- a/packages/lib/src/hooks/useKeyboardShortcut/useKeyboardShortcut.test.tsx
+++ b/packages/lib/src/hooks/useKeyboardShortcut/useKeyboardShortcut.test.tsx
@@ -32,13 +32,13 @@ describe("useKeyboardShortcut", () => {
           callback,
         ),
       );
-      render(<input data-cy="test-input" />);
+      render(<input data-testid="test-input" />);
 
-      await user.click(screen.getByDataCy("test-input"));
-      expect(screen.getByDataCy("test-input")).toHaveFocus();
+      await user.click(screen.getByDataTestId("test-input"));
+      expect(screen.getByDataTestId("test-input")).toHaveFocus();
       await user.keyboard("{Control>}{a}{/Control}");
       expect(callback).toHaveBeenCalledTimes(0);
-      expect(screen.getByDataCy("test-input")).toHaveValue("");
+      expect(screen.getByDataTestId("test-input")).toHaveValue("");
     });
   });
 
@@ -59,13 +59,13 @@ describe("useKeyboardShortcut", () => {
       const user = userEvent.setup();
       const callback = vi.fn();
       renderHook(() => useKeyboardShortcut({ charKey: CharKey.A }, callback));
-      render(<input data-cy="test-input" />);
+      render(<input data-testid="test-input" />);
 
-      await user.click(screen.getByDataCy("test-input"));
-      expect(screen.getByDataCy("test-input")).toHaveFocus();
+      await user.click(screen.getByDataTestId("test-input"));
+      expect(screen.getByDataTestId("test-input")).toHaveFocus();
       await user.keyboard("{a}");
       expect(callback).toHaveBeenCalledTimes(0);
-      expect(screen.getByDataCy("test-input")).toHaveValue("a");
+      expect(screen.getByDataTestId("test-input")).toHaveValue("a");
     });
   });
 
@@ -81,9 +81,9 @@ describe("useKeyboardShortcut", () => {
         },
       ),
     );
-    render(<input data-cy="test-input" />);
-    await user.click(screen.getByDataCy("test-input"));
-    expect(screen.getByDataCy("test-input")).toHaveFocus();
+    render(<input data-testid="test-input" />);
+    await user.click(screen.getByDataTestId("test-input"));
+    expect(screen.getByDataTestId("test-input")).toHaveFocus();
     await user.keyboard("{Control>}{a}{/Control}");
     expect(callback).toHaveBeenCalledTimes(1);
   });

--- a/packages/lib/src/hooks/usePagination/usePagination.test.tsx
+++ b/packages/lib/src/hooks/usePagination/usePagination.test.tsx
@@ -5,8 +5,9 @@ import { getDefaultPageSize } from "../../utils/pagination";
 import usePagination from "./index";
 
 describe("usePagination", () => {
-  // @ts-expect-error: FIXME. This comment was added by an automated script.
-  const wrapper = ({ children }) => <MemoryRouter>{children}</MemoryRouter>;
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <MemoryRouter>{children}</MemoryRouter>
+  );
 
   beforeEach(() => {
     // Mock localStorage

--- a/packages/lib/src/pages/LoginPage/LoginPage.test.tsx
+++ b/packages/lib/src/pages/LoginPage/LoginPage.test.tsx
@@ -52,13 +52,13 @@ describe("LoginPage", () => {
         <Routes>
           <Route element={<LoginPage />} path="/login" />
           <Route
-            element={<div data-cy="waterfall">Waterfall</div>}
+            element={<div data-testid="waterfall">Waterfall</div>}
             path="/waterfall"
           />
         </Routes>
       </MemoryRouter>,
     );
 
-    expect(screen.getByDataCy("waterfall")).toBeInTheDocument();
+    expect(screen.getByDataTestId("waterfall")).toBeInTheDocument();
   });
 });

--- a/packages/lib/src/utils/sentry/index.ts
+++ b/packages/lib/src/utils/sentry/index.ts
@@ -35,6 +35,9 @@ const initializeSentry = ({
           if (target?.dataset?.cy) {
             breadcrumb.message = `${target.tagName.toLowerCase()}[data-cy="${target.dataset.cy}"]`;
           }
+          if (target?.dataset?.testid) {
+            breadcrumb.message = `${target.tagName.toLowerCase()}[data-testid="${target.dataset.testid}"]`;
+          }
           breadcrumb.data = processHtmlAttributes(target);
         }
         return breadcrumb;

--- a/packages/lib/src/utils/sentry/utils.test.ts
+++ b/packages/lib/src/utils/sentry/utils.test.ts
@@ -6,22 +6,22 @@ describe("processHtmlAttributes", () => {
     const htmlElement = document.createElement("input");
     htmlElement.setAttribute("aria-label", "custom-aria-label");
     htmlElement.setAttribute("title", "custom-title");
-    htmlElement.setAttribute("data-cy", "custom-data-cy");
+    htmlElement.setAttribute("data-testid", "custom-data-testid");
     htmlElement.setAttribute("data-loading", "false");
 
     const htmlAttributes = processHtmlAttributes(htmlElement);
     expect(htmlAttributes.ariaLabel).toBe("custom-aria-label");
-    expect(htmlAttributes?.dataset?.cy).toBe("custom-data-cy");
+    expect(htmlAttributes?.dataset?.testid).toBe("custom-data-testid");
     expect(htmlAttributes?.dataset?.loading).toBe("false");
     expect(htmlAttributes.title).toBe("custom-title");
   });
 
   it("omits attributes that are unset", () => {
     const htmlElement = document.createElement("div");
-    htmlElement.setAttribute("data-cy", "custom-data-cy");
+    htmlElement.setAttribute("data-testid", "custom-data-testid");
 
     const htmlAttributes = processHtmlAttributes(htmlElement);
-    expect(htmlAttributes?.dataset?.cy).toBe("custom-data-cy");
+    expect(htmlAttributes?.dataset?.testid).toBe("custom-data-testid");
     expect(htmlAttributes.ariaLabel).toBeUndefined();
     expect(htmlAttributes.title).toBeUndefined();
   });


### PR DESCRIPTION
DEVPROD-31461

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->

<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
Facilitates `data-cy` -> `data-testid` migration for Spruce by supporting both attributes in `lib` temporarily
