### PR TITLE
DEVPROD-36862: Use webhook secret correctly

### DIFF
--- a/apps/spruce/src/pages/projectAndRepoSettings/shared/HeaderButtons.test.tsx
+++ b/apps/spruce/src/pages/projectAndRepoSettings/shared/HeaderButtons.test.tsx
@@ -1,0 +1,160 @@
+import { MemoryRouter } from "react-router-dom";
+import { RenderFakeToastContext } from "@evg-ui/lib/context/toast/__mocks__";
+import {
+  render,
+  screen,
+  stubGetClientRects,
+  userEvent,
+} from "@evg-ui/lib/test_utils";
+import { ProjectSettingsTabRoutes } from "constants/routes";
+import { HeaderButtons } from "./HeaderButtons";
+import * as notificationUtils from "./tabs/NotificationsTab/utils";
+import { ProjectType } from "./tabs/utils";
+
+const { saveChangesModal, saveSettings, sendEvent } = vi.hoisted(() => ({
+  saveSettings: vi.fn(),
+  sendEvent: vi.fn(),
+  saveChangesModal: vi.fn(),
+}));
+
+vi.mock("@apollo/client/react", () => ({
+  useMutation: () => [saveSettings],
+}));
+
+vi.mock("analytics", () => ({
+  useProjectSettingsAnalytics: () => ({ sendEvent }),
+}));
+
+vi.mock("hooks", () => ({
+  useHasProjectOrRepoEditPermission: () => ({ canEdit: true }),
+}));
+
+vi.mock("./Context", () => ({
+  useProjectSettingsContext: () => ({
+    getTab: () => ({
+      formData: {
+        buildBreakSettings: { notifyOnBuildFailure: false },
+        subscriptions: [
+          {
+            subscriptionData: {
+              id: "webhook_subscription",
+              event: {
+                eventSelect: "any-task-finishes",
+                extraFields: {},
+              },
+              notification: {
+                notificationSelect: "evergreen-webhook",
+                webhookInput: {
+                  secretInput: "",
+                  urlInput: "https://example.com/webhook",
+                  httpHeaders: [],
+                  retryInput: 1,
+                  minDelayInput: 100,
+                  timeoutInput: 1000,
+                },
+              },
+            },
+          },
+        ],
+      },
+      hasChanges: true,
+      hasError: false,
+      initialData: {
+        projectId: "project_id",
+        projectRef: {
+          id: "project_id",
+          notifyOnBuildFailure: false,
+        },
+        subscriptions: [],
+      },
+    }),
+    saveTab: vi.fn(),
+  }),
+}));
+
+vi.mock("./SaveChangesModal", () => ({
+  SaveChangesModal: ({
+    after,
+    onConfirm,
+    open,
+  }: {
+    after: unknown;
+    onConfirm: () => void;
+    open: boolean;
+  }) => {
+    saveChangesModal({ after });
+    return open ? (
+      <button onClick={onConfirm} type="button">
+        Save preview
+      </button>
+    ) : null;
+  },
+}));
+
+describe("HeaderButtons", () => {
+  beforeAll(() => {
+    stubGetClientRects();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    saveSettings.mockReset();
+    sendEvent.mockReset();
+    saveChangesModal.mockReset();
+  });
+
+  it("saves the generated webhook secret displayed in the review modal", async () => {
+    vi.spyOn(notificationUtils, "generateWebhookSecret").mockReturnValue(
+      "preview-secret",
+    );
+    const user = userEvent.setup();
+    const { Component } = RenderFakeToastContext(
+      <MemoryRouter>
+        <HeaderButtons
+          id="project_id"
+          projectType={ProjectType.Project}
+          tab={ProjectSettingsTabRoutes.Notifications}
+        />
+      </MemoryRouter>,
+    );
+
+    render(<Component />);
+
+    await user.click(
+      screen.getByRole("button", { name: "Save changes on page" }),
+    );
+
+    expect(saveChangesModal).toHaveBeenLastCalledWith({
+      after: expect.objectContaining({
+        subscriptions: [
+          expect.objectContaining({
+            subscriber: expect.objectContaining({
+              webhookSubscriber: expect.objectContaining({
+                secret: "preview-secret",
+              }),
+            }),
+          }),
+        ],
+      }),
+    });
+
+    await user.click(screen.getByRole("button", { name: "Save preview" }));
+
+    expect(saveSettings).toHaveBeenCalledWith({
+      variables: {
+        projectSettings: expect.objectContaining({
+          subscriptions: [
+            expect.objectContaining({
+              subscriber: expect.objectContaining({
+                webhookSubscriber: expect.objectContaining({
+                  secret: "preview-secret",
+                }),
+              }),
+            }),
+          ],
+        }),
+        section: "NOTIFICATIONS",
+      },
+    });
+  });
+});

--- a/apps/spruce/src/pages/projectAndRepoSettings/shared/HeaderButtons.tsx
+++ b/apps/spruce/src/pages/projectAndRepoSettings/shared/HeaderButtons.tsx
@@ -42,13 +42,17 @@ const defaultToRepoDisabled: Set<WritableProjectSettingsType> = new Set([
   ProjectSettingsTabRoutes.GithubPermissionGroups,
 ]);
 
