### PR TITLE
DEVPROD-37527 accept regex for Single Task Distro projects

### DIFF
--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -3043,12 +3043,14 @@ export type ProjectTasksPair = {
   allowedBVs: Array<Scalars["String"]["output"]>;
   allowedTasks: Array<Scalars["String"]["output"]>;
   displayName: Scalars["String"]["output"];
+  isRegex: Scalars["Boolean"]["output"];
   projectId: Scalars["String"]["output"];
 };
 
 export type ProjectTasksPairInput = {
   allowedBVs: Array<Scalars["String"]["input"]>;
   allowedTasks: Array<Scalars["String"]["input"]>;
+  isRegex: Scalars["Boolean"]["input"];
   projectID: Scalars["String"]["input"];
 };
 
@@ -7940,6 +7942,7 @@ export type AdminSettingsQuery = {
         __typename?: "ProjectTasksPair";
         allowedBVs: Array<string>;
         allowedTasks: Array<string>;
+        isRegex: boolean;
         projectId: string;
       }>;
     } | null;
@@ -10783,6 +10786,7 @@ export type SingleTaskDistroQuery = {
         allowedBVs: Array<string>;
         allowedTasks: Array<string>;
         displayName: string;
+        isRegex: boolean;
         projectId: string;
       }>;
     } | null;

--- a/apps/spruce/src/gql/queries/admin-settings.ts
+++ b/apps/spruce/src/gql/queries/admin-settings.ts
@@ -351,6 +351,7 @@ export const ADMIN_SETTINGS = gql`
         projectTasksPairs {
           allowedBVs
           allowedTasks
+          isRegex
           projectId
         }
       }

--- a/apps/spruce/src/gql/queries/single-task-distro.ts
+++ b/apps/spruce/src/gql/queries/single-task-distro.ts
@@ -8,6 +8,7 @@ export const SINGLE_TASK_DISTRO = gql`
           allowedBVs
           allowedTasks
           displayName
+          isRegex
           projectId
         }
       }

--- a/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/OtherTab/OtherTab.tsx
+++ b/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/OtherTab/OtherTab.tsx
@@ -1,12 +1,6 @@
 import { useMemo } from "react";
-import { useQuery } from "@apollo/client/react";
 import { H2 } from "@leafygreen-ui/typography";
 import { AdminSettingsGeneralSection } from "constants/routes";
-import {
-  ViewableProjectRefsQuery,
-  ViewableProjectRefsQueryVariables,
-} from "gql/generated/types";
-import { VIEWABLE_PROJECTS } from "gql/queries";
 import { BaseTab } from "../../BaseTab";
 import { getFormSchema } from "./getFormSchema";
 import { TabProps } from "./types";
