### PR TITLE
DEVPROD-27824: Cache improvements

### DIFF
--- a/apps/spruce/index.html
+++ b/apps/spruce/index.html
@@ -19,6 +19,11 @@
     You need to enable JavaScript to run this app.
   </noscript>
   <div id="root" style="height: 100%"></div>
+  <script>
+    globalThis[Symbol.for("apollo.cacheSize")] = {
+      "inMemoryCache.executeSelectionSet": 150000,
+    };
+  </script>
   <script type="module" src="/src/index.tsx"></script>
   <!--
         Load LeafyGreen's monospace font dependency via Google Fonts' CDN

--- a/apps/spruce/src/pages/waterfall/EmptyState/EmptyState.test.tsx
+++ b/apps/spruce/src/pages/waterfall/EmptyState/EmptyState.test.tsx
@@ -23,7 +23,7 @@ const renderEmptyState = (
 ) =>
   render(
     <>
-      <EmptyState pagination={pagination} />
+      <EmptyState pagination={pagination} projectIdentifier="spruce" />
       <LocationDisplay />
     </>,
     {

--- a/apps/spruce/src/pages/waterfall/EmptyState/index.tsx
+++ b/apps/spruce/src/pages/waterfall/EmptyState/index.tsx
@@ -9,12 +9,16 @@ import { EmptyGraphic } from "./EmptyGraphic";
 
 interface EmptyStateProps {
   pagination: Pagination;
+  projectIdentifier: string;
 }
 
-export const EmptyState: React.FC<EmptyStateProps> = ({ pagination }) => {
+export const EmptyState: React.FC<EmptyStateProps> = ({
+  pagination,
+  projectIdentifier,
+}) => {
   const { sendEvent } = useWaterfallAnalytics();
   const { goToNextPage, hasNextPage, isNavigatingToPage } =
-    usePaginationNavigation(pagination);
+    usePaginationNavigation(pagination, projectIdentifier);
 
   const [tasks] = useQueryParam<string[]>(WaterfallFilterOptions.Task, []);
   const [statuses] = useQueryParam<string[]>(

--- a/apps/spruce/src/pages/waterfall/PaginationButtons/index.tsx
+++ b/apps/spruce/src/pages/waterfall/PaginationButtons/index.tsx
@@ -8,10 +8,12 @@ import { usePaginationNavigation } from "../usePaginationNavigation";
 
 interface PaginationButtonsProps {
   pagination: Pagination | undefined;
+  projectIdentifier: string;
 }
 
 export const PaginationButtons: React.FC<PaginationButtonsProps> = ({
   pagination,
+  projectIdentifier,
 }) => {
   const { sendEvent } = useWaterfallAnalytics();
   const {
@@ -20,7 +22,7 @@ export const PaginationButtons: React.FC<PaginationButtonsProps> = ({
     hasNextPage,
     hasPrevPage,
     isNavigatingToPage,
-  } = usePaginationNavigation(pagination);
+  } = usePaginationNavigation(pagination, projectIdentifier);
 
   const onNextClick = () => {
     sendEvent({ name: "Changed page", direction: "next" });

--- a/apps/spruce/src/pages/waterfall/WaterfallFilters.tsx
+++ b/apps/spruce/src/pages/waterfall/WaterfallFilters.tsx
@@ -1,4 +1,5 @@
 import { useCallback } from "react";
+import { useApolloClient } from "@apollo/client/react";
 import styled from "@emotion/styled";
 import { useQueryParam, useQueryParams } from "@evg-ui/lib/hooks";
 import { useWaterfallAnalytics } from "analytics";
@@ -30,6 +31,7 @@ export const WaterfallFilters: React.FC<WaterfallFiltersProps> = ({
   setOmitInactiveBuilds,
 }) => {
   const { sendEvent } = useWaterfallAnalytics();
+  const { cache } = useApolloClient();
 
   const [queryParams, setQueryParams] = useQueryParams();
   const [statuses] = useQueryParam<string[]>(
@@ -78,6 +80,12 @@ export const WaterfallFilters: React.FC<WaterfallFiltersProps> = ({
         <ProjectSelect
           getProjectRoute={projectSelectRoute}
           onSubmit={(project: string) => {
+            cache.evict({
+              id: "ROOT_QUERY",
+              fieldName: "waterfall",
+            });
+            cache.gc();
+
             sendEvent({
               name: "Changed project",
               project,

--- a/apps/spruce/src/pages/waterfall/WaterfallFilters.tsx
+++ b/apps/spruce/src/pages/waterfall/WaterfallFilters.tsx
@@ -100,7 +100,10 @@ export const WaterfallFilters: React.FC<WaterfallFiltersProps> = ({
         restartWalkthrough={restartWalkthrough}
         setOmitInactiveBuilds={setOmitInactiveBuilds}
       />
-      <PaginationButtons pagination={pagination} />
+      <PaginationButtons
+        pagination={pagination}
+        projectIdentifier={projectIdentifier}
+      />
     </Container>
   );
 };

--- a/apps/spruce/src/pages/waterfall/WaterfallGrid.tsx
+++ b/apps/spruce/src/pages/waterfall/WaterfallGrid.tsx
@@ -40,7 +40,10 @@ import {
 } from "./styles";
 import { Pagination, Version, WaterfallFilterOptions } from "./types";
 import { useFilters } from "./useFilters";
-import { useWaterfallTrace } from "./useWaterfallTrace";
+import {
+  useWaterfallNavigationTrace,
+  useWaterfallTrace,
+} from "./useWaterfallTrace";
 import { VersionLabel, VersionLabelView } from "./VersionLabel";
 
 type ServerFilters = Pick<
@@ -187,6 +190,9 @@ export const WaterfallGrid: React.FC<WaterfallGridProps> = ({
   });
   // TODO DEVPROD-26717: This can be removed if the invalid arguments are fixed in useSuspenseQuery.
   const dataIsComplete = dataState === "complete";
+  useWaterfallNavigationTrace({
+    data: dataState === "complete" ? data : undefined,
+  });
 
   useEffect(() => {
     if (dataIsComplete) {
@@ -228,7 +234,12 @@ export const WaterfallGrid: React.FC<WaterfallGridProps> = ({
     dataIsComplete &&
     data?.waterfall?.pagination?.activeVersionIds?.length === 0
   ) {
-    return <EmptyState pagination={data.waterfall.pagination} />;
+    return (
+      <EmptyState
+        pagination={data.waterfall.pagination}
+        projectIdentifier={projectIdentifier}
+      />
+    );
   }
 
   return (

--- a/apps/spruce/src/pages/waterfall/caching/caching.test.ts
+++ b/apps/spruce/src/pages/waterfall/caching/caching.test.ts
@@ -1,555 +1,151 @@
-import { FieldFunctionOptions } from "@apollo/client";
-import { FieldMergeFunctionOptions } from "@apollo/client/cache";
-import { versions } from "../testData";
+import {
+  FieldFunctionOptions,
+  FieldMergeFunctionOptions,
+} from "@apollo/client/cache";
+import { WaterfallQuery } from "gql/generated/types";
 import { mergeVersions, readVersions } from ".";
 
-// @ts-expect-error: we don't need to type the args for this mock
+type Waterfall = WaterfallQuery["waterfall"];
+
+// @ts-expect-error: the cache tests only use plain objects.
 const readField = (field, obj) => obj[field];
 
-describe("mergeVersions", () => {
-  const readFn = {
+const makePage = (orders: number[]) => {
+  const activeVersionIds = orders.map((order) => `version-${order}`);
+  return {
+    pagination: {
+      activeVersionIds,
+      hasNextPage: true,
+      hasPrevPage: true,
+      mostRecentVersionOrder: 20,
+      nextPageOrder: Math.min(...orders) - 1,
+      prevPageOrder: Math.max(...orders) + 1,
+    },
+    versions: orders.map((order) => ({
+      id: `version-${order}`,
+      order,
+    })),
+  } as Waterfall;
+};
+
+const page1 = makePage([20, 19, 18, 17, 16]);
+const page2 = makePage([15, 14, 13, 12, 11]);
+const page3 = makePage([10, 9, 8, 7, 6]);
+
+const mergePage = (
+  existing: Waterfall | undefined,
+  incoming: Waterfall,
+  options: Record<string, unknown> = {},
+) =>
+  mergeVersions(existing, incoming, {
+    args: {
+      options: {
+        limit: 5,
+        projectIdentifier: "mongodb-mongo-master",
+        ...options,
+      },
+    },
     readField,
-    extensions: {},
-    existingData: undefined,
-  } as FieldMergeFunctionOptions;
+  } as unknown as FieldMergeFunctionOptions);
 
-  it("handles undefined existing on first cache write", () => {
-    const pagination = {
-      activeVersionIds: ["b", "c"],
-      nextPageOrder: 0,
-      prevPageOrder: 0,
-      hasNextPage: false,
-      hasPrevPage: false,
-      mostRecentVersionOrder: 5,
-    };
-    expect(
-      mergeVersions(
-        undefined,
-        {
-          pagination,
-          versions: versions.slice(0, 2),
-        },
-        readFn,
+const readPage = (existing: Waterfall, options: Record<string, unknown> = {}) =>
+  readVersions(existing, {
+    args: { options: { limit: 5, ...options } },
+    readField,
+  } as unknown as FieldFunctionOptions);
+
+const getVersionIds = (cache: Waterfall) => cache.versions.map(({ id }) => id);
+
+describe("bounded waterfall cache", () => {
+  it("retains up to two pages of active versions", () => {
+    let cache = mergePage(undefined, page1);
+    cache = mergePage(cache, page2, { maxOrder: 16 });
+
+    expect(getVersionIds(cache)).toStrictEqual([
+      ...getVersionIds(page1),
+      ...getVersionIds(page2),
+    ]);
+  });
+
+  it("retains up to six pages for other projects", () => {
+    const pages = Array.from({ length: 7 }, (_page, pageIndex) =>
+      makePage(
+        Array.from(
+          { length: 5 },
+          (_version, versionIndex) => 35 - pageIndex * 5 - versionIndex,
+        ),
       ),
-    ).toStrictEqual({
-      allActiveVersions: new Set(["b", "c"]),
-      pagination,
-      versions: versions.slice(0, 2),
+    );
+    let cache: Waterfall | undefined;
+    pages.forEach((page, pageIndex) => {
+      cache = mergePage(cache, page, {
+        maxOrder: pageIndex ? 1 : 0,
+        projectIdentifier: "small-project",
+      });
     });
+
+    expect(getVersionIds(cache as Waterfall)).toStrictEqual(
+      pages.slice(1).flatMap(getVersionIds),
+    );
   });
 
-  it("merges version arrays", () => {
-    const pagination = {
-      activeVersionIds: ["b", "c", "f"],
-      nextPageOrder: 0,
-      prevPageOrder: 0,
-      hasNextPage: true,
-      hasPrevPage: true,
-      mostRecentVersionOrder: 5,
-    };
-    expect(
-      mergeVersions(
-        {
-          pagination,
-          versions: versions.slice(0, 2),
-        },
-        {
-          pagination,
-          versions: versions.slice(2, -1),
-        },
-        readFn,
-      ),
-    ).toStrictEqual({
-      allActiveVersions: new Set(["b", "c", "f"]),
-      pagination,
-      versions: versions.slice(0, -1),
-    });
+  it("evicts the newest active versions when paginating forward", () => {
+    let cache = mergePage(undefined, page1);
+    cache = mergePage(cache, page2, { maxOrder: 16 });
+    cache = mergePage(cache, page3, { maxOrder: 11 });
+
+    expect(getVersionIds(cache)).toStrictEqual([
+      ...getVersionIds(page2),
+      ...getVersionIds(page3),
+    ]);
   });
 
-  it("merges version when incoming is newer than existing", () => {
-    const pagination = {
-      activeVersionIds: ["b", "c", "f"],
-      nextPageOrder: 3,
-      prevPageOrder: 0,
-      hasNextPage: true,
-      hasPrevPage: false,
-      mostRecentVersionOrder: 5,
-    };
-    expect(
-      mergeVersions(
-        {
-          pagination,
-          versions: versions.slice(2, -1),
-        },
-        {
-          pagination,
-          versions: versions.slice(0, 2),
-        },
-        readFn,
-      ),
-    ).toStrictEqual({
-      allActiveVersions: new Set(["b", "c", "f"]),
-      pagination,
-      versions: versions.slice(0, -1),
-    });
+  it("evicts the oldest active versions when paginating backward", () => {
+    let cache = mergePage(undefined, page3, { maxOrder: 11 });
+    cache = mergePage(cache, page2, { minOrder: 10 });
+    cache = mergePage(cache, page1, { minOrder: 15 });
+
+    expect(getVersionIds(cache)).toStrictEqual([
+      ...getVersionIds(page1),
+      ...getVersionIds(page2),
+    ]);
   });
 
-  it("deduplicates versions when merging", () => {
-    const pagination = {
-      activeVersionIds: ["b", "c", "f"],
-      nextPageOrder: 0,
-      prevPageOrder: 1,
-      hasNextPage: false,
-      hasPrevPage: true,
-      mostRecentVersionOrder: 5,
-    };
-    expect(
-      mergeVersions(
-        {
-          pagination,
-          versions: versions.slice(0, 4),
-        },
-        {
-          pagination,
-          versions: versions.slice(2),
-        },
-        readFn,
-      ),
-    ).toStrictEqual({
-      allActiveVersions: new Set(["b", "c", "f"]),
-      pagination,
-      versions: versions,
-    });
+  it("does not grow when polling an already cached page", () => {
+    let cache = mergePage(undefined, page1);
+    cache = mergePage(cache, page1);
+
+    expect(getVersionIds(cache)).toStrictEqual(getVersionIds(page1));
   });
 
-  it("returns an identical cache when duplicate data is incoming", () => {
-    const pagination = {
-      activeVersionIds: ["b", "c", "f"],
-      nextPageOrder: 0,
-      prevPageOrder: 0,
-      hasNextPage: false,
-      hasPrevPage: false,
-      mostRecentVersionOrder: 5,
-    };
+  it("does not count inactive versions toward the bound", () => {
+    const pageWithInactiveVersion = {
+      ...page3,
+      versions: [{ id: "inactive-version", order: 10.5 }, ...page3.versions],
+    } as Waterfall;
+    let cache = mergePage(undefined, page1);
+    cache = mergePage(cache, page2, { maxOrder: 16 });
+    cache = mergePage(cache, pageWithInactiveVersion, { maxOrder: 11 });
+
+    expect(getVersionIds(cache)).toContain("inactive-version");
     expect(
-      mergeVersions(
-        {
-          pagination,
-          versions: versions,
-        },
-        {
-          pagination,
-          versions: versions,
-        },
-        readFn,
-      ),
-    ).toStrictEqual({
-      allActiveVersions: new Set(["b", "c", "f"]),
-      versions: versions,
-      pagination,
-    });
+      (cache as Waterfall & { allActiveVersions: Set<string> })
+        .allActiveVersions.size,
+    ).toBe(10);
   });
 
-  it("combines lists of active versions", () => {
-    const pagination = {
-      activeVersionIds: ["b", "c", "f"],
-      nextPageOrder: 0,
-      prevPageOrder: 1,
-      hasNextPage: false,
-      hasPrevPage: true,
-      mostRecentVersionOrder: 5,
-    };
-    expect(
-      mergeVersions(
-        {
-          allActiveVersions: new Set(["x", "y", "b"]),
-          versions: versions.slice(0, 4),
-          pagination,
-        },
-        {
-          versions: versions.slice(2),
-          pagination,
-        },
-        readFn,
-      ),
-    ).toStrictEqual({
-      allActiveVersions: new Set(["b", "c", "f", "x", "y"]),
-      versions: versions,
-      pagination,
-    });
-  });
-});
+  it("reads cached versions in either pagination direction", () => {
+    let cache = mergePage(undefined, page1);
+    cache = mergePage(cache, page2, { maxOrder: 16 });
 
-describe("readVersions", () => {
-  it("returns undefined when the cache is empty", () => {
+    expect(getVersionIds(readPage(cache) as Waterfall)).toStrictEqual(
+      getVersionIds(page1),
+    );
     expect(
-      readVersions(
-        undefined,
-        // @ts-expect-error: for tests we can omit unused fields from the args
-        {
-          args: {
-            options: { limit: 5 },
-          },
-          readField,
-        } as FieldFunctionOptions,
-      ),
-    ).toBe(undefined);
-  });
-
-  it("reads the first page and returns limit active versions", () => {
+      getVersionIds(readPage(cache, { maxOrder: 16 }) as Waterfall),
+    ).toStrictEqual(getVersionIds(page2));
     expect(
-      readVersions(
-        {
-          allActiveVersions: new Set(["b", "c", "f"]),
-          versions: versions,
-          // @ts-expect-error: only mostRecentVersionOrder affects reading versions
-          pagination: {
-            mostRecentVersionOrder: 5,
-          },
-        },
-        // @ts-expect-error: for tests we can omit unused fields from the args
-        {
-          args: {
-            options: { limit: 3, maxOrder: 6 },
-          },
-          readField,
-        } as FieldFunctionOptions,
-      ),
-    ).toStrictEqual({
-      versions: versions,
-      pagination: {
-        activeVersionIds: ["b", "c", "f"],
-        hasPrevPage: false,
-        hasNextPage: false,
-        mostRecentVersionOrder: 5,
-        prevPageOrder: 0,
-        nextPageOrder: 0,
-      },
-    });
-  });
-
-  it("truncates after limit active versions", () => {
-    expect(
-      readVersions(
-        {
-          allActiveVersions: new Set(["b", "c", "f"]),
-          versions: versions,
-          // @ts-expect-error: only mostRecentVersionOrder affects reading versions
-          pagination: {
-            mostRecentVersionOrder: 5,
-          },
-        },
-        // @ts-expect-error: for tests we can omit unused fields from the args
-        {
-          args: {
-            options: { limit: 2, maxOrder: 5 },
-          },
-          readField,
-        } as FieldFunctionOptions,
-      ),
-    ).toStrictEqual({
-      versions: versions.slice(1, 3),
-      pagination: {
-        activeVersionIds: ["b", "c"],
-        hasPrevPage: true,
-        hasNextPage: true,
-        mostRecentVersionOrder: 5,
-        prevPageOrder: 4,
-        nextPageOrder: 3,
-      },
-    });
-  });
-
-  it("correctly reads a page", () => {
-    expect(
-      readVersions(
-        {
-          allActiveVersions: new Set(["b", "c", "f"]),
-          versions: versions,
-          // @ts-expect-error: only mostRecentVersionOrder affects reading versions
-          pagination: {
-            mostRecentVersionOrder: 5,
-          },
-        },
-        // @ts-expect-error: for tests we can omit unused fields from the args
-        {
-          args: {
-            options: {
-              limit: 2,
-              maxOrder: 4,
-            },
-          },
-          readField,
-        } as FieldFunctionOptions,
-      ),
-    ).toStrictEqual({
-      versions: versions.slice(2),
-      pagination: {
-        activeVersionIds: ["c", "f"],
-        hasPrevPage: true,
-        hasNextPage: false,
-        mostRecentVersionOrder: 5,
-        prevPageOrder: 3,
-        nextPageOrder: 0,
-      },
-    });
-  });
-
-  it("reads a page using minOrder", () => {
-    expect(
-      readVersions(
-        {
-          allActiveVersions: new Set(["b", "c", "f"]),
-          versions: versions,
-          // @ts-expect-error: only mostRecentVersionOrder affects reading versions
-          pagination: {
-            mostRecentVersionOrder: 5,
-          },
-        },
-        // @ts-expect-error: for tests we can omit unused fields from the args
-        {
-          args: {
-            options: {
-              limit: 2,
-              minOrder: 2,
-            },
-          },
-          readField,
-        } as FieldFunctionOptions,
-      ),
-    ).toStrictEqual({
-      versions: versions.slice(0, 3),
-      pagination: {
-        activeVersionIds: ["b", "c"],
-        hasPrevPage: false,
-        hasNextPage: true,
-        mostRecentVersionOrder: 5,
-        prevPageOrder: 0,
-        nextPageOrder: 3,
-      },
-    });
-  });
-
-  it("reads a page using minOrder with previous pages", () => {
-    expect(
-      readVersions(
-        {
-          allActiveVersions: new Set(["b", "c", "f"]),
-          versions: versions,
-          // @ts-expect-error: only mostRecentVersionOrder affects reading versions
-          pagination: {
-            mostRecentVersionOrder: 5,
-          },
-        },
-        // @ts-expect-error: for tests we can omit unused fields from the args
-        {
-          args: {
-            options: {
-              limit: 1,
-              minOrder: 2,
-            },
-          },
-          readField,
-        } as FieldFunctionOptions,
-      ),
-    ).toStrictEqual({
-      versions: versions.slice(2, 3),
-      pagination: {
-        activeVersionIds: ["c"],
-        hasPrevPage: true,
-        hasNextPage: true,
-        mostRecentVersionOrder: 5,
-        prevPageOrder: 3,
-        nextPageOrder: 3,
-      },
-    });
-  });
-
-  it("returns undefined when the order is not found in the cache", () => {
-    expect(
-      readVersions(
-        {
-          versions: versions,
-          // @ts-expect-error: only mostRecentVersionOrder affects reading versions
-          pagination: {
-            mostRecentVersionOrder: 5,
-          },
-        },
-        // @ts-expect-error: for tests we can omit unused fields from the args
-        {
-          args: {
-            options: {
-              limit: 5,
-              minOrder: 8,
-            },
-          },
-          readField,
-        } as FieldFunctionOptions,
-      ),
-    ).toBe(undefined);
-  });
-
-  it("returns undefined when the number of activated versions found is less than the limit and server has next page", () => {
-    expect(
-      readVersions(
-        {
-          versions: versions,
-          // @ts-expect-error: only mostRecentVersionOrder affects reading versions
-          pagination: {
-            mostRecentVersionOrder: 5,
-            hasNextPage: true,
-          },
-        },
-        // @ts-expect-error: for tests we can omit unused fields from the args
-        {
-          args: {
-            options: {
-              limit: 3,
-              maxOrder: 4,
-            },
-          },
-          readField,
-        } as FieldFunctionOptions,
-      ),
-    ).toBe(undefined);
-  });
-
-  it("returns available versions when active versions are less than limit and server has no next page", () => {
-    expect(
-      readVersions(
-        {
-          allActiveVersions: new Set(["c", "f"]),
-          versions: versions,
-          // @ts-expect-error: only mostRecentVersionOrder affects reading versions
-          pagination: {
-            mostRecentVersionOrder: 5,
-            hasNextPage: false,
-          },
-        },
-        // @ts-expect-error: for tests we can omit unused fields from the args
-        {
-          args: {
-            options: {
-              limit: 3,
-              maxOrder: 4,
-            },
-          },
-          readField,
-        } as FieldFunctionOptions,
-      ),
-    ).toStrictEqual({
-      versions: versions.slice(2),
-      pagination: {
-        activeVersionIds: ["c", "f"],
-        hasPrevPage: true,
-        hasNextPage: false,
-        mostRecentVersionOrder: 5,
-        prevPageOrder: 3,
-        nextPageOrder: 0,
-      },
-    });
-  });
-
-  it("returns first page if it exists in cache, even if minOrder and maxOrder are undefined", () => {
-    expect(
-      readVersions(
-        {
-          allActiveVersions: new Set(["b", "c", "f"]),
-          versions: versions,
-          // @ts-expect-error: only mostRecentVersionOrder affects reading versions
-          pagination: {
-            mostRecentVersionOrder: 5,
-          },
-        },
-        // @ts-expect-error: for tests we can omit unused fields from the args
-        {
-          args: {
-            options: {
-              maxOrder: undefined,
-              minOrder: undefined,
-              limit: 3,
-            },
-          },
-          readField,
-        } as FieldFunctionOptions,
-      ),
-    ).toStrictEqual({
-      versions: versions,
-      pagination: {
-        activeVersionIds: ["b", "c", "f"],
-        hasPrevPage: false,
-        hasNextPage: false,
-        mostRecentVersionOrder: 5,
-        prevPageOrder: 0,
-        nextPageOrder: 0,
-      },
-    });
-  });
-
-  it("returns all versions on initial load when project has fewer active versions than limit and no next page", () => {
-    expect(
-      readVersions(
-        {
-          allActiveVersions: new Set(["b", "c"]),
-          versions: versions.slice(0, 3),
-          // @ts-expect-error: only mostRecentVersionOrder and hasNextPage affect reading versions
-          pagination: {
-            mostRecentVersionOrder: 5,
-            hasNextPage: false,
-          },
-        },
-        // @ts-expect-error: for tests we can omit unused fields from the args
-        {
-          args: {
-            options: {
-              limit: 5,
-            },
-          },
-          readField,
-        } as FieldFunctionOptions,
-      ),
-    ).toStrictEqual({
-      versions: versions.slice(0, 3),
-      pagination: {
-        activeVersionIds: ["b", "c"],
-        hasPrevPage: false,
-        hasNextPage: true,
-        mostRecentVersionOrder: 5,
-        prevPageOrder: 0,
-        nextPageOrder: 3,
-      },
-    });
-  });
-
-  it("only applies active versions against the version limit", () => {
-    expect(
-      readVersions(
-        {
-          allActiveVersions: new Set(["b", "c", "f"]),
-          versions: versions,
-          // @ts-expect-error: only mostRecentVersionOrder affects reading versions
-          pagination: {
-            mostRecentVersionOrder: 5,
-          },
-        },
-        // @ts-expect-error: for tests we can omit unused fields from the args
-        {
-          args: {
-            options: { limit: 2 },
-          },
-          readField,
-        } as FieldFunctionOptions,
-      ),
-    ).toStrictEqual({
-      versions: versions.slice(0, 3),
-      pagination: {
-        activeVersionIds: ["b", "c"],
-        hasPrevPage: false,
-        hasNextPage: true,
-        mostRecentVersionOrder: 5,
-        prevPageOrder: 0,
-        nextPageOrder: 3,
-      },
-    });
+      getVersionIds(readPage(cache, { minOrder: 15 }) as Waterfall),
+    ).toStrictEqual(getVersionIds(page1));
   });
 });

--- a/apps/spruce/src/pages/waterfall/caching/index.ts
+++ b/apps/spruce/src/pages/waterfall/caching/index.ts
@@ -1,73 +1,130 @@
-import { FieldMergeFunction, FieldReadFunction } from "@apollo/client";
+import {
+  FieldFunctionOptions,
+  FieldMergeFunction,
+  FieldReadFunction,
+} from "@apollo/client";
 import { WaterfallQuery } from "gql/generated/types";
 import { VERSION_LIMIT } from "../constants";
 
-export const readVersions = ((existing, { args, readField }) => {
-  if (!existing) {
-    return undefined;
-  }
+const DEFAULT_CACHED_PAGE_LIMIT = 6;
+const MONGODB_MONGO_CACHED_PAGE_LIMIT = 2;
+const MONGODB_MONGO_PROJECT_PREFIX = "mongodb-mongo-";
 
-  const minOrder = args?.options?.minOrder ?? 0;
-  let maxOrder = args?.options?.maxOrder ?? 0;
-  const limit = args?.options?.limit ?? VERSION_LIMIT;
-  const date = args?.options?.date ?? "";
-  const revision = args?.options?.revision ?? "";
+type Waterfall = WaterfallQuery["waterfall"];
+type Version = Waterfall["versions"][number];
+type ReadField = FieldFunctionOptions["readField"];
 
-  const { hasNextPage = true, mostRecentVersionOrder = 0 } =
-    readField<WaterfallQuery["waterfall"]["pagination"]>(
-      "pagination",
-      existing,
-    ) ?? {};
+const getCacheOptions = (args: FieldFunctionOptions["args"]) => ({
+  date: args?.options?.date ?? "",
+  limit: args?.options?.limit ?? VERSION_LIMIT,
+  maxOrder: args?.options?.maxOrder ?? 0,
+  minOrder: args?.options?.minOrder ?? 0,
+  projectIdentifier: args?.options?.projectIdentifier ?? "",
+  revision: args?.options?.revision ?? "",
+});
 
-  // Leverage cache if there are no other query params.
-  if (minOrder === 0 && maxOrder === 0 && !date && !revision) {
-    maxOrder = mostRecentVersionOrder + 1;
-  }
+const getCachedPageLimit = (projectIdentifier: string) =>
+  projectIdentifier.startsWith(MONGODB_MONGO_PROJECT_PREFIX)
+    ? MONGODB_MONGO_CACHED_PAGE_LIMIT
+    : DEFAULT_CACHED_PAGE_LIMIT;
 
-  const existingVersions =
-    readField<WaterfallQuery["waterfall"]["versions"]>("versions", existing) ??
-    [];
+const getVersionId = (version: Version, readField: ReadField) =>
+  readField<string>("id", version) ?? "";
 
-  const idx = existingVersions.findIndex((v) => {
-    const versionOrder = readField<number>("order", v) ?? 0;
-    if (minOrder) {
-      return versionOrder - 1 === minOrder;
-    }
-    if (maxOrder) {
-      return versionOrder + 1 === maxOrder;
-    }
-    return false;
+const getVersionOrder = (version: Version, readField: ReadField) =>
+  readField<number>("order", version) ?? 0;
+
+const deduplicateAndSortVersions = (
+  versions: readonly Version[],
+  readField: ReadField,
+) => {
+  const versionsByOrder = new Map<number, Version>();
+  versions.forEach((version) => {
+    versionsByOrder.set(getVersionOrder(version, readField), version);
   });
+  return [...versionsByOrder.values()].sort(
+    (a, b) => getVersionOrder(b, readField) - getVersionOrder(a, readField),
+  );
+};
 
-  if (idx === -1) {
+const boundVersions = ({
+  activeVersionIds,
+  keepOldest,
+  maxActiveVersions,
+  readField,
+  versions,
+}: {
+  activeVersionIds: Set<string>;
+  keepOldest: boolean;
+  maxActiveVersions: number;
+  readField: ReadField;
+  versions: readonly Version[];
+}) => {
+  const activeVersionIndexes = versions.reduce<number[]>(
+    (indexes, version, index) => {
+      if (activeVersionIds.has(getVersionId(version, readField))) {
+        indexes.push(index);
+      }
+      return indexes;
+    },
+    [],
+  );
+
+  if (activeVersionIndexes.length <= maxActiveVersions) {
+    return [...versions];
+  }
+  if (keepOldest) {
+    const startIndex =
+      activeVersionIndexes[activeVersionIndexes.length - maxActiveVersions];
+    return versions.slice(startIndex);
+  }
+  const endIndex = activeVersionIndexes[maxActiveVersions - 1];
+  return versions.slice(0, endIndex + 1);
+};
+
+const findPageRange = ({
+  activeVersionIds,
+  hasNextPage,
+  limit,
+  maxOrder,
+  minOrder,
+  readField,
+  versions,
+}: {
+  activeVersionIds: Set<string>;
+  hasNextPage: boolean;
+  limit: number;
+  maxOrder: number;
+  minOrder: number;
+  readField: ReadField;
+  versions: readonly Version[];
+}) => {
+  const anchorIndex = versions.findIndex((version) => {
+    const order = getVersionOrder(version, readField);
+    return minOrder ? order - 1 === minOrder : order + 1 === maxOrder;
+  });
+  if (anchorIndex === -1) {
     return undefined;
   }
 
-  let startIndex = maxOrder ? idx : 0;
-  let endIndex = maxOrder ? existingVersions.length : idx;
+  let startIndex = maxOrder ? anchorIndex : 0;
+  let endIndex = maxOrder ? versions.length : anchorIndex;
+  const pageActiveVersionIds: string[] = [];
 
-  const activeVersionIds = [];
-  const allActiveVersions =
-    readField<Set<string>>("allActiveVersions", existing) ?? new Set();
-
-  // Count backwards for paginating backwards.
   if (minOrder) {
     for (let i = endIndex; i >= 0; i--) {
-      const id = readField<string>("id", existingVersions[i]) ?? "";
-      if (allActiveVersions.has(id)) {
-        activeVersionIds.push(id);
-        if (activeVersionIds.length === limit) {
+      const versionId = getVersionId(versions[i], readField);
+      if (activeVersionIds.has(versionId)) {
+        pageActiveVersionIds.push(versionId);
+        if (pageActiveVersionIds.length === limit) {
           startIndex = i;
-          // Handle unmatching leading versions
-          i -= 1;
           while (
-            i >= 0 &&
-            !allActiveVersions.has(
-              readField<string>("id", existingVersions[i]) ?? "",
+            startIndex > 0 &&
+            !activeVersionIds.has(
+              getVersionId(versions[startIndex - 1], readField),
             )
           ) {
-            startIndex = i;
-            i -= 1;
+            startIndex -= 1;
           }
           break;
         }
@@ -75,37 +132,77 @@ export const readVersions = ((existing, { args, readField }) => {
     }
   }
 
-  // Count forwards for paginating forwards.
   if (maxOrder) {
-    for (let i = startIndex; i < existingVersions.length; i++) {
-      const id = readField<string>("id", existingVersions[i]) ?? "";
-      if (allActiveVersions.has(id)) {
-        activeVersionIds.push(id);
-        if (activeVersionIds.length === limit) {
+    for (let i = startIndex; i < versions.length; i++) {
+      const versionId = getVersionId(versions[i], readField);
+      if (activeVersionIds.has(versionId)) {
+        pageActiveVersionIds.push(versionId);
+        if (pageActiveVersionIds.length === limit) {
           endIndex = i;
           break;
         }
       }
     }
-    if (activeVersionIds.length < limit) {
-      // If the server already indicated there are no more pages, return the
-      // data we have rather than triggering an infinite refetch loop.
-      if (!hasNextPage) {
-        endIndex = existingVersions.length - 1;
-      } else {
+    if (pageActiveVersionIds.length < limit) {
+      if (hasNextPage) {
         return undefined;
       }
+      endIndex = versions.length - 1;
     }
   }
 
+  return {
+    activeVersionIds: pageActiveVersionIds,
+    endIndex,
+    startIndex,
+  };
+};
+
+export const readVersions = ((existing, { args, readField }) => {
+  if (!existing) {
+    return undefined;
+  }
+
+  const options = getCacheOptions(args);
+  const { date, limit, minOrder, revision } = options;
+  let { maxOrder } = options;
+
+  const { hasNextPage = true, mostRecentVersionOrder = 0 } =
+    readField<Waterfall["pagination"]>("pagination", existing) ?? {};
+
+  // Leverage cache if there are no other query params.
+  if (minOrder === 0 && maxOrder === 0 && !date && !revision) {
+    maxOrder = mostRecentVersionOrder + 1;
+  }
+
+  const existingVersions =
+    readField<Waterfall["versions"]>("versions", existing) ?? [];
+  const allActiveVersions =
+    readField<Set<string>>("allActiveVersions", existing) ?? new Set();
+  const pageRange = findPageRange({
+    activeVersionIds: allActiveVersions,
+    hasNextPage,
+    limit,
+    maxOrder,
+    minOrder,
+    readField,
+    versions: existingVersions,
+  });
+  if (!pageRange) {
+    return undefined;
+  }
+
+  const { activeVersionIds, endIndex, startIndex } = pageRange;
   // Add 1 because slice is [inclusive, exclusive).
   const versions = existingVersions.slice(startIndex, endIndex + 1);
-  const zerothOrder = readField<number>("order", versions[0]) ?? 0;
+  const zerothOrder = getVersionOrder(versions[0], readField);
   const prevOrderNumber =
     mostRecentVersionOrder === zerothOrder ? 0 : zerothOrder;
 
-  const lastVersionOrder =
-    readField<number>("order", versions[versions.length - 1]) ?? 0;
+  const lastVersionOrder = getVersionOrder(
+    versions[versions.length - 1],
+    readField,
+  );
   const nextOrderNumber = lastVersionOrder === 1 ? 0 : lastVersionOrder;
 
   return {
@@ -120,34 +217,21 @@ export const readVersions = ((existing, { args, readField }) => {
     },
     versions,
   };
-}) satisfies FieldReadFunction<WaterfallQuery["waterfall"]>;
+}) satisfies FieldReadFunction<Waterfall>;
 
-export const mergeVersions = ((existing, incoming, { readField }) => {
+export const mergeVersions = ((existing, incoming, { args, readField }) => {
+  const { limit, maxOrder, projectIdentifier } = getCacheOptions(args);
   const existingVersions = existing
-    ? (readField<WaterfallQuery["waterfall"]["versions"]>(
-        "versions",
-        existing,
-      ) ?? [])
+    ? (readField<Waterfall["versions"]>("versions", existing) ?? [])
     : [];
   const incomingVersions =
-    readField<WaterfallQuery["waterfall"]["versions"]>("versions", incoming) ??
-    [];
-  const versions = [...existingVersions, ...incomingVersions];
+    readField<Waterfall["versions"]>("versions", incoming) ?? [];
+  const mergedVersions = deduplicateAndSortVersions(
+    [...existingVersions, ...incomingVersions],
+    readField,
+  );
 
-  // Use a map to enforce that there are no duplicates.
-  const versionsMap = new Map();
-  versions.forEach((v) => {
-    const order = readField<number>("order", v) ?? 0;
-    versionsMap.set(order, v);
-  });
-
-  const v = Array.from(versionsMap.values()).sort((a, b) => {
-    const aOrder = readField<number>("order", a) ?? 0;
-    const bOrder = readField<number>("order", b) ?? 0;
-    return bOrder - aOrder;
-  });
-
-  const pagination = readField<WaterfallQuery["waterfall"]["pagination"]>(
+  const pagination = readField<Waterfall["pagination"]>(
     "pagination",
     incoming,
   ) ?? {
@@ -159,17 +243,37 @@ export const mergeVersions = ((existing, incoming, { readField }) => {
     prevPageOrder: 0,
   };
 
-  const existingActiveVersions = existing
-    ? (readField<Set<string>>("allActiveVersions", existing) ?? new Set())
+  const allActiveVersions = existing
+    ? new Set(readField<Set<string>>("allActiveVersions", existing) ?? [])
     : new Set<string>();
   const incomingActiveVersions =
     readField<string[]>("activeVersionIds", pagination) ?? [];
-  incomingActiveVersions.forEach((vId) => existingActiveVersions.add(vId));
+  incomingActiveVersions.forEach((versionId) =>
+    allActiveVersions.add(versionId),
+  );
+
+  const boundedVersions = boundVersions({
+    activeVersionIds: allActiveVersions,
+    keepOldest: Boolean(maxOrder),
+    maxActiveVersions: limit * getCachedPageLimit(projectIdentifier),
+    readField,
+    versions: mergedVersions,
+  });
+
+  const retainedVersionIds = new Set(
+    boundedVersions.map((version) => getVersionId(version, readField)),
+  );
+  const retainedActiveVersions = new Set(
+    [...allActiveVersions].filter((versionId) =>
+      retainedVersionIds.has(versionId),
+    ),
+  );
+
   return {
-    versions: v,
+    versions: boundedVersions,
     pagination,
-    allActiveVersions: existingActiveVersions,
+    allActiveVersions: retainedActiveVersions,
   };
 }) satisfies FieldMergeFunction<
-  WaterfallQuery["waterfall"] & { allActiveVersions?: Set<string> }
+  Waterfall & { allActiveVersions?: Set<string> }
 >;

--- a/apps/spruce/src/pages/waterfall/index.tsx
+++ b/apps/spruce/src/pages/waterfall/index.tsx
@@ -1,4 +1,5 @@
-import { Suspense, useCallback, useRef, useState } from "react";
+import { Suspense, useCallback, useEffect, useRef, useState } from "react";
+import { useApolloClient } from "@apollo/client/react";
 import { Global, css } from "@emotion/react";
 import styled from "@emotion/styled";
 import { useParams } from "react-router-dom";
@@ -27,6 +28,7 @@ const Waterfall: React.FC = () => {
   );
 
   const { sendEvent } = useWaterfallAnalytics();
+  const { cache } = useApolloClient();
 
   const [pagination, setPagination] = useState<Pagination>();
 
@@ -38,6 +40,19 @@ const Waterfall: React.FC = () => {
   const restartWalkthrough = useCallback(
     () => guideCueRef.current?.restart(),
     [],
+  );
+
+  useEffect(
+    () =>
+      // Remove waterfall data from cache upon navigation
+      () => {
+        cache.evict({
+          id: "ROOT_QUERY",
+          fieldName: "waterfall",
+        });
+        cache.gc();
+      },
+    [cache],
   );
 
   return (

--- a/apps/spruce/src/pages/waterfall/usePaginationNavigation.ts
+++ b/apps/spruce/src/pages/waterfall/usePaginationNavigation.ts
@@ -1,8 +1,12 @@
 import { useCallback } from "react";
 import { useQueryParam, useQueryParams } from "@evg-ui/lib/hooks";
 import { Pagination, WaterfallFilterOptions } from "./types";
+import { startWaterfallNavigationTrace } from "./useWaterfallTrace";
 
-export const usePaginationNavigation = (pagination: Pagination | undefined) => {
+export const usePaginationNavigation = (
+  pagination: Pagination | undefined,
+  projectIdentifier: string,
+) => {
   const [, setQueryParams] = useQueryParams();
 
   const { hasNextPage, hasPrevPage, nextPageOrder, prevPageOrder } =
@@ -24,6 +28,10 @@ export const usePaginationNavigation = (pagination: Pagination | undefined) => {
     prevPageOrder === minOrder || nextPageOrder === maxOrder;
 
   const goToNextPage = useCallback(() => {
+    startWaterfallNavigationTrace({
+      direction: "next",
+      projectIdentifier,
+    });
     setQueryParams((queryParams) => ({
       ...queryParams,
       [WaterfallFilterOptions.Date]: undefined,
@@ -31,9 +39,13 @@ export const usePaginationNavigation = (pagination: Pagination | undefined) => {
       [WaterfallFilterOptions.MinOrder]: undefined,
       [WaterfallFilterOptions.Revision]: undefined,
     }));
-  }, [setQueryParams, nextPageOrder]);
+  }, [setQueryParams, nextPageOrder, projectIdentifier]);
 
   const goToPrevPage = useCallback(() => {
+    startWaterfallNavigationTrace({
+      direction: "previous",
+      projectIdentifier,
+    });
     setQueryParams((queryParams) => ({
       ...queryParams,
       [WaterfallFilterOptions.Date]: undefined,
@@ -41,7 +53,7 @@ export const usePaginationNavigation = (pagination: Pagination | undefined) => {
       [WaterfallFilterOptions.MinOrder]: prevPageOrder,
       [WaterfallFilterOptions.Revision]: undefined,
     }));
-  }, [setQueryParams, prevPageOrder]);
+  }, [setQueryParams, prevPageOrder, projectIdentifier]);
 
   return {
     goToNextPage,

--- a/apps/spruce/src/pages/waterfall/useWaterfallTrace.ts
+++ b/apps/spruce/src/pages/waterfall/useWaterfallTrace.ts
@@ -1,7 +1,90 @@
 import { useEffect, useRef } from "react";
 import { Span, trace } from "@opentelemetry/api";
+import { WaterfallQuery } from "gql/generated/types";
+import { getGQLUrl } from "utils/environmentVariables";
 
 const tracer = trace.getTracer("performance");
+
+type NavigationDirection = "next" | "previous";
+
+interface ActiveNavigation {
+  span: Span;
+  startTime: number;
+}
+
+let activeNavigation: ActiveNavigation | null = null;
+
+const getProjectClass = (projectIdentifier: string) => {
+  if (projectIdentifier.startsWith("mongodb-mongo-")) {
+    return "mongodb-mongo";
+  }
+  if (projectIdentifier === "mms" || projectIdentifier.startsWith("mms-")) {
+    return "mms";
+  }
+  return "other";
+};
+
+export const startWaterfallNavigationTrace = ({
+  direction,
+  projectIdentifier,
+}: {
+  direction: NavigationDirection;
+  projectIdentifier: string;
+}) => {
+  if (activeNavigation) {
+    activeNavigation.span.setAttribute("waterfall.navigation.cancelled", true);
+    activeNavigation.span.end();
+  }
+
+  const span = tracer.startSpan("Navigate waterfall");
+  span.setAttributes({
+    "waterfall.navigation.direction": direction,
+    "waterfall.project_class": getProjectClass(projectIdentifier),
+    "waterfall.project_identifier": projectIdentifier,
+  });
+  activeNavigation = { span, startTime: performance.now() };
+};
+
+export const finishWaterfallNavigationTrace = ({
+  buildCount,
+  taskCount,
+  versionCount,
+}: {
+  buildCount: number;
+  taskCount: number;
+  versionCount: number;
+}) => {
+  const navigation = activeNavigation;
+  if (!navigation) {
+    return;
+  }
+
+  requestAnimationFrame(() => {
+    setTimeout(() => {
+      if (activeNavigation !== navigation) {
+        return;
+      }
+
+      const gqlURL = new URL(getGQLUrl(), window.location.origin).href;
+      const networkRequestOccurred = performance
+        .getEntriesByType("resource")
+        .some(
+          (entry) =>
+            entry.startTime >= navigation.startTime &&
+            entry.name.startsWith(gqlURL),
+        );
+
+      navigation.span.setAttributes({
+        "waterfall.build.count": buildCount,
+        "waterfall.navigation.network_request": networkRequestOccurred,
+        "waterfall.task.count": taskCount,
+        "waterfall.version.count": versionCount,
+      });
+      navigation.span.end();
+      activeNavigation = null;
+    }, 0);
+  });
+};
 
 export const useWaterfallTrace = () => {
   const resolveRenderRef = useRef<(() => void) | null>(null);
@@ -32,4 +115,33 @@ export const useWaterfallTrace = () => {
       resolveRenderRef.current();
     }
   }, []);
+};
+
+export const useWaterfallNavigationTrace = ({
+  data,
+}: {
+  data: WaterfallQuery | undefined;
+}) => {
+  useEffect(() => {
+    if (!data) {
+      return;
+    }
+
+    const { buildCount, taskCount } = data.waterfall.versions.reduce(
+      (counts, version) => {
+        version.waterfallBuilds?.forEach((build) => {
+          counts.buildCount += 1;
+          counts.taskCount += build.tasks?.length ?? 0;
+        });
+        return counts;
+      },
+      { buildCount: 0, taskCount: 0 },
+    );
+
+    finishWaterfallNavigationTrace({
+      buildCount,
+      taskCount,
+      versionCount: data.waterfall.versions.length,
+    });
+  }, [data]);
 };


### PR DESCRIPTION
DEVPROD-27284

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->

<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
<!-- add description, context, thought process, etc -->

A couple Apollo caching updates I've been meaning to make:
- Set `executionSelectionSet` max size of 150,000 (from default 50,000). Since server projects hit 60,000 upon first load, we don't want to have to begin cache eviction on initial load.
- Configure version limit for the waterfall page's cache. For server projects, limit to 2 pages (10 active versions) to remain under the 150k limit. Other projects get a conservative 6 pages (mms is ~20,000 entries per page so this should be no problem).
- Clear waterfall queries from the cache on project switching and when navigating away from the page. They are just so large, the data is never used by other queries on the site, and users should hit updated data instead of the cache next time they go to the waterfall.
- Split out caching read/merge functions into more understandable utils
- Add instrumentation for the waterfall performance board