### PR TITLE
DEVPROD-32852: create admin settings for subnet discovery

### DIFF
--- a/apps/parsley/src/gql/generated/types.ts
+++ b/apps/parsley/src/gql/generated/types.ts
@@ -72,6 +72,8 @@ export type AwsConfig = {
   maxVolumeSizePerUser?: Maybe<Scalars["Int"]["output"]>;
   parserProject?: Maybe<ParserProjectS3Config>;
   persistentDNS?: Maybe<PersistentDnsConfig>;
+  subnetTagName?: Maybe<Scalars["String"]["output"]>;
+  subnetTagValue?: Maybe<Scalars["String"]["output"]>;
   subnets: Array<Subnet>;
 };
 
@@ -87,6 +89,8 @@ export type AwsConfigInput = {
   maxVolumeSizePerUser?: InputMaybe<Scalars["Int"]["input"]>;
   parserProject?: InputMaybe<ParserProjectS3ConfigInput>;
   persistentDNS?: InputMaybe<PersistentDnsConfigInput>;
+  subnetTagName?: InputMaybe<Scalars["String"]["input"]>;
+  subnetTagValue?: InputMaybe<Scalars["String"]["input"]>;
   subnets: Array<SubnetInput>;
 };
 
@@ -3318,6 +3322,7 @@ export type QueryWaterfallArgs = {
 export type RateLimitConfig = {
   __typename?: "RateLimitConfig";
   elevatedUserIds?: Maybe<Array<Scalars["String"]["output"]>>;
+  exemptUserIds?: Maybe<Array<Scalars["String"]["output"]>>;
   graphqlComplexityLimit?: Maybe<Scalars["Int"]["output"]>;
   graphqlServiceBurst?: Maybe<Scalars["Int"]["output"]>;
   graphqlServicePerHour?: Maybe<Scalars["Int"]["output"]>;
@@ -3331,6 +3336,7 @@ export type RateLimitConfig = {
 
 export type RateLimitConfigInput = {
   elevatedUserIds: Array<Scalars["String"]["input"]>;
+  exemptUserIds?: InputMaybe<Array<Scalars["String"]["input"]>>;
   graphqlComplexityLimit: Scalars["Int"]["input"];
   graphqlServiceBurst: Scalars["Int"]["input"];
   graphqlServicePerHour: Scalars["Int"]["input"];
@@ -4082,6 +4088,8 @@ export type Task = {
   baseStatus?: Maybe<Scalars["String"]["output"]>;
   baseTask?: Maybe<Task>;
   blocked: Scalars["Boolean"]["output"];
+  buildBaronCreatedTickets: Array<JiraTicket>;
+  buildBaronSuggestions?: Maybe<SearchReturnInfo>;
   buildId: Scalars["String"]["output"];
   buildVariant: Scalars["String"]["output"];
   buildVariantDisplayName?: Maybe<Scalars["String"]["output"]>;
@@ -4922,7 +4930,6 @@ export type Version = {
   user: User;
   versionTiming?: Maybe<VersionTiming>;
   warnings: Array<Scalars["String"]["output"]>;
-  waterfallBuilds?: Maybe<Array<WaterfallBuild>>;
 };
 
 /** Version models a commit within a project. */
@@ -5036,7 +5043,6 @@ export type VolumeHost = {
 
 export type Waterfall = {
   __typename?: "Waterfall";
-  flattenedVersions: Array<Version>;
   pagination: WaterfallPagination;
   versions: Array<VersionLite>;
 };

--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -3319,6 +3319,7 @@ export type QueryWaterfallArgs = {
 export type RateLimitConfig = {
   __typename?: "RateLimitConfig";
   elevatedUserIds?: Maybe<Array<Scalars["String"]["output"]>>;
+  exemptUserIds?: Maybe<Array<Scalars["String"]["output"]>>;
   graphqlComplexityLimit?: Maybe<Scalars["Int"]["output"]>;
   graphqlServiceBurst?: Maybe<Scalars["Int"]["output"]>;
   graphqlServicePerHour?: Maybe<Scalars["Int"]["output"]>;
@@ -3332,6 +3333,7 @@ export type RateLimitConfig = {
 
 export type RateLimitConfigInput = {
   elevatedUserIds: Array<Scalars["String"]["input"]>;
+  exemptUserIds?: InputMaybe<Array<Scalars["String"]["input"]>>;
   graphqlComplexityLimit: Scalars["Int"]["input"];
   graphqlServiceBurst: Scalars["Int"]["input"];
   graphqlServicePerHour: Scalars["Int"]["input"];
@@ -4083,6 +4085,8 @@ export type Task = {
   baseStatus?: Maybe<Scalars["String"]["output"]>;
   baseTask?: Maybe<Task>;
   blocked: Scalars["Boolean"]["output"];
+  buildBaronCreatedTickets: Array<JiraTicket>;
+  buildBaronSuggestions?: Maybe<SearchReturnInfo>;
   buildId: Scalars["String"]["output"];
   buildVariant: Scalars["String"]["output"];
   buildVariantDisplayName?: Maybe<Scalars["String"]["output"]>;
@@ -4924,7 +4928,6 @@ export type Version = {
   user: User;
   versionTiming?: Maybe<VersionTiming>;
   warnings: Array<Scalars["String"]["output"]>;
-  waterfallBuilds?: Maybe<Array<WaterfallBuild>>;
 };
 
 /** Version models a commit within a project. */
@@ -5038,7 +5041,6 @@ export type VolumeHost = {
 
 export type Waterfall = {
   __typename?: "Waterfall";
-  flattenedVersions: Array<Version>;
   pagination: WaterfallPagination;
   versions: Array<VersionLite>;
 };

--- a/apps/spruce/src/gql/generated/types.ts
+++ b/apps/spruce/src/gql/generated/types.ts
@@ -69,6 +69,8 @@ export type AwsConfig = {
   maxVolumeSizePerUser?: Maybe<Scalars["Int"]["output"]>;
   parserProject?: Maybe<ParserProjectS3Config>;
   persistentDNS?: Maybe<PersistentDnsConfig>;
+  subnetTagName?: Maybe<Scalars["String"]["output"]>;
+  subnetTagValue?: Maybe<Scalars["String"]["output"]>;
   subnets: Array<Subnet>;
 };
 
@@ -84,6 +86,8 @@ export type AwsConfigInput = {
   maxVolumeSizePerUser?: InputMaybe<Scalars["Int"]["input"]>;
   parserProject?: InputMaybe<ParserProjectS3ConfigInput>;
   persistentDNS?: InputMaybe<PersistentDnsConfigInput>;
+  subnetTagName?: InputMaybe<Scalars["String"]["input"]>;
+  subnetTagValue?: InputMaybe<Scalars["String"]["input"]>;
   subnets: Array<SubnetInput>;
 };
 
@@ -7864,6 +7868,8 @@ export type AdminSettingsQuery = {
         elasticIPUsageRate?: number | null;
         ipamPoolID?: string | null;
         maxVolumeSizePerUser?: number | null;
+        subnetTagName?: string | null;
+        subnetTagValue?: string | null;
         accountRoles: Array<{
           __typename?: "AWSAccountRoleMapping";
           account: string;

--- a/apps/spruce/src/gql/queries/admin-settings.ts
+++ b/apps/spruce/src/gql/queries/admin-settings.ts
@@ -283,6 +283,8 @@ export const ADMIN_SETTINGS = gql`
             az
             subnetId
           }
+          subnetTagName
+          subnetTagValue
         }
         docker {
           apiVersion

--- a/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/ProvidersTab/schemaFields.ts
+++ b/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/ProvidersTab/schemaFields.ts
@@ -162,6 +162,16 @@ export const docker = {
 export const aws = {
   schema: {
     subnets: subnets.schema,
+    subnetTagName: {
+      type: "string" as const,
+      title: "Subnet Tag Name",
+      default: "",
+    },
+    subnetTagValue: {
+      type: "string" as const,
+      title: "Subnet Tag Value",
+      default: "",
+    },
     accountRoles: accountRoles.schema,
     parameterStorePrefix: {
       type: "string" as const,

--- a/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/ProvidersTab/transformers.test.ts
+++ b/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/ProvidersTab/transformers.test.ts
@@ -42,6 +42,8 @@ const form: ProvidersFormState = {
           subnetId: "subnet-67890",
         },
       ],
+      subnetTagName: "SubnetGroupName",
+      subnetTagValue: "workloads",
       parameterStorePrefix: "/evergreen/test",
       persistentDNS: {
         hostedZoneID: "Z123456789",
@@ -140,6 +142,8 @@ const gql: AdminSettingsInput = {
           subnetId: "subnet-67890",
         },
       ],
+      subnetTagName: "SubnetGroupName",
+      subnetTagValue: "workloads",
     },
     docker: {
       apiVersion: "1.40",
@@ -210,6 +214,8 @@ const testAdminSettings = {
           subnetId: "subnet-67890",
         },
       ],
+      subnetTagName: "SubnetGroupName",
+      subnetTagValue: "workloads",
     },
     docker: {
       apiVersion: "1.40",

--- a/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/ProvidersTab/transformers.ts
+++ b/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/ProvidersTab/transformers.ts
@@ -26,6 +26,8 @@ export const gqlToForm = ((data) => {
             az: subnet.az ?? "",
             subnetId: subnet.subnetId ?? "",
           })) ?? [],
+        subnetTagName: providers?.aws?.subnetTagName ?? "",
+        subnetTagValue: providers?.aws?.subnetTagValue ?? "",
         accountRoles:
           providers?.aws?.accountRoles?.map((role) => ({
             account: role.account ?? "",
@@ -106,6 +108,8 @@ export const formToGql = ((form: ProvidersFormState) => {
           az: subnet.az,
           subnetId: subnet.subnetId,
         })),
+        subnetTagName: aws.subnetTagName || undefined,
+        subnetTagValue: aws.subnetTagValue || undefined,
       },
       docker: {
         apiVersion: docker.apiVersion || undefined,

--- a/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/ProvidersTab/types.ts
+++ b/apps/spruce/src/pages/adminSettings/tabs/GeneralTab/ProvidersTab/types.ts
@@ -14,6 +14,8 @@ export interface ProvidersFormState {
         az: string;
         subnetId: string;
       }>;
+      subnetTagName: string;
+      subnetTagValue: string;
       accountRoles: Array<{
         account: string;
         role: string;


### PR DESCRIPTION
DEVPROD-32852

### Description
Add two new admin settings that will be used to dynamically find subnets in AWS that match a tag key/value.

### Screenshots
<img width="1132" height="326" alt="image" src="https://github.com/user-attachments/assets/b8a2e560-ff6e-4593-b354-cbc90d9b0446" />

### Testing
Tested locally to confirm that I could set/view the new tag settings.

### Evergreen PR
https://github.com/evergreen-ci/evergreen/pull/10632