@@ -14,34 +8,7 @@ import { TabProps } from "./types";
 export const OtherTab: React.FC<TabProps> = ({ otherData }) => {
   const initialFormState = otherData;
 
-  const { data: viewableProjectsData } = useQuery<
-    ViewableProjectRefsQuery,
-    ViewableProjectRefsQueryVariables
-  >(VIEWABLE_PROJECTS);
-
-  const formSchema = useMemo(() => {
-    const projects =
-      viewableProjectsData?.viewableProjectRefs
-        ?.flatMap((group) => group.projects)
-        ?.map((p) => ({
-          id: p.id,
-          displayName: `${p.displayName || p.identifier || p.id}${p.enabled ? " (Project)" : " (Disabled Project)"}`,
-        }))
-        ?.sort((a, b) => a.displayName.localeCompare(b.displayName)) ?? [];
-
-    const repos =
-      viewableProjectsData?.viewableProjectRefs
-        ?.filter((group) => group.repo != null)
-        ?.map((group) => ({
-          id: group.repo!.id,
-          displayName: `${group.groupDisplayName || group.repo!.id} (Repository)`,
-        }))
-        ?.sort((a, b) => a.displayName.localeCompare(b.displayName)) ?? [];
-    return getFormSchema({
-      projectRefs: projects,
-      repoRefs: repos,
-    });
-  }, [viewableProjectsData]);
+  const formSchema = useMemo(() => getFormSchema(), []);
   return (
     <>
       <H2>Other</H2>

--- a/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/OtherTab/getFormSchema.ts
+++ b/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/OtherTab/getFormSchema.ts
@@ -17,14 +17,8 @@ import {
   tracerConfiguration,
 } from "./schemaFields";
 
-export const getFormSchema = ({
-  projectRefs = [],
-  repoRefs = [],
-}: {
-  projectRefs?: Array<{ id: string; displayName: string }>;
-  repoRefs?: Array<{ id: string; displayName: string }>;
-}): ReturnType<GetFormSchema> => {
-  const singleTaskDistro = getSingleTaskDistroSchema({ projectRefs, repoRefs });
+export const getFormSchema = (): ReturnType<GetFormSchema> => {
+  const singleTaskDistro = getSingleTaskDistroSchema();
   return {
     fields: {},
     schema: {

--- a/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/OtherTab/schemaFields.ts
+++ b/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/OtherTab/schemaFields.ts
@@ -278,84 +278,74 @@ export const miscSettings = {
   },
 };
 
-export const getSingleTaskDistroSchema = ({
-  projectRefs = [],
-  repoRefs = [],
-}: {
-  projectRefs?: Array<{ id: string; displayName: string }>;
-  repoRefs?: Array<{ id: string; displayName: string }>;
-}) => {
-  const projectRepoOptions = [
-    ...projectRefs.map((p) => ({
-      type: "string" as const,
-      title: p.displayName,
-      enum: [p.id],
-    })),
-    ...repoRefs.map((r) => ({
-      type: "string" as const,
-      title: r.displayName,
-      enum: [r.id],
-    })),
-  ];
-
-  return {
-    schema: {
-      projectTasksPairs: {
-        type: "array" as const,
-        title: "Project Tasks Pairs",
-        items: {
-          type: "object" as const,
-          properties: {
-            projectId: {
-              type: "string" as const,
-              title: "Project ID / Repo ID",
-              oneOf: projectRepoOptions,
-              default: "",
-            },
-            allowedTasks: {
-              type: "array" as const,
-              title: "Allowed Tasks",
-              items: {
-                type: "string" as const,
-              },
-            },
-            allowedBVs: {
-              type: "array" as const,
-              title: "Allowed Build Variants",
-              items: {
-                type: "string" as const,
-              },
-            },
-          },
-        },
-      },
-    },
-    uiSchema: {
-      "ui:ObjectFieldTemplate": CardFieldTemplate,
-      "ui:data-cy": "single-task-host",
-      "ui:objectFieldCss": objectGridCss,
-      projectTasksPairs: {
-        "ui:addButtonText": "Add project tasks pair",
-        "ui:data-cy": "project-tasks-pairs-list",
-        "ui:orderable": false,
-        "ui:fullWidth": true,
-        "ui:fieldCss": fullWidthCss,
-        "ui:arrayItemCSS": arrayItemCSS,
-        items: {
+export const getSingleTaskDistroSchema = () => ({
+  schema: {
+    projectTasksPairs: {
+      type: "array" as const,
+      title: "Project Tasks Pairs",
+      items: {
+        type: "object" as const,
+        properties: {
           projectId: {
-            "ui:widget": widgets.ComboboxWidget,
+            type: "string" as const,
+            title: "Project",
+            default: "",
+          },
+          isRegex: {
+            type: "boolean" as const,
+            title: "Treat as regular expression",
+            default: false,
           },
           allowedTasks: {
-            "ui:widget": widgets.ChipInputWidget,
+            type: "array" as const,
+            title: "Allowed Tasks",
+            items: {
+              type: "string" as const,
+            },
           },
           allowedBVs: {
-            "ui:widget": widgets.ChipInputWidget,
+            type: "array" as const,
+            title: "Allowed Build Variants",
+            items: {
+              type: "string" as const,
+            },
           },
         },
       },
     },
-  };
-};
+  },
+  uiSchema: {
+    "ui:ObjectFieldTemplate": CardFieldTemplate,
+    "ui:data-cy": "single-task-host",
+    "ui:objectFieldCss": objectGridCss,
+    projectTasksPairs: {
+      "ui:addButtonText": "Add project tasks pair",
+      "ui:data-cy": "project-tasks-pairs-list",
+      "ui:orderable": false,
+      "ui:fullWidth": true,
+      "ui:fieldCss": fullWidthCss,
+      "ui:arrayItemCSS": arrayItemCSS,
+      items: {
+        "ui:order": ["projectId", "allowedTasks", "isRegex", "allowedBVs"],
+        projectId: {
+          "ui:description":
+            "An exact project ID or identifier. Enable 'Treat as regular expression' to match project identifiers by pattern instead.",
+          "ui:data-cy": "project-id-input",
+        },
+        isRegex: {
+          "ui:widget": widgets.CheckboxWidget,
+          "ui:data-cy": "project-is-regex",
+        },
+        allowedTasks: {
+          "ui:widget": widgets.ChipInputWidget,
+        },
+        allowedBVs: {
+          "ui:widget": widgets.ChipInputWidget,
+        },
+      },
+    },
+  },
+});
 
 export const bucketConfig = {
   schema: {

--- a/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/OtherTab/transformers.test.ts
+++ b/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/OtherTab/transformers.test.ts
@@ -108,6 +108,7 @@ const mockAdminSettings: AdminSettingsData = {
     projectTasksPairs: [
       {
         projectId: "test-project",
+        isRegex: true,
         allowedTasks: ["compile", "test"],
         allowedBVs: ["ubuntu", "windows"],
       },
@@ -248,6 +249,7 @@ const expectedForm: OtherFormState = {
       projectTasksPairs: [
         {
           projectId: "test-project",
+          isRegex: true,
           allowedTasks: ["compile", "test"],
           allowedBVs: ["ubuntu", "windows"],
         },
@@ -389,6 +391,7 @@ const expectedGql: AdminSettingsInput = {
     projectTasksPairs: [
       {
         projectID: "test-project",
+        isRegex: true,
         allowedTasks: ["compile", "test"],
         allowedBVs: ["ubuntu", "windows"],
       },

--- a/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/OtherTab/transformers.ts
+++ b/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/OtherTab/transformers.ts
@@ -106,6 +106,7 @@ export const gqlToForm = ((data) => {
         projectTasksPairs:
           singleTaskDistro?.projectTasksPairs?.map((pair) => ({
             projectId: pair.projectId ?? "",
+            isRegex: pair.isRegex ?? false,
             allowedTasks: pair.allowedTasks ?? [],
             allowedBVs: pair.allowedBVs ?? [],
           })) ?? [],
@@ -353,6 +354,7 @@ export const formToGql = ((form: OtherFormState) => {
         .filter((pair) => pair.projectId)
         .map((pair) => ({
           projectID: pair.projectId,
+          isRegex: pair.isRegex ?? false,
           allowedTasks: pair.allowedTasks || [],
           allowedBVs: pair.allowedBVs || [],
         })),

--- a/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/OtherTab/types.ts
+++ b/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/OtherTab/types.ts
@@ -44,6 +44,7 @@ export interface OtherFormState {
     singleTaskDistro: {
       projectTasksPairs: Array<{
         projectId: string;
+        isRegex: boolean;
         allowedTasks: string[];
         allowedBVs: string[];
       }>;

--- a/apps/spruce/src/pages/distroSettings/tabs/SingleTaskDistroTab/getFormSchema.ts
+++ b/apps/spruce/src/pages/distroSettings/tabs/SingleTaskDistroTab/getFormSchema.ts
@@ -1,4 +1,5 @@
 import { GetFormSchema } from "components/SpruceForm";
+import widgets from "components/SpruceForm/Widgets";
 
 export const getFormSchema = (): ReturnType<GetFormSchema> => ({
   fields: {},
@@ -13,7 +14,11 @@ export const getFormSchema = (): ReturnType<GetFormSchema> => ({
           properties: {
             projectId: {
               type: "string" as const,
-              title: "Project ID / Repo ID",
+              title: "Project ID / Identifier / Repo ID",
+            },
+            isRegex: {
+              type: "boolean" as const,
+              title: "Regex",
             },
             allowedTasks: {
               type: "array" as const,
@@ -44,6 +49,11 @@ export const getFormSchema = (): ReturnType<GetFormSchema> => ({
       "ui:description":
         "This list is shared between all single task distros. Only Evergreen admins can add/edit/delete allowed tasks and build variants. Please file a DEVPROD ticket to request any changes to this list.",
       items: {
+        isRegex: {
+          "ui:widget": widgets.CheckboxWidget,
+          "ui:description":
+            "When enabled, the project value is a regular expression matched against project identifiers.",
+        },
         allowedTasks: {
           "ui:orderable": false,
           "ui:placeholder": "No tasks.",

--- a/apps/spruce/src/pages/distroSettings/tabs/SingleTaskDistroTab/transformers.test.ts
+++ b/apps/spruce/src/pages/distroSettings/tabs/SingleTaskDistroTab/transformers.test.ts
@@ -6,15 +6,17 @@ const singleTaskDistroData = {
       projectTasksPairs: [
         {
           projectId: "spruce",
+          isRegex: false,
           allowedTasks: ["storybook", "lint"],
           allowedBVs: ["ubuntu1604"],
           displayName: "spruce (Repo)",
         },
         {
-          projectId: "evergreen",
+          projectId: "mongodb-mongo-v.*",
+          isRegex: true,
           allowedTasks: ["test", "compile"],
           allowedBVs: ["windows", "ubuntu1604"],
-          displayName: "evergreen (Project)",
+          displayName: "mongodb-mongo-v.*",
         },
       ],
     },
@@ -26,14 +28,16 @@ describe("single task distro data", () => {
     expect(gqlToForm(singleTaskDistroData)).toStrictEqual({
       projectTasksPairs: [
         {
-          displayTitle: "evergreen (Project)",
-          projectId: "evergreen",
+          displayTitle: "mongodb-mongo-v.*",
+          projectId: "mongodb-mongo-v.*",
+          isRegex: true,
           allowedTasks: ["compile", "test"],
           allowedBVs: ["ubuntu1604", "windows"],
         },
         {
           displayTitle: "spruce (Repo)",
           projectId: "spruce",
+          isRegex: false,
           allowedTasks: ["lint", "storybook"],
           allowedBVs: ["ubuntu1604"],
         },

--- a/apps/spruce/src/pages/distroSettings/tabs/SingleTaskDistroTab/transformers.ts
+++ b/apps/spruce/src/pages/distroSettings/tabs/SingleTaskDistroTab/transformers.ts
@@ -4,9 +4,10 @@ export const gqlToForm = (data?: SingleTaskDistroQuery) => {
   const sortedProjectTasksPairs = (
     data?.spruceConfig?.singleTaskDistro?.projectTasksPairs || []
   )
-    .map(({ allowedBVs, allowedTasks, displayName, projectId }) => ({
+    .map(({ allowedBVs, allowedTasks, displayName, isRegex, projectId }) => ({
       displayTitle: displayName,
       projectId,
+      isRegex,
       allowedTasks: [...allowedTasks].sort(),
       allowedBVs: [...allowedBVs].sort(),
     }))

--- a/apps/spruce/src/pages/distroSettings/tabs/SingleTaskDistroTab/types.ts
+++ b/apps/spruce/src/pages/distroSettings/tabs/SingleTaskDistroTab/types.ts
@@ -2,6 +2,7 @@ export interface SingleTaskDistroFormState {
   projectTasksPairs: Array<{
     displayTitle: string;
     projectId: string;
+    isRegex: boolean;
     allowedBVs: Array<string>;
     allowedTasks: Array<string>;
   }>;


### PR DESCRIPTION
DEVPROD-37527

<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
Replace the Combobox project selector in the admin Single Task Distro configuration with a free-text field that accepts a project ID, project identifier, or a regular expression matching project IDs/identifiers.

### Screenshots
<img width="691" height="341" alt="image" src="https://github.com/user-attachments/assets/d95868dd-9fd9-4144-a413-b27bf4d2688a" />

And from the distro page:
<img width="806" height="458" alt="image" src="https://github.com/user-attachments/assets/c1d79a1d-c75c-4ed3-bd55-3a5948f75630" />

### Testing
Verified via manual testing and unit tests in the backend PR.

### Evergreen PR
https://github.com/evergreen-ci/evergreen/pull/10562