### PR TITLE
DEVPROD-32801: Delete unused EC2Keys field

### DIFF
--- a/apps/parsley/src/gql/generated/types.ts
+++ b/apps/parsley/src/gql/generated/types.ts
@@ -3106,6 +3106,13 @@ export type QuarantineVariantInput = {
   projectIdentifier: Scalars["String"]["input"];
 };
 
+/** QuarantinedTest represents a test skipped because it was quarantined in TSS at execution time. */
+export type QuarantinedTest = {
+  __typename?: "QuarantinedTest";
+  displayTestName?: Maybe<Scalars["String"]["output"]>;
+  testName: Scalars["String"]["output"];
+};
+
 export type Query = {
   __typename?: "Query";
   adminEvents: AdminEventsPayload;
@@ -4138,6 +4145,8 @@ export type Task = {
   prevTaskPassing?: Maybe<Task>;
   priority?: Maybe<Scalars["Int"]["output"]>;
   project?: Maybe<Project>;
+  /** quarantinedTestsSkippedCount is the number of tests this execution skipped because they were quarantined in TSS at execution time. */
+  quarantinedTestsSkippedCount: Scalars["Int"]["output"];
   requester: Scalars["String"]["output"];
   resetWhenFinished: Scalars["Boolean"]["output"];
   revision?: Maybe<Scalars["String"]["output"]>;
@@ -4406,6 +4415,18 @@ export type TaskQuarantineEntry = {
   __typename?: "TaskQuarantineEntry";
   taskName: Scalars["String"]["output"];
   tests: Array<TestQuarantineEntry>;
+};
+
+/**
+ * TaskQuarantinedTestsSample is the return value for Version.taskQuarantinedTestsSample.
+ * It contains the execution-time snapshot of tests skipped because they were quarantined in TSS.
+ */
+export type TaskQuarantinedTestsSample = {
+  __typename?: "TaskQuarantinedTestsSample";
+  execution: Scalars["Int"]["output"];
+  quarantinedTests: Array<QuarantinedTest>;
+  quarantinedTestsSkippedCount: Scalars["Int"]["output"];
+  taskId: Scalars["String"]["output"];
 };
 
 /**
@@ -4900,6 +4921,8 @@ export type Version = {
   startTime?: Maybe<Scalars["Time"]["output"]>;
   status: Scalars["String"]["output"];
   taskCount?: Maybe<Scalars["Int"]["output"]>;
+  /** Returns up to limit (default 50) TSS-quarantined tests per task; quarantinedTestsSkippedCount is authoritative because stored samples may be truncated. */
+  taskQuarantinedTestsSample?: Maybe<Array<TaskQuarantinedTestsSample>>;
   taskStatusStats?: Maybe<TaskStats>;
   taskStatuses: Array<Scalars["String"]["output"]>;
   tasks: VersionTasks;
@@ -4924,6 +4947,12 @@ export type VersionBuildVariantsArgs = {
 /** Version models a commit within a project. */
 export type VersionTaskCountArgs = {
   options?: InputMaybe<TaskCountOptions>;
+};
+
+/** Version models a commit within a project. */
+export type VersionTaskQuarantinedTestsSampleArgs = {
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  taskIds: Array<Scalars["String"]["input"]>;
 };
 
 /** Version models a commit within a project. */

--- a/apps/parsley/src/gql/generated/types.ts
+++ b/apps/parsley/src/gql/generated/types.ts
@@ -66,7 +66,6 @@ export type AwsConfig = {
   allowedInstanceTypes: Array<Scalars["String"]["output"]>;
   allowedRegions: Array<Scalars["String"]["output"]>;
   defaultSecurityGroup?: Maybe<Scalars["String"]["output"]>;
-  ec2Keys: Array<Ec2Key>;
   elasticIPUsageRate?: Maybe<Scalars["Float"]["output"]>;
   ipamPoolID?: Maybe<Scalars["String"]["output"]>;
   maxVolumeSizePerUser?: Maybe<Scalars["Int"]["output"]>;
@@ -81,7 +80,6 @@ export type AwsConfigInput = {
   allowedInstanceTypes: Array<Scalars["String"]["input"]>;
   allowedRegions: Array<Scalars["String"]["input"]>;
   defaultSecurityGroup?: InputMaybe<Scalars["String"]["input"]>;
-  ec2Keys: Array<Ec2KeyInput>;
   elasticIPUsageRate?: InputMaybe<Scalars["Float"]["input"]>;
   ipamPoolID?: InputMaybe<Scalars["String"]["input"]>;
   maxVolumeSizePerUser?: InputMaybe<Scalars["Int"]["input"]>;
@@ -989,12 +987,6 @@ export type Ec2Key = {
   key: Scalars["String"]["output"];
   name: Scalars["String"]["output"];
   secret: Scalars["String"]["output"];
-};
-
-export type Ec2KeyInput = {
-  key: Scalars["String"]["input"];
-  name: Scalars["String"]["input"];
-  secret: Scalars["String"]["input"];
 };
 
 /**

--- a/apps/spruce/playwright/tests/adminSettings/save_function.spec.ts
+++ b/apps/spruce/playwright/tests/adminSettings/save_function.spec.ts
@@ -307,45 +307,6 @@ test.describe("admin settings save properly", () => {
       );
     });
 
-    test("saves AWS EC2 Keys parameter store values independently", async ({
-      page,
-    }) => {
-      await expect(page.getByTestId("save-settings-button")).toBeDisabled();
-
-      const awsConfiguration = page.getByTestId("aws-configuration");
-      await awsConfiguration.getByLabel("EC2 Key").clear();
-      await awsConfiguration.getByLabel("EC2 Key").fill("test-ec2-key");
-      await awsConfiguration.getByLabel("EC2 Secret").clear();
-      await awsConfiguration.getByLabel("EC2 Secret").fill("test-ec2-secret");
-
-      await save(page);
-      await validateToast(page, "success", "Settings saved successfully");
-      await page.reload();
-
-      await expect(awsConfiguration.getByLabel("EC2 Key")).toHaveValue(
-        "test-ec2-key",
-      );
-      await expect(awsConfiguration.getByLabel("EC2 Secret")).toHaveValue(
-        "test-ec2-secret",
-      );
-
-      const bannerText = page.getByTestId("banner-text");
-      await bannerText.clear();
-      await bannerText.fill("AWS EC2 param store test");
-
-      await save(page);
-      await validateToast(page, "success", "Settings saved successfully");
-      await page.reload();
-
-      await expect(bannerText).toHaveValue("AWS EC2 param store test");
-      await expect(awsConfiguration.getByLabel("EC2 Key")).toHaveValue(
-        "test-ec2-key",
-      );
-      await expect(awsConfiguration.getByLabel("EC2 Secret")).toHaveValue(
-        "test-ec2-secret",
-      );
-    });
-
     test("saves S3 Keys parameter store values independently", async ({
       page,
     }) => {

--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -63,7 +63,6 @@ export type AwsConfig = {
   allowedInstanceTypes: Array<Scalars["String"]["output"]>;
   allowedRegions: Array<Scalars["String"]["output"]>;
   defaultSecurityGroup?: Maybe<Scalars["String"]["output"]>;
-  ec2Keys: Array<Ec2Key>;
   elasticIPUsageRate?: Maybe<Scalars["Float"]["output"]>;
   ipamPoolID?: Maybe<Scalars["String"]["output"]>;
   maxVolumeSizePerUser?: Maybe<Scalars["Int"]["output"]>;
@@ -78,7 +77,6 @@ export type AwsConfigInput = {
   allowedInstanceTypes: Array<Scalars["String"]["input"]>;
   allowedRegions: Array<Scalars["String"]["input"]>;
   defaultSecurityGroup?: InputMaybe<Scalars["String"]["input"]>;
-  ec2Keys: Array<Ec2KeyInput>;
   elasticIPUsageRate?: InputMaybe<Scalars["Float"]["input"]>;
   ipamPoolID?: InputMaybe<Scalars["String"]["input"]>;
   maxVolumeSizePerUser?: InputMaybe<Scalars["Int"]["input"]>;
@@ -986,12 +984,6 @@ export type Ec2Key = {
   key: Scalars["String"]["output"];
   name: Scalars["String"]["output"];
   secret: Scalars["String"]["output"];
-};
-
-export type Ec2KeyInput = {
-  key: Scalars["String"]["input"];
-  name: Scalars["String"]["input"];
-  secret: Scalars["String"]["input"];
 };
 
 /**
@@ -7852,12 +7844,6 @@ export type AdminSettingsQuery = {
           __typename?: "AWSAccountRoleMapping";
           account: string;
           role: string;
-        }>;
-        ec2Keys: Array<{
-          __typename?: "EC2Key";
-          key: string;
-          name: string;
-          secret: string;
         }>;
         parserProject?: {
           __typename?: "ParserProjectS3Config";

--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -3103,6 +3103,13 @@ export type QuarantineVariantInput = {
   projectIdentifier: Scalars["String"]["input"];
 };
 
+/** QuarantinedTest represents a test skipped because it was quarantined in TSS at execution time. */
+export type QuarantinedTest = {
+  __typename?: "QuarantinedTest";
+  displayTestName?: Maybe<Scalars["String"]["output"]>;
+  testName: Scalars["String"]["output"];
+};
+
 export type Query = {
   __typename?: "Query";
   adminEvents: AdminEventsPayload;
@@ -4135,6 +4142,8 @@ export type Task = {
   prevTaskPassing?: Maybe<Task>;
   priority?: Maybe<Scalars["Int"]["output"]>;
   project?: Maybe<Project>;
+  /** quarantinedTestsSkippedCount is the number of tests this execution skipped because they were quarantined in TSS at execution time. */
+  quarantinedTestsSkippedCount: Scalars["Int"]["output"];
   requester: Scalars["String"]["output"];
   resetWhenFinished: Scalars["Boolean"]["output"];
   reviewed?: Maybe<Scalars["Boolean"]["output"]>;
@@ -4404,6 +4413,18 @@ export type TaskQuarantineEntry = {
   __typename?: "TaskQuarantineEntry";
   taskName: Scalars["String"]["output"];
   tests: Array<TestQuarantineEntry>;
+};
+
+/**
+ * TaskQuarantinedTestsSample is the return value for Version.taskQuarantinedTestsSample.
+ * It contains the execution-time snapshot of tests skipped because they were quarantined in TSS.
+ */
+export type TaskQuarantinedTestsSample = {
+  __typename?: "TaskQuarantinedTestsSample";
+  execution: Scalars["Int"]["output"];
+  quarantinedTests: Array<QuarantinedTest>;
+  quarantinedTestsSkippedCount: Scalars["Int"]["output"];
+  taskId: Scalars["String"]["output"];
 };
 
 /**
@@ -4898,6 +4919,8 @@ export type Version = {
   startTime?: Maybe<Scalars["Time"]["output"]>;
   status: Scalars["String"]["output"];
   taskCount?: Maybe<Scalars["Int"]["output"]>;
+  /** Returns up to limit (default 50) TSS-quarantined tests per task; quarantinedTestsSkippedCount is authoritative because stored samples may be truncated. */
+  taskQuarantinedTestsSample?: Maybe<Array<TaskQuarantinedTestsSample>>;
   taskStatusStats?: Maybe<TaskStats>;
   taskStatuses: Array<Scalars["String"]["output"]>;
   tasks: VersionTasks;
@@ -4922,6 +4945,12 @@ export type VersionBuildVariantsArgs = {
 /** Version models a commit within a project. */
 export type VersionTaskCountArgs = {
   options?: InputMaybe<TaskCountOptions>;
+};
+
+/** Version models a commit within a project. */
+export type VersionTaskQuarantinedTestsSampleArgs = {
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  taskIds: Array<Scalars["String"]["input"]>;
 };
 
 /** Version models a commit within a project. */

--- a/apps/spruce/src/gql/queries/admin-settings.ts
+++ b/apps/spruce/src/gql/queries/admin-settings.ts
@@ -264,11 +264,6 @@ export const ADMIN_SETTINGS = gql`
           allowedInstanceTypes
           allowedRegions
           defaultSecurityGroup
-          ec2Keys {
-            key
-            name
-            secret
-          }
           elasticIPUsageRate
           ipamPoolID
           maxVolumeSizePerUser

--- a/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/ProvidersTab/schemaFields.ts
+++ b/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/ProvidersTab/schemaFields.ts
@@ -163,16 +163,6 @@ export const aws = {
   schema: {
     subnets: subnets.schema,
     accountRoles: accountRoles.schema,
-    ec2Key: {
-      type: "string" as const,
-      title: "EC2 Key",
-      default: "",
-    },
-    ec2Secret: {
-      type: "string" as const,
-      title: "EC2 Secret",
-      default: "",
-    },
     parameterStorePrefix: {
       type: "string" as const,
       title: "Parameter Store Prefix",

--- a/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/ProvidersTab/transformers.test.ts
+++ b/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/ProvidersTab/transformers.test.ts
@@ -42,8 +42,6 @@ const form: ProvidersFormState = {
           subnetId: "subnet-67890",
         },
       ],
-      ec2Key: "test-ec2-key",
-      ec2Secret: "test-ec2-secret",
       parameterStorePrefix: "/evergreen/test",
       persistentDNS: {
         hostedZoneID: "Z123456789",
@@ -116,13 +114,6 @@ const gql: AdminSettingsInput = {
       allowedInstanceTypes: ["m5.large", "m5.xlarge", "c5.large"],
       allowedRegions: ["us-east-1", "us-west-2"],
       defaultSecurityGroup: "sg-default123",
-      ec2Keys: [
-        {
-          name: "default",
-          key: "test-ec2-key",
-          secret: "test-ec2-secret",
-        },
-      ],
       elasticIPUsageRate: 0.8,
       ipamPoolID: "ipam-pool-123",
       maxVolumeSizePerUser: 100,
@@ -192,13 +183,6 @@ const testAdminSettings = {
       allowedInstanceTypes: ["m5.large", "m5.xlarge", "c5.large"],
       allowedRegions: ["us-east-1", "us-west-2"],
       defaultSecurityGroup: "sg-default123",
-      ec2Keys: [
-        {
-          name: "default",
-          key: "test-ec2-key",
-          secret: "test-ec2-secret",
-        },
-      ],
       elasticIPUsageRate: 0.8,
       ipamPoolID: "ipam-pool-123",
       maxVolumeSizePerUser: 100,

--- a/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/ProvidersTab/transformers.ts
+++ b/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/ProvidersTab/transformers.ts
@@ -31,8 +31,6 @@ export const gqlToForm = ((data) => {
             account: role.account ?? "",
             role: role.role ?? "",
           })) ?? [],
-        ec2Key: providers?.aws?.ec2Keys?.[0]?.key ?? "",
-        ec2Secret: providers?.aws?.ec2Keys?.[0]?.secret ?? "",
         parameterStorePrefix: parameterStore?.prefix ?? "",
         defaultSecurityGroup: providers?.aws?.defaultSecurityGroup ?? "",
         maxVolumeSizePerUser: providers?.aws?.maxVolumeSizePerUser ?? 0,
@@ -87,13 +85,6 @@ export const formToGql = ((form: ProvidersFormState) => {
         allowedInstanceTypes: aws.allowedInstanceTypes,
         allowedRegions: aws.allowedRegions,
         defaultSecurityGroup: aws.defaultSecurityGroup || undefined,
-        ec2Keys: [
-          {
-            name: "default", // We'll use a default name since we flattened this
-            key: aws.ec2Key,
-            secret: aws.ec2Secret,
-          },
-        ],
         elasticIPUsageRate: aws.elasticIPUsageRate || undefined,
         ipamPoolID: aws.ipamPoolID || undefined,
         maxVolumeSizePerUser: aws.maxVolumeSizePerUser || undefined,

--- a/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/ProvidersTab/types.ts
+++ b/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/ProvidersTab/types.ts
@@ -18,8 +18,6 @@ export interface ProvidersFormState {
         account: string;
         role: string;
       }>;
-      ec2Key: string;
-      ec2Secret: string;
       parameterStorePrefix: string;
       defaultSecurityGroup: string;
       maxVolumeSizePerUser: number;

--- a/packages/lib/src/gql/generated/types.ts
+++ b/packages/lib/src/gql/generated/types.ts
@@ -3106,6 +3106,13 @@ export type QuarantineVariantInput = {
   projectIdentifier: Scalars["String"]["input"];
 };
 
+/** QuarantinedTest represents a test skipped because it was quarantined in TSS at execution time. */
+export type QuarantinedTest = {
+  __typename?: "QuarantinedTest";
+  displayTestName?: Maybe<Scalars["String"]["output"]>;
+  testName: Scalars["String"]["output"];
+};
+
 export type Query = {
   __typename?: "Query";
   adminEvents: AdminEventsPayload;
@@ -4138,6 +4145,8 @@ export type Task = {
   prevTaskPassing?: Maybe<Task>;
   priority?: Maybe<Scalars["Int"]["output"]>;
   project?: Maybe<Project>;
+  /** quarantinedTestsSkippedCount is the number of tests this execution skipped because they were quarantined in TSS at execution time. */
+  quarantinedTestsSkippedCount: Scalars["Int"]["output"];
   requester: Scalars["String"]["output"];
   resetWhenFinished: Scalars["Boolean"]["output"];
   revision?: Maybe<Scalars["String"]["output"]>;
@@ -4406,6 +4415,18 @@ export type TaskQuarantineEntry = {
   __typename?: "TaskQuarantineEntry";
   taskName: Scalars["String"]["output"];
   tests: Array<TestQuarantineEntry>;
+};
+
+/**
+ * TaskQuarantinedTestsSample is the return value for Version.taskQuarantinedTestsSample.
+ * It contains the execution-time snapshot of tests skipped because they were quarantined in TSS.
+ */
+export type TaskQuarantinedTestsSample = {
+  __typename?: "TaskQuarantinedTestsSample";
+  execution: Scalars["Int"]["output"];
+  quarantinedTests: Array<QuarantinedTest>;
+  quarantinedTestsSkippedCount: Scalars["Int"]["output"];
+  taskId: Scalars["String"]["output"];
 };
 
 /**
@@ -4900,6 +4921,8 @@ export type Version = {
   startTime?: Maybe<Scalars["Time"]["output"]>;
   status: Scalars["String"]["output"];
   taskCount?: Maybe<Scalars["Int"]["output"]>;
+  /** Returns up to limit (default 50) TSS-quarantined tests per task; quarantinedTestsSkippedCount is authoritative because stored samples may be truncated. */
+  taskQuarantinedTestsSample?: Maybe<Array<TaskQuarantinedTestsSample>>;
   taskStatusStats?: Maybe<TaskStats>;
   taskStatuses: Array<Scalars["String"]["output"]>;
   tasks: VersionTasks;
@@ -4924,6 +4947,12 @@ export type VersionBuildVariantsArgs = {
 /** Version models a commit within a project. */
 export type VersionTaskCountArgs = {
   options?: InputMaybe<TaskCountOptions>;
+};
+
+/** Version models a commit within a project. */
+export type VersionTaskQuarantinedTestsSampleArgs = {
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  taskIds: Array<Scalars["String"]["input"]>;
 };
 
 /** Version models a commit within a project. */

--- a/packages/lib/src/gql/generated/types.ts
+++ b/packages/lib/src/gql/generated/types.ts
@@ -66,7 +66,6 @@ export type AwsConfig = {
   allowedInstanceTypes: Array<Scalars["String"]["output"]>;
   allowedRegions: Array<Scalars["String"]["output"]>;
   defaultSecurityGroup?: Maybe<Scalars["String"]["output"]>;
-  ec2Keys: Array<Ec2Key>;
   elasticIPUsageRate?: Maybe<Scalars["Float"]["output"]>;
   ipamPoolID?: Maybe<Scalars["String"]["output"]>;
   maxVolumeSizePerUser?: Maybe<Scalars["Int"]["output"]>;
@@ -81,7 +80,6 @@ export type AwsConfigInput = {
   allowedInstanceTypes: Array<Scalars["String"]["input"]>;
   allowedRegions: Array<Scalars["String"]["input"]>;
   defaultSecurityGroup?: InputMaybe<Scalars["String"]["input"]>;
-  ec2Keys: Array<Ec2KeyInput>;
   elasticIPUsageRate?: InputMaybe<Scalars["Float"]["input"]>;
   ipamPoolID?: InputMaybe<Scalars["String"]["input"]>;
   maxVolumeSizePerUser?: InputMaybe<Scalars["Int"]["input"]>;
@@ -989,12 +987,6 @@ export type Ec2Key = {
   key: Scalars["String"]["output"];
   name: Scalars["String"]["output"];
   secret: Scalars["String"]["output"];
-};
-
-export type Ec2KeyInput = {
-  key: Scalars["String"]["input"];
-  name: Scalars["String"]["input"];
-  secret: Scalars["String"]["input"];
 };
 
 /**


### PR DESCRIPTION
DEVPROD-32801

### Description
[This EC2Keys field](https://github.com/evergreen-ci/evergreen/blob/2f60a81e0c5087b591bff6d7561f91ba1be69a44/config_cloud.go#L61) is unused and will likely never be used because Evergreen doesn't use long-lived AWS credentials anymore.

### Testing
Existing tests
### Evergreen PR
https://github.com/evergreen-ci/evergreen/pull/10553