### PR TITLE
DEVPROD-31451: Fix execution task ID config in version tasks table

### DIFF
--- a/apps/spruce/src/pages/version/Tabs/Tasks/VersionTasksTable/VersionTasksTable.test.tsx
+++ b/apps/spruce/src/pages/version/Tabs/Tasks/VersionTasksTable/VersionTasksTable.test.tsx
@@ -78,6 +78,48 @@ describe("VersionTasksTable", () => {
     expect(screen.queryByText("e2e_spruce_0")).toBeVisible();
   });
 
+  it("uses unique row identities when an execution task is also a top-level result", async () => {
+    const user = userEvent.setup();
+    const duplicateKeyWarnings: unknown[][] = [];
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation((...args) => {
+        if (
+          typeof args[0] === "string" &&
+          args[0].includes("Encountered two children with the same key")
+        ) {
+          duplicateKeyWarnings.push(args);
+        }
+      });
+    const displayTask = tasks[3];
+    const executionTask = displayTask.executionTasksFull?.[0];
+    const filteredTasks = [executionTask, displayTask].filter(
+      (task): task is NonNullable<typeof task> => task !== undefined,
+    );
+    const { rerender } = render(
+      <MockedProvider cache={cache}>
+        <VersionTasksTable {...sharedProps} tasks={filteredTasks} />
+      </MockedProvider>,
+    );
+
+    const displayTaskRow = screen.getAllByDataCy("tasks-table-row")[1];
+    await user.click(within(displayTaskRow).getByRole("button"));
+    expect(screen.getAllByText("e2e_spruce_0")).toHaveLength(2);
+
+    await user.click(within(displayTaskRow).getByRole("button"));
+    expect(screen.getAllByDataCy("tasks-table-row")).toHaveLength(2);
+
+    rerender(
+      <MockedProvider cache={cache}>
+        <VersionTasksTable {...sharedProps} tasks={[displayTask]} />
+      </MockedProvider>,
+    );
+    expect(screen.queryByText("e2e_spruce_0")).not.toBeInTheDocument();
+    expect(screen.getAllByDataCy("tasks-table-row")).toHaveLength(1);
+    consoleError.mockRestore();
+    expect(duplicateKeyWarnings).toHaveLength(0);
+  });
+
   it("links the variant column to the variant history page using the task's project identifier", () => {
     render(
       <MockedProvider cache={cache}>

--- a/apps/spruce/src/pages/version/Tabs/Tasks/VersionTasksTable/index.tsx
+++ b/apps/spruce/src/pages/version/Tabs/Tasks/VersionTasksTable/index.tsx
@@ -143,7 +143,8 @@ export const VersionTasksTable: React.FC<VersionTasksTableProps> = ({
         // Handle bug in sorting order (https://github.com/TanStack/table/issues/4289)
         sortDescFirst: false,
       },
-      getRowId: (originalRow) => originalRow.id,
+      getRowId: (originalRow, _index, parentRow) =>
+        parentRow ? `${parentRow.id}.${originalRow.id}` : originalRow.id,
       initialState: {
         columnVisibility: { reviewed: taskReviewEnabled },
       },


### PR DESCRIPTION
DEVPROD-31451

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->

<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
<!-- add description, context, thought process, etc -->
Use a parent task ID as part of an execution task's row ID in the version tasks table. This ensures execution tasks are distinct and can expand/collapse as desired.

### Testing
<!-- add a description of how you tested it -->
- Add unit test
- Verified fix on version linked in description