-interface Props {
+interface Props<T extends WritableProjectSettingsType> {
   id: string;
   projectType: ProjectType;
-  tab: WritableProjectSettingsType;
+  tab: T;
 }
 
-export const HeaderButtons: React.FC<Props> = ({ id, projectType, tab }) => {
+export const HeaderButtons = <T extends WritableProjectSettingsType>({
+  id,
+  projectType,
+  tab,
+}: Props<T>) => {
   const { sendEvent } = useProjectSettingsAnalytics();
   const dispatchToast = useToastContext();
 
@@ -60,6 +64,9 @@ export const HeaderButtons: React.FC<Props> = ({ id, projectType, tab }) => {
 
   const [defaultModalOpen, setDefaultModalOpen] = useState(false);
   const [saveModalOpen, setSaveModalOpen] = useState(false);
+  const [savePayload, setSavePayload] = useState<
+    ProjectSettingsInput | RepoSettingsInput | null
+  >(null);
   const [debugSpawnHostsModalOpen, setDebugSpawnHostsModalOpen] =
     useState(false);
 
@@ -111,10 +118,7 @@ export const HeaderButtons: React.FC<Props> = ({ id, projectType, tab }) => {
     refetchQueries: ["RepoSettings", "ViewableProjectRefs"],
   });
 
-  const performSave = () => {
-    // @ts-expect-error: FIXME. This comment was added by an automated script.
-    const formToGql: FormToGqlFunction<typeof tab> = formToGqlMap[tab];
-    const newData = formToGql(formData, isRepo, id);
+  const performSave = (newData: ProjectSettingsInput | RepoSettingsInput) => {
     // @ts-expect-error: FIXME. This comment was added by an automated script.
     const save = (update, section) =>
       isRepo
@@ -133,6 +137,7 @@ export const HeaderButtons: React.FC<Props> = ({ id, projectType, tab }) => {
 
     const section = mapRouteToSection[tab];
     save(newData, section);
+    setSavePayload(null);
     sendEvent({
       section,
       name: isRepo ? "Saved repo settings" : "Saved project settings",
@@ -144,7 +149,6 @@ export const HeaderButtons: React.FC<Props> = ({ id, projectType, tab }) => {
       return false;
     }
     const formToGql: FormToGqlFunction<typeof tab> = formToGqlMap[tab];
-    // @ts-expect-error: FIXME. This comment was added by an automated script.
     const newData = formToGql(formData, isRepo, id);
     const wasDisabled =
       initialData?.projectRef?.debugSpawnHostsDisabled === true;
@@ -155,29 +159,28 @@ export const HeaderButtons: React.FC<Props> = ({ id, projectType, tab }) => {
 
   const onSaveConfirm = () => {
     setSaveModalOpen(false);
+    if (!savePayload) {
+      return;
+    }
     if (isDisablingDebugSpawnHosts()) {
       setDebugSpawnHostsModalOpen(true);
     } else {
-      performSave();
+      performSave(savePayload);
     }
   };
 
   const onClick = () => {
+    const formToGql = formToGqlMap[tab];
+    const newData = formToGql(formData, isRepo, id);
+    setSavePayload(newData);
     setSaveModalOpen(true);
   };
 
-  // Only compute the diff payload while the modal is open so that tab
-  // transformers aren't invoked against partially-loaded form state on
-  // every render.
   let diffPayload: {
     after: ProjectSettingsInput | RepoSettingsInput;
     before: ProjectSettingsInput | RepoSettingsInput | null;
   } | null = null;
-  if (saveModalOpen) {
-    const formToGql = formToGqlMap[tab];
-    // @ts-expect-error: FIXME. This comment was added by an automated script.
-    const afterData = formToGql(formData, isRepo, id);
-
+  if (savePayload) {
     // Normalize beforeData to match afterData's shape.
     let beforeData: ProjectSettingsInput | RepoSettingsInput | null = null;
     if (initialData) {
@@ -198,7 +201,7 @@ export const HeaderButtons: React.FC<Props> = ({ id, projectType, tab }) => {
       }
     }
     diffPayload = {
-      after: afterData,
+      after: savePayload,
       before: beforeData,
     };
   }
@@ -233,7 +236,10 @@ export const HeaderButtons: React.FC<Props> = ({ id, projectType, tab }) => {
           after={diffPayload.after}
           before={diffPayload.before}
           customKeyValueRenderConfig={getDiffRenderConfig(tab)}
-          onCancel={() => setSaveModalOpen(false)}
+          onCancel={() => {
+            setSaveModalOpen(false);
+            setSavePayload(null);
+          }}
           onConfirm={onSaveConfirm}
           open={saveModalOpen}
           tabTitle={getTabTitle(tab).title}
@@ -265,7 +271,9 @@ export const HeaderButtons: React.FC<Props> = ({ id, projectType, tab }) => {
           children: "Yes, save",
           onClick: () => {
             setDebugSpawnHostsModalOpen(false);
-            performSave();
+            if (savePayload) {
+              performSave(savePayload);
+            }
           },
         }}
         data-cy="disable-debug-spawn-hosts-modal"


### PR DESCRIPTION
DEVPROD-36862

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->

<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
<!-- add description, context, thought process, etc -->
Use a state to track a single secret value across the save process (i.e. clicking save and the confirmation modal). Previously calling `generateWebhookSecret()` twice yielded a different display value than was actually saved.

### Testing
<!-- add a description of how you tested it -->
- Tested against staging db
- Added unit test
