### PR TITLE
DEVPROD-36652: add admin setting for SNS topics

### DIFF
--- a/apps/parsley/src/gql/generated/types.ts
+++ b/apps/parsley/src/gql/generated/types.ts
@@ -65,6 +65,7 @@ export type AwsConfig = {
   alertableInstanceTypes: Array<Scalars["String"]["output"]>;
   allowedInstanceTypes: Array<Scalars["String"]["output"]>;
   allowedRegions: Array<Scalars["String"]["output"]>;
+  allowedSNSTopicARNs: Array<Scalars["String"]["output"]>;
   defaultSecurityGroup?: Maybe<Scalars["String"]["output"]>;
   elasticIPUsageRate?: Maybe<Scalars["Float"]["output"]>;
   ipamPoolID?: Maybe<Scalars["String"]["output"]>;
@@ -79,6 +80,7 @@ export type AwsConfigInput = {
   alertableInstanceTypes: Array<Scalars["String"]["input"]>;
   allowedInstanceTypes: Array<Scalars["String"]["input"]>;
   allowedRegions: Array<Scalars["String"]["input"]>;
+  allowedSNSTopicARNs: Array<Scalars["String"]["input"]>;
   defaultSecurityGroup?: InputMaybe<Scalars["String"]["input"]>;
   elasticIPUsageRate?: InputMaybe<Scalars["Float"]["input"]>;
   ipamPoolID?: InputMaybe<Scalars["String"]["input"]>;
@@ -1017,6 +1019,14 @@ export type EnvVar = {
 export type EnvVarInput = {
   key: Scalars["String"]["input"];
   value: Scalars["String"]["input"];
+};
+
+/**
+ * ExecutionTasksFilterOptions is an input for the task.executionTasksFull field.
+ * It's used to filter a display task's execution tasks.
+ */
+export type ExecutionTasksFilterOptions = {
+  statuses?: InputMaybe<Array<Scalars["String"]["input"]>>;
 };
 
 export type Expansion = {
@@ -4158,6 +4168,11 @@ export type Task = {
   totalTestCount: Scalars["Int"]["output"];
   version: VersionLite;
   versionMetadata: Version;
+};
+
+/** Task models a task, the simplest unit of execution for Evergreen. */
+export type TaskExecutionTasksFullArgs = {
+  options?: InputMaybe<ExecutionTasksFilterOptions>;
 };
 
 /** Task models a task, the simplest unit of execution for Evergreen. */

--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -62,13 +62,13 @@ export type AwsConfig = {
   alertableInstanceTypes: Array<Scalars["String"]["output"]>;
   allowedInstanceTypes: Array<Scalars["String"]["output"]>;
   allowedRegions: Array<Scalars["String"]["output"]>;
+  allowedSNSTopicARNs: Array<Scalars["String"]["output"]>;
   defaultSecurityGroup?: Maybe<Scalars["String"]["output"]>;
   elasticIPUsageRate?: Maybe<Scalars["Float"]["output"]>;
   ipamPoolID?: Maybe<Scalars["String"]["output"]>;
   maxVolumeSizePerUser?: Maybe<Scalars["Int"]["output"]>;
   parserProject?: Maybe<ParserProjectS3Config>;
   persistentDNS?: Maybe<PersistentDnsConfig>;
-  snsTopicARNs: Array<Scalars["String"]["output"]>;
   subnets: Array<Subnet>;
 };
 
@@ -77,13 +77,13 @@ export type AwsConfigInput = {
   alertableInstanceTypes: Array<Scalars["String"]["input"]>;
   allowedInstanceTypes: Array<Scalars["String"]["input"]>;
   allowedRegions: Array<Scalars["String"]["input"]>;
+  allowedSNSTopicARNs: Array<Scalars["String"]["input"]>;
   defaultSecurityGroup?: InputMaybe<Scalars["String"]["input"]>;
   elasticIPUsageRate?: InputMaybe<Scalars["Float"]["input"]>;
   ipamPoolID?: InputMaybe<Scalars["String"]["input"]>;
   maxVolumeSizePerUser?: InputMaybe<Scalars["Int"]["input"]>;
   parserProject?: InputMaybe<ParserProjectS3ConfigInput>;
   persistentDNS?: InputMaybe<PersistentDnsConfigInput>;
-  snsTopicARNs: Array<Scalars["String"]["input"]>;
   subnets: Array<SubnetInput>;
 };
 
@@ -7850,7 +7850,7 @@ export type AdminSettingsQuery = {
         elasticIPUsageRate?: number | null;
         ipamPoolID?: string | null;
         maxVolumeSizePerUser?: number | null;
-        snsTopicARNs: Array<string>;
+        allowedSNSTopicARNs: Array<string>;
         accountRoles: Array<{
           __typename?: "AWSAccountRoleMapping";
           account: string;

--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -1018,6 +1018,14 @@ export type EnvVarInput = {
   value: Scalars["String"]["input"];
 };
 
+/**
+ * ExecutionTasksFilterOptions is an input for the task.executionTasksFull field.
+ * It's used to filter a display task's execution tasks.
+ */
+export type ExecutionTasksFilterOptions = {
+  statuses?: InputMaybe<Array<Scalars["String"]["input"]>>;
+};
+
 export type Expansion = {
   __typename?: "Expansion";
   key: Scalars["String"]["output"];
@@ -4158,6 +4166,11 @@ export type Task = {
   totalTestCount: Scalars["Int"]["output"];
   version: VersionLite;
   versionMetadata: Version;
+};
+
+/** Task models a task, the simplest unit of execution for Evergreen. */
+export type TaskExecutionTasksFullArgs = {
+  options?: InputMaybe<ExecutionTasksFilterOptions>;
 };
 
 /** Task models a task, the simplest unit of execution for Evergreen. */
@@ -7846,11 +7859,11 @@ export type AdminSettingsQuery = {
         alertableInstanceTypes: Array<string>;
         allowedInstanceTypes: Array<string>;
         allowedRegions: Array<string>;
+        allowedSNSTopicARNs: Array<string>;
         defaultSecurityGroup?: string | null;
         elasticIPUsageRate?: number | null;
         ipamPoolID?: string | null;
         maxVolumeSizePerUser?: number | null;
-        allowedSNSTopicARNs: Array<string>;
         accountRoles: Array<{
           __typename?: "AWSAccountRoleMapping";
           account: string;

--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -68,6 +68,7 @@ export type AwsConfig = {
   maxVolumeSizePerUser?: Maybe<Scalars["Int"]["output"]>;
   parserProject?: Maybe<ParserProjectS3Config>;
   persistentDNS?: Maybe<PersistentDnsConfig>;
+  snsTopicARNs: Array<Scalars["String"]["output"]>;
   subnets: Array<Subnet>;
 };
 
@@ -82,6 +83,7 @@ export type AwsConfigInput = {
   maxVolumeSizePerUser?: InputMaybe<Scalars["Int"]["input"]>;
   parserProject?: InputMaybe<ParserProjectS3ConfigInput>;
   persistentDNS?: InputMaybe<PersistentDnsConfigInput>;
+  snsTopicARNs: Array<Scalars["String"]["input"]>;
   subnets: Array<SubnetInput>;
 };
 
@@ -7848,6 +7850,7 @@ export type AdminSettingsQuery = {
         elasticIPUsageRate?: number | null;
         ipamPoolID?: string | null;
         maxVolumeSizePerUser?: number | null;
+        snsTopicARNs: Array<string>;
         accountRoles: Array<{
           __typename?: "AWSAccountRoleMapping";
           account: string;

--- a/apps/spruce/src/gql/queries/admin-settings.ts
+++ b/apps/spruce/src/gql/queries/admin-settings.ts
@@ -263,6 +263,7 @@ export const ADMIN_SETTINGS = gql`
           alertableInstanceTypes
           allowedInstanceTypes
           allowedRegions
+          allowedSNSTopicARNs
           defaultSecurityGroup
           elasticIPUsageRate
           ipamPoolID
@@ -278,7 +279,6 @@ export const ADMIN_SETTINGS = gql`
             domain
             hostedZoneID
           }
-          snsTopicARNs
           subnets {
             az
             subnetId

--- a/apps/spruce/src/gql/queries/admin-settings.ts
+++ b/apps/spruce/src/gql/queries/admin-settings.ts
@@ -278,6 +278,7 @@ export const ADMIN_SETTINGS = gql`
             domain
             hostedZoneID
           }
+          snsTopicARNs
           subnets {
             az
             subnetId

--- a/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/ProvidersTab/schemaFields.ts
+++ b/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/ProvidersTab/schemaFields.ts
@@ -206,15 +206,6 @@ export const aws = {
       },
       default: [],
     },
-    snsTopicARNs: {
-      type: "array" as const,
-      title: "SNS Topic ARNs",
-      items: {
-        type: "string" as const,
-        minLength: 1,
-      },
-      default: [],
-    },
     elasticIPUsageRate: {
       type: "number" as const,
       title: "Elastic IP Usage Rate",
@@ -225,6 +216,15 @@ export const aws = {
       type: "string" as const,
       title: "IPAM Pool ID",
       default: "",
+    },
+    allowedSNSTopicARNs: {
+      type: "array" as const,
+      title: "Allowed SNS Topic ARNs",
+      items: {
+        type: "string" as const,
+        minLength: 1,
+      },
+      default: [],
     },
     persistentDNS: {
       type: "object" as const,
@@ -289,7 +289,7 @@ export const aws = {
     allowedRegions: {
       "ui:widget": widgets.ChipInputWidget,
     },
-    snsTopicARNs: {
+    allowedSNSTopicARNs: {
       "ui:widget": widgets.ChipInputWidget,
     },
     persistentDNS: {

--- a/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/ProvidersTab/schemaFields.ts
+++ b/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/ProvidersTab/schemaFields.ts
@@ -206,6 +206,15 @@ export const aws = {
       },
       default: [],
     },
+    snsTopicARNs: {
+      type: "array" as const,
+      title: "SNS Topic ARNs",
+      items: {
+        type: "string" as const,
+        minLength: 1,
+      },
+      default: [],
+    },
     elasticIPUsageRate: {
       type: "number" as const,
       title: "Elastic IP Usage Rate",
@@ -278,6 +287,9 @@ export const aws = {
       "ui:widget": widgets.ChipInputWidget,
     },
     allowedRegions: {
+      "ui:widget": widgets.ChipInputWidget,
+    },
+    snsTopicARNs: {
       "ui:widget": widgets.ChipInputWidget,
     },
     persistentDNS: {

--- a/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/ProvidersTab/transformers.test.ts
+++ b/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/ProvidersTab/transformers.test.ts
@@ -71,6 +71,7 @@ const form: ProvidersFormState = {
       ],
       ipamPoolID: "ipam-pool-123",
       elasticIPUsageRate: 0.8,
+      snsTopicARNs: ["arn:aws:sns:us-east-1:123456789:evergreen-events"],
     },
     docker: {
       apiVersion: "1.40",
@@ -128,6 +129,7 @@ const gql: AdminSettingsInput = {
         hostedZoneID: "Z123456789",
         domain: "test.example.com",
       },
+      snsTopicARNs: ["arn:aws:sns:us-east-1:123456789:evergreen-events"],
       subnets: [
         {
           az: "us-east-1a",
@@ -197,6 +199,7 @@ const testAdminSettings = {
         hostedZoneID: "Z123456789",
         domain: "test.example.com",
       },
+      snsTopicARNs: ["arn:aws:sns:us-east-1:123456789:evergreen-events"],
       subnets: [
         {
           az: "us-east-1a",

--- a/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/ProvidersTab/transformers.test.ts
+++ b/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/ProvidersTab/transformers.test.ts
@@ -71,7 +71,7 @@ const form: ProvidersFormState = {
       ],
       ipamPoolID: "ipam-pool-123",
       elasticIPUsageRate: 0.8,
-      snsTopicARNs: ["arn:aws:sns:us-east-1:123456789:evergreen-events"],
+      allowedSNSTopicARNs: ["arn:aws:sns:us-east-1:123456789:evergreen-events"],
     },
     docker: {
       apiVersion: "1.40",
@@ -129,7 +129,7 @@ const gql: AdminSettingsInput = {
         hostedZoneID: "Z123456789",
         domain: "test.example.com",
       },
-      snsTopicARNs: ["arn:aws:sns:us-east-1:123456789:evergreen-events"],
+      allowedSNSTopicARNs: ["arn:aws:sns:us-east-1:123456789:evergreen-events"],
       subnets: [
         {
           az: "us-east-1a",
@@ -199,7 +199,7 @@ const testAdminSettings = {
         hostedZoneID: "Z123456789",
         domain: "test.example.com",
       },
-      snsTopicARNs: ["arn:aws:sns:us-east-1:123456789:evergreen-events"],
+      allowedSNSTopicARNs: ["arn:aws:sns:us-east-1:123456789:evergreen-events"],
       subnets: [
         {
           az: "us-east-1a",

--- a/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/ProvidersTab/transformers.ts
+++ b/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/ProvidersTab/transformers.ts
@@ -39,7 +39,7 @@ export const gqlToForm = ((data) => {
         allowedRegions: providers?.aws?.allowedRegions ?? [],
         ipamPoolID: providers?.aws?.ipamPoolID ?? "",
         elasticIPUsageRate: providers?.aws?.elasticIPUsageRate ?? 0,
-        snsTopicARNs: providers?.aws?.snsTopicARNs ?? [],
+        allowedSNSTopicARNs: providers?.aws?.allowedSNSTopicARNs ?? [],
         persistentDNS: {
           hostedZoneID: providers?.aws?.persistentDNS?.hostedZoneID ?? "",
           domain: providers?.aws?.persistentDNS?.domain ?? "",
@@ -89,7 +89,7 @@ export const formToGql = ((form: ProvidersFormState) => {
         elasticIPUsageRate: aws.elasticIPUsageRate || undefined,
         ipamPoolID: aws.ipamPoolID || undefined,
         maxVolumeSizePerUser: aws.maxVolumeSizePerUser || undefined,
-        snsTopicARNs: aws.snsTopicARNs,
+        allowedSNSTopicARNs: aws.allowedSNSTopicARNs,
         persistentDNS: {
           hostedZoneID: aws.persistentDNS.hostedZoneID,
           domain: aws.persistentDNS.domain || undefined,

--- a/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/ProvidersTab/transformers.ts
+++ b/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/ProvidersTab/transformers.ts
@@ -39,6 +39,7 @@ export const gqlToForm = ((data) => {
         allowedRegions: providers?.aws?.allowedRegions ?? [],
         ipamPoolID: providers?.aws?.ipamPoolID ?? "",
         elasticIPUsageRate: providers?.aws?.elasticIPUsageRate ?? 0,
+        snsTopicARNs: providers?.aws?.snsTopicARNs ?? [],
         persistentDNS: {
           hostedZoneID: providers?.aws?.persistentDNS?.hostedZoneID ?? "",
           domain: providers?.aws?.persistentDNS?.domain ?? "",
@@ -88,6 +89,7 @@ export const formToGql = ((form: ProvidersFormState) => {
         elasticIPUsageRate: aws.elasticIPUsageRate || undefined,
         ipamPoolID: aws.ipamPoolID || undefined,
         maxVolumeSizePerUser: aws.maxVolumeSizePerUser || undefined,
+        snsTopicARNs: aws.snsTopicARNs,
         persistentDNS: {
           hostedZoneID: aws.persistentDNS.hostedZoneID,
           domain: aws.persistentDNS.domain || undefined,

--- a/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/ProvidersTab/types.ts
+++ b/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/ProvidersTab/types.ts
@@ -26,6 +26,7 @@ export interface ProvidersFormState {
       allowedRegions: string[];
       ipamPoolID: string;
       elasticIPUsageRate: number;
+      snsTopicARNs: string[];
 
       persistentDNS: {
         hostedZoneID: string;

--- a/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/ProvidersTab/types.ts
+++ b/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/ProvidersTab/types.ts
@@ -26,7 +26,7 @@ export interface ProvidersFormState {
       allowedRegions: string[];
       ipamPoolID: string;
       elasticIPUsageRate: number;
-      snsTopicARNs: string[];
+      allowedSNSTopicARNs: string[];
 
       persistentDNS: {
         hostedZoneID: string;


### PR DESCRIPTION
DEVPROD-36652

### Description
Create admin setting for the allowed set of SNS topics that can send webhooks to Evergreen.

### Screenshots
<img width="1101" height="232" alt="image" src="https://github.com/user-attachments/assets/f20bea90-ba99-476d-9d3e-0919be63447c" />

### Testing
* Tested locally to verify that the setting works as expected.

### Evergreen PR
https://github.com/evergreen-ci/evergreen/pull/10611
