### PR TITLE
DEVPROD-36201: Splitt TSS being enabled by mainline and patch versions

### DIFF
--- a/apps/parsley/src/gql/generated/types.ts
+++ b/apps/parsley/src/gql/generated/types.ts
@@ -3518,6 +3518,7 @@ export type RepoTestSelectionSettings = {
   __typename?: "RepoTestSelectionSettings";
   allowed: Scalars["Boolean"]["output"];
   defaultEnabled: Scalars["Boolean"]["output"];
+  mainlineDefaultEnabled: Scalars["Boolean"]["output"];
 };
 
 export type RepoWorkstationConfig = {
@@ -4578,11 +4579,13 @@ export type TestSelectionSettings = {
   __typename?: "TestSelectionSettings";
   allowed?: Maybe<Scalars["Boolean"]["output"]>;
   defaultEnabled?: Maybe<Scalars["Boolean"]["output"]>;
+  mainlineDefaultEnabled?: Maybe<Scalars["Boolean"]["output"]>;
 };
 
 export type TestSelectionSettingsInput = {
   allowed?: InputMaybe<Scalars["Boolean"]["input"]>;
   defaultEnabled?: InputMaybe<Scalars["Boolean"]["input"]>;
+  mainlineDefaultEnabled?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
 export enum TestSortCategory {

--- a/apps/spruce/src/gql/fragments/projectSettings/testSelection.ts
+++ b/apps/spruce/src/gql/fragments/projectSettings/testSelection.ts
@@ -6,6 +6,7 @@ export const PROJECT_TEST_SELECTION_SETTINGS = gql`
     testSelection {
       allowed
       defaultEnabled
+      mainlineDefaultEnabled
     }
   }
 `;
@@ -16,6 +17,7 @@ export const REPO_TEST_SELECTION_SETTINGS = gql`
     testSelection {
       allowed
       defaultEnabled
+      mainlineDefaultEnabled
     }
   }
 `;

--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -3515,6 +3515,7 @@ export type RepoTestSelectionSettings = {
   __typename?: "RepoTestSelectionSettings";
   allowed: Scalars["Boolean"]["output"];
   defaultEnabled: Scalars["Boolean"]["output"];
+  mainlineDefaultEnabled: Scalars["Boolean"]["output"];
 };
 
 export type RepoWorkstationConfig = {
@@ -4576,11 +4577,13 @@ export type TestSelectionSettings = {
   __typename?: "TestSelectionSettings";
   allowed?: Maybe<Scalars["Boolean"]["output"]>;
   defaultEnabled?: Maybe<Scalars["Boolean"]["output"]>;
+  mainlineDefaultEnabled?: Maybe<Scalars["Boolean"]["output"]>;
 };
 
 export type TestSelectionSettingsInput = {
   allowed?: InputMaybe<Scalars["Boolean"]["input"]>;
   defaultEnabled?: InputMaybe<Scalars["Boolean"]["input"]>;
+  mainlineDefaultEnabled?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
 export enum TestSortCategory {
@@ -5714,6 +5717,7 @@ export type ProjectSettingsFieldsFragment = {
       __typename?: "TestSelectionSettings";
       allowed?: boolean | null;
       defaultEnabled?: boolean | null;
+      mainlineDefaultEnabled?: boolean | null;
     } | null;
     triggers?: Array<{
       __typename?: "TriggerAlias";
@@ -5922,6 +5926,7 @@ export type RepoSettingsFieldsFragment = {
       __typename?: "RepoTestSelectionSettings";
       allowed: boolean;
       defaultEnabled: boolean;
+      mainlineDefaultEnabled: boolean;
     } | null;
     triggers: Array<{
       __typename?: "TriggerAlias";
@@ -6327,6 +6332,7 @@ export type ProjectEventSettingsFragment = {
       __typename?: "TestSelectionSettings";
       allowed?: boolean | null;
       defaultEnabled?: boolean | null;
+      mainlineDefaultEnabled?: boolean | null;
     } | null;
     triggers?: Array<{
       __typename?: "TriggerAlias";
@@ -6473,6 +6479,7 @@ export type ProjectTestSelectionSettingsFragment = {
     __typename?: "TestSelectionSettings";
     allowed?: boolean | null;
     defaultEnabled?: boolean | null;
+    mainlineDefaultEnabled?: boolean | null;
   } | null;
 };
 
@@ -6483,6 +6490,7 @@ export type RepoTestSelectionSettingsFragment = {
     __typename?: "RepoTestSelectionSettings";
     allowed: boolean;
     defaultEnabled: boolean;
+    mainlineDefaultEnabled: boolean;
   } | null;
 };
 
@@ -9404,6 +9412,7 @@ export type ProjectEventLogsQuery = {
             __typename?: "TestSelectionSettings";
             allowed?: boolean | null;
             defaultEnabled?: boolean | null;
+            mainlineDefaultEnabled?: boolean | null;
           } | null;
           triggers?: Array<{
             __typename?: "TriggerAlias";
@@ -9627,6 +9636,7 @@ export type ProjectEventLogsQuery = {
             __typename?: "TestSelectionSettings";
             allowed?: boolean | null;
             defaultEnabled?: boolean | null;
+            mainlineDefaultEnabled?: boolean | null;
           } | null;
           triggers?: Array<{
             __typename?: "TriggerAlias";
@@ -9915,6 +9925,7 @@ export type ProjectSettingsQuery = {
         __typename?: "TestSelectionSettings";
         allowed?: boolean | null;
         defaultEnabled?: boolean | null;
+        mainlineDefaultEnabled?: boolean | null;
       } | null;
       triggers?: Array<{
         __typename?: "TriggerAlias";
@@ -10186,6 +10197,7 @@ export type RepoEventLogsQuery = {
             __typename?: "TestSelectionSettings";
             allowed?: boolean | null;
             defaultEnabled?: boolean | null;
+            mainlineDefaultEnabled?: boolean | null;
           } | null;
           triggers?: Array<{
             __typename?: "TriggerAlias";
@@ -10409,6 +10421,7 @@ export type RepoEventLogsQuery = {
             __typename?: "TestSelectionSettings";
             allowed?: boolean | null;
             defaultEnabled?: boolean | null;
+            mainlineDefaultEnabled?: boolean | null;
           } | null;
           triggers?: Array<{
             __typename?: "TriggerAlias";
@@ -10637,6 +10650,7 @@ export type RepoSettingsQuery = {
         __typename?: "RepoTestSelectionSettings";
         allowed: boolean;
         defaultEnabled: boolean;
+        mainlineDefaultEnabled: boolean;
       } | null;
       triggers: Array<{
         __typename?: "TriggerAlias";

--- a/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/TestSelectionTab/getFormSchema.tsx
+++ b/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/TestSelectionTab/getFormSchema.tsx
@@ -1,10 +1,43 @@
 import { GetFormSchema } from "components/SpruceForm";
 import { CardFieldTemplate } from "components/SpruceForm/FieldTemplates";
+import { SpruceFormProps } from "components/SpruceForm/types";
 import widgets from "components/SpruceForm/Widgets";
 import { form } from "../utils";
-import { TestSelectionFormState } from "./types";
+import { TaskLevelTestSelection, TestSelectionFormState } from "./types";
 
 const { radioBoxOptions } = form;
+
+const taskLevelLabels: Record<TaskLevelTestSelection, string> = {
+  [TaskLevelTestSelection.Disabled]: "Disabled",
+  [TaskLevelTestSelection.Patches]: "Enabled for patches",
+  [TaskLevelTestSelection.PatchesAndMainline]:
+    "Enabled for patches and mainline commits",
+};
+
+const taskLevelOption = (
+  title: string,
+  value: TaskLevelTestSelection | null,
+): SpruceFormProps["schema"] => ({
+  type: ["string", "null"],
+  title,
+  enum: [value],
+});
+
+const taskLevelOptions = (
+  repoSetting?: TaskLevelTestSelection,
+): Array<SpruceFormProps["schema"]> => [
+  ...Object.entries(taskLevelLabels).map(([value, title]) =>
+    taskLevelOption(title, value as TaskLevelTestSelection),
+  ),
+  ...(repoSetting
+    ? [
+        taskLevelOption(
+          `Default to repo (${taskLevelLabels[repoSetting].toLowerCase()})`,
+          null,
+        ),
+      ]
+    : []),
+];
 
 export const getFormSchema = ({
   canEnableTaskLevel,
@@ -26,13 +59,10 @@ export const getFormSchema = ({
           repoData?.allowed ?? undefined,
         ),
       },
-      defaultEnabled: {
-        type: ["boolean", "null"],
+      taskLevel: {
+        type: ["string", "null"],
         title: "Task-Level Test Selection",
-        oneOf: radioBoxOptions(
-          ["Enabled", "Disabled"],
-          repoData?.defaultEnabled ?? undefined,
-        ),
+        oneOf: taskLevelOptions(repoData?.taskLevel ?? undefined),
       },
     },
   },
@@ -43,10 +73,10 @@ export const getFormSchema = ({
       "ui:description":
         "Sets if the project can use test selection features or not.",
     },
-    defaultEnabled: {
+    taskLevel: {
       "ui:widget": widgets.RadioBoxWidget,
       "ui:description":
-        "If enabled, all tasks in patches run with test selection enabled by default.",
+        "Controls whether test selection is enabled by default for patch tasks, or for both patch and mainline commit tasks.",
       ...(!canEnableTaskLevel && {
         "ui:warnings": [
           "This setting will only have an effect if test selection is enabled for the project.",

--- a/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/TestSelectionTab/getFormSchema.tsx
+++ b/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/TestSelectionTab/getFormSchema.tsx
@@ -14,6 +14,12 @@ const taskLevelLabels: Record<TaskLevelTestSelection, string> = {
     "Enabled for patches and mainline commits",
 };
 
+const taskLevelSettings = [
+  TaskLevelTestSelection.Disabled,
+  TaskLevelTestSelection.Patches,
+  TaskLevelTestSelection.PatchesAndMainline,
+];
+
 const taskLevelOption = (
   title: string,
   value: TaskLevelTestSelection | null,
@@ -25,19 +31,22 @@ const taskLevelOption = (
 
 const taskLevelOptions = (
   repoSetting?: TaskLevelTestSelection,
-): Array<SpruceFormProps["schema"]> => [
-  ...Object.entries(taskLevelLabels).map(([value, title]) =>
-    taskLevelOption(title, value as TaskLevelTestSelection),
-  ),
-  ...(repoSetting
-    ? [
-        taskLevelOption(
-          `Default to repo (${taskLevelLabels[repoSetting].toLowerCase()})`,
-          null,
-        ),
-      ]
-    : []),
-];
+): Array<SpruceFormProps["schema"]> => {
+  const options = taskLevelSettings.map((setting) =>
+    taskLevelOption(taskLevelLabels[setting], setting),
+  );
+
+  if (repoSetting) {
+    options.push(
+      taskLevelOption(
+        `Default to repo (${taskLevelLabels[repoSetting].toLowerCase()})`,
+        null,
+      ),
+    );
+  }
+
+  return options;
+};
 
 export const getFormSchema = ({
   canEnableTaskLevel,

--- a/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/TestSelectionTab/transformers.test.ts
+++ b/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/TestSelectionTab/transformers.test.ts
@@ -1,7 +1,7 @@
 import { ProjectSettingsInput, RepoSettingsInput } from "gql/generated/types";
 import { data } from "../testData";
 import { formToGql, gqlToForm } from "./transformers";
-import { TestSelectionFormState } from "./types";
+import { TaskLevelTestSelection, TestSelectionFormState } from "./types";
 
 const { projectBase, repoBase } = data;
 
@@ -27,9 +27,77 @@ describe("repo data", () => {
   });
 });
 
+describe("task-level settings", () => {
+  it.each([
+    {
+      defaultEnabled: false,
+      expected: TaskLevelTestSelection.Disabled,
+      mainlineDefaultEnabled: false,
+    },
+    {
+      defaultEnabled: true,
+      expected: TaskLevelTestSelection.Patches,
+      mainlineDefaultEnabled: false,
+    },
+    {
+      defaultEnabled: true,
+      expected: TaskLevelTestSelection.PatchesAndMainline,
+      mainlineDefaultEnabled: true,
+    },
+  ])(
+    "converts defaultEnabled=$defaultEnabled and mainlineDefaultEnabled=$mainlineDefaultEnabled from GQL",
+    ({ defaultEnabled, expected, mainlineDefaultEnabled }) => {
+      const projectRef = repoBase.projectRef!;
+      expect(
+        gqlToForm({
+          ...repoBase,
+          projectRef: {
+            ...projectRef,
+            testSelection: {
+              allowed: true,
+              defaultEnabled,
+              mainlineDefaultEnabled,
+            },
+          },
+        }),
+      ).toMatchObject({ taskLevel: expected });
+    },
+  );
+
+  it.each([
+    {
+      defaultEnabled: false,
+      mainlineDefaultEnabled: false,
+      taskLevel: TaskLevelTestSelection.Disabled,
+    },
+    {
+      defaultEnabled: true,
+      mainlineDefaultEnabled: false,
+      taskLevel: TaskLevelTestSelection.Patches,
+    },
+    {
+      defaultEnabled: true,
+      mainlineDefaultEnabled: true,
+      taskLevel: TaskLevelTestSelection.PatchesAndMainline,
+    },
+  ])(
+    "converts $taskLevel to GQL",
+    ({ defaultEnabled, mainlineDefaultEnabled, taskLevel }) => {
+      expect(
+        formToGql({ allowed: true, taskLevel }, false, "project").projectRef
+          .testSelection,
+      ).toStrictEqual({
+        allowed: true,
+        defaultEnabled,
+        mainlineDefaultEnabled,
+      });
+    },
+  );
+});
+
 const projectForm: TestSelectionFormState = {
   allowed: null,
-  defaultEnabled: null,
+  taskLevel: null,
 };
 
 const projectResult: Pick<ProjectSettingsInput, "projectId" | "projectRef"> = {
@@ -39,13 +107,14 @@ const projectResult: Pick<ProjectSettingsInput, "projectId" | "projectRef"> = {
     testSelection: {
       allowed: null,
       defaultEnabled: null,
+      mainlineDefaultEnabled: null,
     },
   },
 };
 
 const repoForm: TestSelectionFormState = {
   allowed: true,
-  defaultEnabled: true,
+  taskLevel: TaskLevelTestSelection.PatchesAndMainline,
 };
 
 const repoResult: Pick<RepoSettingsInput, "repoId" | "projectRef"> = {
@@ -55,6 +124,7 @@ const repoResult: Pick<RepoSettingsInput, "repoId" | "projectRef"> = {
     testSelection: {
       allowed: true,
       defaultEnabled: true,
+      mainlineDefaultEnabled: true,
     },
   },
 };

--- a/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/TestSelectionTab/transformers.ts
+++ b/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/TestSelectionTab/transformers.ts
@@ -1,7 +1,23 @@
 import { ProjectSettingsTabRoutes } from "constants/routes";
 import { FormToGqlFunction, GqlToFormFunction } from "../types";
+import { TaskLevelTestSelection } from "./types";
 
 type Tab = ProjectSettingsTabRoutes.TestSelection;
+
+const getTaskLevelSetting = (
+  defaultEnabled?: boolean | null,
+  mainlineDefaultEnabled?: boolean | null,
+): TaskLevelTestSelection | null => {
+  if (defaultEnabled === null || defaultEnabled === undefined) {
+    return null;
+  }
+  if (!defaultEnabled) {
+    return TaskLevelTestSelection.Disabled;
+  }
+  return mainlineDefaultEnabled
+    ? TaskLevelTestSelection.PatchesAndMainline
+    : TaskLevelTestSelection.Patches;
+};
 
 export const gqlToForm = ((data) => {
   if (!data) return null;
@@ -11,17 +27,30 @@ export const gqlToForm = ((data) => {
 
   return {
     allowed: testSelection?.allowed ?? null,
-    defaultEnabled: testSelection?.defaultEnabled ?? null,
+    taskLevel: getTaskLevelSetting(
+      testSelection?.defaultEnabled,
+      testSelection?.mainlineDefaultEnabled,
+    ),
   };
 }) satisfies GqlToFormFunction<Tab>;
 
-export const formToGql = ((formState, isRepo, id) => ({
-  ...(isRepo ? { repoId: id } : { projectId: id }),
-  projectRef: {
-    id,
-    testSelection: {
-      allowed: formState.allowed,
-      defaultEnabled: formState.defaultEnabled,
+export const formToGql = ((formState, isRepo, id) => {
+  const { taskLevel } = formState;
+  return {
+    ...(isRepo ? { repoId: id } : { projectId: id }),
+    projectRef: {
+      id,
+      testSelection: {
+        allowed: formState.allowed,
+        defaultEnabled:
+          taskLevel === null
+            ? null
+            : taskLevel !== TaskLevelTestSelection.Disabled,
+        mainlineDefaultEnabled:
+          taskLevel === null
+            ? null
+            : taskLevel === TaskLevelTestSelection.PatchesAndMainline,
+      },
     },
-  },
-})) satisfies FormToGqlFunction<Tab>;
+  };
+}) satisfies FormToGqlFunction<Tab>;

--- a/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/TestSelectionTab/types.ts
+++ b/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/TestSelectionTab/types.ts
@@ -1,8 +1,14 @@
 import { ProjectType } from "../utils";
 
+export enum TaskLevelTestSelection {
+  Disabled = "disabled",
+  Patches = "patches",
+  PatchesAndMainline = "patches-and-mainline",
+}
+
 export interface TestSelectionFormState {
   allowed: boolean | null;
-  defaultEnabled: boolean | null;
+  taskLevel: TaskLevelTestSelection | null;
 }
 
 export type TabProps = {

--- a/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/testData.ts
+++ b/apps/spruce/src/pages/projectAndRepoSettings/shared/tabs/testData.ts
@@ -80,6 +80,7 @@ const projectBase: ProjectSettingsQuery["projectSettings"] = {
     testSelection: {
       allowed: null,
       defaultEnabled: null,
+      mainlineDefaultEnabled: null,
     },
     buildBaronSettings: {
       // @ts-expect-error: FIXME. This comment was added by an automated script.
@@ -259,6 +260,7 @@ const repoBase: RepoSettingsQuery["repoSettings"] = {
     testSelection: {
       allowed: true,
       defaultEnabled: true,
+      mainlineDefaultEnabled: true,
     },
     buildBaronSettings: {
       ticketCreateProject: "EVG",

--- a/packages/lib/src/gql/generated/types.ts
+++ b/packages/lib/src/gql/generated/types.ts
@@ -3518,6 +3518,7 @@ export type RepoTestSelectionSettings = {
   __typename?: "RepoTestSelectionSettings";
   allowed: Scalars["Boolean"]["output"];
   defaultEnabled: Scalars["Boolean"]["output"];
+  mainlineDefaultEnabled: Scalars["Boolean"]["output"];
 };
 
 export type RepoWorkstationConfig = {
@@ -4578,11 +4579,13 @@ export type TestSelectionSettings = {
   __typename?: "TestSelectionSettings";
   allowed?: Maybe<Scalars["Boolean"]["output"]>;
   defaultEnabled?: Maybe<Scalars["Boolean"]["output"]>;
+  mainlineDefaultEnabled?: Maybe<Scalars["Boolean"]["output"]>;
 };
 
 export type TestSelectionSettingsInput = {
   allowed?: InputMaybe<Scalars["Boolean"]["input"]>;
   defaultEnabled?: InputMaybe<Scalars["Boolean"]["input"]>;
+  mainlineDefaultEnabled?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
 export enum TestSortCategory {


### PR DESCRIPTION
DEVPROD-36201

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

<!-- Does this PR have a minor or major SemVer version change? Include [minor] or [major] in the title ☝️. Checkout the versioning guideline: https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.70z2y1glupqo -->

<!-- Does this PR need a 🔵Spruce or 🟢Parsley label? Add it in the sidebar 👉 -->

### Description
Split TSS being enabled to let people run TSS on just patches and/or patches and mainline. 

* Adding new option to the TSS setting page
* Making sure TSS is correctly enabled on the patch+mainline version pages 

- [ ] Blocked till the [BE PR merged](https://github.com/evergreen-ci/evergreen/pull/10622)




### Screenshots
<img width="1233" height="555" alt="Screenshot 2026-08-04 at 1 27 42 PM" src="https://github.com/user-attachments/assets/8f8e1b29-9ad4-4bb0-9c52-71f4a26d3515" />

### Testing
* Unit testing
* Locally smoke tested

Full video of changes 
https://github.com/user-attachments/assets/ec4c4588-7697-4807-b2ab-f8e62bc96e4e


### Evergreen PR
https://github.com/evergreen-ci/evergreen/pull/10622