### PR TITLE
DEVPROD-27824: Fix waterfall scroll performance

### DIFF
--- a/apps/spruce/src/components/TaskBox/index.tsx
+++ b/apps/spruce/src/components/TaskBox/index.tsx
@@ -40,7 +40,6 @@ const taskBoxStyles = css`
   height: ${DEFAULT_SQUARE_SIZE}px;
   border: ${SQUARE_BORDER}px solid ${white};
   box-sizing: content-box;
-  float: left;
   position: relative;
   cursor: pointer;
 
@@ -106,7 +105,6 @@ export const CollapsedBox = styled.div`
   height: ${DEFAULT_SQUARE_SIZE}px;
   border: ${SQUARE_BORDER}px solid ${white};
   box-sizing: content-box;
-  float: left;
   position: relative;
   min-width: ${DEFAULT_SQUARE_SIZE}px;
   width: fit-content;

--- a/apps/spruce/src/components/VersionRestartModal/TaskStatusCheckbox.tsx
+++ b/apps/spruce/src/components/VersionRestartModal/TaskStatusCheckbox.tsx
@@ -58,7 +58,6 @@ const StateItemWrapper = styled.div`
 const TaskBox = styled(BaseTaskBox)`
   width: ${CHECKBOX_SQUARE_SIZE}px;
   height: ${CHECKBOX_SQUARE_SIZE}px;
-  float: none;
   flex-shrink: 0;
 `;
 

--- a/apps/spruce/src/pages/waterfall/BuildRow.tsx
+++ b/apps/spruce/src/pages/waterfall/BuildRow.tsx
@@ -161,7 +161,7 @@ const BuildRowInner: React.FC<Props> = ({
         className={buildGroupClassName}
         data-cy="build-group"
         offset={1000}
-        style={{ height: containerHeight }}
+        style={{ minHeight: containerHeight }}
       >
         {buildColumns}
       </VisibilityContainer>
@@ -235,7 +235,10 @@ const calculateBVContainerHeight = ({
   columnWidth: number;
 }) => {
   const numTasks = Math.max(...builds.map((b) => b.tasks.length));
-  const numSquaresInRow = Math.floor(columnWidth / SQUARE_WITH_BORDER);
+  const numSquaresInRow = Math.max(
+    Math.floor(columnWidth / SQUARE_WITH_BORDER),
+    1,
+  );
   const numRows = Math.ceil(numTasks / numSquaresInRow);
   return numRows * SQUARE_WITH_BORDER + containerPaddingAndBorder;
 };
@@ -251,6 +254,10 @@ const buildGroupClassName = classNameCss(buildGroupCss.styles);
 
 const BuildContainer = styled.div`
   ${columnBasis}
+  display: grid;
+  grid-template-columns: repeat(auto-fill, ${SQUARE_WITH_BORDER}px);
+  align-content: start;
+  min-width: 0;
 `;
 
 const StyledIconButton = styled(IconButton)<{ active: boolean }>`

--- a/apps/spruce/src/pages/waterfall/WaterfallGrid.tsx
+++ b/apps/spruce/src/pages/waterfall/WaterfallGrid.tsx
@@ -8,6 +8,7 @@ import {
   stringifyQuery,
 } from "@evg-ui/lib/utils/query-string";
 import { useWaterfallAnalytics } from "analytics";
+import { navBarHeight } from "components/styles/Layout";
 import { WalkthroughGuideCueRef } from "components/WalkthroughGuideCue";
 import {
   DEFAULT_POLL_INTERVAL,
@@ -297,7 +298,7 @@ const Container = styled.div`
 
 const StickyHeader = styled(Row)<{ showShadow: boolean }>`
   position: sticky;
-  top: -${size.m};
+  top: ${navBarHeight};
   z-index: 1;
 
   background: white;

--- a/apps/spruce/src/pages/waterfall/index.tsx
+++ b/apps/spruce/src/pages/waterfall/index.tsx
@@ -97,8 +97,6 @@ const PageContainer = styled.div`
   flex-direction: column;
   gap: ${size.xs};
   padding: ${size.m};
-  // Setting overflow-x allows floating content to be correctly positioned on the page.
-  overflow-x: hidden;
 `;
 
 /* Safari performance of the waterfall chokes if using overflow-y: scroll, so we need the page to scroll instead.


### PR DESCRIPTION
DEVPROD-27824

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->

<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
<!-- add description, context, thought process, etc -->
We have a comment that says
> Safari performance of the waterfall chokes if using overflow-y: scroll, so we need the page to scroll instead.

...but unfortunately `overflow-y: scroll` was still being applied due to the presence of `overflow-x: hidden` 😭 

I also replaced each variant/version combination with a small grid instead of using `float: left`, which is supposed to help with performance. This enabled us to fix an occasional bug caused by an incorrectly-measured row.

### Testing
<!-- add a description of how you tested it -->
Deployed to [beta](https://spruce-beta.corp.mongodb.com/project/mongodb-mongo-master/waterfall)